### PR TITLE
Add --publish flag for ATP registry integration

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1688,12 +1688,13 @@ Examples:
   .option('-l, --level <level>', 'Benchmark level: L1 (Essential), L2 (Standard), L3 (Hardened)', 'L1')
   .option('-c, --category <name>', 'Filter to specific benchmark category')
   .option('--deep', 'Enable LLM-powered semantic analysis (requires ANTHROPIC_API_KEY)')
+  .option('--publish', 'Push scan results to the OpenA2A Registry (ATP)')
   .option('--registry-report', 'Post results to OpenA2A Registry')
   .option('--no-registry', 'Skip auto-publishing results to OpenA2A Registry')
   .option('--version-id <id>', 'Registry version ID to report against')
-  .option('--registry-url <url>', 'Registry URL (default: REGISTRY_URL env)')
+  .option('--registry-url <url>', 'Registry URL (default: REGISTRY_URL env)', process.env.REGISTRY_URL || 'https://registry.opena2a.org')
   .option('--registry-key <key>', 'Registry API key (default: REGISTRY_API_KEY env)')
-  .action(async (directory: string, options: { fix?: boolean; dryRun?: boolean; ignore?: string; json?: boolean; format?: string; output?: string; failBelow?: string; verbose?: boolean; benchmark?: string; level?: string; category?: string; deep?: boolean; registryReport?: boolean; registry?: boolean; versionId?: string; registryUrl?: string; registryKey?: string }) => {
+  .action(async (directory: string, options: { fix?: boolean; dryRun?: boolean; ignore?: string; json?: boolean; format?: string; output?: string; failBelow?: string; verbose?: boolean; benchmark?: string; level?: string; category?: string; deep?: boolean; publish?: boolean; registryReport?: boolean; registry?: boolean; versionId?: string; registryUrl?: string; registryKey?: string }) => {
     try {
       const targetDir = directory.startsWith('/') ? directory : process.cwd() + '/' + directory;
 
@@ -2069,6 +2070,43 @@ Examples:
           }
         } catch (_reportErr: any) {
           // Silently ignore registry errors - they are not relevant to local scan results
+        }
+      }
+
+      // ATP Publish: push results to registry when --publish is used
+      if (options.publish) {
+        try {
+          const { publishScanResults, formatPublishOutput } = await import('./registry/publish');
+          const registryUrl = options.registryUrl || process.env.REGISTRY_URL || 'https://registry.opena2a.org';
+          const packageName = resolvePackageName(targetDir);
+
+          if (!packageName) {
+            console.error('\nCould not determine package name. Publish requires a package.json with a name field.');
+          } else {
+            if (format === 'text') {
+              console.log('\nPublishing results to registry...\n');
+            }
+
+            const publishData = {
+              packageName,
+              packageVersion: resolvePackageVersion(targetDir) ?? undefined,
+              directory: targetDir,
+              hardeningFindings: result.findings,
+            };
+
+            const publishResult = await publishScanResults(publishData, registryUrl);
+            if (format === 'text') {
+              console.log(formatPublishOutput(publishResult, publishData, registryUrl));
+              console.log();
+            } else if (format === 'json') {
+              // Append publish result to JSON output in a separate log
+              console.error(JSON.stringify({ publish: publishResult }, null, 2));
+            }
+          }
+        } catch (publishErr: unknown) {
+          const msg = publishErr instanceof Error ? publishErr.message : 'unknown error';
+          console.error(`\nFailed to publish to registry: ${msg}`);
+          console.error('Scan results are still available locally.');
         }
       }
 
@@ -2541,10 +2579,11 @@ Examples:
   .option('-f, --format <format>', 'Output format: text, json, sarif, html', 'text')
   .option('-o, --output <file>', 'Write output to file')
   .option('-v, --verbose', 'Show detailed output for each payload')
+  .option('--publish', 'Push scan results to the OpenA2A Registry (ATP)')
   .option('--registry-report', 'Post results to OpenA2A Registry')
   .option('--no-registry', 'Skip auto-publishing results to OpenA2A Registry')
   .option('--version-id <id>', 'Registry version ID to report against')
-  .option('--registry-url <url>', 'Registry URL (default: REGISTRY_URL env)')
+  .option('--registry-url <url>', 'Registry URL (default: REGISTRY_URL env)', process.env.REGISTRY_URL || 'https://registry.opena2a.org')
   .option('--registry-key <key>', 'Registry API key (default: REGISTRY_API_KEY env)')
   .action(async (targetUrl: string | undefined, options: {
     intensity?: string;
@@ -2566,6 +2605,7 @@ Examples:
     format?: string;
     output?: string;
     verbose?: boolean;
+    publish?: boolean;
     registryReport?: boolean;
     registry?: boolean;
     versionId?: string;
@@ -2766,6 +2806,35 @@ Examples:
           }
         } catch (_reportErr: any) {
           // Silently ignore registry errors - they are not relevant to local scan results
+        }
+      }
+
+      // ATP Publish: push attack results to registry when --publish is used
+      if (options.publish && targetType !== 'local') {
+        try {
+          const { publishScanResults, formatPublishOutput } = await import('./registry/publish');
+          const regUrl = options.registryUrl || process.env.REGISTRY_URL || 'https://registry.opena2a.org';
+          const packageName = target.url || targetUrl || 'unknown';
+
+          if (format === 'text') {
+            console.log('\nPublishing results to registry...\n');
+          }
+
+          const publishData = {
+            packageName,
+            directory: process.cwd(),
+            attackReport: report,
+          };
+
+          const publishResult = await publishScanResults(publishData, regUrl);
+          if (format === 'text') {
+            console.log(formatPublishOutput(publishResult, publishData, regUrl));
+            console.log();
+          }
+        } catch (publishErr: unknown) {
+          const msg = publishErr instanceof Error ? publishErr.message : 'unknown error';
+          console.error(`\nFailed to publish to registry: ${msg}`);
+          console.error('Scan results are still available locally.');
         }
       }
 
@@ -4099,7 +4168,9 @@ Examples:
   .option('--profile <profile>', 'Override agent profile (conversational, code-assistant, tool-agent, autonomous, orchestrator, custom)')
   .option('--fail-below <score>', 'Exit 1 if score below threshold (0-100)')
   .option('--deep', 'Enable LLM semantic analysis for ambiguous controls (requires claude CLI or ANTHROPIC_API_KEY)')
-  .action(async (directory: string, options: { json?: boolean; verbose?: boolean; tier?: string; profile?: string; failBelow?: string; deep?: boolean }) => {
+  .option('--publish', 'Push scan results to the OpenA2A Registry (ATP)')
+  .option('--registry-url <url>', 'Registry URL (default: REGISTRY_URL env)', process.env.REGISTRY_URL || 'https://registry.opena2a.org')
+  .action(async (directory: string, options: { json?: boolean; verbose?: boolean; tier?: string; profile?: string; failBelow?: string; deep?: boolean; publish?: boolean; registryUrl?: string }) => {
     try {
       const targetDir = directory.startsWith('/') ? directory : process.cwd() + '/' + directory;
 
@@ -4216,6 +4287,39 @@ Examples:
       }
 
       process.stdout.write('\n');
+
+      // ATP Publish: push SOUL results to registry when --publish is used
+      if (options.publish) {
+        try {
+          const { publishScanResults, formatPublishOutput } = await import('./registry/publish');
+          const registryUrl = options.registryUrl || process.env.REGISTRY_URL || 'https://registry.opena2a.org';
+          const packageName = resolvePackageName(targetDir);
+
+          if (!packageName) {
+            process.stderr.write('Could not determine package name. Publish requires a package.json with a name field.\n');
+          } else {
+            if (!options.json) {
+              process.stdout.write('Publishing results to registry...\n\n');
+            }
+
+            const publishData = {
+              packageName,
+              packageVersion: resolvePackageVersion(targetDir) ?? undefined,
+              directory: targetDir,
+              soulResult: result,
+            };
+
+            const publishResult = await publishScanResults(publishData, registryUrl);
+            if (!options.json) {
+              process.stdout.write(formatPublishOutput(publishResult, publishData, registryUrl) + '\n\n');
+            }
+          }
+        } catch (publishErr: unknown) {
+          const msg = publishErr instanceof Error ? publishErr.message : 'unknown error';
+          process.stderr.write(`Failed to publish to registry: ${msg}\n`);
+          process.stderr.write('Scan results are still available locally.\n');
+        }
+      }
 
       // Check fail threshold
       if (options.failBelow) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -97,6 +97,12 @@ export {
   buildAttackReport,
   buildCommunityReport,
   buildCommunityAttackReport,
+  // ATP Publish flow
+  readAgentKeypair,
+  signPayload,
+  buildPublishPayload,
+  publishScanResults,
+  formatPublishOutput,
 } from './registry';
 
 export type {
@@ -104,6 +110,9 @@ export type {
   RegistryPackage,
   ScanReportPayload,
   CommunityScanPayload,
+  AgentKeypair,
+  PublishScanData,
+  PublishResult,
 } from './registry';
 
 // Semantic engine (Layer 2 + Layer 3 analysis)

--- a/src/registry/client.ts
+++ b/src/registry/client.ts
@@ -26,6 +26,31 @@ export interface ScanReportPayload {
   behavioralFindings: BehavioralFinding[];
   behavioralScore: number;
   rawReport: Record<string, unknown>;
+  // ATP publish extensions (optional, included when --publish is used)
+  /** OASB benchmark compliance percentage (0-100) */
+  oasbCompliance?: number;
+  /** OASB benchmark rating */
+  oasbRating?: string;
+  /** OASB L1 compliance percentage */
+  oasbL1?: number;
+  /** OASB L2 compliance percentage */
+  oasbL2?: number;
+  /** OASB L3 compliance percentage */
+  oasbL3?: number;
+  /** SOUL governance score (0-100) */
+  soulScore?: number;
+  /** SOUL conformance level */
+  soulConformance?: string;
+  /** SOUL agent tier */
+  soulAgentTier?: string;
+  /** Attack risk score (0-100) */
+  attackRiskScore?: number;
+  /** Attack risk rating */
+  attackRiskRating?: string;
+  /** Total attack payloads tested */
+  attackTotal?: number;
+  /** Number of successful attacks */
+  attackSucceeded?: number;
 }
 
 interface VulnerabilityFinding {
@@ -222,6 +247,62 @@ export class RegistryClient {
     }
 
     return response.json() as Promise<RegistryPackage>;
+  }
+
+  /**
+   * Post scan results as a claimed agent via ATP --publish flow.
+   * Uses Ed25519 signature for authentication.
+   * Returns the scan ID and profile URL on success.
+   */
+  async reportPublishResult(
+    payload: CommunityScanPayload & {
+      oasbCompliance?: number;
+      oasbRating?: string;
+      oasbL1?: number;
+      oasbL2?: number;
+      oasbL3?: number;
+      soulScore?: number;
+      soulConformance?: string;
+      soulAgentTier?: string;
+      attackRiskScore?: number;
+      attackRiskRating?: string;
+      attackTotal?: number;
+      attackSucceeded?: number;
+      signature?: string;
+      publicKey?: string;
+    },
+  ): Promise<{ scanId: string; profileUrl: string; status: string }> {
+    const url = `${this.config.registryUrl}/api/v1/registry/community/scan-result`;
+
+    const headers: Record<string, string> = {
+      'Content-Type': 'application/json',
+      'User-Agent': 'HackMyAgent-CLI/ATP-Publish',
+    };
+
+    if (payload.signature) {
+      headers['X-Agent-Signature'] = payload.signature;
+    }
+    if (payload.publicKey) {
+      headers['X-Agent-Public-Key'] = payload.publicKey;
+    }
+
+    const response = await fetch(url, {
+      method: 'POST',
+      headers,
+      body: JSON.stringify(payload),
+    });
+
+    if (!response.ok) {
+      const body = await response.text().catch(() => '');
+      throw new Error(`Registry publish failed (${response.status}): ${body}`);
+    }
+
+    const result = await response.json() as Record<string, unknown>;
+    return {
+      scanId: (result.scanId as string) || payload.scanId,
+      profileUrl: (result.profileUrl as string) || `${this.config.registryUrl}/agents/${payload.packageName}`,
+      status: (result.status as string) || 'accepted',
+    };
   }
 }
 

--- a/src/registry/index.ts
+++ b/src/registry/index.ts
@@ -12,3 +12,18 @@ export type {
   ScanReportPayload,
   CommunityScanPayload,
 } from './client';
+
+// ATP Publish flow
+export {
+  readAgentKeypair,
+  signPayload,
+  buildPublishPayload,
+  publishScanResults,
+  formatPublishOutput,
+} from './publish';
+
+export type {
+  AgentKeypair,
+  PublishScanData,
+  PublishResult,
+} from './publish';

--- a/src/registry/publish.test.ts
+++ b/src/registry/publish.test.ts
@@ -1,0 +1,617 @@
+/**
+ * Tests for ATP Publish flow (--publish flag)
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import * as fs from 'fs';
+import * as path from 'path';
+import * as os from 'os';
+import {
+  readAgentKeypair,
+  signPayload,
+  buildPublishPayload,
+  publishScanResults,
+  formatPublishOutput,
+  type PublishScanData,
+  type PublishResult,
+} from './publish';
+import type { SecurityFinding } from '../hardening';
+import type { AttackReport } from '../attack';
+import type { SoulScanResult } from '../soul';
+import type { BenchmarkResult } from '../benchmarks';
+
+// Helper: create a temporary directory
+function createTempDir(): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'publish-test-'));
+}
+
+// Helper: clean up temporary directory
+function cleanupDir(dir: string): void {
+  fs.rmSync(dir, { recursive: true, force: true });
+}
+
+// Helper: create fake keypair in a temp opena2a home
+function createFakeKeypair(opena2aHome: string): void {
+  const keysDir = path.join(opena2aHome, 'keys');
+  fs.mkdirSync(keysDir, { recursive: true });
+  const crypto = require('crypto');
+  const { publicKey, privateKey } = crypto.generateKeyPairSync('ed25519', {
+    publicKeyEncoding: { type: 'spki', format: 'pem' },
+    privateKeyEncoding: { type: 'pkcs8', format: 'pem' },
+  });
+  fs.writeFileSync(path.join(keysDir, 'agent.pub'), publicKey);
+  fs.writeFileSync(path.join(keysDir, 'agent.key'), privateKey);
+  fs.writeFileSync(path.join(keysDir, 'agent-id'), 'test-agent-123');
+}
+
+// Minimal fixtures
+function makeHardeningFindings(): SecurityFinding[] {
+  return [
+    {
+      checkId: 'CRED-001',
+      name: 'API key in code',
+      description: 'Found hardcoded API key',
+      severity: 'critical' as const,
+      category: 'credentials',
+      passed: false,
+      fixed: false,
+      fix: 'Remove the key',
+    },
+    {
+      checkId: 'GIT-001',
+      name: 'Git ignoring secrets',
+      description: '.gitignore covers secrets',
+      severity: 'low' as const,
+      category: 'git',
+      passed: true,
+      fixed: false,
+    },
+    {
+      checkId: 'MCP-002',
+      name: 'MCP config exposed',
+      description: 'MCP config readable',
+      severity: 'medium' as const,
+      category: 'mcp',
+      passed: false,
+      fixed: false,
+      fix: 'Restrict permissions',
+    },
+  ] as SecurityFinding[];
+}
+
+function makeAttackReport(): AttackReport {
+  return {
+    target: 'https://example.com/api',
+    targetType: 'api',
+    intensity: 'active',
+    categories: ['prompt-injection'],
+    startTime: new Date(),
+    endTime: new Date(),
+    duration: 5000,
+    summary: {
+      total: 10,
+      successful: 2,
+      blocked: 7,
+      inconclusive: 1,
+      bySeverity: { critical: 1, high: 1, medium: 0, low: 0 } as any,
+      byCategory: { 'prompt-injection': { total: 10, successful: 2 } } as any,
+    },
+    results: [
+      {
+        payload: {
+          id: 'PI-001',
+          name: 'Basic injection',
+          category: 'prompt-injection',
+          severity: 'high',
+          intensity: 'active',
+          prompt: 'ignore previous instructions',
+          remediation: 'Add input sanitization',
+        },
+        success: true,
+        blocked: false,
+        evidence: 'Model responded to injected prompt',
+      },
+      {
+        payload: {
+          id: 'PI-002',
+          name: 'Advanced injection',
+          category: 'prompt-injection',
+          severity: 'critical',
+          intensity: 'active',
+          prompt: 'system override',
+          remediation: 'Use system prompt isolation',
+        },
+        success: true,
+        blocked: false,
+        evidence: 'Model broke out of system prompt',
+      },
+    ],
+    riskScore: 65,
+    riskRating: 'high',
+  } as AttackReport;
+}
+
+function makeSoulResult(): SoulScanResult {
+  return {
+    file: 'SOUL.md',
+    fileSize: 1200,
+    agentTier: 'AGENTIC',
+    tierForced: false,
+    agentProfile: 'tool-agent',
+    profileForced: false,
+    skippedDomains: [],
+    domains: [],
+    score: 72,
+    grade: 'B' as any,
+    level: 'Standard' as any,
+    conformance: 'standard',
+    criticalFloor: false,
+    criticalMissing: [],
+    totalControls: 72,
+    totalPassed: 52,
+  } as SoulScanResult;
+}
+
+function makeOasbResult(): BenchmarkResult {
+  return {
+    benchmark: 'OASB-1',
+    version: '1.0',
+    level: 'L1',
+    timestamp: new Date(),
+    compliance: 85,
+    l1Compliance: 90,
+    l2Compliance: 78,
+    l3Compliance: 65,
+    rating: 'Compliant',
+    categories: [],
+    totalControls: 46,
+    passedControls: 39,
+    failedControls: 5,
+    unverifiedControls: 2,
+  } as BenchmarkResult;
+}
+
+// ---------------------------------------------------------------
+// readAgentKeypair
+// ---------------------------------------------------------------
+
+describe('readAgentKeypair', () => {
+  let tmpHome: string;
+  let originalEnv: string | undefined;
+
+  beforeEach(() => {
+    tmpHome = createTempDir();
+    originalEnv = process.env.OPENA2A_HOME;
+    process.env.OPENA2A_HOME = tmpHome;
+  });
+
+  afterEach(() => {
+    if (originalEnv === undefined) {
+      delete process.env.OPENA2A_HOME;
+    } else {
+      process.env.OPENA2A_HOME = originalEnv;
+    }
+    cleanupDir(tmpHome);
+  });
+
+  it('returns null when keys directory does not exist', () => {
+    const result = readAgentKeypair();
+    expect(result).toBeNull();
+  });
+
+  it('returns null when keys directory exists but files are missing', () => {
+    fs.mkdirSync(path.join(tmpHome, 'keys'), { recursive: true });
+    const result = readAgentKeypair();
+    expect(result).toBeNull();
+  });
+
+  it('returns keypair when both key files exist', () => {
+    createFakeKeypair(tmpHome);
+    const result = readAgentKeypair();
+    expect(result).not.toBeNull();
+    expect(result!.publicKey).toContain('PUBLIC KEY');
+    expect(result!.privateKey).toContain('PRIVATE KEY');
+    expect(result!.agentId).toBe('test-agent-123');
+  });
+
+  it('returns keypair without agentId when agent-id file is missing', () => {
+    createFakeKeypair(tmpHome);
+    fs.unlinkSync(path.join(tmpHome, 'keys', 'agent-id'));
+    const result = readAgentKeypair();
+    expect(result).not.toBeNull();
+    expect(result!.agentId).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------
+// signPayload
+// ---------------------------------------------------------------
+
+describe('signPayload', () => {
+  let tmpDir: string;
+  let privateKey: string;
+
+  beforeEach(() => {
+    tmpDir = createTempDir();
+    createFakeKeypair(tmpDir);
+    privateKey = fs.readFileSync(path.join(tmpDir, 'keys', 'agent.key'), 'utf-8');
+  });
+
+  afterEach(() => {
+    cleanupDir(tmpDir);
+  });
+
+  it('signs a payload and returns base64 signature', () => {
+    const signature = signPayload('test payload', privateKey);
+    expect(signature).not.toBeNull();
+    expect(typeof signature).toBe('string');
+    expect(signature!.length).toBeGreaterThan(10);
+  });
+
+  it('returns null for invalid private key', () => {
+    const signature = signPayload('test payload', 'invalid-key');
+    expect(signature).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------
+// buildPublishPayload
+// ---------------------------------------------------------------
+
+describe('buildPublishPayload', () => {
+  it('builds payload from hardening findings', () => {
+    const data: PublishScanData = {
+      packageName: '@test/my-agent',
+      packageVersion: '1.0.0',
+      directory: '/tmp/test',
+      hardeningFindings: makeHardeningFindings(),
+    };
+
+    const payload = buildPublishPayload(data);
+
+    expect(payload.packageName).toBe('@test/my-agent');
+    expect(payload.version).toBe('1.0.0');
+    expect(payload.scanId).toMatch(/^hma-publish-/);
+    expect(payload.status).toBe('failed'); // has a critical finding
+    expect(payload.criticalCount).toBe(1);
+    expect(payload.mediumCount).toBe(1);
+    expect(payload.vulnerabilities).toHaveLength(2); // 2 failed (critical + medium)
+    expect(payload.contentHash).toBeDefined();
+    expect(typeof payload.contentHash).toBe('string');
+  });
+
+  it('builds payload from attack report', () => {
+    const data: PublishScanData = {
+      packageName: 'my-target',
+      directory: '/tmp/test',
+      attackReport: makeAttackReport(),
+    };
+
+    const payload = buildPublishPayload(data);
+
+    expect(payload.status).toBe('failed');
+    expect(payload.criticalCount).toBe(1);
+    expect(payload.highCount).toBe(1);
+    expect(payload.attackRiskScore).toBe(65);
+    expect(payload.attackRiskRating).toBe('high');
+    expect(payload.attackTotal).toBe(10);
+    expect(payload.attackSucceeded).toBe(2);
+  });
+
+  it('builds payload from SOUL scan result', () => {
+    const data: PublishScanData = {
+      packageName: '@test/agent',
+      directory: '/tmp/test',
+      soulResult: makeSoulResult(),
+    };
+
+    const payload = buildPublishPayload(data);
+
+    expect(payload.status).toBe('passed');
+    expect(payload.soulScore).toBe(72);
+    expect(payload.soulConformance).toBe('standard');
+    expect(payload.soulAgentTier).toBe('AGENTIC');
+  });
+
+  it('builds payload from OASB benchmark result', () => {
+    const data: PublishScanData = {
+      packageName: '@test/agent',
+      directory: '/tmp/test',
+      oasbResult: makeOasbResult(),
+    };
+
+    const payload = buildPublishPayload(data);
+
+    expect(payload.oasbCompliance).toBe(85);
+    expect(payload.oasbRating).toBe('Compliant');
+    expect(payload.oasbL1).toBe(90);
+    expect(payload.oasbL2).toBe(78);
+    expect(payload.oasbL3).toBe(65);
+  });
+
+  it('combines all scan types into a unified payload', () => {
+    const data: PublishScanData = {
+      packageName: '@test/full-scan',
+      packageVersion: '2.0.0',
+      directory: '/tmp/test',
+      hardeningFindings: makeHardeningFindings(),
+      attackReport: makeAttackReport(),
+      soulResult: makeSoulResult(),
+      oasbResult: makeOasbResult(),
+    };
+
+    const payload = buildPublishPayload(data);
+
+    expect(payload.vulnerabilities.length).toBeGreaterThan(0);
+    expect(payload.oasbCompliance).toBe(85);
+    expect(payload.soulScore).toBe(72);
+    expect(payload.attackRiskScore).toBe(65);
+
+    const raw = payload.rawReport as Record<string, unknown>;
+    expect(raw.hardening).toBeDefined();
+    expect(raw.attack).toBeDefined();
+    expect(raw.soul).toBeDefined();
+    expect(raw.oasb).toBeDefined();
+    expect(raw.publishedVia).toBe('atp-publish');
+  });
+
+  it('sets status to passed when no failed findings exist', () => {
+    const passingFindings: SecurityFinding[] = [
+      {
+        checkId: 'GIT-001',
+        name: 'Git config',
+        description: 'OK',
+        severity: 'low' as const,
+        category: 'git',
+        passed: true,
+        fixed: false,
+      },
+    ] as SecurityFinding[];
+
+    const data: PublishScanData = {
+      packageName: '@test/clean',
+      directory: '/tmp/test',
+      hardeningFindings: passingFindings,
+    };
+
+    const payload = buildPublishPayload(data);
+    expect(payload.status).toBe('passed');
+    expect(payload.criticalCount).toBe(0);
+    expect(payload.highCount).toBe(0);
+  });
+
+  it('sets status to warnings when only medium/low findings', () => {
+    const findings: SecurityFinding[] = [
+      {
+        checkId: 'LOG-001',
+        name: 'Verbose logging',
+        description: 'Logging too verbose',
+        severity: 'low' as const,
+        category: 'logging',
+        passed: false,
+        fixed: false,
+      },
+    ] as SecurityFinding[];
+
+    const data: PublishScanData = {
+      packageName: '@test/warn',
+      directory: '/tmp/test',
+      hardeningFindings: findings,
+    };
+
+    const payload = buildPublishPayload(data);
+    expect(payload.status).toBe('warnings');
+  });
+});
+
+// ---------------------------------------------------------------
+// publishScanResults (with mocked fetch)
+// ---------------------------------------------------------------
+
+describe('publishScanResults', () => {
+  let tmpHome: string;
+  let originalEnv: string | undefined;
+
+  beforeEach(() => {
+    tmpHome = createTempDir();
+    originalEnv = process.env.OPENA2A_HOME;
+    process.env.OPENA2A_HOME = tmpHome;
+  });
+
+  afterEach(() => {
+    if (originalEnv === undefined) {
+      delete process.env.OPENA2A_HOME;
+    } else {
+      process.env.OPENA2A_HOME = originalEnv;
+    }
+    vi.unstubAllGlobals();
+    cleanupDir(tmpHome);
+  });
+
+  it('publishes as community scan when no keypair exists', async () => {
+    const mockResponse = {
+      ok: true,
+      json: async () => ({ scanId: 'scan-abc', profileUrl: 'https://registry.opena2a.org/agents/test', status: 'accepted' }),
+    };
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(mockResponse));
+
+    const data: PublishScanData = {
+      packageName: '@test/agent',
+      directory: '/tmp/test',
+      hardeningFindings: makeHardeningFindings(),
+    };
+
+    const result = await publishScanResults(data, 'https://registry.opena2a.org');
+
+    expect(result.success).toBe(true);
+    expect(result.isCommunity).toBe(true);
+    expect(result.scanId).toBe('scan-abc');
+    expect(result.status).toBe('accepted');
+  });
+
+  it('publishes as claimed agent when keypair exists', async () => {
+    createFakeKeypair(tmpHome);
+
+    const mockResponse = {
+      ok: true,
+      json: async () => ({ scanId: 'scan-xyz', profileUrl: 'https://registry.opena2a.org/agents/claimed', status: 'accepted' }),
+    };
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(mockResponse));
+
+    const data: PublishScanData = {
+      packageName: '@test/claimed-agent',
+      directory: '/tmp/test',
+      soulResult: makeSoulResult(),
+    };
+
+    const result = await publishScanResults(data, 'https://registry.opena2a.org');
+
+    expect(result.success).toBe(true);
+    expect(result.isCommunity).toBe(false);
+
+    // Check that signature and publicKey were sent
+    const fetchCalls = (fetch as any).mock.calls;
+    expect(fetchCalls.length).toBe(1);
+    const body = JSON.parse(fetchCalls[0][1].body);
+    expect(body.signature).toBeDefined();
+    expect(body.publicKey).toBeDefined();
+    expect(body.agentId).toBe('test-agent-123');
+  });
+
+  it('handles registry errors gracefully', async () => {
+    const mockResponse = {
+      ok: false,
+      status: 500,
+      text: async () => 'Internal Server Error',
+    };
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(mockResponse));
+
+    const data: PublishScanData = {
+      packageName: '@test/agent',
+      directory: '/tmp/test',
+      hardeningFindings: makeHardeningFindings(),
+    };
+
+    const result = await publishScanResults(data, 'https://registry.opena2a.org');
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain('500');
+    expect(result.isCommunity).toBe(true);
+  });
+
+  it('handles network errors gracefully', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new Error('ECONNREFUSED')));
+
+    const data: PublishScanData = {
+      packageName: '@test/agent',
+      directory: '/tmp/test',
+      hardeningFindings: [],
+    };
+
+    const result = await publishScanResults(data, 'https://registry.opena2a.org');
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain('ECONNREFUSED');
+  });
+});
+
+// ---------------------------------------------------------------
+// formatPublishOutput
+// ---------------------------------------------------------------
+
+describe('formatPublishOutput', () => {
+  it('formats successful claimed publish', () => {
+    const result: PublishResult = {
+      success: true,
+      scanId: 'scan-abc',
+      profileUrl: 'https://registry.opena2a.org/agents/123',
+      status: 'passed (3 warnings)',
+      isCommunity: false,
+    };
+
+    const data: PublishScanData = {
+      packageName: '@anthropic/mcp-server-fetch',
+      directory: '/tmp/test',
+      hardeningFindings: makeHardeningFindings(),
+    };
+
+    const output = formatPublishOutput(result, data, 'https://registry.opena2a.org');
+
+    expect(output).toContain('Published to registry.opena2a.org');
+    expect(output).toContain('@anthropic/mcp-server-fetch');
+    expect(output).toContain('scan-abc');
+    expect(output).toContain('Trust impact');
+    expect(output).toContain('https://registry.opena2a.org/agents/123');
+    expect(output).not.toContain('community scan');
+  });
+
+  it('formats successful community publish with fallback notice', () => {
+    const result: PublishResult = {
+      success: true,
+      scanId: 'scan-def',
+      profileUrl: 'https://registry.opena2a.org/agents/456',
+      status: 'passed',
+      isCommunity: true,
+    };
+
+    const data: PublishScanData = {
+      packageName: 'my-agent',
+      directory: '/tmp/test',
+      soulResult: makeSoulResult(),
+    };
+
+    const output = formatPublishOutput(result, data, 'https://registry.opena2a.org');
+
+    expect(output).toContain('Published to registry.opena2a.org');
+    expect(output).toContain('community scan (0.5x weight)');
+    expect(output).toContain('opena2a claim');
+  });
+
+  it('formats failed publish', () => {
+    const result: PublishResult = {
+      success: false,
+      scanId: 'scan-fail',
+      profileUrl: '',
+      status: 'error',
+      isCommunity: true,
+      error: 'Connection refused',
+    };
+
+    const data: PublishScanData = {
+      packageName: 'my-agent',
+      directory: '/tmp/test',
+    };
+
+    const output = formatPublishOutput(result, data, 'https://registry.opena2a.org');
+
+    expect(output).toContain('Failed to publish');
+    expect(output).toContain('Connection refused');
+    expect(output).toContain('available locally');
+  });
+
+  it('includes scan type summary in output', () => {
+    const result: PublishResult = {
+      success: true,
+      scanId: 'scan-all',
+      profileUrl: 'https://registry.opena2a.org/agents/789',
+      status: 'passed',
+      isCommunity: false,
+    };
+
+    const data: PublishScanData = {
+      packageName: '@test/all-scans',
+      directory: '/tmp/test',
+      hardeningFindings: makeHardeningFindings(),
+      attackReport: makeAttackReport(),
+      soulResult: makeSoulResult(),
+      oasbResult: makeOasbResult(),
+    };
+
+    const output = formatPublishOutput(result, data, 'https://registry.opena2a.org');
+
+    expect(output).toContain('hardening');
+    expect(output).toContain('OASB');
+    expect(output).toContain('SOUL');
+    expect(output).toContain('attack');
+  });
+});

--- a/src/registry/publish.ts
+++ b/src/registry/publish.ts
@@ -1,0 +1,372 @@
+/**
+ * ATP Publish Flow — Push scan results to the OpenA2A Registry.
+ *
+ * Supports two paths:
+ *   1. Claimed agent: reads Ed25519 keypair from ~/.opena2a/keys/, signs payload, full weight (1.0x)
+ *   2. Community fallback: no auth, results have lower weight (0.5x)
+ *
+ * Used by the --publish flag on secure, attack, and scan-soul commands.
+ */
+
+import { createHash } from 'crypto';
+import type { SecurityFinding, Severity } from '../hardening';
+import type { AttackReport } from '../attack';
+import type { SoulScanResult } from '../soul';
+import type { BenchmarkResult } from '../benchmarks';
+import { RegistryClient, type CommunityScanPayload } from './client';
+
+/** Result of reading a keypair from ~/.opena2a/keys/ */
+export interface AgentKeypair {
+  publicKey: string;
+  privateKey: string;
+  agentId?: string;
+}
+
+/** Composite scan data collected from all scan types for publishing */
+export interface PublishScanData {
+  packageName: string;
+  packageVersion?: string;
+  packageType?: string;
+  directory: string;
+  /** Hardening scan findings (from `secure` command) */
+  hardeningFindings?: SecurityFinding[];
+  /** Attack scan report (from `attack` command) */
+  attackReport?: AttackReport;
+  /** SOUL governance scan result (from `scan-soul` command) */
+  soulResult?: SoulScanResult;
+  /** OASB benchmark result (from `secure -b oasb-1`) */
+  oasbResult?: BenchmarkResult;
+}
+
+/** Result returned after publishing to registry */
+export interface PublishResult {
+  success: boolean;
+  scanId: string;
+  profileUrl: string;
+  status: string;
+  isCommunity: boolean;
+  error?: string;
+}
+
+/**
+ * Read the agent's Ed25519 keypair from ~/.opena2a/keys/.
+ * Returns null if no keypair exists (agent not claimed).
+ *
+ * The keys directory can be overridden via OPENA2A_HOME env var
+ * (defaults to ~/.opena2a).
+ */
+export function readAgentKeypair(): AgentKeypair | null {
+  try {
+    const fs = require('fs');
+    const path = require('path');
+    const os = require('os');
+
+    const opena2aHome = process.env.OPENA2A_HOME || path.join(os.homedir(), '.opena2a');
+    const keysDir = path.join(opena2aHome, 'keys');
+    if (!fs.existsSync(keysDir)) {
+      return null;
+    }
+
+    const pubKeyPath = path.join(keysDir, 'agent.pub');
+    const privKeyPath = path.join(keysDir, 'agent.key');
+    const agentIdPath = path.join(keysDir, 'agent-id');
+
+    if (!fs.existsSync(pubKeyPath) || !fs.existsSync(privKeyPath)) {
+      return null;
+    }
+
+    const publicKey = fs.readFileSync(pubKeyPath, 'utf-8').trim();
+    const privateKey = fs.readFileSync(privKeyPath, 'utf-8').trim();
+    const agentId = fs.existsSync(agentIdPath)
+      ? fs.readFileSync(agentIdPath, 'utf-8').trim()
+      : undefined;
+
+    return { publicKey, privateKey, agentId };
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Sign a payload string with the agent's Ed25519 private key.
+ * Returns the base64-encoded signature, or null if signing fails.
+ */
+export function signPayload(payload: string, privateKeyPem: string): string | null {
+  try {
+    const crypto = require('crypto');
+    const privateKey = crypto.createPrivateKey(privateKeyPem);
+    const signature = crypto.sign(null, Buffer.from(payload), privateKey);
+    return signature.toString('base64');
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Build a unified publish payload from scan data.
+ * Combines results from hardening, attack, SOUL, and OASB scans.
+ */
+export function buildPublishPayload(data: PublishScanData): CommunityScanPayload & Record<string, unknown> {
+  const scanId = `hma-publish-${Date.now()}`;
+  const completedAt = new Date().toISOString();
+
+  // Determine overall status from hardening findings
+  let status: 'passed' | 'failed' | 'warnings' | 'error' = 'passed';
+  let criticalCount = 0;
+  let highCount = 0;
+  let mediumCount = 0;
+  let lowCount = 0;
+  const vulnerabilities: Array<{
+    id: string;
+    severity: string;
+    title: string;
+    description: string;
+  }> = [];
+
+  if (data.hardeningFindings) {
+    const failed = data.hardeningFindings.filter(f => !f.passed && !f.fixed);
+    for (const f of failed) {
+      if (f.severity === 'critical') criticalCount++;
+      else if (f.severity === 'high') highCount++;
+      else if (f.severity === 'medium') mediumCount++;
+      else if (f.severity === 'low') lowCount++;
+
+      vulnerabilities.push({
+        id: f.checkId,
+        severity: f.severity,
+        title: f.name,
+        description: f.description,
+      });
+    }
+  }
+
+  // Incorporate attack results into severity counts
+  if (data.attackReport) {
+    const successfulAttacks = data.attackReport.results.filter(r => r.success);
+    for (const r of successfulAttacks) {
+      if (r.payload.severity === 'critical') criticalCount++;
+      else if (r.payload.severity === 'high') highCount++;
+      else if (r.payload.severity === 'medium') mediumCount++;
+      else lowCount++;
+
+      vulnerabilities.push({
+        id: r.payload.id,
+        severity: r.payload.severity,
+        title: `Attack: ${r.payload.category} - ${r.payload.id}`,
+        description: r.response?.substring(0, 500) || 'Attack succeeded',
+      });
+    }
+  }
+
+  // Derive overall status
+  if (criticalCount > 0 || highCount > 0) status = 'failed';
+  else if (mediumCount > 0 || lowCount > 0) status = 'warnings';
+
+  // Build raw report with all scan type data
+  const rawReport: Record<string, unknown> = {
+    generator: 'hackmyagent',
+    publishedVia: 'atp-publish',
+  };
+
+  if (data.hardeningFindings) {
+    const total = data.hardeningFindings.length;
+    const failed = data.hardeningFindings.filter(f => !f.passed && !f.fixed).length;
+    rawReport.hardening = {
+      totalChecks: total,
+      failedChecks: failed,
+      passRate: total > 0 ? Math.round(((total - failed) / total) * 100) : 100,
+    };
+  }
+
+  if (data.attackReport) {
+    rawReport.attack = {
+      riskScore: data.attackReport.riskScore,
+      riskRating: data.attackReport.riskRating,
+      totalPayloads: data.attackReport.summary.total,
+      successfulAttacks: data.attackReport.summary.successful,
+      blockedAttacks: data.attackReport.summary.blocked,
+    };
+  }
+
+  if (data.soulResult) {
+    rawReport.soul = {
+      score: data.soulResult.score,
+      conformance: data.soulResult.conformance,
+      agentTier: data.soulResult.agentTier,
+      totalControls: data.soulResult.totalControls,
+      totalPassed: data.soulResult.totalPassed,
+    };
+  }
+
+  if (data.oasbResult) {
+    rawReport.oasb = {
+      compliance: data.oasbResult.compliance,
+      rating: data.oasbResult.rating,
+      l1Compliance: data.oasbResult.l1Compliance,
+      l2Compliance: data.oasbResult.l2Compliance,
+      l3Compliance: data.oasbResult.l3Compliance,
+    };
+  }
+
+  // Compute content hash
+  const canonical = [
+    scanId,
+    data.packageName,
+    data.packageType || '',
+    data.packageVersion || '',
+    status,
+    criticalCount,
+    highCount,
+    mediumCount,
+    lowCount,
+  ].join('|');
+  const contentHash = createHash('sha256').update(canonical).digest('hex');
+
+  const payload: CommunityScanPayload & Record<string, unknown> = {
+    packageName: data.packageName,
+    packageType: data.packageType,
+    version: data.packageVersion,
+    scanId,
+    status,
+    completedAt,
+    vulnerabilities,
+    criticalCount,
+    highCount,
+    mediumCount,
+    lowCount,
+    rawReport,
+    contentHash,
+  };
+
+  // Add ATP extension fields
+  if (data.oasbResult) {
+    payload.oasbCompliance = data.oasbResult.compliance;
+    payload.oasbRating = data.oasbResult.rating;
+    payload.oasbL1 = data.oasbResult.l1Compliance;
+    payload.oasbL2 = data.oasbResult.l2Compliance;
+    payload.oasbL3 = data.oasbResult.l3Compliance;
+  }
+
+  if (data.soulResult) {
+    payload.soulScore = data.soulResult.score;
+    payload.soulConformance = data.soulResult.conformance;
+    payload.soulAgentTier = data.soulResult.agentTier;
+  }
+
+  if (data.attackReport) {
+    payload.attackRiskScore = data.attackReport.riskScore;
+    payload.attackRiskRating = data.attackReport.riskRating;
+    payload.attackTotal = data.attackReport.summary.total;
+    payload.attackSucceeded = data.attackReport.summary.successful;
+  }
+
+  return payload;
+}
+
+/**
+ * Publish scan results to the OpenA2A Registry.
+ *
+ * Flow:
+ *   1. Read keypair from ~/.opena2a/keys/ (if claimed)
+ *   2. Build unified payload from scan data
+ *   3. Sign payload if keypair exists
+ *   4. POST to registry (claimed or community path)
+ */
+export async function publishScanResults(
+  data: PublishScanData,
+  registryUrl: string,
+): Promise<PublishResult> {
+  const keypair = readAgentKeypair();
+  const isCommunity = !keypair;
+
+  const payload = buildPublishPayload(data);
+
+  // Sign if we have a keypair
+  if (keypair) {
+    const payloadString = JSON.stringify(payload);
+    const signature = signPayload(payloadString, keypair.privateKey);
+    if (signature) {
+      (payload as Record<string, unknown>).signature = signature;
+      (payload as Record<string, unknown>).publicKey = keypair.publicKey;
+    }
+    if (keypair.agentId) {
+      (payload as Record<string, unknown>).agentId = keypair.agentId;
+    }
+  }
+
+  try {
+    const client = new RegistryClient({ registryUrl, apiKey: '' });
+    const result = await client.reportPublishResult(payload as any);
+
+    return {
+      success: true,
+      scanId: result.scanId,
+      profileUrl: result.profileUrl,
+      status: result.status,
+      isCommunity,
+    };
+  } catch (err: unknown) {
+    const message = err instanceof Error ? err.message : 'Unknown error';
+    return {
+      success: false,
+      scanId: payload.scanId,
+      profileUrl: `${registryUrl}/agents/${data.packageName}`,
+      status: 'error',
+      isCommunity,
+      error: message,
+    };
+  }
+}
+
+/**
+ * Format the publish result for terminal output.
+ */
+export function formatPublishOutput(
+  result: PublishResult,
+  data: PublishScanData,
+  registryUrl: string,
+): string {
+  const lines: string[] = [];
+
+  if (result.success) {
+    lines.push('Published to ' + new URL(registryUrl).hostname);
+    lines.push('  Agent: ' + data.packageName);
+    lines.push('  Scan ID: ' + result.scanId);
+    lines.push('  Status: ' + result.status);
+
+    // Build summary of what was included
+    const parts: string[] = [];
+    if (data.hardeningFindings) {
+      const failed = data.hardeningFindings.filter(f => !f.passed && !f.fixed);
+      parts.push(`hardening (${failed.length} finding${failed.length === 1 ? '' : 's'})`);
+    }
+    if (data.oasbResult) {
+      parts.push(`OASB (${data.oasbResult.compliance}% compliance)`);
+    }
+    if (data.soulResult) {
+      parts.push(`SOUL (${data.soulResult.score}/100)`);
+    }
+    if (data.attackReport) {
+      parts.push(`attack (${data.attackReport.riskRating} risk)`);
+    }
+    if (parts.length > 0) {
+      lines.push('  Scans: ' + parts.join(', '));
+    }
+
+    lines.push('  Trust impact: score may increase on next recalculation');
+
+    if (result.isCommunity) {
+      lines.push('');
+      lines.push('  Published as community scan (0.5x weight).');
+      lines.push('  Run `opena2a claim` first for full weight (1.0x).');
+    }
+
+    lines.push('');
+    lines.push('Profile: ' + result.profileUrl);
+  } else {
+    lines.push('Failed to publish to registry: ' + (result.error || 'unknown error'));
+    lines.push('Scan results are still available locally.');
+  }
+
+  return lines.join('\n');
+}


### PR DESCRIPTION
## Summary
- Add `--publish` flag to push scan results to the OpenA2A registry
- Extend ScanReportPayload with OASB, SOUL, and attack mode fields
- Ed25519 signing of scan reports for authenticity verification
- Community scan fallback when publisher identity is not configured
- 21 new tests (838 total)

## Test plan
- [x] Verify build passes
- [x] Verify tests pass (838 passing)
- [ ] Review Ed25519 signing implementation
- [ ] Review scan report payload schema extensions