### PR TITLE
Rename L1 behavioral twin to RuntimeTwin for @nanomind/runtime-core split

### DIFF
--- a/__tests__/arp/intelligence/behavioral-risk.test.ts
+++ b/__tests__/arp/intelligence/behavioral-risk.test.ts
@@ -15,7 +15,7 @@ import {
 } from '../../../src/arp/intelligence/behavioral-risk';
 import { startBehavioralRiskServer } from '../../../src/arp/intelligence/behavioral-risk-server';
 import type { ARPEvent } from '../../../src/arp/types';
-import { NanoMindL1 } from '../../../src/arp/intelligence/nanomind-l1';
+import { RuntimeTwin } from '../../../src/arp/intelligence/runtime-twin';
 
 /**
  * Coverage for the behavioral risk IPC surface.
@@ -323,15 +323,15 @@ describe('UnixSocketBehavioralRiskSource circuit breaker', () => {
   });
 });
 
-describe('NanoMindL1.scoreARPEvent readonly seam', () => {
+describe('RuntimeTwin.scoreARPEvent readonly seam', () => {
   it('returns null when the baseline is not yet trained', () => {
-    const twin = new NanoMindL1('test-agent-seam-1');
+    const twin = new RuntimeTwin('test-agent-seam-1');
     const result = twin.scoreARPEvent(makeEvent());
     expect(result).toBeNull();
   });
 
   it('returns a score when a baseline is installed via the test seam', () => {
-    const twin = new NanoMindL1('test-agent-seam-2');
+    const twin = new RuntimeTwin('test-agent-seam-2');
     twin._setBaselineForTest({
       eventTypeCounts: { TOOL_CALL: 200 },
       avgTimingDelta: 100,
@@ -353,7 +353,7 @@ describe('NanoMindL1.scoreARPEvent readonly seam', () => {
   });
 
   it('does not advance sequenceNum or lastEventTime when scoring', () => {
-    const twin = new NanoMindL1('test-agent-seam-3');
+    const twin = new RuntimeTwin('test-agent-seam-3');
     twin._setBaselineForTest({
       eventTypeCounts: { TOOL_CALL: 200 },
       avgTimingDelta: 0,

--- a/src/arp/index.ts
+++ b/src/arp/index.ts
@@ -32,7 +32,7 @@ export { CorrelationEngine } from './engine/correlation';
 export { IntelligenceCoordinator } from './intelligence/coordinator';
 export { BudgetController } from './intelligence/budget';
 export { AnomalyDetector } from './intelligence/anomaly';
-export { NanoMindL1 } from './intelligence/nanomind-l1';
+export { RuntimeTwin } from './intelligence/runtime-twin';
 export { AnthropicAdapter, OpenAIAdapter, OllamaAdapter, createAdapter, autoDetectAdapter } from './intelligence/adapters';
 export { ProcessMonitor } from './monitors/process';
 export { NetworkMonitor } from './monitors/network';
@@ -78,7 +78,7 @@ import * as path from 'path';
 import type { ARPConfig, ARPEvent, Monitor } from './types';
 import { EventEngine } from './engine/event-engine';
 import { IntelligenceCoordinator } from './intelligence/coordinator';
-import { NanoMindL1 } from './intelligence/nanomind-l1';
+import { RuntimeTwin } from './intelligence/runtime-twin';
 import {
   InProcessBehavioralRiskSource,
   type BehavioralRiskSource,
@@ -131,7 +131,7 @@ export class AgentRuntimeProtection {
    * start() so every event trains the twin's baseline. Null when the
    * runtime twin is disabled in config.
    */
-  private readonly runtimeTwin: NanoMindL1 | null;
+  private readonly runtimeTwin: RuntimeTwin | null;
   /**
    * Transport-agnostic view of the runtime twin passed to the
    * coordinator. Null when the twin is disabled.
@@ -355,16 +355,16 @@ export class AgentRuntimeProtection {
   }
 
   /** The runtime twin instance, or null when disabled. */
