### PR TITLE
0.17.10: NanoMind opt-in + analyzer dedup + dynamic counts + docs sync

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,41 @@
 
 All notable changes to HackMyAgent are documented in this file.
 
+## [0.17.10] - 2026-04-17
+
+### Added
+- **`hackmyagent detect` — Shadow AI audit command.** New top-level command that scans the local machine and current project for AI tools, MCP server configurations, AI config files, and SOUL.md governance files. Reports a governance score and actionable findings designed for CISOs and security engineers who need an inventory of what's actually running. Supports `--json`, `--verbose`, and `--export-csv` for CMDB integration.
+- **`--nanomind` opt-in flag for generative analysis.** The NanoMind generative layer (Tier 2) is now opt-in instead of always-on. Users who want AI-powered threat narratives on findings invoke `secure --nanomind` or `check --nanomind`; default `secure`/`check` runs the static analyzer suite only. Adds 15-30s per finding when enabled, surfaced via a one-line latency disclosure. Static AST analyzers (Tier 0/1) run regardless.
+- **`hackmyagent nanomind` subcommand.** Renamed from `analm`. `nanomind setup` downloads the generative model; `nanomind status` reports model + runtime state.
+- **Smart registry ping with health preflight.** `secure --publish` and equivalent flows now run a one-line health check against the registry before attempting a publish, and emit a `scan_ping` heartbeat for observability. Fails fast on unreachable / degraded registry instead of timing out the whole publish.
+- **Opportunistic retry backoff for failed contributions.** Anonymous scan summaries that fail to upload are retried in the background with exponential backoff. No new user-visible UI; previously failures were silently dropped.
+- **Unified contribution config.** All scan types (`secure`, `check`, `scan-soul`, `detect`) now share `~/.opena2a/config.json`. Set `--no-contribute` once and it applies everywhere.
+
+### Changed
+- **Unified output formatter across `secure` / `scan-soul` / `harden-soul` / `explain` / `detect`.** All repo-style commands now route through the `secure` formatter: same badges, same severity grouping, same Verify/Fix per finding. `check` (package-style) keeps its registry-oriented format. Eliminates the cross-command UX divergence that made the tool look like four separate scanners stitched together.
+- **CISO-grade UX rework.** Every finding now ships with a one-line `Verify:` command and a one-line `Fix:` command. Credential findings no longer shame the user for env-var usage; capability-abuse findings replace wall-of-names listings with a single runnable `harden-soul` command. The dim/highlight conventions were standardized so the eye can scan a 200-finding report without losing its place.
+- **NanoMind generative findings are capped at HIGH when confidence < 0.80.** Previously low-confidence generative findings rendered as CRITICAL with a hardcoded 60% confidence stamp. Now CRITICAL only emits when the model is genuinely confident; below threshold the severity is capped and the finding shows a qualitative confidence label instead of a measurement.
+- **NanoMind `max_tokens` raised 512 → 2048.** Generative descriptions previously truncated mid-word (300-char ceiling) because the inference budget was too tight. Now full descriptions render reliably.
+- **`--analm` flag and `analm` subcommand renamed to `--nanomind`.** The internal model is NanoMind; the legacy `analm` name was a research-era artifact. Both old names are aliased for one release; the alias will be removed in 0.18.
+- **Check + category counts derived dynamically from the taxonomy map.** Previously hardcoded as `CHECK_COUNT = 209` and `60 categories` in CLI help text — both drifted (categories were actually 44, not 60). Now both numbers are computed at module load from the same source of truth `check-metadata` reads, so help text, command descriptions, and metadata JSON cannot disagree.
+- **`--ignore` re-applied after the NanoMind merge step.** Previously the `--ignore` filter ran before NanoMind merged its findings in, so ignored check IDs reappeared if NanoMind also surfaced them. `--fail-below` is now wired to standard scan mode in addition to `--ci`.
+- **`AnaLM` → `NanoMind` rendering in `check` output.** `check` no longer shows a separate AnaLM analyst block; the generative output is integrated into the standard finding format when `--nanomind` is enabled.
+
+### Fixed
+- **Self-scan score: 100/100.** All CRITICAL and HIGH findings on the HMA codebase itself are resolved, and the `secure` self-scan returns clean.
+- **TOCTOU-001 stops flagging legitimate `existsSync → readFileSync` config-load patterns.** Previously fired on any access-check followed by a read; now requires a write or exec between the check and the read. Adds `import(varPath)` to the exec sinks so dynamic-import abuse is still caught. Eliminated 11 FPs across `secretless`. The `import(varPath)` exec sink was added after an adversarial review surfaced that the first fix accidentally created a dynamic-import bypass.
+- **Analyzer pileup on bug-bounty target descriptors collapsed.** Files named `salesforce-mcp.json` (etc.) — bug-bounty target metadata, not MCP server configs — were misclassified as `mcp_config` and routed through every agent analyzer, producing 6 overlapping findings on a single descriptor. Fixed two ways: (1) MCP classifier now matches a known-basename allowlist (`mcp.json`, `.mcp.json`, `mcpServers.json`) plus a content-fallback that requires an actual `"mcpServers":` key with BOM/whitespace tolerance; (2) capability-analyzer no longer emits `AST-GOVERN-002` — `AST-GOV-003` in governance-analyzer is the canonical zero-constraints emitter.
+- **Three detection-narrowing gaps closed (adversarial review).** Surfaced by an adversarial subagent: the previous fix-pass had narrowed three patterns just enough to miss a real attack vector. Fixes restored detection without reintroducing the FPs.
+- **NEMO-009 false positive on `model.eval()`, `tensor.eval()`, etc.** PyTorch's `.eval()` method is not Python's `eval()` builtin. Pattern now requires the bare `eval(` form, not method dispatch.
+- **Path-context exemptions for corpus/, test/, example/ paths.** Findings inside known fixture/corpus directories no longer escalate to CRITICAL. Test fixtures are intentionally vulnerable.
+- **Frontend-project signal includes Angular and Vue CLI configs.** Previously only React/Next/Vite were recognized.
+- **3 FPs suppressed + TOCTOU/env-exfil hardened + AST-SCOPE dispatch corrected.**
+- **webcred handles `./dist/` leading segment in package.json browser field.**
+- **Project constraints propagate from sibling SOUL.md to capability-analyzer.** Fix routing for ungoverned-capability findings now references the project's actual SOUL.md when one exists, instead of suggesting the user add governance that already exists elsewhere in the repo.
+- **Governance SOUL FPs eliminated.** Multiple paths where governance findings fired against well-governed agents have been suppressed.
+- **`GIT-001` skipped for npm package scans.** A missing `.gitignore` is meaningful in a project repo, irrelevant in a published npm tarball.
+- **SOUL/MCP oracle label accuracy.** Oracle eval labels for SOUL and MCP fixtures corrected.
+
 ## [0.17.9] - 2026-04-15
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -3,10 +3,10 @@
 
 [![npm version](https://img.shields.io/npm/v/hackmyagent.svg)](https://www.npmjs.com/package/hackmyagent)
 [![License: Apache-2.0](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
-[![Tests](https://img.shields.io/badge/tests-1580%20passing-brightgreen)](https://github.com/opena2a-org/hackmyagent)
+[![Tests](https://img.shields.io/badge/tests-1723%20passing-brightgreen)](https://github.com/opena2a-org/hackmyagent)
 [![NanoMind](https://img.shields.io/badge/NanoMind-semantic%20compiler-teal)](https://huggingface.co/opena2a/nanomind-security-classifier)
 
-**204 security checks + 28 semantic checks + behavioral simulation. The first security scanner that secures itself.**
+**209 security checks + 29 semantic checks + behavioral simulation. The first security scanner that secures itself.**
 
 Security scanner, red-team toolkit, behavioral simulation engine, and skill builder for AI agents. Powered by the NanoMind Semantic Compiler -- a compiler-style architecture where every artifact is compiled into an Abstract Security Tree before analysis.
 
@@ -46,12 +46,12 @@ npx opena2a-cli review
 
 **Skills builder** -- `hackmyagent create-skill "describe what you need"` generates a complete, secured skill with SOUL.md governance, capability manifest, and security metadata.
 
-**Attack testing** -- 115 adversarial payloads across 11 categories (prompt injection, data exfiltration, jailbreak, MCP exploitation, supply chain, memory weaponization, A2A protocol attacks, context window attacks).
+**Attack testing** -- 164 adversarial payloads across 16 categories (prompt injection, jailbreak, data exfiltration, capability abuse, context manipulation, MCP exploitation, A2A protocol attacks, memory weaponization, context window, supply chain, tool shadow, parser differential, persistent agent, fake tool, context lifecycle, policy enforcement integrity).
 
-**Static analysis** -- 204 security checks across 60 categories covering credentials, MCP configs, OpenClaw/NemoClaw, Unicode steganography, CVE detection, governance, supply chain, memory poisoning, agent identity, and sandbox escape patterns.
+**Static analysis** -- 209 security checks across 44 categories covering credentials, MCP configs, OpenClaw/NemoClaw, Unicode steganography, CVE detection, governance, supply chain, memory poisoning, agent identity, and sandbox escape patterns.
 
 <details>
-<summary>Attack testing details (115 payloads)</summary>
+<summary>Attack testing details (164 payloads)</summary>
 
 - **Prompt injection** -- tests whether agents follow injected instructions from untrusted input
 - **Data exfiltration** -- checks if agents can be tricked into leaking sensitive data to external endpoints
@@ -66,7 +66,7 @@ npx opena2a-cli review
 </details>
 
 <details>
-<summary>Static analysis details (204 checks)</summary>
+<summary>Static analysis details (209 checks)</summary>
 
 - **Unicode steganography** -- invisible codepoints, zero-width chars, bidi attacks, homoglyph confusables, GlassWorm decoders ([real-world: os-info-checker-es6 npm attack, May 2025](https://thehackernews.com/2025/05/malicious-npm-package-leverages-unicode.html))
 - **Hardcoded credentials** -- API keys, tokens, and passwords in source or config files
@@ -82,7 +82,7 @@ npx opena2a-cli review
 
 </details>
 
-204 checks across 60 categories. 115 attack payloads. No flags needed.
+209 checks across 44 categories. 164 attack payloads. No flags needed.
 
 ---
 
@@ -104,7 +104,7 @@ npm install --save-dev hackmyagent
 
 ```
 ┌─────────────────────────────────────────────────────┐
-│  HackMyAgent v0.12.6 -- Security Scanner             │
+│  HackMyAgent v0.17.10 -- Security Scanner            │
 │  Found: 3 critical · 5 high · 12 medium             │
 │                                                     │
 │  CRED-001  critical  Hardcoded API key in .env      │
@@ -123,7 +123,7 @@ npm install --save-dev hackmyagent
 
 Step-by-step guides for common workflows:
 
-- **[Scan my agent](docs/use-cases/scan-my-agent.md)** -- Run all 204 checks and auto-fix findings (5 min)
+- **[Scan my agent](docs/use-cases/scan-my-agent.md)** -- Run all 209 checks and auto-fix findings (5 min)
 - **[Red-team MCP servers](docs/use-cases/red-team-mcp.md)** -- Test MCP servers with adversarial payloads (10 min)
 - **[Secure OpenClaw](docs/use-cases/openclaw-security.md)** -- Auto-detected when OpenClaw files are present. Includes CVE detection and ClawHavoc IOC scanning (10 min)
 - **[CI/CD pipeline](docs/use-cases/ci-pipeline.md)** -- GitHub Actions with JSON/SARIF output (5 min)
@@ -165,7 +165,7 @@ NanoMind runs automatically on every `secure` scan. No flags, no config. On firs
 
 **What it detects (9 attack classes):** exfiltration, injection, privilege_escalation, persistence, credential_abuse, lateral_movement, social_engineering, policy_violation, benign.
 
-**6 AST analyzers** compile every artifact into an Abstract Security Tree before querying:
+**7 AST analyzers** compile every artifact into an Abstract Security Tree before querying:
 
 | Analyzer | What it checks |
 |----------|---------------|
@@ -175,11 +175,13 @@ NanoMind runs automatically on every `secure` scan. No flags, no config. On firs
 | `scope` | Access boundary violations, resource overreach |
 | `prompt` | Injection vectors, instruction leakage |
 | `code` | Unsafe patterns, exec injection, deserialization |
+| `stego` | Unicode steganography, GlassWorm decoders, invisible codepoints |
 
 **Flags that affect NanoMind:**
 
 - `--deep` -- adds behavioral simulation (20 probes) on top of NanoMind static analysis
 - `--static-only` -- disables NanoMind semantic analysis entirely for CI/deterministic mode
+- `--nanomind` -- enables the NanoMind generative-analysis layer (Tier 2). Opt-in: adds 15-30s per finding for AI-powered threat narratives. Static analyzers above run regardless.
 
 ---
 
@@ -268,7 +270,7 @@ Use `--dry-run` to preview changes. Backups are created in `.hackmyagent-backup/
 
 ### `hackmyagent attack` -- Red Team
 
-Test your AI agent with 115 adversarial payloads across 11 attack categories.
+Test your AI agent with 164 adversarial payloads across 16 attack categories.
 
 ```bash
 hackmyagent attack --local                                    # local simulation
@@ -288,12 +290,17 @@ hackmyagent attack https://api.example.com --fail-on-vulnerable medium  # CI gat
 | `data-exfiltration` | 11 | Extract sensitive data, system prompts, credentials |
 | `capability-abuse` | 10 | Misuse agent tools for unintended actions |
 | `context-manipulation` | 10 | Poison agent context or memory |
+| `mcp-exploitation` | 10 | MCP protocol abuse, tool injection |
+| `a2a-attack` | 10 | Agent-to-agent identity spoofing |
+| `memory-weaponization` | 10 | Persistent memory poisoning attacks |
+| `context-window` | 10 | Token flooding, attention manipulation |
 | `supply-chain` | 10 | Dependency confusion, package impersonation |
 | `tool-shadow` | 10 | Tool shadowing, capability escalation |
-| `mcp-exploitation` | 10 | MCP protocol abuse, tool injection |
-| `memory-weaponization` | 10 | Persistent memory poisoning attacks |
-| `a2a-attacks` | 10 | Agent-to-agent identity spoofing |
-| `context-window` | 10 | Token flooding, attention manipulation |
+| `parser-differential` | 10 | Parser-mismatch attacks across runtimes |
+| `persistent-agent` | 10 | Long-lived agent persistence + escalation |
+| `fake-tool` | 10 | Fake / lookalike tool registration |
+| `context-lifecycle` | 10 | Context-handoff and lifecycle abuse |
+| `policy-enforcement-integrity` | 9 | Policy-bypass and enforcement integrity |
 
 > Only test systems you own or have written authorization to test.
 
@@ -340,10 +347,24 @@ hackmyagent harden-soul --dry-run         # preview without writing
 
 ### OpenClaw and NemoClaw Detection
 
-`hackmyagent secure` auto-detects OpenClaw and NemoClaw installations by looking for `.openclaw/`, `.moltbot/`, `.nemoclaw/`, `openclaw.json`, and `openclaw.plugin.json`. When detected, it automatically runs platform-specific checks (28 NemoClaw checks, 34 OpenClaw checks) alongside the standard 204 security checks. No separate commands needed.
+`hackmyagent secure` auto-detects OpenClaw and NemoClaw installations by looking for `.openclaw/`, `.moltbot/`, `.nemoclaw/`, `openclaw.json`, and `openclaw.plugin.json`. When detected, it automatically runs platform-specific checks (28 NemoClaw checks, 34 OpenClaw checks) alongside the standard 209 security checks. No separate commands needed.
 
 
 ---
+
+### `hackmyagent detect` -- Shadow AI Audit
+
+Discover AI tools, MCP servers, and governance gaps across your machine and project. Built for CISOs and security engineers who need an inventory of what's actually running.
+
+```bash
+hackmyagent detect                              # audit current directory
+hackmyagent detect /path/to/project             # audit a specific project
+hackmyagent detect --json                       # machine-readable output
+hackmyagent detect --verbose                    # show full MCP server list
+hackmyagent detect --export-csv inventory.csv   # asset inventory for CMDB
+```
+
+Reports a governance score and actionable findings. Detects running AI coding assistants and local LLMs (Claude Code, Cursor, Copilot, etc.), MCP server configurations across all tools (project-local and machine-wide), AI config files with credential references or broad permission grants, and SOUL.md governance files.
 
 ### `hackmyagent trust` -- Package Trust Verification
 
@@ -358,6 +379,15 @@ hackmyagent trust express --json             # JSON output
 
 
 Uses [ai-trust](https://github.com/opena2a-org/ai-trust) under the hood.
+
+### `hackmyagent nanomind` -- Generative Model Setup
+
+Manage the optional NanoMind generative model. Used by the `--nanomind` opt-in flag on `secure`/`check` for AI-powered threat narratives.
+
+```bash
+hackmyagent nanomind setup    # download the generative model
+hackmyagent nanomind status   # check model + runtime status
+```
 
 ### More Commands
 

--- a/__tests__/hardening/scanner.test.ts
+++ b/__tests__/hardening/scanner.test.ts
@@ -2586,13 +2586,17 @@ describe('OpenClaw gateway auto-fix', () => {
     });
   });
 
-  describe('TOCTOU-001: widened patterns — statSync+exec and access-gate+read', () => {
-    it('flags accessSync + readFileSync on same variable within function', async () => {
+  describe('TOCTOU-001: access-gate+exec and stat+exec patterns', () => {
+    it('does NOT flag accessSync + readFileSync (config-load pattern, not TOCTOU)', async () => {
+      // Real-world reproducer (2026-04-17 audit): secretless and ai-trust
+      // surfaced 11+ FPs of TOCTOU-001 on the idiomatic config-load shape
+      // `if (existsSync(p)) return readFileSync(p)`. Reading a swapped file
+      // just produces attacker-controlled content that the application must
+      // already sanitize — no security trust is transferred from the check.
       const code = [
         'import * as fs from "fs";',
         'export function loadConfig(configPath: string) {',
         '  fs.accessSync(configPath);',
-        '  // TOCTOU window — file can be swapped here',
         '  return fs.readFileSync(configPath, "utf-8");',
         '}',
       ].join('\n');
@@ -2600,8 +2604,71 @@ describe('OpenClaw gateway auto-fix', () => {
       await fs.writeFile(path.join(tempDir, 'loader.ts'), code);
 
       const result = await scanner.scan({ targetDir: tempDir });
+      const toctou = result.findings.find(
+        f => f.checkId === 'TOCTOU-001' && f.file === 'loader.ts',
+      );
+      expect(toctou, 'accessSync+readFileSync (config load) must not fire TOCTOU-001').toBeUndefined();
+    });
+
+    it('flags accessSync + execSync on same variable (real access-gate TOCTOU)', async () => {
+      const code = [
+        'import * as fs from "fs";',
+        'import { execSync } from "child_process";',
+        'export function runScript(scriptPath: string) {',
+        '  fs.accessSync(scriptPath);',
+        '  // TOCTOU window — file can be swapped here',
+        '  execSync(scriptPath);',
+        '}',
+      ].join('\n');
+      await fs.writeFile(path.join(tempDir, 'SKILL.md'), '# Test Skill');
+      await fs.writeFile(path.join(tempDir, 'access-exec.ts'), code);
+
+      const result = await scanner.scan({ targetDir: tempDir });
       const toctou = result.findings.find(f => f.checkId === 'TOCTOU-001');
-      expect(toctou, 'accessSync+readFileSync on same var must fire TOCTOU-001').toBeDefined();
+      expect(toctou, 'accessSync+execSync on same var must fire TOCTOU-001').toBeDefined();
+    });
+
+    it('flags existsSync + dynamic import(p) on same variable (RCE-equivalent)', async () => {
+      // Adversarial review (2026-04-17) flagged dynamic import as an exec sink
+      // that was silently slipping past after the read-narrowing.
+      const code = [
+        'import * as fs from "fs";',
+        'export async function loadPlugin(pluginPath: string) {',
+        '  if (fs.existsSync(pluginPath)) {',
+        '    const mod = await import(pluginPath);',
+        '    return mod;',
+        '  }',
+        '}',
+      ].join('\n');
+      await fs.writeFile(path.join(tempDir, 'SKILL.md'), '# Test Skill');
+      await fs.writeFile(path.join(tempDir, 'plugin-loader.ts'), code);
+
+      const result = await scanner.scan({ targetDir: tempDir });
+      const toctou = result.findings.find(
+        f => f.checkId === 'TOCTOU-001' && f.file === 'plugin-loader.ts',
+      );
+      expect(toctou, 'existsSync+import(varPath) must fire TOCTOU-001').toBeDefined();
+    });
+
+    it('does NOT flag existsSync + writeFileSync (write is not a trust-transfer use)', async () => {
+      // Lock current behavior: write-after-check is not TOCTOU under this
+      // model. Documented in the analyzer comment block at scanner.ts:9851.
+      const code = [
+        'import * as fs from "fs";',
+        'export function persist(outPath: string, data: string) {',
+        '  if (fs.existsSync(outPath)) {',
+        '    fs.writeFileSync(outPath, data);',
+        '  }',
+        '}',
+      ].join('\n');
+      await fs.writeFile(path.join(tempDir, 'SKILL.md'), '# Test Skill');
+      await fs.writeFile(path.join(tempDir, 'writer.ts'), code);
+
+      const result = await scanner.scan({ targetDir: tempDir });
+      const toctou = result.findings.find(
+        f => f.checkId === 'TOCTOU-001' && f.file === 'writer.ts',
+      );
+      expect(toctou, 'existsSync+writeFileSync should not fire TOCTOU-001').toBeUndefined();
     });
 
     it('flags statSync + execSync on same variable (stat-then-exec is a real TOCTOU)', async () => {

--- a/__tests__/nanomind-core/capability-analyzer.test.ts
+++ b/__tests__/nanomind-core/capability-analyzer.test.ts
@@ -92,13 +92,15 @@ It is recommended to check permissions when appropriate.
   describe('Skill with no constraints', () => {
     const skill = `A helper that does whatever you ask.`;
 
-    it('flags missing governance', async () => {
+    it('does not emit AST-GOVERN-002 (delegated to governance-analyzer AST-GOV-003)', async () => {
+      // Capability-analyzer used to emit AST-GOVERN-002 for the same condition
+      // governance-analyzer emits AST-GOV-003. Both fired on every bare skill,
+      // producing a duplicate Governance finding. The emitter was consolidated
+      // in governance-analyzer; capability-analyzer must no longer emit it.
       const { ast } = await compiler.compile(skill, 'no-rules.skill.md');
       const findings = analyzeCapabilities(ast);
       const noGov = findings.filter(f => f.checkId === 'AST-GOVERN-002');
-      // May or may not flag depending on whether capabilities are detected
-      // The key check is that it doesn't crash
-      expect(findings).toBeTruthy();
+      expect(noGov).toHaveLength(0);
     });
   });
 

--- a/__tests__/nanomind-core/compiler.test.ts
+++ b/__tests__/nanomind-core/compiler.test.ts
@@ -117,6 +117,46 @@ describe('Artifact Parser', () => {
     expect(classifyArtifactType('{"mcpServers":{}}', 'mcp.json')).toBe('mcp_config');
   });
 
+  it('matches mcp.json by basename, not by suffix', () => {
+    // Bug-bounty target descriptors named *-mcp.json describe an MCP server,
+    // they are NOT themselves MCP configs. Misclassification routed them
+    // through the agent analyzers and produced six-finding pileups.
+    const targetDescriptor = JSON.stringify({
+      id: 'salesforce-mcp',
+      category: 'mcp-server',
+      attackSurface: [{ surface: 'SOQL injection' }],
+    });
+    expect(classifyArtifactType(targetDescriptor, 'data/targets/salesforce-mcp.json'))
+      .not.toBe('mcp_config');
+    expect(classifyArtifactType(targetDescriptor, 'github-mcp.json'))
+      .not.toBe('mcp_config');
+    // Real MCP configs in subdirectories still match by basename.
+    expect(classifyArtifactType('{"mcpServers":{}}', '.cursor/mcp.json'))
+      .toBe('mcp_config');
+    expect(classifyArtifactType('{"mcpServers":{}}', '.well-known/mcp.json'))
+      .toBe('mcp_config');
+    // Claude Code project config and assembly-scanner variants must still match.
+    expect(classifyArtifactType('{"mcpServers":{}}', '.mcp.json'))
+      .toBe('mcp_config');
+    expect(classifyArtifactType('{"mcpServers":{}}', '/repo/.mcp.json'))
+      .toBe('mcp_config');
+    expect(classifyArtifactType('{"mcpServers":{}}', 'mcpServers.json'))
+      .toBe('mcp_config');
+    // Content-based fallback still catches mcp configs with non-standard names.
+    expect(classifyArtifactType('{"mcpServers":{"x":{}}}', 'config/custom.json'))
+      .toBe('mcp_config');
+    // Content fallback tolerates a leading BOM and pretty-printed whitespace
+    // (JSONC-style files were previously missed when basename mismatched).
+    expect(classifyArtifactType('\uFEFF\n  {\n  "mcpServers": {}\n}', 'evil/config.json'))
+      .toBe('mcp_config');
+    // Content fallback must NOT match prose mentioning "mcpServers" as a string;
+    // only the key syntax `"mcpServers":` qualifies.
+    expect(classifyArtifactType(
+      '{"description": "talks about \\"mcpServers\\" as a topic"}',
+      'docs/notes.json',
+    )).not.toBe('mcp_config');
+  });
+
   it('classifies SOUL files', () => {
     expect(classifyArtifactType('', 'SOUL.md')).toBe('soul');
   });

--- a/__tests__/nanomind-core/scanner-bridge.test.ts
+++ b/__tests__/nanomind-core/scanner-bridge.test.ts
@@ -328,6 +328,77 @@ describe('runNanoMindScan', () => {
     expect(result.integrityStatus).toBe('CLEAN');
     expect(typeof result.nanomindAvailable).toBe('boolean');
   });
+
+  it('does not run agent analyzers on bug-bounty target descriptors named *-mcp.json', async () => {
+    // Reproducer for the audit P0-4 case: hma-hunter/data/targets/salesforce-mcp.json
+    // is a bug-bounty target descriptor — NOT an MCP server config. The previous
+    // classifier matched any path ending in `mcp.json`, routing this file through
+    // the agent analyzers and producing six overlapping findings (governance +
+    // capability + scope all misfiring on the descriptor's prose). After the fix
+    // the file classifies as `unknown` and only credential/code/stego analyzers
+    // run on it, eliminating the pileup.
+    const targetDescriptor = JSON.stringify({
+      id: 'salesforce-mcp',
+      name: 'Salesforce MCP Server',
+      category: 'mcp-server',
+      program: { platform: 'bugcrowd' },
+      scope: { inScope: ['@salesforce/mcp npm package'] },
+      attackSurface: [{
+        surface: 'SOQL/SOSL Injection via MCP Tools',
+        modules: ['query', 'search'],
+        notes: 'Test SOQL injection to access records beyond intended scope.',
+      }],
+      tips: ['Check if the MCP server can execute anonymous Apex code'],
+    });
+    await mkdir(join(tempDir, 'data', 'targets'), { recursive: true });
+    await writeFile(join(tempDir, 'data', 'targets', 'salesforce-mcp.json'), targetDescriptor);
+
+    const result = await runNanoMindScan(tempDir, []);
+    const findingsOnTarget = result.astFindings.filter(
+      f => !f.passed && f.file?.includes('salesforce-mcp.json'),
+    );
+    // Agent-specific analyzers (governance, capability, scope) must not fire on
+    // a bug-bounty target descriptor. Only credential/code/stego analyzers run
+    // on `unknown` artifacts; they must produce zero findings on this content.
+    const agentSpecificCategories = new Set(['Governance', 'Capability Security', 'Scope Security']);
+    const agentSpecificFindings = findingsOnTarget.filter(
+      f => agentSpecificCategories.has(f.category),
+    );
+    expect(
+      agentSpecificFindings,
+      `Bug-bounty target descriptors must not trigger agent analyzers. Got: ${agentSpecificFindings.map(f => f.checkId).join(', ')}`,
+    ).toHaveLength(0);
+  });
+
+  it('emits exactly one zero-constraints governance finding per artifact (no AST-GOVERN-002 / AST-GOV-003 duplicate)', async () => {
+    // Capability-analyzer used to emit AST-GOVERN-002 with message "Zero
+    // constraints declared" while governance-analyzer emitted AST-GOV-003 with
+    // message "Zero constraints for active capabilities" — same Governance
+    // category, same condition, on the same file. Consolidated to AST-GOV-003.
+    const skillNoConstraints = `---
+description: Admin power tool
+capabilities:
+  - db.delete
+  - file.write
+  - api.call
+  - shell.execute
+---
+A powerful tool that does anything you ask.`;
+    await writeFile(join(tempDir, 'admin.skill.md'), skillNoConstraints);
+
+    const result = await runNanoMindScan(tempDir, []);
+    const onSkill = result.astFindings.filter(
+      f => !f.passed && f.file?.includes('admin.skill.md'),
+    );
+    const govern002 = onSkill.filter(f => f.checkId === 'AST-GOVERN-002');
+    expect(
+      govern002,
+      'AST-GOVERN-002 was retired — emission moved to governance-analyzer AST-GOV-003.',
+    ).toHaveLength(0);
+    // AST-GOV-003 (the canonical emitter) still fires for this case.
+    const gov003 = onSkill.filter(f => f.checkId === 'AST-GOV-003');
+    expect(gov003.length).toBeGreaterThan(0);
+  });
 });
 
 // ============================================================================

--- a/__tests__/output/analyst-render.test.ts
+++ b/__tests__/output/analyst-render.test.ts
@@ -2,6 +2,9 @@ import { describe, it, expect } from 'vitest';
 import {
   isRenderableAnalystFinding,
   formatAnalystDescription,
+  capAnalystThreatLevel,
+  formatAnalystConfidence,
+  LOW_CONFIDENCE_CAP,
 } from '../../src/output/analyst-render';
 
 describe('isRenderableAnalystFinding', () => {
@@ -129,5 +132,86 @@ describe('formatAnalystDescription', () => {
   it('returns empty string when input is only headers', () => {
     const { text } = formatAnalystDescription('## Header\n### Another\n', { verbose: false });
     expect(text).toBe('');
+  });
+});
+
+describe('capAnalystThreatLevel', () => {
+  it('caps CRITICAL to HIGH when confidence is below the calibration threshold', () => {
+    // Real-world reproducer: NanoMind emits CRITICAL with hardcoded 60% confidence.
+    const { level, capped } = capAnalystThreatLevel('CRITICAL', 0.60);
+    expect(level).toBe('HIGH');
+    expect(capped).toBe(true);
+  });
+
+  it('preserves CRITICAL when confidence meets the threshold', () => {
+    const { level, capped } = capAnalystThreatLevel('CRITICAL', LOW_CONFIDENCE_CAP);
+    expect(level).toBe('CRITICAL');
+    expect(capped).toBe(false);
+  });
+
+  it('preserves CRITICAL when confidence is above the threshold', () => {
+    const { level, capped } = capAnalystThreatLevel('CRITICAL', 0.95);
+    expect(level).toBe('CRITICAL');
+    expect(capped).toBe(false);
+  });
+
+  it('does not cap HIGH at any confidence (only CRITICAL is capped)', () => {
+    for (const conf of [0.30, 0.60, 0.79, 0.85]) {
+      const { level, capped } = capAnalystThreatLevel('HIGH', conf);
+      expect(level).toBe('HIGH');
+      expect(capped).toBe(false);
+    }
+  });
+
+  it('does not cap MEDIUM or LOW at low confidence', () => {
+    for (const lvl of ['MEDIUM', 'LOW', 'INFO']) {
+      const { level, capped } = capAnalystThreatLevel(lvl, 0.40);
+      expect(level).toBe(lvl);
+      expect(capped).toBe(false);
+    }
+  });
+
+  it('normalizes case and treats lowercase critical the same as uppercase', () => {
+    const { level, capped } = capAnalystThreatLevel('critical', 0.60);
+    expect(level).toBe('HIGH');
+    expect(capped).toBe(true);
+  });
+
+  it('returns unknown when threatLevel is missing', () => {
+    const { level, capped } = capAnalystThreatLevel(undefined, 0.95);
+    expect(level).toBe('UNKNOWN');
+    expect(capped).toBe(false);
+  });
+});
+
+describe('formatAnalystConfidence', () => {
+  it('shows numeric % when confidence meets the threshold', () => {
+    const { label, numeric } = formatAnalystConfidence(0.85);
+    expect(label).toBe('85%');
+    expect(numeric).toBe(true);
+  });
+
+  it('shows numeric % at the threshold boundary (>= cap is numeric)', () => {
+    const { label, numeric } = formatAnalystConfidence(LOW_CONFIDENCE_CAP);
+    expect(label).toBe('80%');
+    expect(numeric).toBe(true);
+  });
+
+  it('shows qualitative label when confidence is below the threshold', () => {
+    // 60% is the hardcoded value the audit found on 14/14 findings.
+    const { label, numeric } = formatAnalystConfidence(0.60);
+    expect(label).toBe('low confidence');
+    expect(numeric).toBe(false);
+  });
+
+  it('shows qualitative label just below the threshold', () => {
+    const { label, numeric } = formatAnalystConfidence(0.79);
+    expect(label).toBe('low confidence');
+    expect(numeric).toBe(false);
+  });
+
+  it('rounds the numeric % rather than truncating', () => {
+    const { label } = formatAnalystConfidence(0.876);
+    expect(label).toBe('88%');
   });
 });

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -52,7 +52,7 @@ import {
 } from './index';
 import { resolveAndLogMcpShorthand } from './resolve-mcp';
 import { WildScanner, type WildScanReport } from './wild';
-import { isRenderableAnalystFinding, formatAnalystDescription } from './output/analyst-render';
+import { isRenderableAnalystFinding, formatAnalystDescription, capAnalystThreatLevel, formatAnalystConfidence } from './output/analyst-render';
 const program = new Command();
 program.showHelpAfterError('(run with --help for usage)');
 
@@ -990,12 +990,13 @@ function displayUnifiedCheck(opts: UnifiedCheckDisplayOptions): void {
     for (const af of renderableAnalystFindings) {
       const r = af.result;
       if (af.taskType === 'threatAnalysis') {
-        const level = String(r.threatLevel ?? 'unknown').toUpperCase();
+        const { level, capped } = capAnalystThreatLevel(r.threatLevel as string | undefined, af.confidence);
         const levelColor = level === 'CRITICAL' || level === 'HIGH' ? colors.red : level === 'MEDIUM' ? colors.yellow : colors.dim;
         // Only show attackVector separator when the field is populated — avoids
         // a naked "CRITICAL  " line with trailing whitespace.
         const vectorText = r.attackVector ? `  ${colors.white}${r.attackVector}${RESET()}` : '';
-        console.log(`  ${levelColor}${colors.bold}${level}${RESET()}${vectorText}`);
+        const cappedSuffix = capped ? `  ${colors.dim}(low confidence — capped from CRITICAL)${RESET()}` : '';
+        console.log(`  ${levelColor}${colors.bold}${level}${RESET()}${vectorText}${cappedSuffix}`);
         if (r.description) {
           const { text, truncated } = formatAnalystDescription(String(r.description), { verbose: !!verbose });
           if (text) console.log(`  ${colors.dim}${text}${RESET()}`);
@@ -1057,10 +1058,15 @@ function displayUnifiedCheck(opts: UnifiedCheckDisplayOptions): void {
         // Generic display
         if (r.description) console.log(`  ${r.description}`);
       }
-      // Only show confidence footer when high enough to be meaningful (>= 75%)
-      if (af.confidence >= 0.75 || verbose) {
-        console.log(`  ${colors.dim}Confidence: ${Math.round(af.confidence * 100)}% | ${af.modelVersion} (${af.durationMs}ms)${RESET()}`);
-      }
+      // Confidence display: numeric only when calibrated (>= LOW_CONFIDENCE_CAP).
+      // Below the threshold show a qualitative label so a hardcoded value doesn't
+      // pose as a measurement. Verbose mode reveals the raw number with an
+      // (uncalibrated) suffix so it can't be mistaken for ground truth.
+      const { label: confLabel, numeric: confNumeric } = formatAnalystConfidence(af.confidence);
+      const display = verbose && !confNumeric
+        ? `${Math.round(af.confidence * 100)}% (uncalibrated)`
+        : confLabel;
+      console.log(`  ${colors.dim}Confidence: ${display} | ${af.modelVersion} (${af.durationMs}ms)${RESET()}`);
       console.log();
     }
   }
@@ -2748,11 +2754,11 @@ Examples:
       }
 
       // Analysis mode: smart defaults, minimal flags
-      // Default: static + NanoMind (if daemon available)
-      // --deep: everything (static + NanoMind + simulation + adaptive attacks)
-      // --static-only: just static checks (CI/deterministic)
-      // NanoMind runs by default on every scan (including CI)
-      // --static-only is the only way to disable it
+      // Default: static checks + NanoMind AST semantic compiler
+      // --nanomind: also runs the generative analyst layer (opt-in; adds latency)
+      // --deep: everything (static + AST + simulation + adaptive attacks)
+      // --static-only: skip the AST semantic compiler too (CI/deterministic baseline)
+      // The AST semantic compiler runs by default; the generative analyst is opt-in.
       const isStaticOnly = (options as Record<string, unknown>).staticOnly as boolean ?? false;
       const isDeep = options.deep ?? (scanDepth === 'deep');
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -53,12 +53,23 @@ import {
 import { resolveAndLogMcpShorthand } from './resolve-mcp';
 import { WildScanner, type WildScanReport } from './wild';
 import { isRenderableAnalystFinding, formatAnalystDescription, capAnalystThreatLevel, formatAnalystConfidence } from './output/analyst-render';
+import { getTaxonomyMap } from './hardening/taxonomy';
 const program = new Command();
 program.showHelpAfterError('(run with --help for usage)');
 
-// Total security check count across all scanner modules.
-// Update when adding new checks (verify with: grep -r "checkId:" src/hardening/ | grep -o "checkId: '[^']*'" | sort -u | wc -l)
-const CHECK_COUNT = 209;
+// Total security check count + distinct category count, derived from the
+// taxonomy map (the same source check-metadata reads). Previously CHECK_COUNT
+// was hardcoded (209) and the category count was hardcoded in help text as
+// "60 categories" — both drifted. Deriving from the taxonomy keeps --help,
+// command descriptions, and check-metadata consistent without manual bumps.
+const CHECK_IDS = Object.keys(getTaxonomyMap());
+const CHECK_COUNT = CHECK_IDS.length;
+const CATEGORY_COUNT = new Set(
+  CHECK_IDS.map(id => {
+    const parts = id.split('-');
+    return (parts.length > 1 ? parts.slice(0, -1).join('-') : parts[0]).toLowerCase();
+  }),
+).size;
 
 // How long registry-cached scan data is considered fresh before `check` re-scans.
 const STALE_SCAN_DAYS = 3;
@@ -2621,13 +2632,13 @@ program
   .command('secure')
   .description(`Scan and harden your agent setup
 
-Performs ${CHECK_COUNT} security checks across 60 categories:
+Performs ${CHECK_COUNT} security checks across ${CATEGORY_COUNT} categories:
   • Credentials: API key exposure, secrets in configs
   • MCP: Server configs, tool permissions, secrets
   • Network: TLS, interface bindings, CORS
   • Prompt: Injection defenses, role protection
   • Encryption: At-rest encryption, secure hashing
-  • And 54 more categories...
+  • And ${CATEGORY_COUNT - 5} more categories...
 
 Benchmark mode (--benchmark):
   oasb-1   OASB-1 infrastructure compliance (L1/L2/L3 levels)

--- a/src/hardening/scanner.ts
+++ b/src/hardening/scanner.ts
@@ -9851,22 +9851,26 @@ dist/
         // Two-tier TOCTOU detection, 40-line proximity window (same function scope):
         //
         //  Tier A — Access-gate TOCTOU: existsSync/accessSync/access() on a variable,
-        //    then any READ or EXEC use of the same variable. The access gate is the
-        //    classic TOCTOU pattern — the check blesses the path, the use trusts it.
+        //    then EXEC use (execFile/spawn/execSync) of the same variable. The check
+        //    blesses the path and the use executes it — an attacker can swap the file
+        //    in the race window. Access-gate + READ is NOT TOCTOU: reading a swapped
+        //    file just produces attacker-controlled content the application must
+        //    sanitize anyway, and idiomatic config loading (`if (existsSync(p))
+        //    return readFileSync(p)`) was producing dominant FPs in real-world repos.
         //
         //  Tier B — Stat-then-exec TOCTOU: statSync/lstatSync/fs.stat/fs.lstat on a
-        //    variable, then EXEC use (execFile/spawn/execSync) of the same variable.
-        //    Stat-then-read alone is tolerated: content scanners legitimately stat
-        //    for size filtering then read for analysis with no trust transfer.
+        //    variable, then EXEC use of the same variable. Stat-then-read alone is
+        //    tolerated for the same reason as access-then-read above.
         const fileLines = content.split('\n');
 
         const accessGatePattern = /\b(?:existsSync|accessSync|fs\.access)\s*\(\s*(\w+)\s*[,)]/g;
         const statPattern = /\b(?:statSync|lstatSync|fs\.stat|fs\.lstat)\s*\(\s*(\w+)\s*[,)]/g;
-        const readUseRe = (v: string) => new RegExp(
-          `\\b(?:readFile(?:Sync)?|createReadStream|open(?:Sync)?|execFile(?:Sync)?|spawn(?:Sync)?|execSync)\\s*\\(\\s*${v}\\b`
-        );
+        // Dynamic `import(varPath)` always evaluates module code — same RCE
+        // surface as exec, low FP risk. `require(varPath)` is intentionally
+        // omitted: JSON loading via `require()` is legitimate config-load and
+        // would re-introduce the dominant FP class this fix targets.
         const execUseRe = (v: string) => new RegExp(
-          `\\b(?:execFile(?:Sync)?|spawn(?:Sync)?|execSync|child_process\\.exec)\\s*\\(\\s*${v}\\b`
+          `\\b(?:execFile(?:Sync)?|spawn(?:Sync)?|execSync|child_process\\.exec|import)\\s*\\(\\s*${v}\\b`
         );
         const windowHasUse = (checkLineIdx: number, re: RegExp): boolean => {
           const windowEnd = Math.min(checkLineIdx + 40, fileLines.length);
@@ -9879,7 +9883,7 @@ dist/
         const accessGateHit = [...content.matchAll(accessGatePattern)].some(m => {
           const varName = m[1];
           const lineIdx = content.slice(0, m.index!).split('\n').length - 1;
-          return windowHasUse(lineIdx, readUseRe(varName));
+          return windowHasUse(lineIdx, execUseRe(varName));
         });
         const statExecHit = [...content.matchAll(statPattern)].some(m => {
           const varName = m[1];

--- a/src/nanomind-core/analyzers/capability-analyzer.ts
+++ b/src/nanomind-core/analyzers/capability-analyzer.ts
@@ -111,26 +111,10 @@ export function analyzeCapabilities(ast: SecurityAST, projectType?: ProjectType,
   if (!isLibOrSDK) {
     findings.push(...checkConstraintWeaknesses(ast));
 
-    // AST-GOVERN-002: no constraints at all, accounting for project-level constraints
-    // from a sibling SOUL.md so that harden-soul → scan shows real improvement.
-    const effectiveConstraintCount = ast.declaredConstraints.length + (projectConstraints?.length ?? 0);
-    if (effectiveConstraintCount === 0 && ast.declaredCapabilities.length > 0) {
-      const govSeverity: ASTFinding['severity'] = isAgentLevelArtifact(ast) ? 'high' : 'medium';
-      findings.push({
-        checkId: 'AST-GOVERN-002',
-        name: 'No Governance Constraints',
-        description: 'This artifact declares capabilities but has no governance constraints. Without constraints, any capability can be abused.',
-        category: 'Governance',
-        severity: govSeverity,
-        passed: false,
-        message: 'Zero constraints declared',
-        fixable: false,
-        file: ast.artifactPath,
-        fix: 'hackmyagent harden-soul .  — generates SOUL.md with governance sections (capability boundaries, data handling, injection resistance) for declared capabilities.',
-        attackClass: 'SOUL-BYPASS',
-        confidence: 0.9,
-      });
-    }
+    // Zero-constraint emission intentionally delegated to governance-analyzer
+    // (AST-GOV-003). That analyzer already covers both declared and inferred
+    // capabilities; emitting AST-GOVERN-002 here produced a duplicate Governance
+    // finding on every artifact with zero constraints. One canonical emitter.
   }
 
   // Check 9: NanoMind manipulation detected

--- a/src/nanomind-core/analyzers/governance-analyzer.ts
+++ b/src/nanomind-core/analyzers/governance-analyzer.ts
@@ -331,9 +331,12 @@ function checkConstraintEnforceability(ast: SecurityAST, effectiveConstraints: C
 function checkMissingGovernance(ast: SecurityAST, effectiveConstraints: Constraint[]): ASTFinding[] {
   const findings: ASTFinding[] = [];
 
-  // No constraints at all -- already covered by capability-analyzer AST-GOVERN-002
-  // Here we check the more nuanced case: some constraints exist but don't cover
-  // specific high-risk capabilities.
+  // Zero-constraint case. Canonical emitter for "no governance at all" —
+  // capability-analyzer used to emit AST-GOVERN-002 for the same condition,
+  // which produced a duplicate Governance finding on every bare skill / MCP
+  // config. That emission was removed in favor of this one because
+  // AST-GOV-003 covers both declared and inferred capabilities, whereas
+  // AST-GOVERN-002 only covered declared capabilities.
   if (effectiveConstraints.length === 0) {
     // Only flag if there are capabilities (avoid noise on pure docs)
     if (ast.declaredCapabilities.length > 0 || ast.inferredCapabilities.length > 0) {

--- a/src/nanomind-core/inference/analm-infer-llamacpp.py
+++ b/src/nanomind-core/inference/analm-infer-llamacpp.py
@@ -86,7 +86,9 @@ def main():
 
     llm = Llama(
         model_path=gguf_path,
-        n_ctx=2048,
+        # n_ctx covers prompt + max_tokens; bumped to 4096 to fit a 2048-token
+        # response on top of typical system+user prompts (~500 tokens).
+        n_ctx=4096,
         n_threads=4,
         verbose=False,
     )
@@ -96,7 +98,8 @@ def main():
             {"role": "system", "content": system_prompt},
             {"role": "user", "content": user_message},
         ],
-        max_tokens=512,
+        # max_tokens=2048 allows complete responses without mid-sentence truncation.
+        max_tokens=2048,
         temperature=0.1,
     )
 

--- a/src/nanomind-core/inference/analm-infer.py
+++ b/src/nanomind-core/inference/analm-infer.py
@@ -91,7 +91,9 @@ def main():
     ]
 
     prompt = tokenizer.apply_chat_template(messages, tokenize=False, add_generation_prompt=True)
-    response = generate(model, tokenizer, prompt=prompt, max_tokens=512, verbose=False)
+    # max_tokens=2048 allows complete responses without mid-sentence truncation.
+    # The previous 512-token cap was producing descriptions truncated at ~300 chars.
+    response = generate(model, tokenizer, prompt=prompt, max_tokens=2048, verbose=False)
 
     parsed = extract_json(response, task_type)
     if parsed:

--- a/src/nanomind-core/ingestion/artifact-parser.ts
+++ b/src/nanomind-core/ingestion/artifact-parser.ts
@@ -57,11 +57,34 @@ const TYPE_SIGNATURES: Array<{ test: (content: string, path?: string) => boolean
       /^---\n[\s\S]*?capabilities:\s*\n/m.test(content),
     type: 'skill',
   },
-  // MCP config: mcp.json, contains mcpServers
+  // MCP config: known basenames (mcp.json, .mcp.json, mcpServers.json)
+  // or content containing an mcpServers object.
+  //
+  // IMPORTANT: match known basenames exactly, not any path ending in
+  // a matching suffix. A bug-bounty target descriptor named
+  // `salesforce-mcp.json` or a vendor target list like `github-mcp.json`
+  // is NOT an agent config — it is metadata about another agent. Running
+  // the agent analyzers on such files produces six-finding pileups
+  // (governance + capability + scope all misfiring). The allowlist mirrors
+  // the canonical MCP filenames referenced across the scanner codebase:
+  // Claude Code project config (`.mcp.json`), client installs (`mcp.json`
+  // in `.cursor/`, `.vscode/`, `.well-known/`), and assembly-scanner's
+  // TOOL_DESC_FILES (`mcpServers.json`).
   {
-    test: (content, path) =>
-      (path?.endsWith('mcp.json') || false) ||
-      (content.startsWith('{') && /"mcpServers"/.test(content)),
+    test: (content, path) => {
+      const basename = path ? path.split(/[/\\]/).pop() : undefined;
+      const isKnownMcpName =
+        basename === 'mcp.json' ||
+        basename === '.mcp.json' ||
+        basename === 'mcpServers.json';
+      if (isKnownMcpName) return true;
+      // Content fallback: strip BOM and leading whitespace so JSONC /
+      // pretty-printed files aren't missed. Require both an opening brace
+      // and an mcpServers key — a loose substring check would false-match
+      // target descriptors that merely discuss mcpServers in prose.
+      const stripped = content.replace(/^\uFEFF/, '').trimStart();
+      return stripped.startsWith('{') && /"mcpServers"\s*:/.test(stripped);
+    },
     type: 'mcp_config',
   },
   // SOUL governance: SOUL.md

--- a/src/nanomind-core/orchestrate.ts
+++ b/src/nanomind-core/orchestrate.ts
@@ -118,7 +118,7 @@ export async function orchestrateNanoMind(
       if (ready) {
         const failed = nmResult.mergedFindings.filter(f => !f.passed && !f.fixed);
         if (failed.length > 0) {
-          if (!silent) process.stderr.write('Running NanoMind analysis...\n');
+          if (!silent) process.stderr.write('Running NanoMind generative analysis (typically adds 15-30s per artifact)...\n');
           result.analystFindings = await runAnalystOnFindings(
             nmResult.mergedFindings,
             runAnalystInference,

--- a/src/output/analyst-render.ts
+++ b/src/output/analyst-render.ts
@@ -28,6 +28,39 @@ export function isRenderableAnalystFinding(af: AnalystFindingLike): boolean {
   return true;
 }
 
+/** Confidence threshold below which a CRITICAL claim is downgraded to HIGH. */
+export const LOW_CONFIDENCE_CAP = 0.80;
+
+/**
+ * Cap CRITICAL severity to HIGH when confidence is below the calibration
+ * threshold. The model emits CRITICAL on findings with hardcoded ~60%
+ * confidence, which is not enough evidence to scream the loudest severity.
+ */
+export function capAnalystThreatLevel(
+  rawLevel: string | undefined,
+  confidence: number,
+): { level: string; capped: boolean } {
+  const upper = String(rawLevel ?? 'unknown').toUpperCase();
+  if (confidence < LOW_CONFIDENCE_CAP && upper === 'CRITICAL') {
+    return { level: 'HIGH', capped: true };
+  }
+  return { level: upper, capped: false };
+}
+
+/**
+ * Render confidence as a number when it crosses the calibration threshold,
+ * and as a qualitative label otherwise. Avoids displaying a hardcoded value
+ * (e.g. exactly 60% on every finding) as if it were a real measurement.
+ */
+export function formatAnalystConfidence(
+  confidence: number,
+): { label: string; numeric: boolean } {
+  if (confidence >= LOW_CONFIDENCE_CAP) {
+    return { label: `${Math.round(confidence * 100)}%`, numeric: true };
+  }
+  return { label: 'low confidence', numeric: false };
+}
+
 export interface FormattedDescription {
   text: string;
   truncated: boolean;


### PR DESCRIPTION
## Summary
Bundled v0.17.10 work in 5 commits:

1. \`8a79f30\` PR 1 — NanoMind generative quality (cap CRITICAL when conf<0.80, qualitative confidence label, max_tokens 512→2048, latency warning)
2. \`ef3b5ab\` PR 2 — TOCTOU-001 narrowed (drop read-after-check config-load FP, keep exec-after-check, add \`import(varPath)\` to exec sinks per adversarial review)
3. \`4b71ac9\` PR 3 — Analyzer pileup collapsed on bug-bounty target descriptors (MCP classifier basename allowlist + dedup of AST-GOVERN-002 / AST-GOV-003)
4. \`646681d\` PR A — CLI category count derived from taxonomy (was hardcoded \"60\", actually 44; \`secure --help\` now reads \"209 security checks across 44 categories\" — internally consistent for the first time)
5. \`92c8c0e\` PR B — README + CHANGELOG synced to ground truth (209/29/44/164/16/1723); added \`detect\` + \`nanomind\` subcommand docs; wrote 0.17.10 changelog entry

## Verification
- 1723 tests pass (3 new regression tests for PR 3)
- HMA self-scan: 100/100, no findings
- Adversarial subagent review: SAFE TO SHIP for each detection-rule change (PRs 1, 2, 3)
- secretless 58→47 findings after PR 2 (−11, all TOCTOU-001 FPs)
- hma-hunter 6→0 findings on \`salesforce-mcp.json\` after PR 3
- CLI \`--help\` now shows correct counts derived from the taxonomy map

## Adversarial review history (each PR was independently reviewed)
- PR 2 v1 review caught a real bypass (dynamic-import sink missing) → fixed in v2
- PR 3 v1 review caught \`.mcp.json\` regression + JSONC bypass → fixed in v2
- Final consolidated 3-PR review: SAFE TO SHIP

## Doc surfaces
README + CHANGELOG synced in this PR. Satellite docs (hackmyagent.com, opena2a.org, github-profile, architecture site) are in 4 separate companion PRs across those repos.

## Skipped in this PR
- npm publish (separate operation)
- Homebrew formula update (already in sync at v0.17.10)

## Test plan
- [x] \`npm test\` — 1723 passing
- [x] \`npm run build\` — clean
- [x] \`hackmyagent secure .\` self-scan — 100/100
- [x] \`hackmyagent secure /path/to/known-bad\` — non-zero exit, findings shown
- [x] \`hackmyagent --help\` — 209 / 164
- [x] \`hackmyagent secure --help\` — 209 / 44 categories