### PR TITLE
feat(arp): default-attach runtime twin and guard anomaly in AgentRuntimeProtection

### DIFF
--- a/__tests__/arp/agent-runtime-protection-wiring.test.ts
+++ b/__tests__/arp/agent-runtime-protection-wiring.test.ts
@@ -1,0 +1,170 @@
+import { describe, it, expect } from 'vitest';
+import { AgentRuntimeProtection } from '../../src/arp';
+import { GuardAnomalyDetector } from '../../src/arp/intelligence/guard-anomaly';
+import type { ARPConfig } from '../../src/arp/types';
+
+/**
+ * Integration coverage for AgentRuntimeProtection default-wiring of
+ * session 28 (behavioral risk IPC) and session 29 (guard anomaly drift)
+ * machinery. Before session 30, those sources existed but were never
+ * instantiated in production. These tests assert that:
+ *
+ *   - Runtime twin is ON by default when intelligence is enabled.
+ *   - Runtime twin can be disabled via config opt-out.
+ *   - Behavioral risk source passed to the coordinator matches the twin.
+ *   - Guard anomaly is OFF unless a baseline is injected.
+ *   - Guard anomaly honors the baseline and windowSize from config.
+ *   - `intelligence.enabled === false` disables everything.
+ *   - start() attaches the twin to the event engine exactly once.
+ */
+
+function baseConfig(overrides: Partial<ARPConfig> = {}): ARPConfig {
+  return {
+    agentName: 'wiring-test-agent',
+    dataDir: '/tmp/arp-wiring-test',
+    // Disable all monitors so start() does not touch the real filesystem.
+    monitors: {
+      process: { enabled: false },
+      network: { enabled: false },
+      filesystem: { enabled: false },
+    },
+    ...overrides,
+  };
+}
+
+describe('AgentRuntimeProtection session 30 wiring', () => {
+  it('attaches a runtime twin and behavioral risk source by default', () => {
+    const arp = new AgentRuntimeProtection(baseConfig());
+    expect(arp.getRuntimeTwin()).not.toBeNull();
+    const coord = arp.getIntelligence();
+    expect(coord.getBehavioralRiskSource()).not.toBeNull();
+  });
+
+  it('passes the runtime twin through as the behavioral risk source', () => {
+    const arp = new AgentRuntimeProtection(baseConfig());
+    const twin = arp.getRuntimeTwin();
+    const src = arp.getIntelligence().getBehavioralRiskSource();
+    // The source wraps the twin. We cannot assert identity on the twin
+    // directly because InProcessBehavioralRiskSource holds it as a
+    // private field, but we can assert both are non-null and the source
+    // type matches the production choice.
+    expect(twin).not.toBeNull();
+    expect(src).not.toBeNull();
+    expect(src?.constructor.name).toBe('InProcessBehavioralRiskSource');
+  });
+
+  it('respects intelligence.runtimeTwin.enabled = false opt-out', () => {
+    const arp = new AgentRuntimeProtection(
+      baseConfig({
+        intelligence: {
+          runtimeTwin: { enabled: false },
+        },
+      }),
+    );
+    expect(arp.getRuntimeTwin()).toBeNull();
+    expect(arp.getIntelligence().getBehavioralRiskSource()).toBeNull();
+  });
+
+  it('respects intelligence.enabled = false as a global kill switch for the twin', () => {
+    const arp = new AgentRuntimeProtection(
+      baseConfig({
+        intelligence: { enabled: false },
+      }),
+    );
+    expect(arp.getRuntimeTwin()).toBeNull();
+    expect(arp.getIntelligence().getBehavioralRiskSource()).toBeNull();
+  });
+
+  it('does not construct a guard anomaly detector without an injected baseline', () => {
+    const arp = new AgentRuntimeProtection(baseConfig());
+    expect(arp.getIntelligence().getGuardAnomaly()).toBeNull();
+  });
+
+  it('constructs a guard anomaly detector when a baseline is injected', () => {
+    const arp = new AgentRuntimeProtection(
+      baseConfig({
+        intelligence: {
+          guardAnomaly: {
+            baseline: {
+              'file-read': 0.4,
+              'network-egress': 0.3,
+              'process-spawn': 0.2,
+              'telemetry': 0.1,
+            },
+            windowSize: 150,
+            alarmThreshold: 18,
+            minObservations: 30,
+          },
+        },
+      }),
+    );
+    const ga = arp.getIntelligence().getGuardAnomaly();
+    expect(ga).not.toBeNull();
+    expect(ga).toBeInstanceOf(GuardAnomalyDetector);
+    const det = ga as GuardAnomalyDetector;
+    expect(det.getWindowCapacity()).toBe(150);
+    // Baseline was normalized to probabilities, keys preserved.
+    const baseline = det.getBaseline();
+    expect(Object.keys(baseline).sort()).toEqual([
+      'file-read',
+      'network-egress',
+      'process-spawn',
+      'telemetry',
+    ]);
+  });
+
+  it('refuses to construct a guard anomaly detector from an empty baseline object', () => {
+    const arp = new AgentRuntimeProtection(
+      baseConfig({
+        intelligence: {
+          guardAnomaly: { baseline: {} },
+        },
+      }),
+    );
+    expect(arp.getIntelligence().getGuardAnomaly()).toBeNull();
+  });
+
+  it('respects guardAnomaly.enabled = false even when a baseline is provided', () => {
+    const arp = new AgentRuntimeProtection(
+      baseConfig({
+        intelligence: {
+          guardAnomaly: {
+            enabled: false,
+            baseline: { 'file-read': 1 },
+          },
+        },
+      }),
+    );
+    expect(arp.getIntelligence().getGuardAnomaly()).toBeNull();
+  });
+
+  it('start() attaches the twin to the event engine and is idempotent', async () => {
+    const arp = new AgentRuntimeProtection(baseConfig());
+    // No pre-start attach; twin.attach() happens inside start().
+    await arp.start();
+    expect(arp.isRunning()).toBe(true);
+    // A second start() is a no-op (running guard) and must not
+    // double-attach the twin.
+    await arp.start();
+    expect(arp.isRunning()).toBe(true);
+    await arp.stop();
+    expect(arp.isRunning()).toBe(false);
+  });
+
+  it('preserves legacy behavior when both twin and guard anomaly are disabled', async () => {
+    const arp = new AgentRuntimeProtection(
+      baseConfig({
+        intelligence: {
+          runtimeTwin: { enabled: false },
+          // guardAnomaly left out entirely
+        },
+      }),
+    );
+    expect(arp.getRuntimeTwin()).toBeNull();
+    expect(arp.getIntelligence().getBehavioralRiskSource()).toBeNull();
+    expect(arp.getIntelligence().getGuardAnomaly()).toBeNull();
+    // start() still works: no attach, just monitors (all disabled here).
+    await arp.start();
+    await arp.stop();
+  });
+});

