### PR TITLE
ci: add Claude-powered PR review workflow

### DIFF
--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -1,0 +1,143 @@
+name: PR Review
+# Runs on every PR to main — calls Claude API for security-focused code review
+
+on:
+  pull_request:
+    branches: [main]
+    types: [opened, synchronize]
+
+concurrency:
+  group: pr-review-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+permissions:
+  pull-requests: write
+  contents: read
+
+jobs:
+  review:
+    name: Claude Code Review
+    runs-on: ubuntu-latest
+    env:
+      PR_NUMBER: ${{ github.event.pull_request.number }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Get PR diff and metadata
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh pr diff "$PR_NUMBER" > /tmp/pr_diff.txt
+          gh pr diff "$PR_NUMBER" --name-only > /tmp/changed_files.txt
+          gh pr view "$PR_NUMBER" --json title -q '.title' > /tmp/pr_title.txt
+          gh pr view "$PR_NUMBER" --json body -q '.body' | head -c 2000 > /tmp/pr_body.txt
+
+          DIFF_BYTES=$(wc -c < /tmp/pr_diff.txt | tr -d ' ')
+          echo "$DIFF_BYTES" > /tmp/diff_size.txt
+          wc -l < /tmp/changed_files.txt | tr -d ' ' > /tmp/file_count.txt
+
+          if [ "$DIFF_BYTES" -gt 120000 ]; then
+            head -c 120000 /tmp/pr_diff.txt > /tmp/pr_diff_trunc.txt
+            printf '\n\n[DIFF TRUNCATED — original was %s bytes]\n' "$DIFF_BYTES" >> /tmp/pr_diff_trunc.txt
+            mv /tmp/pr_diff_trunc.txt /tmp/pr_diff.txt
+          fi
+
+      - name: Run Claude review
+        env:
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+        run: |
+          PR_TITLE=$(cat /tmp/pr_title.txt)
+
+          # Build system prompt
+          cat > /tmp/system_prompt.txt << 'SYSPROMPT'
+          You are a senior security engineer reviewing a pull request for HackMyAgent — an open-source security scanner CLI for AI agents ("OWASP ZAP for AI Agents").
+
+          Tech stack: TypeScript/Node.js Turborepo monorepo (packages/cli + packages/core), ES modules, vitest for testing.
+
+          Review focus (in priority order):
+          1. SECURITY: Command injection (child_process, exec, spawn with unsanitized input), prototype pollution, path traversal, unsafe eval/Function constructors, dependency confusion, regex DoS, SSRF in HTTP clients
+          2. CORRECTNESS: Logic errors, unhandled promise rejections, type safety gaps, race conditions, resource leaks (open handles, unclosed streams)
+          3. QUALITY: Breaking CLI interface changes, incorrect exit codes, missing input validation at system boundaries, unsafe JSON parsing
+
+          Do NOT flag: style preferences, missing docs, test coverage, pre-existing issues.
+
+          Response format (strict):
+          VERDICT: APPROVE or REQUEST_CHANGES
+          SUMMARY: One paragraph.
+          FINDINGS:
+          - [CRITICAL|HIGH|MEDIUM] path/file.ts:line — Description
+          (omit FINDINGS section if none)
+
+          Rules:
+          - APPROVE if no CRITICAL or HIGH findings
+          - Only REQUEST_CHANGES for genuine security/correctness issues introduced in this PR
+          - CI/config/docs-only changes: always APPROVE
+          - Max 10 findings, most important first
+          SYSPROMPT
+
+          # Build user message
+          {
+            printf 'PR #%s: %s\n\nDescription:\n' "$PR_NUMBER" "$PR_TITLE"
+            cat /tmp/pr_body.txt
+            printf '\n\nChanged files:\n'
+            cat /tmp/changed_files.txt
+            printf '\n\nDiff:\n'
+            cat /tmp/pr_diff.txt
+          } > /tmp/user_msg.txt
+
+          # Call Anthropic API via jq + curl
+          RESPONSE=$(jq -n \
+            --rawfile system /tmp/system_prompt.txt \
+            --rawfile user /tmp/user_msg.txt \
+            '{
+              model: "claude-sonnet-4-5-20250929",
+              max_tokens: 4096,
+              system: $system,
+              messages: [{ role: "user", content: $user }]
+            }' | curl -s -X POST "https://api.anthropic.com/v1/messages" \
+              -H "Content-Type: application/json" \
+              -H "x-api-key: ${ANTHROPIC_API_KEY}" \
+              -H "anthropic-version: 2023-06-01" \
+              -d @-)
+
+          # Extract response text
+          REVIEW_TEXT=$(echo "$RESPONSE" | jq -r '.content[0].text // empty')
+
+          if [ -z "$REVIEW_TEXT" ]; then
+            ERROR=$(echo "$RESPONSE" | jq -r '.error.message // "Unknown API error"')
+            echo "::error::Claude API call failed: $ERROR"
+            exit 1
+          else
+            echo "$REVIEW_TEXT" > /tmp/review_body.txt
+            VERDICT=$(grep -oP 'VERDICT:\s*\K(APPROVE|REQUEST_CHANGES)' /tmp/review_body.txt | head -1)
+            echo "${VERDICT:-APPROVE}" > /tmp/verdict.txt
+          fi
+
+      - name: Post review
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          VERDICT=$(cat /tmp/verdict.txt)
+          DIFF_SIZE=$(cat /tmp/diff_size.txt)
+          FILE_COUNT=$(cat /tmp/file_count.txt)
+
+          {
+            echo "## Claude Code Review"
+            echo ""
+            cat /tmp/review_body.txt
+            echo ""
+            echo "---"
+            echo "*Reviewed ${FILE_COUNT} files changed (${DIFF_SIZE} bytes)*"
+          } > /tmp/full_review.txt
+
+          BODY=$(cat /tmp/full_review.txt)
+
+          if [ "$VERDICT" = "REQUEST_CHANGES" ]; then
+            gh pr review "$PR_NUMBER" --request-changes --body "$BODY" 2>/dev/null || \
+              gh pr comment "$PR_NUMBER" --body "$BODY"
+          else
+            gh pr review "$PR_NUMBER" --approve --body "$BODY" 2>/dev/null || \
+              gh pr comment "$PR_NUMBER" --body "$BODY"
+          fi


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/pr-review.yml` for automated code review on PRs to main
- Uses Claude Sonnet 4.5 via Anthropic API with a system prompt tailored for TypeScript/Node.js security scanner context
- Focuses on command injection, prototype pollution, dependency safety, unsafe eval/exec, path traversal

## Test plan
- [ ] Verify workflow triggers on this PR
- [ ] Confirm Claude API call succeeds and posts a review comment
- [ ] Check VERDICT is parsed correctly (APPROVE or REQUEST_CHANGES)