### PR TITLE
Add MCP JSON-RPC and A2A attack modes

### DIFF
--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -2268,7 +2268,7 @@ program
   .command('attack')
   .description(`Adversarial security testing for AI agents
 
-Red team your AI agent with up to ${PAYLOAD_STATS.total} attack payloads across 7 categories:
+Red team your AI agent with ${PAYLOAD_STATS.total} attack payloads across 7 categories:
   • Prompt Injection: ${PAYLOAD_STATS.byCategory['prompt-injection']} payloads
   • Jailbreaking: ${PAYLOAD_STATS.byCategory['jailbreak']} payloads
   • Data Exfiltration: ${PAYLOAD_STATS.byCategory['data-exfiltration']} payloads
@@ -2281,6 +2281,12 @@ Intensity levels (controls how many payloads run):
   passive     Observation only (${PAYLOAD_STATS.byIntensity.passive} payloads)
   active      Standard payloads (${PAYLOAD_STATS.byIntensity.passive + PAYLOAD_STATS.byIntensity.active} payloads, default)
   aggressive  All payloads including creative/risky (${PAYLOAD_STATS.total} payloads)
+
+Target types:
+  api         OpenAI/Anthropic chat completions (default)
+  mcp         MCP JSON-RPC server (tools/call, tools/list)
+  a2a         A2A agent messaging endpoint (/a2a/message)
+  local       Local simulation (no API calls)
 
 Target types:
   api         OpenAI/Anthropic chat completions (default)


### PR DESCRIPTION
## Summary
- Add 10 MCP exploitation payloads: path traversal, command injection, SSRF, SQL injection, env extraction — sent as JSON-RPC 2.0 `tools/call` requests
- Add 10 A2A attack payloads: identity spoofing, delegation abuse, embedded prompt injection, chain attacks, message replay probes
- Implement `sendMcpRequest()` with proper JSON-RPC 2.0 request building from structured payload metadata
- Implement `sendA2ARequest()` with `{from, to, content}` message format matching DVAA v0.4.0
- Add `--target-type` CLI flag (`api`, `mcp`, `a2a`, `local`) with auto-detection of API format
- Add `--mcp-tool`, `--a2a-sender`, `--a2a-recipient` CLI options
- Total payloads: 75 across 7 categories (was 55 across 5)

## Usage
```bash
# MCP exploitation against DVAA ToolBot
hackmyagent attack http://localhost:3010 --target-type mcp --category mcp-exploitation

# A2A attacks against DVAA Orchestrator
hackmyagent attack http://localhost:3020 --target-type a2a --category a2a-attack

# Full attack suite against all protocols
hackmyagent attack http://localhost:3003 --intensity aggressive
```

## Test plan
- [x] Build passes (all 8 packages)
- [x] 282 tests pass in core (was 281)
- [x] New payload IDs follow naming convention (MCP-001..010, A2A-001..010)
- [x] Category stats correctly reflect 7 categories
- [ ] Manual: Run MCP payloads against DVAA ToolBot
- [ ] Manual: Run A2A payloads against DVAA Orchestrator/Worker