### PR TITLE
chore(deps): bump vite 7.3.2 + hono 4.12.12 to patch 9 advisories

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -485,9 +485,9 @@
       }
     },
     "node_modules/@hono/node-server": {
-      "version": "1.19.11",
-      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.11.tgz",
-      "integrity": "sha512-dr8/3zEaB+p0D2n/IUrlPF1HZm586qgJNXK1a9fhg/PzdtkK7Ksd5l312tJX2yBuALqDYBlG20QEbayqPyxn+g==",
+      "version": "1.19.14",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.14.tgz",
+      "integrity": "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==",
       "license": "MIT",
       "engines": {
         "node": ">=18.14.1"
@@ -1946,9 +1946,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.12.7",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.7.tgz",
-      "integrity": "sha512-jq9l1DM0zVIvsm3lv9Nw9nlJnMNPOcAtsbsgiUhWcFzPE99Gvo6yRTlszSLLYacMeQ6quHD6hMfId8crVHvexw==",
+      "version": "4.12.12",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.12.tgz",
+      "integrity": "sha512-p1JfQMKaceuCbpJKAPKVqyqviZdS0eUxH9v82oWo1kb9xjQ5wA6iP3FNVAPDFlz5/p7d45lO+BpSk1tuSZMF4Q==",
       "license": "MIT",
       "engines": {
         "node": ">=16.9.0"
@@ -2890,9 +2890,9 @@
       }
     },
     "node_modules/vite": {
-      "version": "7.3.1",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.1.tgz",
-      "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
+      "version": "7.3.2",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.2.tgz",
+      "integrity": "sha512-Bby3NOsna2jsjfLVOHKes8sGwgl4TT0E6vvpYgnAYDIF/tie7MRaFthmKuHx1NSXjiTueXH3do80FMQgvEktRg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {


### PR DESCRIPTION
## Summary

Resolves all 9 open Dependabot alerts on this repo by bumping transitive dev/runtime dependencies in `package-lock.json`. No direct-dep changes, no major version bumps, no code changes required.

## Alerts fixed

| Pkg | Before | After | Advisories |
|---|---|---|---|
| vite | 7.3.1 | 7.3.2 | GHSA-4w7w-66w2-5vf9 (high), GHSA-p9ff-h696-f583 (high), GHSA-v2wj-q39q-566r (moderate) |
| hono | 4.12.7 | 4.12.12 | GHSA-26pp-8wgv-hjvm, GHSA-r5rp-j6wh-rvv4, GHSA-xpcf-pg52-r92g, GHSA-xf4j-xp2r-rqqx, GHSA-wmmm-f939-6g9c (all moderate) |
| @hono/node-server | 1.19.11 | 1.19.14 | GHSA-92pp-h63x-v22m (moderate) |

Closes #17 #18 #19 #20 #21 #22 #23 #24 #25.

## How they get pulled in

- `vite` is a transitive of `vitest` (devDep)
- `hono` and `@hono/node-server` are transitives of `@modelcontextprotocol/sdk` (runtime dep)

None of the vulnerable call paths (vite dev server, hono routing/cookies/serveStatic) are exercised by HMA at runtime — the hono chain is inside MCP SDK, and vite only runs during local `npm test`. Bumping is still the right call: `npm audit` should stay clean for anyone who clones the repo and installs.

## Test plan

- [x] `npm audit` reports 0 vulnerabilities
- [x] `npm run build` succeeds
- [x] `npm test` — 1570 tests pass, 16 skipped, 10 todo
- [x] `npm ls vite hono @hono/node-server` confirms patched versions