--- a/src/arp/index.ts
+++ b/src/arp/index.ts
@@ -78,6 +78,15 @@ import * as path from 'path';
 import type { ARPConfig, ARPEvent, Monitor } from './types';
 import { EventEngine } from './engine/event-engine';
 import { IntelligenceCoordinator } from './intelligence/coordinator';
+import { NanoMindL1 } from './intelligence/nanomind-l1';
+import {
+  InProcessBehavioralRiskSource,
+  type BehavioralRiskSource,
+} from './intelligence/behavioral-risk';
+import {
+  GuardAnomalyDetector,
+  type GuardAnomalySource,
+} from './intelligence/guard-anomaly';
 import { EnforcementEngine, type AlertCallback } from './enforcement/kill-switch';
 import { LocalLogger } from './reporting/local-log';
 import { ProcessMonitor } from './monitors/process';
@@ -116,6 +125,23 @@ export class AgentRuntimeProtection {
   private readonly monitors: Monitor[] = [];
   private gtinForwarder: GTINForwarder | null = null;
   private running = false;
+  /**
+   * In-process runtime twin (behavioral anomaly scorer). Held for the
+   * lifetime of the ARP instance, attached to the event engine in
+   * start() so every event trains the twin's baseline. Null when the
+   * runtime twin is disabled in config.
+   */
+  private readonly runtimeTwin: NanoMindL1 | null;
+  /**
+   * Transport-agnostic view of the runtime twin passed to the
+   * coordinator. Null when the twin is disabled.
+   */
+  private readonly behavioralRiskSource: BehavioralRiskSource | null;
+  /**
+   * Classification drift detector. Non-null only when the caller
+   * provided a baseline in `config.intelligence.guardAnomaly.baseline`.
+   */
+  private readonly guardAnomaly: GuardAnomalySource | null;
 
   constructor(configOrPath?: ARPConfig | string) {
     if (typeof configOrPath === 'string') {
@@ -127,7 +153,33 @@ export class AgentRuntimeProtection {
     const dataDir = this.config.dataDir ?? path.join(process.cwd(), '.opena2a', 'arp');
 
     this.engine = new EventEngine(this.config);
-    this.intelligence = new IntelligenceCoordinator(this.config, dataDir);
+
+    // Build the runtime twin and behavioral risk source. Runtime twin is
+    // on by default when intelligence is enabled; opt out via
+    // `intelligence.runtimeTwin.enabled = false`. We do NOT attach the
+    // twin to the event engine here; start() does that so a user who
+    // constructs an ARP without calling start() does not get surprise
+    // event handlers.
+    this.runtimeTwin = buildRuntimeTwin(this.config);
+    this.behavioralRiskSource = this.runtimeTwin
+      ? new InProcessBehavioralRiskSource(this.runtimeTwin, 'runtime-twin-inproc')
+      : null;
+
+    // Build the guard anomaly detector. Only constructed when the caller
+    // injected a baseline; otherwise drift detection is inert.
+    this.guardAnomaly = buildGuardAnomaly(this.config);
+
+    // Wire both sources into the coordinator. The third argument
+    // (manifest) stays null here; capability manifests are loaded by
+    // ARPProxy.start for HTTP proxy deployments and are not part of the
+    // AgentRuntimeProtection constructor surface today.
+    this.intelligence = new IntelligenceCoordinator(
+      this.config,
+      dataDir,
+      null,
+      this.behavioralRiskSource,
+      this.guardAnomaly,
+    );
     this.enforcement = new EnforcementEngine();
     this.logger = new LocalLogger(dataDir);
 
@@ -199,6 +251,14 @@ export class AgentRuntimeProtection {
   /** Start all monitors */
   async start(): Promise<void> {
     if (this.running) return;
+
+    // Attach the runtime twin to the event engine BEFORE monitors start
+    // so the twin observes every event from the first tick. The twin
+    // trains its own baseline over the first 100 events and does not
+    // mutate the event or block the L0 decision.
+    if (this.runtimeTwin) {
+      this.runtimeTwin.attach(this.engine);
+    }
 
     for (const monitor of this.monitors) {
       await monitor.start();
@@ -283,4 +343,69 @@ export class AgentRuntimeProtection {
   getEnforcement(): EnforcementEngine {
     return this.enforcement;
   }
+
+  /**
+   * Get the intelligence coordinator. Exposed so tests can assert the
+   * coordinator was constructed with the expected behavioral risk and
+   * guard anomaly sources, and so advanced integrations can swap
+   * sources at runtime via `setBehavioralRiskSource` / `setGuardAnomaly`.
+   */
+  getIntelligence(): IntelligenceCoordinator {
+    return this.intelligence;
+  }
+
+  /** The runtime twin instance, or null when disabled. */
+  getRuntimeTwin(): NanoMindL1 | null {
+    return this.runtimeTwin;
+  }
+}
+
+/**
+ * Construct an in-process `NanoMindL1` runtime twin from the ARP config,
+ * or return null when the caller disabled intelligence or the runtime
+ * twin explicitly. Kept as a free function so the constructor stays
+ * short and the default policy is visible in one place.
+ *
+ * Default policy:
+ *   - When `intelligence.enabled === false`: no twin (L2 disabled implies
+ *     the behavioral layer is also unwanted).
+ *   - When `intelligence.runtimeTwin.enabled === false`: no twin.
+ *   - Otherwise: construct a twin seeded from `config.agentName`, with
+ *     fleet federation opt-in from the config (default off).
+ */
+function buildRuntimeTwin(config: ARPConfig): NanoMindL1 | null {
+  const ic = config.intelligence;
+  if (ic?.enabled === false) return null;
+  const twinCfg = ic?.runtimeTwin;
+  if (twinCfg?.enabled === false) return null;
+  return new NanoMindL1(config.agentName, {
+    enabled: true,
+    fleetEnabled: twinCfg?.fleetEnabled ?? false,
+    agentCategory: twinCfg?.agentCategory ?? 'general',
+  });
+}
+
+/**
+ * Construct a `GuardAnomalyDetector` from the ARP config, or return
+ * null when no baseline was provided or the caller explicitly disabled
+ * guard anomaly detection. A baseline is required: drift detection
+ * without a reference distribution is nonsense, so we refuse to
+ * auto-bootstrap one from observations. The caller supplies a
+ * Registry-exported training distribution in production, or a
+ * snapshotted JSON file pre-Registry.
+ */
+function buildGuardAnomaly(config: ARPConfig): GuardAnomalySource | null {
+  const gaCfg = config.intelligence?.guardAnomaly;
+  if (!gaCfg) return null;
+  if (gaCfg.enabled === false) return null;
+  const baseline = gaCfg.baseline;
+  if (!baseline || Object.keys(baseline).length === 0) return null;
+  return new GuardAnomalyDetector({
+    baseline,
+    windowSize: gaCfg.windowSize,
+    alarmThreshold: gaCfg.alarmThreshold,
+    smoothing: gaCfg.smoothing,
+    minObservations: gaCfg.minObservations,
+    sourceName: gaCfg.sourceName,
+  });
 }

--- a/src/arp/types.ts
+++ b/src/arp/types.ts
@@ -156,6 +156,66 @@ export interface IntelligenceConfig {
    * otherwise.
    */
   behavioralRiskTimeoutMs?: number;
+
+  /**
+   * Runtime twin (NanoMindL1 behavioral twin) configuration. When enabled,
+   * `AgentRuntimeProtection` constructs an in-process `NanoMindL1`, wraps
+   * it in `InProcessBehavioralRiskSource`, and passes it to the
+   * `IntelligenceCoordinator` so behavioral risk signals are fused into
+   * every analyzed event.
+   *
+   * Default: enabled when `intelligence.enabled !== false`. Opt out by
+   * setting `runtimeTwin.enabled = false`. Fleet federated learning is a
+   * separate, explicit opt-in governed by `fleetEnabled`.
+   *
+   * The twin boots with a cold baseline and returns `NOT_READY` until it
+   * has observed at least 100 events. During that warm-up the coordinator
+   * records the unavailable signal and does not raise severity, matching
+   * the record-and-ignore policy documented on `BehavioralRiskRecord`.
+   */
+  runtimeTwin?: {
+    /** Default: true when intelligence is enabled. */
+    enabled?: boolean;
+    /** Default: false. Opt-in fleet federated learning participation. */
+    fleetEnabled?: boolean;
+    /** Default: 'general'. Agent category for fleet aggregation bucketing. */
+    agentCategory?: string;
+  };
+
+  /**
+   * Guard anomaly (classification distribution drift) detector
+   * configuration. When `baseline` is provided, `AgentRuntimeProtection`
+   * constructs a `GuardAnomalyDetector` and passes it to the
+   * `IntelligenceCoordinator` so every classified event contributes to
+   * the drift window. Without a baseline the detector is not instantiated
+   * and drift detection is inert.
+   *
+   * The baseline is intentionally injected rather than auto-bootstrapped
+   * to prevent a compromised learning period from baking an attack into
+   * the reference distribution. Callers should source the baseline from
+   * the Registry-exported Guard training distribution in production
+   * deployments, or from a snapshotted JSON file in pre-Registry
+   * deployments.
+   *
+   * See `src/arp/intelligence/guard-anomaly.ts` for the chi-square drift
+   * model, bounded-memory contract, and parameter semantics.
+   */
+  guardAnomaly?: {
+    /** Default: true when a baseline is provided. */
+    enabled?: boolean;
+    /** Required. Keys are classification labels, values are counts or probabilities. */
+    baseline?: Record<string, number>;
+    /** Sliding window capacity. Default: 200. */
+    windowSize?: number;
+    /** Chi-square statistic threshold that triggers a drift alarm. Default: ~21.666. */
+    alarmThreshold?: number;
+    /** Laplace smoothing alpha. Default: 0.01. */
+    smoothing?: number;
+    /** Minimum observations before drift scoring activates. Default: max(30, windowSize / 4). */
+    minObservations?: number;
+    /** Audit source tag. Default: 'guard-anomaly'. */
+    sourceName?: string;
+  };
 }
 
 export type LLMAdapterType =


### PR DESCRIPTION
## Summary

Sessions 28 and 29 built the BehavioralRiskSource IPC channel and the GuardAnomalyDetector drift layer but neither was instantiated in production. The only construction site for IntelligenceCoordinator passed no sources, so the coordinator's fusion paths ran against null and every deployed ARP had dormant machinery.

This PR wires both sources by default through new `intelligence.runtimeTwin` and `intelligence.guardAnomaly` config sections on ARPConfig.

### Runtime twin (RuntimeTwin)

- Default ON when intelligence is enabled. Opt out via `intelligence.runtimeTwin.enabled = false` or the global `intelligence.enabled = false` kill switch.
- `AgentRuntimeProtection` constructs a `NanoMindL1` seeded with `config.agentName`, wraps it in `InProcessBehavioralRiskSource` tagged `runtime-twin-inproc`, and passes it to `IntelligenceCoordinator`.
- `start()` attaches the twin to the event engine so a user who instantiates ARP but never calls `start()` does not get surprise event handlers.
- Fleet federated learning is a separate, explicit opt-in via `intelligence.runtimeTwin.fleetEnabled`. Default off. Implementation does not exist yet; the config knob is forward-compatible.

### Guard anomaly (classification drift)

- Constructed only when `intelligence.guardAnomaly.baseline` is present AND `intelligence.guardAnomaly.enabled !== false`.
- Without a baseline the detector is not instantiated. Drift relative to nothing is nonsense and we refuse to auto-bootstrap.
- Config passes through windowSize, alarmThreshold, smoothing, minObservations, sourceName.

### Backward compatibility

Both config sections are additive. Existing configs get the default behavior: runtime twin ON, guard anomaly OFF.

## Test plan

- [x] `npm run build` clean
- [x] Full suite: 1543 passed / 16 skipped / 10 todo across 121 files (+10 tests, +1 file over the previous 1533 passed)
- [x] Wiring integration tests: 10 new tests covering default-on, opt-out, global kill switch, baseline injection, empty baseline refused, enabled-false with baseline, start() attach + idempotency, legacy behavior preserved
- [x] Pre-push review 8-phase gate PASS
- [x] HMA scan: zero new CRITICAL/HIGH (32 C / 112 H / 53 M vs session 29 baseline 32 C / 114 H / 53 M)