### PR TITLE
Fix --publish UX issues from fresh-user testing

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1890,11 +1890,37 @@ Examples:
       }
 
       if (format === 'json') {
+        // Run publish in JSON mode and include result in output
+        let publishStatus: Record<string, unknown> | undefined;
+        if (options.publish && options.registry !== false) {
+          try {
+            const { publishScanResults } = await import('./registry/publish');
+            const registryUrl = options.registryUrl || process.env.REGISTRY_URL || 'https://registry.opena2a.org';
+            const packageName = resolvePackageName(targetDir);
+            if (packageName) {
+              const publishData = {
+                packageName,
+                packageVersion: resolvePackageVersion(targetDir) ?? undefined,
+                directory: targetDir,
+                hardeningFindings: result.findings,
+              };
+              const publishResult = await publishScanResults(publishData, registryUrl);
+              publishStatus = { ...publishResult, registryUrl };
+            } else {
+              publishStatus = { success: false, error: 'Could not determine package name' };
+            }
+          } catch (publishErr: unknown) {
+            const msg = publishErr instanceof Error ? publishErr.message : 'unknown error';
+            publishStatus = { success: false, error: msg };
+          }
+        }
+
+        const jsonOutput = publishStatus ? { ...result, publish: publishStatus } : result;
         if (options.output) {
-          require('fs').writeFileSync(options.output, JSON.stringify(result, null, 2) + '\n');
+          require('fs').writeFileSync(options.output, JSON.stringify(jsonOutput, null, 2) + '\n');
           console.error(`Report written to ${options.output}`);
         } else {
-          writeJsonStdout(result);
+          writeJsonStdout(jsonOutput);
         }
         const critHigh = result.findings.filter((f: SecurityFinding) => !f.passed && !f.fixed && (f.severity === 'critical' || f.severity === 'high'));
         if (critHigh.length > 0) process.exitCode = 1;
@@ -2074,7 +2100,11 @@ Examples:
       }
 
       // ATP Publish: push results to registry when --publish is used
-      if (options.publish) {
+      if (options.publish && options.registry === false) {
+        if (format === 'text') {
+          console.log('\nPublish skipped: --no-registry flag is active.');
+        }
+      } else if (options.publish) {
         try {
           const { publishScanResults, formatPublishOutput } = await import('./registry/publish');
           const registryUrl = options.registryUrl || process.env.REGISTRY_URL || 'https://registry.opena2a.org';
@@ -2810,7 +2840,15 @@ Examples:
       }
 
       // ATP Publish: push attack results to registry when --publish is used
-      if (options.publish && targetType !== 'local') {
+      if (options.publish && options.registry === false) {
+        if (format === 'text') {
+          console.log('\nPublish skipped: --no-registry flag is active.');
+        }
+      } else if (options.publish && targetType === 'local') {
+        if (format === 'text') {
+          console.log('\nPublish skipped: only available for live target scans.');
+        }
+      } else if (options.publish && targetType !== 'local') {
         try {
           const { publishScanResults, formatPublishOutput } = await import('./registry/publish');
           const regUrl = options.registryUrl || process.env.REGISTRY_URL || 'https://registry.opena2a.org';
@@ -4190,7 +4228,33 @@ Examples:
 
       // JSON output
       if (options.json) {
-        writeJsonStdout(result);
+        // Run publish in JSON mode and include result in output
+        let publishStatus: Record<string, unknown> | undefined;
+        if (options.publish) {
+          try {
+            const { publishScanResults } = await import('./registry/publish');
+            const registryUrl = options.registryUrl || process.env.REGISTRY_URL || 'https://registry.opena2a.org';
+            const packageName = resolvePackageName(targetDir);
+            if (packageName) {
+              const publishData = {
+                packageName,
+                packageVersion: resolvePackageVersion(targetDir) ?? undefined,
+                directory: targetDir,
+                soulResult: result,
+              };
+              const publishResult = await publishScanResults(publishData, registryUrl);
+              publishStatus = { ...publishResult, registryUrl };
+            } else {
+              publishStatus = { success: false, error: 'Could not determine package name' };
+            }
+          } catch (publishErr: unknown) {
+            const msg = publishErr instanceof Error ? publishErr.message : 'unknown error';
+            publishStatus = { success: false, error: msg };
+          }
+        }
+
+        const jsonOutput = publishStatus ? { ...result, publish: publishStatus } : result;
+        writeJsonStdout(jsonOutput);
         // Check fail threshold
         if (options.failBelow) {
           const threshold = parseInt(options.failBelow, 10);

--- a/src/registry/publish.ts
+++ b/src/registry/publish.ts
@@ -279,6 +279,10 @@ export async function publishScanResults(
   const keypair = readAgentKeypair();
   const isCommunity = !keypair;
 
+  if (isCommunity) {
+    console.log("No signing keys found at ~/.opena2a/keys/. Run 'opena2a claim <package>' to create keys for full-weight publishing. Submitting as community contribution (0.5x weight).");
+  }
+
   const payload = buildPublishPayload(data);
 
   // Sign if we have a keypair


### PR DESCRIPTION
## Summary
- `attack --local --publish` now prints skip message instead of silently doing nothing
- `--no-registry` now correctly suppresses `--publish`
- Missing signing keys now show guidance to run `opena2a claim`
- JSON mode includes `publish` field in output object

## Test plan
- [x] 838/838 tests pass
- [x] Build clean