### PR TITLE
Add OpenA2A Registry integration for scan reporting

### DIFF
--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1430,7 +1430,11 @@ Examples:
   .option('-b, --benchmark <name>', 'Run benchmark compliance check (e.g., oasb-1)')
   .option('-l, --level <level>', 'Benchmark level: L1 (Essential), L2 (Standard), L3 (Hardened)', 'L1')
   .option('-c, --category <name>', 'Filter to specific benchmark category')
-  .action(async (directory: string, options: { fix?: boolean; dryRun?: boolean; ignore?: string; json?: boolean; format?: string; output?: string; failBelow?: string; verbose?: boolean; benchmark?: string; level?: string; category?: string }) => {
+  .option('--registry-report', 'Post results to OpenA2A Registry')
+  .option('--version-id <id>', 'Registry version ID to report against')
+  .option('--registry-url <url>', 'Registry URL (default: REGISTRY_URL env)')
+  .option('--registry-key <key>', 'Registry API key (default: REGISTRY_API_KEY env)')
+  .action(async (directory: string, options: { fix?: boolean; dryRun?: boolean; ignore?: string; json?: boolean; format?: string; output?: string; failBelow?: string; verbose?: boolean; benchmark?: string; level?: string; category?: string; registryReport?: boolean; versionId?: string; registryUrl?: string; registryKey?: string }) => {
     try {
       const targetDir = directory.startsWith('/') ? directory : process.cwd() + '/' + directory;
 
@@ -1604,6 +1608,37 @@ Examples:
         if (result.backupPath) {
           console.log(`Backup: ${result.backupPath}`);
           console.log(`Undo: hackmyagent rollback ${directory}\n`);
+        }
+      }
+
+      // Report to registry if requested
+      if (options.registryReport) {
+        const { RegistryClient, buildScanReport } = await import('hackmyagent-core');
+        const registryUrl = options.registryUrl || process.env.REGISTRY_URL;
+        const registryKey = options.registryKey || process.env.REGISTRY_API_KEY;
+        const versionId = options.versionId;
+
+        if (!registryUrl) {
+          console.error('Error: --registry-url or REGISTRY_URL env is required for registry reporting');
+          process.exit(1);
+        }
+        if (!registryKey) {
+          console.error('Error: --registry-key or REGISTRY_API_KEY env is required for registry reporting');
+          process.exit(1);
+        }
+        if (!versionId) {
+          console.error('Error: --version-id is required for registry reporting');
+          process.exit(1);
+        }
+
+        const client = new RegistryClient({ registryUrl, apiKey: registryKey });
+        const payload = buildScanReport(versionId, result.findings);
+
+        try {
+          await client.reportScanResult(payload);
+          console.log(`Registry: scan results reported for version ${versionId}`);
+        } catch (regErr) {
+          console.error(`Registry report failed: ${regErr instanceof Error ? regErr.message : regErr}`);
         }
       }
 
@@ -2047,6 +2082,10 @@ Examples:
   .option('-f, --format <format>', 'Output format: text, json, sarif, html', 'text')
   .option('-o, --output <file>', 'Write output to file')
   .option('-v, --verbose', 'Show detailed output for each payload')
+  .option('--registry-report', 'Post results to OpenA2A Registry')
+  .option('--version-id <id>', 'Registry version ID to report against')
+  .option('--registry-url <url>', 'Registry URL (default: REGISTRY_URL env)')
+  .option('--registry-key <key>', 'Registry API key (default: REGISTRY_API_KEY env)')
   .action(async (targetUrl: string | undefined, options: {
     intensity?: string;
     category?: string;
@@ -2063,6 +2102,10 @@ Examples:
     format?: string;
     output?: string;
     verbose?: boolean;
+    registryReport?: boolean;
+    versionId?: string;
+    registryUrl?: string;
+    registryKey?: string;
   }) => {
     try {
       // Validate target
@@ -2183,6 +2226,37 @@ Examples:
           console.error(`Report written to ${options.output}`);
         } else {
           console.log(output);
+        }
+      }
+
+      // Report to registry if requested
+      if (options.registryReport) {
+        const { RegistryClient, buildAttackReport } = await import('hackmyagent-core');
+        const registryUrl = options.registryUrl || process.env.REGISTRY_URL;
+        const registryKey = options.registryKey || process.env.REGISTRY_API_KEY;
+        const versionId = options.versionId;
+
+        if (!registryUrl) {
+          console.error('Error: --registry-url or REGISTRY_URL env is required for registry reporting');
+          process.exit(1);
+        }
+        if (!registryKey) {
+          console.error('Error: --registry-key or REGISTRY_API_KEY env is required for registry reporting');
+          process.exit(1);
+        }
+        if (!versionId) {
+          console.error('Error: --version-id is required for registry reporting');
+          process.exit(1);
+        }
+
+        const client = new RegistryClient({ registryUrl, apiKey: registryKey });
+        const payload = buildAttackReport(versionId, report);
+
+        try {
+          await client.reportScanResult(payload);
+          console.log(`Registry: attack results reported for version ${versionId}`);
+        } catch (regErr) {
+          console.error(`Registry report failed: ${regErr instanceof Error ? regErr.message : regErr}`);
         }
       }
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -88,6 +88,19 @@ export type {
   BenchmarkName,
 } from './benchmarks';
 
+// Registry module
+export {
+  RegistryClient,
+  buildScanReport,
+  buildAttackReport,
+} from './registry';
+
+export type {
+  RegistryConfig,
+  RegistryPackage,
+  ScanReportPayload,
+} from './registry';
+
 // Legacy scanner (for scan command)
 export interface ScanResult {
   target: string;

--- a/packages/core/src/registry/client.ts
+++ b/packages/core/src/registry/client.ts
@@ -1,0 +1,244 @@
+/**
+ * OpenA2A Registry client for posting scan results.
+ *
+ * Maps HackMyAgent scan findings to the registry's ScanResult format
+ * and POSTs them to the registry callback endpoint.
+ */
+
+import type { SecurityFinding, Severity } from '../hardening';
+import type { AttackReport } from '../attack';
+
+// Registry ScanResult format (must match hackmyagent_service.go:175-200)
+export interface ScanReportPayload {
+  versionId: string;
+  scanId: string;
+  status: 'passed' | 'failed' | 'warnings' | 'error';
+  completedAt: string;
+  vulnerabilities: VulnerabilityFinding[];
+  criticalCount: number;
+  highCount: number;
+  mediumCount: number;
+  lowCount: number;
+  observedCapabilities: string[];
+  observedExternalApis: string[];
+  capabilityMismatch: boolean;
+  behavioralFindings: BehavioralFinding[];
+  behavioralScore: number;
+  rawReport: Record<string, unknown>;
+}
+
+interface VulnerabilityFinding {
+  id: string;
+  severity: string;
+  title: string;
+  description: string;
+  package?: string;
+  version?: string;
+  fixedIn?: string;
+  cves?: string[];
+  cvss?: number;
+}
+
+interface BehavioralFinding {
+  type: string;
+  severity: string;
+  description: string;
+  evidence?: string;
+}
+
+export interface RegistryConfig {
+  registryUrl: string;
+  apiKey: string;
+}
+
+export interface RegistryPackage {
+  id: string;
+  publisherId: string;
+  name: string;
+  packageType: string;
+}
+
+export class RegistryClient {
+  private config: RegistryConfig;
+
+  constructor(config: RegistryConfig) {
+    this.config = config;
+  }
+
+  /**
+   * Post scan results to registry callback endpoint.
+   */
+  async reportScanResult(payload: ScanReportPayload): Promise<void> {
+    const url = `${this.config.registryUrl}/api/v1/registry/internal/scan-result`;
+
+    const response = await fetch(url, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'Authorization': `Bearer ${this.config.apiKey}`,
+        'User-Agent': 'HackMyAgent-CLI',
+      },
+      body: JSON.stringify(payload),
+    });
+
+    if (!response.ok) {
+      const body = await response.text().catch(() => '');
+      throw new Error(
+        `Registry report failed (${response.status}): ${body}`
+      );
+    }
+  }
+
+  /**
+   * Look up package info from registry.
+   */
+  async getPackage(
+    publisherName: string,
+    packageType: string,
+    name: string,
+  ): Promise<RegistryPackage | null> {
+    const url = `${this.config.registryUrl}/api/v1/registry/${packageType}/${name}?publisher=${publisherName}`;
+
+    const response = await fetch(url, {
+      headers: {
+        'User-Agent': 'HackMyAgent-CLI',
+      },
+    });
+
+    if (response.status === 404) {
+      return null;
+    }
+
+    if (!response.ok) {
+      throw new Error(`Registry lookup failed (${response.status})`);
+    }
+
+    return response.json() as Promise<RegistryPackage>;
+  }
+}
+
+/**
+ * Build a ScanReportPayload from HMA hardening scan results.
+ */
+export function buildScanReport(
+  versionId: string,
+  findings: SecurityFinding[],
+): ScanReportPayload {
+  const failed = findings.filter(f => !f.passed && !f.fixed);
+
+  const counts = countBySeverity(failed);
+  const status = deriveStatus(counts);
+
+  // Map failed findings to vulnerability format
+  const vulnerabilities: VulnerabilityFinding[] = failed.map(f => ({
+    id: f.checkId,
+    severity: f.severity,
+    title: f.name,
+    description: f.description,
+  }));
+
+  // Extract observed capabilities from capability-related checks
+  const observedCapabilities: string[] = [];
+  for (const f of findings) {
+    if (f.checkId.startsWith('FS-') && !f.passed) observedCapabilities.push('filesystem');
+    if (f.checkId.startsWith('NET-') && !f.passed) observedCapabilities.push('network');
+    if (f.checkId.startsWith('SHELL-') && !f.passed) observedCapabilities.push('shell_exec');
+  }
+
+  return {
+    versionId,
+    scanId: `hma-${Date.now()}`,
+    status,
+    completedAt: new Date().toISOString(),
+    vulnerabilities,
+    criticalCount: counts.critical,
+    highCount: counts.high,
+    mediumCount: counts.medium,
+    lowCount: counts.low,
+    observedCapabilities: [...new Set(observedCapabilities)],
+    observedExternalApis: [],
+    capabilityMismatch: false,
+    behavioralFindings: [],
+    behavioralScore: 0,
+    rawReport: {
+      generator: 'hackmyagent',
+      totalFindings: findings.length,
+      failedFindings: failed.length,
+    },
+  };
+}
+
+/**
+ * Build a ScanReportPayload from HMA attack results.
+ */
+export function buildAttackReport(
+  versionId: string,
+  report: AttackReport,
+): ScanReportPayload {
+  const vulnerabilities: VulnerabilityFinding[] = report.results
+    .filter(r => r.success)
+    .map(r => ({
+      id: r.payload.id,
+      severity: r.payload.severity,
+      title: `${r.payload.category}: ${r.payload.id}`,
+      description: r.response?.substring(0, 500) || 'Attack succeeded',
+    }));
+
+  const counts = {
+    critical: vulnerabilities.filter(v => v.severity === 'critical').length,
+    high: vulnerabilities.filter(v => v.severity === 'high').length,
+    medium: vulnerabilities.filter(v => v.severity === 'medium').length,
+    low: vulnerabilities.filter(v => v.severity === 'low').length,
+  };
+
+  const status = deriveStatus(counts);
+
+  return {
+    versionId,
+    scanId: `hma-attack-${Date.now()}`,
+    status,
+    completedAt: new Date().toISOString(),
+    vulnerabilities,
+    criticalCount: counts.critical,
+    highCount: counts.high,
+    mediumCount: counts.medium,
+    lowCount: counts.low,
+    observedCapabilities: [],
+    observedExternalApis: [],
+    capabilityMismatch: false,
+    behavioralFindings: [],
+    behavioralScore: 0,
+    rawReport: {
+      generator: 'hackmyagent-attack',
+      target: report.target,
+      riskRating: report.riskRating,
+      totalPayloads: report.summary.total,
+      successfulAttacks: report.summary.successful,
+    },
+  };
+}
+
+function countBySeverity(findings: { severity: Severity | string }[]): {
+  critical: number;
+  high: number;
+  medium: number;
+  low: number;
+} {
+  return {
+    critical: findings.filter(f => f.severity === 'critical').length,
+    high: findings.filter(f => f.severity === 'high').length,
+    medium: findings.filter(f => f.severity === 'medium').length,
+    low: findings.filter(f => f.severity === 'low').length,
+  };
+}
+
+function deriveStatus(counts: {
+  critical: number;
+  high: number;
+  medium: number;
+  low: number;
+}): 'passed' | 'failed' | 'warnings' {
+  if (counts.critical > 0 || counts.high > 0) return 'failed';
+  if (counts.medium > 0 || counts.low > 0) return 'warnings';
+  return 'passed';
+}

--- a/packages/core/src/registry/index.ts
+++ b/packages/core/src/registry/index.ts
@@ -1,0 +1,11 @@
+export {
+  RegistryClient,
+  buildScanReport,
+  buildAttackReport,
+} from './client';
+
+export type {
+  RegistryConfig,
+  RegistryPackage,
+  ScanReportPayload,
+} from './client';


### PR DESCRIPTION
## Summary
- Add `RegistryClient` in `@hackmyagent/core` for posting scan results to the OpenA2A Registry
- Add `--registry-report` flag to both `secure` and `attack` CLI commands
- Maps HMA findings to the registry's `ScanResult` format (vulnerability counts, observed capabilities, status derivation)

## Changes

### Core Package (`packages/core/src/registry/`)
- `client.ts`: `RegistryClient` class with `reportScanResult()` and `getPackage()` methods
- `buildScanReport()`: Maps `SecurityFinding[]` to registry `ScanReportPayload`
- `buildAttackReport()`: Maps `AttackReport` to registry `ScanReportPayload`
- `index.ts`: Barrel export file

### CLI (`packages/cli/src/index.ts`)
- Added to `secure` command: `--registry-report`, `--version-id`, `--registry-url`, `--registry-key`
- Added to `attack` command: same four flags
- After scan/attack completes, if `--registry-report` is set, POSTs results to `{registryUrl}/api/v1/registry/internal/scan-result`

## Test plan
- [ ] `npx tsc --project packages/core/tsconfig.json --noEmit` passes
- [ ] `npx tsc --project packages/cli/tsconfig.json --noEmit` passes
- [ ] `hackmyagent secure --help` shows new registry flags
- [ ] `hackmyagent attack --help` shows new registry flags
- [ ] E2E: `hackmyagent secure --registry-report --version-id <id> --registry-url http://localhost:8080 --registry-key <key> .` posts results to registry