-  getRuntimeTwin(): NanoMindL1 | null {
+  getRuntimeTwin(): RuntimeTwin | null {
     return this.runtimeTwin;
   }
 }
 
 /**
- * Construct an in-process `NanoMindL1` runtime twin from the ARP config,
- * or return null when the caller disabled intelligence or the runtime
- * twin explicitly. Kept as a free function so the constructor stays
- * short and the default policy is visible in one place.
+ * Construct an in-process `RuntimeTwin` from the ARP config, or return
+ * null when the caller disabled intelligence or the runtime twin
+ * explicitly. Kept as a free function so the constructor stays short
+ * and the default policy is visible in one place.
  *
  * Default policy:
  *   - When `intelligence.enabled === false`: no twin (L2 disabled implies
@@ -373,12 +373,12 @@ export class AgentRuntimeProtection {
  *   - Otherwise: construct a twin seeded from `config.agentName`, with
  *     fleet federation opt-in from the config (default off).
  */
-function buildRuntimeTwin(config: ARPConfig): NanoMindL1 | null {
+function buildRuntimeTwin(config: ARPConfig): RuntimeTwin | null {
   const ic = config.intelligence;
   if (ic?.enabled === false) return null;
   const twinCfg = ic?.runtimeTwin;
   if (twinCfg?.enabled === false) return null;
-  return new NanoMindL1(config.agentName, {
+  return new RuntimeTwin(config.agentName, {
     enabled: true,
     fleetEnabled: twinCfg?.fleetEnabled ?? false,
     agentCategory: twinCfg?.agentCategory ?? 'general',

--- a/src/arp/intelligence/behavioral-risk-server.ts
+++ b/src/arp/intelligence/behavioral-risk-server.ts
@@ -4,7 +4,7 @@
  * Partner to `behavioral-risk.ts`. Listens on a unix domain socket (or
  * Windows named pipe) and answers risk signal requests by delegating to a
  * caller-supplied `BehavioralRiskScoreable`, which in production is a
- * `NanoMindL1` instance running in the twin's own process.
+ * `RuntimeTwin` instance running in the twin's own process.
  *
  * The server is deliberately narrow: one request per connection, no
  * session state, no authentication beyond filesystem permissions on the
@@ -44,7 +44,7 @@ import {
 export interface BehavioralRiskServerOptions {
   /**
    * Handle that knows how to score an ARP event. In production this is a
-   * NanoMindL1 instance. In tests it can be any stub that returns a
+   * RuntimeTwin instance. In tests it can be any stub that returns a
    * deterministic risk score.
    */
   twin: BehavioralRiskScoreable;

--- a/src/arp/intelligence/behavioral-risk.ts
+++ b/src/arp/intelligence/behavioral-risk.ts
@@ -2,9 +2,9 @@
  * Behavioral risk signal channel (AIComply P1, coordinator hot path).
  *
  * The `IntelligenceCoordinator` needs a way to ask the behavioral twin
- * (`NanoMindL1` in `nanomind-l1.ts`) "how anomalous does this event look
- * against the agent's behavioral baseline?" without importing the twin
- * directly into the comply path. Direct coupling would re-introduce the
+ * (`RuntimeTwin` in `runtime-twin.ts`) "how anomalous does this event
+ * look against the agent's behavioral baseline?" without importing the
+ * twin directly into the comply path. Direct coupling would re-introduce the
  * layering break that the L0-comply gate was added to prevent: the twin
  * would sit inline with the crypto verifier, and a bug in the twin would
  * cascade into every classified event.
@@ -16,8 +16,8 @@
  *   - `InProcessBehavioralRiskSource` wraps any object that exposes
  *     `scoreARPEvent(event)`. This is the single-process fast path: no
  *     serialization, no socket, just a direct call guarded by a try/catch.
- *     `NanoMindL1` satisfies the interface via its readonly scoreARPEvent
- *     method, but tests can inject any stub.
+ *     `RuntimeTwin` satisfies the interface via its readonly
+ *     scoreARPEvent method, but tests can inject any stub.
  *
  *   - `UnixSocketBehavioralRiskSource` speaks newline-delimited JSON over
  *     a unix domain socket (or a Windows named pipe via node `net`). This
@@ -56,10 +56,10 @@ import * as path from 'path';
 import type { ARPEvent } from '../types';
 
 /**
- * Shape returned by the twin's on-demand scorer. Mirrors NanoMindL1's
+ * Shape returned by the twin's on-demand scorer. Mirrors RuntimeTwin's
  * internal AnomalyResult so this module does not need to import the twin
  * directly, and so test stubs can produce it without depending on the
- * full NanoMindL1 class surface.
+ * full RuntimeTwin class surface.
  */
 export interface BehavioralRiskScore {
   /** Normalized anomaly score in [0, 1]. Higher is riskier. */
@@ -72,7 +72,7 @@ export interface BehavioralRiskScore {
 
 /**
  * Minimum interface an in-process twin handle must satisfy to be plugged
- * into `InProcessBehavioralRiskSource`. NanoMindL1.scoreARPEvent matches
+ * into `InProcessBehavioralRiskSource`. RuntimeTwin.scoreARPEvent matches
  * this shape by construction.
  */
 export interface BehavioralRiskScoreable {
@@ -182,7 +182,7 @@ export function defaultBehavioralRiskSocketPath(agentId: string): string {
  * misbehaving twin that throws.
  *
  * Decoupling rationale: the coordinator holds this as a
- * `BehavioralRiskSource`, not as a `NanoMindL1`. The comply path has no
+ * `BehavioralRiskSource`, not as a `RuntimeTwin`. The comply path has no
  * knowledge of twin internals and a bug in the twin surfaces as an
  * `unavailable` result, not a cascade failure.
  */

--- a/src/arp/intelligence/coordinator.ts
+++ b/src/arp/intelligence/coordinator.ts
@@ -632,8 +632,8 @@ function raiseSeverity(
 /**
  * Bands the behavioral risk score is sorted into, matched to severity
  * floors raised on the event when the band fires. The score ranges come
- * from NanoMindL1's response table; they are deliberately mirrored here
- * rather than imported, so the coordinator's policy can drift
+ * from RuntimeTwin's response table; they are deliberately mirrored
+ * here rather than imported, so the coordinator's policy can drift
  * independently of the twin's internal action labels if needed.
  *
  *   >= 0.8 : critical   -> event.category >= threat, severity >= critical

--- a/src/arp/intelligence/runtime-twin.test.ts
+++ b/src/arp/intelligence/runtime-twin.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { NanoMindL1 } from './nanomind-l1';
+import { RuntimeTwin } from './runtime-twin';
 import { EventEngine } from '../engine/event-engine';
 import type { ARPEvent, ARPConfig } from '../types';
 
@@ -24,17 +24,17 @@ function emitTestEvent(engine: EventEngine, overrides: Partial<ARPEvent> = {}): 
   });
 }
 
-describe('NanoMindL1 E2E Integration', () => {
+describe('RuntimeTwin E2E Integration', () => {
   it('attaches to EventEngine without errors', () => {
     const engine = new EventEngine(testConfig);
-    const l1 = new NanoMindL1('test-agent');
+    const l1 = new RuntimeTwin('test-agent');
     l1.attach(engine);
     expect(true).toBe(true);
   });
 
   it('processes events through L1 pipeline', async () => {
     const engine = new EventEngine(testConfig);
-    const l1 = new NanoMindL1('pipeline-test');
+    const l1 = new RuntimeTwin('pipeline-test');
     l1.attach(engine);
 
     // Emit 10 events
@@ -49,7 +49,7 @@ describe('NanoMindL1 E2E Integration', () => {
 
   it('builds baseline from normal events', async () => {
     const engine = new EventEngine(testConfig);
-    const l1 = new NanoMindL1('baseline-test');
+    const l1 = new RuntimeTwin('baseline-test');
     l1.attach(engine);
 
     // Feed 150 normal events to build baseline
@@ -66,7 +66,7 @@ describe('NanoMindL1 E2E Integration', () => {
 
   it('detects anomalous events after baseline', async () => {
     const engine = new EventEngine(testConfig);
-    const l1 = new NanoMindL1('anomaly-test');
+    const l1 = new RuntimeTwin('anomaly-test');
     l1.attach(engine);
 
     // Build baseline with normal events
@@ -93,7 +93,7 @@ describe('NanoMindL1 E2E Integration', () => {
 
   it('respects enabled=false', () => {
     const engine = new EventEngine(testConfig);
-    const l1 = new NanoMindL1('disabled-test', { enabled: false });
+    const l1 = new RuntimeTwin('disabled-test', { enabled: false });
     l1.attach(engine);
     // Should not crash and should not process events
     expect(true).toBe(true);
@@ -101,7 +101,7 @@ describe('NanoMindL1 E2E Integration', () => {
 
   it('L1 does not block L0 event processing', async () => {
     const engine = new EventEngine(testConfig);
-    const l1 = new NanoMindL1('nonblocking-test');
+    const l1 = new RuntimeTwin('nonblocking-test');
     l1.attach(engine);
 
     // Time L0 event emission

--- a/src/arp/intelligence/runtime-twin.ts
+++ b/src/arp/intelligence/runtime-twin.ts
@@ -1,15 +1,32 @@
 /**
- * NanoMind L1 — Behavioral Anomaly Detection Layer
+ * RuntimeTwin - Behavioral Anomaly Detection Layer (L1).
  *
- * Integrates NanoMind-Runtime into ARP's event pipeline.
- * Processes every L0 event through the behavioral twin for anomaly scoring.
+ * Integrates the RuntimeTwin behavioral scorer into ARP's event pipeline.
+ * Processes every L0 event through the twin for anomaly scoring.
  *
  * Three-tier ARP model:
- *   L0: Rule-based (EventEngine) — microseconds, always runs
- *   L1: NanoMind-Runtime behavioral twin — milliseconds, this module
- *   L2: Claude/LLM intelligence — seconds, existing IntelligenceCoordinator
+ *   L0: Rule-based (EventEngine)           microseconds, always runs
+ *   L1: RuntimeTwin behavioral twin        milliseconds, this module
+ *   L2: Claude or local LLM intelligence   seconds, IntelligenceCoordinator
  *
- * L1 runs in parallel with L0 — never blocks the L0 decision.
+ * L1 runs in parallel with L0. It never blocks the L0 decision.
+ *
+ * === SOURCE-OF-TRUTH NOTE ===
+ *
+ * The canonical implementation of this class lives at:
+ *     opena2a-org/nanomind/packages/nanomind-runtime-core/src/index.ts
+ *
+ * This file is a temporary integration-layer mirror maintained in lockstep
+ * with the canonical source until PR 1b publishes @nanomind/runtime-core
+ * to npm. Until that cut-over, any change to the LSTM scoring logic,
+ * gradient accumulation, or differential privacy path MUST be made in
+ * both files. See todo/NANOMIND_V3_AUDIT.md Section 8 PR 1 and Section 9
+ * item 1 for the rationale.
+ *
+ * This mirror retains the hackmyagent-local imports of ARPEvent and
+ * ARPConfig so ARP integration stays type-safe. The canonical package
+ * defines a structural ARPEventInput equivalent to keep itself free of
+ * cross-repo dependencies.
  */
 
 import * as crypto from 'crypto';
@@ -19,7 +36,7 @@ import * as os from 'os';
 import type { ARPEvent, ARPConfig, EnforcementAction } from '../types';
 import type { EventEngine } from '../engine/event-engine';
 
-// === Types (mirroring @nanomind/runtime) ===
+// === Types (mirroring @nanomind/runtime-core) ===
 
 type EventType =
   | 'TOOL_CALL'
@@ -81,7 +98,7 @@ const EVENT_TYPE_INDEX: Record<string, number> = {
   MEMORY_READ: 3, MEMORY_WRITE: 4, EXTERNAL_CALL: 5,
 };
 
-export class NanoMindL1 {
+export class RuntimeTwin {
   private agentId: string;
   private sessionId: string;
   private baseline: BaselineStats | null = null;
@@ -276,7 +293,7 @@ export class NanoMindL1 {
   }
 
   /**
-   * Compute anomaly score (same algorithm as @nanomind/runtime).
+   * Compute anomaly score (same algorithm as @nanomind/runtime-core).
    */
   private computeAnomalyScore(event: BehavioralEvent): number {
     if (!this.baseline || this.baseline.totalEvents < 100) {
@@ -473,8 +490,9 @@ export class NanoMindL1 {
 
   /**
    * Apply differential privacy: clip to L2 norm 1.0, add Gaussian noise.
-   * Matches the privacy guarantees in @nanomind/runtime/fleet.ts
-   * (epsilon=1.0, delta=1e-5).
+   * Matches the privacy guarantees inlined in @nanomind/runtime-core
+   * (epsilon=1.0, delta=1e-5). The statistical twin's @nanomind/runtime
+   * package was retired in the Q5 split (audit Section 9 item 1).
    */
   private addPrivacyNoise(gradient: number[]): number[] {
     // Clip to max L2 norm = 1.0

--- a/src/arp/types.ts
+++ b/src/arp/types.ts
@@ -158,9 +158,10 @@ export interface IntelligenceConfig {
   behavioralRiskTimeoutMs?: number;
 
   /**
-   * Runtime twin (NanoMindL1 behavioral twin) configuration. When enabled,
-   * `AgentRuntimeProtection` constructs an in-process `NanoMindL1`, wraps
-   * it in `InProcessBehavioralRiskSource`, and passes it to the
+   * Runtime twin (RuntimeTwin behavioral scorer) configuration. When
+   * enabled, `AgentRuntimeProtection` constructs an in-process
+   * `RuntimeTwin`, wraps it in `InProcessBehavioralRiskSource`, and
+   * passes it to the
    * `IntelligenceCoordinator` so behavioral risk signals are fused into
    * every analyzed event.
    *


### PR DESCRIPTION
## Summary

- Renames `NanoMindL1` to `RuntimeTwin` across all ARP intelligence modules
- Renames `nanomind-l1.ts` / `nanomind-l1.test.ts` to `runtime-twin.ts` / `runtime-twin.test.ts`
- Updates all imports, type references, and doc comments in behavioral-risk, coordinator, and proxy modules

Zero behavior change. All 1569 tests pass.

## Context

- **Audit Section 9 item 1, path (a):** Abdel approved retiring the statistical twin and relocating the LSTM to `@nanomind/runtime-core` (2026-04-11). This PR is the hackmyagent side of that split.
- **Temporary mirror:** `src/arp/intelligence/runtime-twin.ts` temporarily mirrors `@nanomind/runtime-core/src/index.ts`. Changes to scoring logic must be mirrored until publication cut-over (PR 1b).
- **FL Design Section 3:** v1 wire format preserved. v2 signed format is a separate follow-up once Phase 1 preconditions are met.

## Companion PR

- nanomind: opena2a-org/nanomind#6

## Test plan

- [x] Build clean (`tsc`)
- [x] 1569/1569 tests pass (`vitest run`)
- [x] Pre-push review 8-phase gate passed
- [x] Rebased on main (includes 0.16.7 and --rescan flag from #89)
- [ ] After both PRs merge: verify ARP default-attach smoke test end-to-end