### PR TITLE
Fix pre-push review findings

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![npm version](https://img.shields.io/npm/v/hackmyagent.svg)](https://www.npmjs.com/package/hackmyagent)
 [![License: Apache-2.0](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
-[![Tests](https://img.shields.io/badge/tests-501%20passing-brightgreen)](https://github.com/opena2a-org/hackmyagent)
+[![Tests](https://img.shields.io/badge/tests-566%20passing-brightgreen)](https://github.com/opena2a-org/hackmyagent)
 
 **Find it. Break it. Fix it.**
 
@@ -531,8 +531,8 @@ Contributions welcome. See [CONTRIBUTING.md](CONTRIBUTING.md).
 git clone https://github.com/opena2a-org/hackmyagent.git
 cd hackmyagent
 npm install
-npx turbo build     # build all 7 packages
-npx turbo test      # run 501 tests
+npx turbo build     # build all 8 packages
+npx turbo test      # run 566 tests
 ```
 
 ### Monorepo Structure
@@ -546,6 +546,7 @@ packages/
   credvault-openclaw/       # Credential scanner plugin
   signcrypt-openclaw/       # Signing and hash pinning plugin
   skillguard-openclaw/      # Permission and pattern scanner plugin
+  semantic-engine/          # Semantic analysis engine for deep scanning
 ```
 
 ---

--- a/packages/core/src/attack/scanner.ts
+++ b/packages/core/src/attack/scanner.ts
@@ -190,7 +190,7 @@ export class AttackScanner {
         };
       case 'anthropic':
         return {
-          model: target.model || 'claude-3-opus-20240229',
+          model: target.model || 'claude-sonnet-4-5-20250929',
           max_tokens: 1024,
           system: target.systemPrompt || undefined,
           messages: [{ role: 'user', content: prompt }],

--- a/packages/core/src/hardening/scanner.ts
+++ b/packages/core/src/hardening/scanner.ts
@@ -670,7 +670,7 @@ export class HardeningScanner {
   private findingAppliesTo(finding: SecurityFinding, projectType: ProjectType): boolean {
     // Find the matching rule based on check ID prefix
     for (const [prefix, types] of Object.entries(CHECK_PROJECT_TYPES)) {
-      if (finding.checkId.startsWith(prefix.replace('-', ''))) {
+      if (finding.checkId.startsWith(prefix)) {
         // Check if 'all' is in the types array
         if (types.includes('all')) {
           return true;

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -3,7 +3,7 @@
  * Core library for HackMyAgent security scanning
  */
 
-export const VERSION = '0.4.4';
+export const VERSION = '0.5.0';
 
 // Checker module
 export {


### PR DESCRIPTION
## Summary
- Update README test count badge (501 -> 566) and package count (7 -> 8)
- Add semantic-engine to monorepo structure listing in README
- Fix `findingAppliesTo()` prefix matching bug in hardening scanner -- was using `prefix.replace('-', '')` which strips the hyphen and causes false prefix collisions (e.g., `CRED` matching `CREDENTIAL`). Now matches directly against the prefix which already includes the trailing hyphen.
- Sync VERSION constant in core/src/index.ts with package.json (0.4.4 -> 0.5.0)
- Update outdated default model in attack scanner (claude-3-opus-20240229 -> claude-sonnet-4-5-20250929)

## Skipped
- **HIGH: No CLI tests** -- deferred as a larger effort, not a quick fix
- **Semantic engine README package name references** -- no README.md exists in semantic-engine package yet

## Test plan
- [x] `npm run build` passes (8 packages)
- [x] `npm test` passes (566 tests)