### PR TITLE
Add standardized OpenA2A ecosystem footer

### DIFF
--- a/README.md
+++ b/README.md
@@ -556,4 +556,14 @@ Apache-2.0
 
 ---
 
-Built by [OpenA2A](https://opena2a.org). HackMyAgent finds vulnerabilities. [AIM](https://github.com/opena2a-org/agent-identity-management) manages identity and access.
+## OpenA2A Ecosystem
+
+| Project | What it does |
+|---------|-------------|
+| [**AIM**](https://github.com/opena2a-org/agent-identity-management) | Identity & access management for AI agents |
+| [**HackMyAgent**](https://github.com/opena2a-org/hackmyagent) | Security scanner — 147 checks, attack mode, auto-fix |
+| [**Secretless AI**](https://github.com/opena2a-org/secretless-ai) | Keep credentials out of AI context windows |
+| [**DVAA**](https://github.com/opena2a-org/damn-vulnerable-ai-agent) | Deliberately vulnerable AI agents for security training |
+| [**OASB**](https://oasb.ai) | Open Agent Security Benchmark |
+
+[Website](https://opena2a.org) · [Discord](https://discord.gg/uRZa3KXgEn) · [Email](mailto:info@opena2a.org)


### PR DESCRIPTION
## Summary

- Replace single-line footer with standardized ecosystem table linking all 5 OpenA2A projects
- Add website, Discord, and email links in consistent format
- Part of cross-repo branding consistency effort

## Test plan

- [ ] Verify README renders correctly on GitHub
- [ ] Confirm all project links resolve
- [ ] Confirm Discord invite link works