### PR TITLE
Fix kill enforcement on SIGSTOPped processes

### DIFF
--- a/src/arp/enforcement/kill-switch.test.ts
+++ b/src/arp/enforcement/kill-switch.test.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { spawn, type ChildProcess } from 'child_process';
+import { EnforcementEngine } from './kill-switch';
+import type { ARPEvent } from '../types';
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function isAlive(pid: number): boolean {
+  try { process.kill(pid, 0); return true; } catch { return false; }
+}
+
+function mockEvent(pid: number): ARPEvent {
+  return {
+    id: 'test',
+    timestamp: new Date().toISOString(),
+    source: 'process',
+    category: 'threat',
+    severity: 'critical',
+    description: 'test',
+    data: { pid },
+    classifiedBy: 'L0-rules',
+  };
+}
+
+describe('EnforcementEngine.kill — paused process regression', () => {
+  let engine: EnforcementEngine;
+  let child: ChildProcess | null = null;
+
+  beforeEach(() => { engine = new EnforcementEngine(); });
+
+  afterEach(() => {
+    if (child?.pid) {
+      try { process.kill(child.pid, 'SIGKILL'); } catch { /* dead */ }
+      child = null;
+    }
+  });
+
+  it('kill terminates a paused (SIGSTOPped) process by resuming it first', async () => {
+    child = spawn('node', ['-e', 'setTimeout(()=>{},30000)'], { stdio: 'ignore' });
+    const pid = child.pid!;
+
+    await engine.execute('pause', mockEvent(pid), pid);
+    expect(engine.getPausedPids()).toContain(pid);
+    expect(isAlive(pid)).toBe(true);
+
+    const result = await engine.execute('kill', mockEvent(pid), pid);
+    expect(result.success).toBe(true);
+    expect(engine.getPausedPids()).not.toContain(pid);
+
+    await sleep(1000);
+    expect(isAlive(pid)).toBe(false);
+  }, 10000);
+});

--- a/src/arp/enforcement/kill-switch.ts
+++ b/src/arp/enforcement/kill-switch.ts
@@ -96,6 +96,12 @@ export class EnforcementEngine {
     }
 
     try {
+      // A SIGSTOPped process can't process SIGTERM — the signal stays queued
+      // until SIGCONT wakes it. Resume paused targets first so graceful kill works.
+      if (this.paused.has(pid)) {
+        try { process.kill(pid, 'SIGCONT'); } catch { /* already gone */ }
+      }
+
       // Graceful first
       process.kill(pid, 'SIGTERM');
 


### PR DESCRIPTION
## Summary
- **Root cause:** \`EnforcementEngine.kill()\` sends \`SIGTERM\` directly; a process previously paused via \`SIGSTOP\` stays frozen and never receives the signal, so the graceful-kill path never fires — only the 5s \`SIGKILL\` fallback terminates it.
- **Fix:** Send \`SIGCONT\` first when the target pid is in the paused set, so \`SIGTERM\` can actually be delivered and handled.
- Adds a focused \`EnforcementEngine\` regression test (pause → kill → process dead within 1s).

Unblocks the pre-existing OASB CI failure \`AT-ENF-004: should remove a killed PID from paused list if it was paused\` (red on every oasb CI run since 2026-02-26).

## Test plan
- [x] New unit test \`src/arp/enforcement/kill-switch.test.ts\` passes (1/1)
- [x] OASB mirror \`__tests__/oasb/atomic/enforcement/AT-ENF-004.kill-sigterm.test.ts\` passes (4/4)
- [x] Full enforcement suite passes (7 files, 39 tests)