### PR TITLE
Fix scan-soul --tier case sensitivity

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hackmyagent",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "description": "Find it. Break it. Fix it. The hacker's toolkit for AI agents.",
   "bin": {
     "hackmyagent": "dist/cli.js"

--- a/src/soul/scanner.ts
+++ b/src/soul/scanner.ts
@@ -288,7 +288,7 @@ export class SoulScanner {
 
     // Detect tier early (needed for applicable control count)
     const contentForTier = govFile ? (() => { try { return fs.readFileSync(govFile, 'utf-8'); } catch { return ''; } })() : '';
-    const tier = (options?.tier as AgentTier) || this.detectTier(targetDir, contentForTier);
+    const tier = (options?.tier ? options.tier.toUpperCase() as AgentTier : null) || this.detectTier(targetDir, contentForTier);
     const applicable = this.applicableControls(tier);
 
     // No governance file found


### PR DESCRIPTION
## Summary

- Normalize `--tier` flag value to uppercase before matching, so `--tier multi-agent` and `--tier MULTI-AGENT` both work correctly.
- Bumps to v0.9.1 (patch).

## Test plan
- [ ] `hackmyagent scan-soul --tier multi-agent` returns MULTI-AGENT tier
- [ ] `hackmyagent scan-soul --tier MULTI-AGENT` still works
- [ ] 32/32 soul tests pass