### PR TITLE
feat: auto-publish scan results to OpenA2A Registry

### DIFF
--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1551,6 +1551,35 @@ function printBenchmarkReport(result: BenchmarkResult, verbose: boolean): void {
   console.log(`Spec: https://oasb.ai/oasb-1\n`);
 }
 
+// Package name resolution for community registry reporting
+function resolvePackageName(targetDir: string): string | null {
+  try {
+    const fs = require('fs');
+    const path = require('path');
+    const pkgJsonPath = path.join(targetDir, 'package.json');
+    if (fs.existsSync(pkgJsonPath)) {
+      const pkg = JSON.parse(fs.readFileSync(pkgJsonPath, 'utf-8'));
+      if (pkg.name) return pkg.name;
+    }
+  } catch { /* ignore */ }
+  // Fallback: use directory name
+  const path = require('path');
+  return path.basename(targetDir);
+}
+
+function resolvePackageVersion(targetDir: string): string | null {
+  try {
+    const fs = require('fs');
+    const path = require('path');
+    const pkgJsonPath = path.join(targetDir, 'package.json');
+    if (fs.existsSync(pkgJsonPath)) {
+      const pkg = JSON.parse(fs.readFileSync(pkgJsonPath, 'utf-8'));
+      if (pkg.version) return pkg.version;
+    }
+  } catch { /* ignore */ }
+  return null;
+}
+
 program
   .command('secure')
   .description(`Scan and harden your agent setup
@@ -1600,10 +1629,11 @@ Examples:
   .option('-c, --category <name>', 'Filter to specific benchmark category')
   .option('--deep', 'Enable LLM-powered semantic analysis (requires ANTHROPIC_API_KEY)')
   .option('--registry-report', 'Post results to OpenA2A Registry')
+  .option('--no-registry', 'Skip auto-publishing results to OpenA2A Registry')
   .option('--version-id <id>', 'Registry version ID to report against')
   .option('--registry-url <url>', 'Registry URL (default: REGISTRY_URL env)')
   .option('--registry-key <key>', 'Registry API key (default: REGISTRY_API_KEY env)')
-  .action(async (directory: string, options: { fix?: boolean; dryRun?: boolean; ignore?: string; json?: boolean; format?: string; output?: string; failBelow?: string; verbose?: boolean; benchmark?: string; level?: string; category?: string; deep?: boolean; registryReport?: boolean; versionId?: string; registryUrl?: string; registryKey?: string }) => {
+  .action(async (directory: string, options: { fix?: boolean; dryRun?: boolean; ignore?: string; json?: boolean; format?: string; output?: string; failBelow?: string; verbose?: boolean; benchmark?: string; level?: string; category?: string; deep?: boolean; registryReport?: boolean; registry?: boolean; versionId?: string; registryUrl?: string; registryKey?: string }) => {
     try {
       const targetDir = directory.startsWith('/') ? directory : process.cwd() + '/' + directory;
 
@@ -1833,34 +1863,42 @@ Examples:
         }
       }
 
-      // Report to registry if requested
-      if (options.registryReport) {
-        const { RegistryClient, buildScanReport } = await import('hackmyagent-core');
-        const registryUrl = options.registryUrl || process.env.REGISTRY_URL;
-        const registryKey = options.registryKey || process.env.REGISTRY_API_KEY;
-        const versionId = options.versionId;
-
-        if (!registryUrl) {
-          console.error('Error: --registry-url or REGISTRY_URL env is required for registry reporting');
-          process.exit(1);
-        }
-        if (!registryKey) {
-          console.error('Error: --registry-key or REGISTRY_API_KEY env is required for registry reporting');
-          process.exit(1);
-        }
-        if (!versionId) {
-          console.error('Error: --version-id is required for registry reporting');
-          process.exit(1);
-        }
-
-        const client = new RegistryClient({ registryUrl, apiKey: registryKey });
-        const payload = buildScanReport(versionId, result.findings);
-
+      // Registry reporting: auto-publish to community endpoint by default
+      const shouldReport = options.registryReport || (options.registry !== false);
+      if (shouldReport) {
         try {
-          await client.reportScanResult(payload);
-          console.log(`Registry: scan results reported for version ${versionId}`);
-        } catch (regErr) {
-          console.error(`Registry report failed: ${regErr instanceof Error ? regErr.message : regErr}`);
+          const { RegistryClient, buildScanReport, buildCommunityReport } = await import('hackmyagent-core');
+          const registryUrl = options.registryUrl || process.env.REGISTRY_URL || 'https://registry.opena2a.org';
+
+          if (options.versionId) {
+            // Authenticated path: existing behavior (version-id + API key)
+            const registryKey = options.registryKey || process.env.REGISTRY_API_KEY;
+            if (!registryKey) {
+              console.error('Error: --registry-key or REGISTRY_API_KEY env is required when using --version-id');
+              process.exit(1);
+            }
+            const client = new RegistryClient({ registryUrl, apiKey: registryKey });
+            const payload = buildScanReport(options.versionId, result.findings);
+            await client.reportScanResult(payload);
+            console.log(`Registry: scan results reported for version ${options.versionId}`);
+          } else {
+            // Community path: auto-publish by package name (HMAC-signed, no user auth)
+            const communitySecret = process.env.HMA_COMMUNITY_SECRET || '';
+            const client = new RegistryClient({ registryUrl, apiKey: '', communitySecret });
+            const packageName = resolvePackageName(targetDir);
+            if (packageName) {
+              const packageVersion = resolvePackageVersion(targetDir);
+              const payload = buildCommunityReport(packageName, result.findings, {
+                version: packageVersion ?? undefined,
+              });
+              const resp = await client.reportCommunityResult(payload);
+              if (resp.status === 'accepted') {
+                console.log('Registry: scan shared with OpenA2A community');
+              }
+            }
+          }
+        } catch {
+          // Never fail the scan because of registry reporting issues
         }
       }
 
@@ -2325,6 +2363,7 @@ Examples:
   .option('-o, --output <file>', 'Write output to file')
   .option('-v, --verbose', 'Show detailed output for each payload')
   .option('--registry-report', 'Post results to OpenA2A Registry')
+  .option('--no-registry', 'Skip auto-publishing results to OpenA2A Registry')
   .option('--version-id <id>', 'Registry version ID to report against')
   .option('--registry-url <url>', 'Registry URL (default: REGISTRY_URL env)')
   .option('--registry-key <key>', 'Registry API key (default: REGISTRY_API_KEY env)')
@@ -2349,6 +2388,7 @@ Examples:
     output?: string;
     verbose?: boolean;
     registryReport?: boolean;
+    registry?: boolean;
     versionId?: string;
     registryUrl?: string;
     registryKey?: string;
@@ -2499,34 +2539,37 @@ Examples:
         }
       }
 
-      // Report to registry if requested
-      if (options.registryReport) {
-        const { RegistryClient, buildAttackReport } = await import('hackmyagent-core');
-        const registryUrl = options.registryUrl || process.env.REGISTRY_URL;
-        const registryKey = options.registryKey || process.env.REGISTRY_API_KEY;
-        const versionId = options.versionId;
-
-        if (!registryUrl) {
-          console.error('Error: --registry-url or REGISTRY_URL env is required for registry reporting');
-          process.exit(1);
-        }
-        if (!registryKey) {
-          console.error('Error: --registry-key or REGISTRY_API_KEY env is required for registry reporting');
-          process.exit(1);
-        }
-        if (!versionId) {
-          console.error('Error: --version-id is required for registry reporting');
-          process.exit(1);
-        }
-
-        const client = new RegistryClient({ registryUrl, apiKey: registryKey });
-        const payload = buildAttackReport(versionId, report);
-
+      // Registry reporting: auto-publish to community endpoint by default
+      const shouldReport = options.registryReport || (options.registry !== false);
+      if (shouldReport) {
         try {
-          await client.reportScanResult(payload);
-          console.log(`Registry: attack results reported for version ${versionId}`);
-        } catch (regErr) {
-          console.error(`Registry report failed: ${regErr instanceof Error ? regErr.message : regErr}`);
+          const { RegistryClient, buildAttackReport, buildCommunityAttackReport } = await import('hackmyagent-core');
+          const registryUrl = options.registryUrl || process.env.REGISTRY_URL || 'https://registry.opena2a.org';
+
+          if (options.versionId) {
+            // Authenticated path: existing behavior (version-id + API key)
+            const registryKey = options.registryKey || process.env.REGISTRY_API_KEY;
+            if (!registryKey) {
+              console.error('Error: --registry-key or REGISTRY_API_KEY env is required when using --version-id');
+              process.exit(1);
+            }
+            const client = new RegistryClient({ registryUrl, apiKey: registryKey });
+            const payload = buildAttackReport(options.versionId, report);
+            await client.reportScanResult(payload);
+            console.log(`Registry: attack results reported for version ${options.versionId}`);
+          } else {
+            // Community path: auto-publish by target name (HMAC-signed, no user auth)
+            const communitySecret = process.env.HMA_COMMUNITY_SECRET || '';
+            const client = new RegistryClient({ registryUrl, apiKey: '', communitySecret });
+            const packageName = target.url || targetUrl || 'unknown';
+            const payload = buildCommunityAttackReport(packageName, report);
+            const resp = await client.reportCommunityResult(payload);
+            if (resp.status === 'accepted') {
+              console.log('Registry: attack results shared with OpenA2A community');
+            }
+          }
+        } catch {
+          // Never fail the scan because of registry reporting issues
         }
       }
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -95,12 +95,15 @@ export {
   RegistryClient,
   buildScanReport,
   buildAttackReport,
+  buildCommunityReport,
+  buildCommunityAttackReport,
 } from './registry';
 
 export type {
   RegistryConfig,
   RegistryPackage,
   ScanReportPayload,
+  CommunityScanPayload,
 } from './registry';
 
 // Legacy scanner (for scan command)

--- a/packages/core/src/registry/client.ts
+++ b/packages/core/src/registry/client.ts
@@ -5,6 +5,7 @@
  * and POSTs them to the registry callback endpoint.
  */
 
+import { createHmac } from 'crypto';
 import type { SecurityFinding, Severity } from '../hardening';
 import type { AttackReport } from '../attack';
 
@@ -46,9 +47,26 @@ interface BehavioralFinding {
   evidence?: string;
 }
 
+// Community scan result format — identifies packages by name, no auth needed
+export interface CommunityScanPayload {
+  packageName: string;
+  packageType?: string;
+  version?: string;
+  scanId: string;
+  status: 'passed' | 'failed' | 'warnings' | 'error';
+  completedAt: string;
+  vulnerabilities: VulnerabilityFinding[];
+  criticalCount: number;
+  highCount: number;
+  mediumCount: number;
+  lowCount: number;
+  rawReport?: Record<string, unknown>;
+}
+
 export interface RegistryConfig {
   registryUrl: string;
   apiKey: string;
+  communitySecret?: string;
 }
 
 export interface RegistryPackage {
@@ -86,6 +104,44 @@ export class RegistryClient {
       throw new Error(
         `Registry report failed (${response.status}): ${body}`
       );
+    }
+  }
+
+  /**
+   * Post community scan results (no auth, HMAC-signed).
+   * Returns { status: 'accepted' | 'unknown_package' | 'failed' }.
+   * Never throws — registry errors are non-fatal for the user's scan.
+   */
+  async reportCommunityResult(
+    payload: CommunityScanPayload,
+  ): Promise<{ status: string; message?: string }> {
+    const url = `${this.config.registryUrl}/api/v1/registry/community/scan-result`;
+    const body = JSON.stringify(payload);
+
+    const headers: Record<string, string> = {
+      'Content-Type': 'application/json',
+      'User-Agent': 'HackMyAgent-CLI',
+    };
+
+    // Sign with HMAC if community secret is configured
+    if (this.config.communitySecret) {
+      headers['X-HMA-Signature'] = computeHMAC(body, this.config.communitySecret);
+    }
+
+    try {
+      const response = await fetch(url, {
+        method: 'POST',
+        headers,
+        body,
+      });
+
+      if (!response.ok) {
+        return { status: 'failed', message: `HTTP ${response.status}` };
+      }
+
+      return await response.json() as { status: string; message?: string };
+    } catch {
+      return { status: 'failed', message: 'Network error' };
     }
   }
 
@@ -216,6 +272,101 @@ export function buildAttackReport(
       successfulAttacks: report.summary.successful,
     },
   };
+}
+
+/**
+ * Build a CommunityScanPayload from HMA hardening scan results.
+ * Used for auto-publishing to the community endpoint (no version ID needed).
+ */
+export function buildCommunityReport(
+  packageName: string,
+  findings: SecurityFinding[],
+  options?: { packageType?: string; version?: string },
+): CommunityScanPayload {
+  const failed = findings.filter(f => !f.passed && !f.fixed);
+  const counts = countBySeverity(failed);
+  const status = deriveStatus(counts);
+
+  const vulnerabilities: VulnerabilityFinding[] = failed.map(f => ({
+    id: f.checkId,
+    severity: f.severity,
+    title: f.name,
+    description: f.description,
+  }));
+
+  return {
+    packageName,
+    packageType: options?.packageType,
+    version: options?.version,
+    scanId: `hma-community-${Date.now()}`,
+    status,
+    completedAt: new Date().toISOString(),
+    vulnerabilities,
+    criticalCount: counts.critical,
+    highCount: counts.high,
+    mediumCount: counts.medium,
+    lowCount: counts.low,
+    rawReport: {
+      generator: 'hackmyagent',
+      totalFindings: findings.length,
+      failedFindings: failed.length,
+    },
+  };
+}
+
+/**
+ * Build a CommunityScanPayload from HMA attack results.
+ */
+export function buildCommunityAttackReport(
+  packageName: string,
+  report: AttackReport,
+  options?: { packageType?: string; version?: string },
+): CommunityScanPayload {
+  const vulnerabilities: VulnerabilityFinding[] = report.results
+    .filter(r => r.success)
+    .map(r => ({
+      id: r.payload.id,
+      severity: r.payload.severity,
+      title: `${r.payload.category}: ${r.payload.id}`,
+      description: r.response?.substring(0, 500) || 'Attack succeeded',
+    }));
+
+  const counts = {
+    critical: vulnerabilities.filter(v => v.severity === 'critical').length,
+    high: vulnerabilities.filter(v => v.severity === 'high').length,
+    medium: vulnerabilities.filter(v => v.severity === 'medium').length,
+    low: vulnerabilities.filter(v => v.severity === 'low').length,
+  };
+
+  const status = deriveStatus(counts);
+
+  return {
+    packageName,
+    packageType: options?.packageType,
+    version: options?.version,
+    scanId: `hma-attack-community-${Date.now()}`,
+    status,
+    completedAt: new Date().toISOString(),
+    vulnerabilities,
+    criticalCount: counts.critical,
+    highCount: counts.high,
+    mediumCount: counts.medium,
+    lowCount: counts.low,
+    rawReport: {
+      generator: 'hackmyagent-attack',
+      target: report.target,
+      riskRating: report.riskRating,
+      totalPayloads: report.summary.total,
+      successfulAttacks: report.summary.successful,
+    },
+  };
+}
+
+/**
+ * Compute HMAC-SHA256 signature for community endpoint authentication.
+ */
+function computeHMAC(body: string, secret: string): string {
+  return createHmac('sha256', secret).update(body).digest('hex');
 }
 
 function countBySeverity(findings: { severity: Severity | string }[]): {

--- a/packages/core/src/registry/index.ts
+++ b/packages/core/src/registry/index.ts
@@ -2,10 +2,13 @@ export {
   RegistryClient,
   buildScanReport,
   buildAttackReport,
+  buildCommunityReport,
+  buildCommunityAttackReport,
 } from './client';
 
 export type {
   RegistryConfig,
   RegistryPackage,
   ScanReportPayload,
+  CommunityScanPayload,
 } from './client';


### PR DESCRIPTION
## Summary
- Every `hackmyagent secure` and `hackmyagent attack` now automatically shares scan results with the OpenA2A Registry community endpoint
- No API key or version-id needed -- resolves package name from `package.json`, signs with HMAC-SHA256
- `--no-registry` flag to opt out; existing `--version-id` + `--registry-key` authenticated path still works
- Registry errors are silently caught -- never affects the user's scan output

## Files Changed
- `packages/core/src/registry/client.ts` -- `CommunityScanPayload` interface, `reportCommunityResult()` with HMAC signing, `buildCommunityReport()`, `buildCommunityAttackReport()`
- `packages/core/src/registry/index.ts` -- new exports
- `packages/core/src/index.ts` -- new exports
- `packages/cli/src/index.ts` -- auto-report in secure + attack commands, `resolvePackageName()`, `resolvePackageVersion()`, `--no-registry` flag

## Depends On
- opena2a-org/opena2a-registry#13 (community scan endpoint must be deployed first)

## Test plan
- [x] `npm run build` passes (all 8 packages)
- [x] All 611 tests pass across monorepo
- [ ] `npx hackmyagent secure .` with no flags -> "Registry: scan shared with OpenA2A community"
- [ ] `npx hackmyagent secure . --no-registry` -> no registry message
- [ ] `npx hackmyagent secure . --version-id <uuid> --registry-key <key>` -> authenticated path
- [ ] `npx hackmyagent attack --local` -> "Registry: attack results shared with OpenA2A community"