### PR TITLE
Fix scan false positives: SKILL-005 severity, AST-CRED-001 doc exclusions

### DIFF
--- a/src/hardening/scanner.ts
+++ b/src/hardening/scanner.ts
@@ -187,7 +187,9 @@ const SKILL_CREDENTIAL_ACCESS_PATTERNS: RegExp[] = [
   /wallet.*\.json/gi,
   /seed.*phrase/gi,
   /private.*key/gi,
-  /\.env/gi,
+  // Match .env as a standalone file reference, not as part of process.env or documentation
+  // like ".env.example in sync" or "set in .env.local"
+  /(?:^|[\s"'`(])\.env(?:\.local|\.production|\.development)?(?:[\s"'`)]|$)/gi,
   /credentials\.json/gi,
 ];
 
@@ -4963,17 +4965,34 @@ dist/
       }
 
       // SKILL-005: Credential File Access
+      // Only flag as CRITICAL inside frontmatter (capabilities section).
+      // Body text often describes credential handling in documentation,
+      // which is informational, not an actual access pattern.
+      let inSkill005Frontmatter = false;
+      let skill005FrontmatterDelimiters = 0;
       for (let i = 0; i < lines.length; i++) {
+        const trimmed = lines[i].trim();
+        if (trimmed === '---') {
+          skill005FrontmatterDelimiters++;
+          inSkill005Frontmatter = skill005FrontmatterDelimiters === 1;
+          if (skill005FrontmatterDelimiters >= 2) inSkill005Frontmatter = false;
+          continue;
+        }
         const line = lines[i];
         for (const pattern of SKILL_CREDENTIAL_ACCESS_PATTERNS) {
           pattern.lastIndex = 0;
           if (pattern.test(line)) {
+            // Frontmatter = actual capability declaration (CRITICAL)
+            // Body = still suspicious but lower severity (MEDIUM)
+            const severity = inSkill005Frontmatter ? 'critical' : 'medium';
             findings.push({
               checkId: 'SKILL-005',
               name: 'Credential File Access',
-              description: 'Skill attempts to access credential or sensitive configuration files',
+              description: inSkill005Frontmatter
+                ? 'Skill declares access to credential or sensitive configuration files'
+                : 'Skill body mentions credential file patterns',
               category: 'skill',
-              severity: 'critical',
+              severity,
               passed: false,
               message: `Credential file access pattern detected: "${line.trim().substring(0, 80)}..."`,
               file: relativePath,

--- a/src/nanomind-core/analyzers/credential-analyzer.ts
+++ b/src/nanomind-core/analyzers/credential-analyzer.ts
@@ -350,15 +350,27 @@ function isDocumentationOrTestContext(ast: SecurityAST): boolean {
     return true;
   }
 
-  // Documentation (but not .skill.md, .soul.md, or CLAUDE.md which are functional)
+  // Documentation (but not .skill.md or .soul.md which are functional)
+  // CLAUDE.md and AGENTS.md are instructions/documentation, not credential access code
   if (
     (path.endsWith('.md') &&
       !path.endsWith('.skill.md') &&
-      !path.endsWith('.soul.md') &&
-      !path.endsWith('claude.md')) ||
+      !path.endsWith('.soul.md')) ||
     path.includes('doc/') ||
     path.includes('docs/') ||
     path.includes('readme')
+  ) {
+    return true;
+  }
+
+  // Lock files and env examples contain credential-like patterns but are not attack surfaces
+  if (
+    path.endsWith('pnpm-lock.yaml') ||
+    path.endsWith('package-lock.json') ||
+    path.endsWith('yarn.lock') ||
+    path.endsWith('.env.example') ||
+    path.endsWith('.env.sample') ||
+    path.endsWith('.env.template')
   ) {
     return true;
   }


### PR DESCRIPTION
## Summary
- **SKILL-005**: Track frontmatter vs body context in SKILL.md files. Credential patterns in documentation body text downgraded from CRITICAL to MEDIUM. Tighten `.env` regex to avoid matching documentation mentions.
- **AST-CRED-001**: Add CLAUDE.md, AGENTS.md, lock files, and env templates to documentation exclusion list.
- No changes to UNICODE-STEGO-001 (already fixed in 0.16.1 via `6cf6ac4`).

## Impact (from registry scan review)
- 362 packages wrongly blocked solely by UNICODE-STEGO-001 false positives (variation selectors in emoji) — fixed by scanner container rebuild with 0.16.1+
- ~2,500 SKILL-005 false CRITICALs on SKILL.md body text mentioning `.env` or `private key` in documentation context
- ~2,300 AST-CRED-001 false positives on CLAUDE.md (48), pnpm-lock.yaml (39), .env.example (24), AGENTS.md (20)

## Test plan
- [x] All 1,374 tests passing (0 failures)
- [x] Manual test: README.md with emoji variation selector (no UNICODE-STEGO-001)
- [x] Manual test: SKILL.md with `.env.local` in body text (no CRITICAL, gets MEDIUM)
- [x] Manual test: CLAUDE.md with credential mentions (no AST-CRED-001)
- [ ] After merge: rebuild scanner container, rescan sample of 362 wrongly-blocked packages