### PR TITLE
Document CLI integration and ecosystem references

### DIFF
--- a/README.md
+++ b/README.md
@@ -598,7 +598,6 @@ Apache-2.0
 | Project | Description | Install |
 |---------|-------------|---------|
 | [**AIM**](https://github.com/opena2a-org/agent-identity-management) | Agent Identity Management -- identity and access control for AI agents | `pip install aim-sdk` |
-| [**HackMyAgent**](https://github.com/opena2a-org/hackmyagent) | Security scanner -- 147 checks, attack mode, auto-fix | `npx hackmyagent secure` |
 | [**OASB**](https://github.com/opena2a-org/oasb) | Open Agent Security Benchmark -- 182 attack scenarios | `npm install @opena2a/oasb` |
 | [**ARP**](https://github.com/opena2a-org/arp) | Agent Runtime Protection -- process, network, filesystem monitoring | `npm install @opena2a/arp` |
 | [**Secretless AI**](https://github.com/opena2a-org/secretless-ai) | Keep credentials out of AI context windows | `npx secretless-ai init` |


### PR DESCRIPTION
## Summary
- Add CLI adapter documentation for HackMyAgent integration with OpenA2A CLI
- Fix self-referencing ecosystem table entries

## Test plan
- [ ] Verify README renders correctly on GitHub
- [ ] Confirm links to CLI docs resolve