### PR TITLE
feat: ATC auth support for Registry client

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -3018,7 +3018,8 @@ Examples:
               console.error('Error: --registry-key or REGISTRY_API_KEY env is required when using --version-id');
               process.exit(1);
             }
-            const client = new core.RegistryClient({ registryUrl, apiKey: registryKey });
+            const atcToken = process.env.ATC_TOKEN;
+            const client = new core.RegistryClient({ registryUrl, apiKey: registryKey, atcToken });
             const payload = core.buildScanReport(options.versionId, result.findings);
             await client.reportScanResult(payload);
             console.log(`Registry: scan results reported for version ${options.versionId}`);
@@ -3883,7 +3884,8 @@ Examples:
               console.error('Error: --registry-key or REGISTRY_API_KEY env is required when using --version-id');
               process.exit(1);
             }
-            const client = new core.RegistryClient({ registryUrl, apiKey: registryKey });
+            const atcToken = process.env.ATC_TOKEN;
+            const client = new core.RegistryClient({ registryUrl, apiKey: registryKey, atcToken });
             const payload = core.buildAttackReport(options.versionId, report);
             await client.reportScanResult(payload);
             console.log(`Registry: attack results reported for version ${options.versionId}`);

--- a/src/registry/client.ts
+++ b/src/registry/client.ts
@@ -128,6 +128,7 @@ export interface UnifiedFinding {
 export interface RegistryConfig {
   registryUrl: string;
   apiKey: string;
+  atcToken?: string; // CBOR ATC token (base64url). If set, prefer ATC auth over Bearer.
 }
 
 export interface RegistryPackage {
@@ -145,6 +146,16 @@ export class RegistryClient {
   }
 
   /**
+   * Returns the Authorization header value: ATC token if available, otherwise Bearer.
+   */
+  private getAuthHeader(): string {
+    if (this.config.atcToken) {
+      return `ATC ${this.config.atcToken}`;
+    }
+    return `Bearer ${this.config.apiKey}`;
+  }
+
+  /**
    * Post scan results to registry callback endpoint.
    */
   async reportScanResult(payload: ScanReportPayload): Promise<void> {
@@ -154,7 +165,7 @@ export class RegistryClient {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
-        'Authorization': `Bearer ${this.config.apiKey}`,
+        'Authorization': this.getAuthHeader(),
         'User-Agent': 'HackMyAgent-CLI',
       },
       body: JSON.stringify(payload),


### PR DESCRIPTION
## Summary
- Add `atcToken` to `RegistryConfig` with `getAuthHeader()` preferring ATC over Bearer
- Read `ATC_TOKEN` env var in CLI for authenticated scan reporting
- Replace deprecated `--rescan` reference with `--deep` in help output

Part of AIM Secrets Phase 7 — enables HMA to authenticate to Registry using ATCs instead of stored credentials.

## Design
- When `ATC_TOKEN` env var is set, no Bearer credential needs to be stored in `secret_credentials`
- Backwards-compatible: falls back to existing Bearer auth when no ATC token present

## Test plan
- [x] Build passes
- [x] All 1569 tests pass
- [ ] CI passes