### PR TITLE
feat(cli): Artifacts block + Verdict names the lead finding

### DIFF
--- a/__tests__/output/observations.test.ts
+++ b/__tests__/output/observations.test.ts
@@ -92,24 +92,52 @@ describe('buildCategorySummaries', () => {
 });
 
 describe('buildVerdict', () => {
-  it('unsafe verdict on critical', () => {
-    const v = buildVerdict({ critical: 3, high: 0, medium: 0, low: 0 }, { kind: 'library' });
+  it('unsafe verdict names the lead critical finding with file:line', () => {
+    const v = buildVerdict(
+      { critical: 3, high: 0, medium: 0, low: 0 },
+      { kind: 'library' },
+      [
+        { severity: 'critical', name: 'Hardcoded API key', file: '.env', line: 3 },
+        { severity: 'critical', name: 'Weak PERM', file: 'config.json' },
+        { severity: 'critical', name: 'Open Port', file: 'server.ts' },
+      ],
+    );
     expect(v.status).toBe('unsafe');
-    expect(v.message).toContain('3 critical');
+    expect(v.message).toContain('Hardcoded API key in .env:3');
+    expect(v.message).toContain('+ 2 more');
     expect(v.message).toContain('production');
   });
 
-  it('unsafe verdict on high', () => {
-    const v = buildVerdict({ critical: 0, high: 2, medium: 0, low: 0 }, { kind: 'library' });
+  it('unsafe verdict on high names the lead high finding', () => {
+    const v = buildVerdict(
+      { critical: 0, high: 2, medium: 0, low: 0 },
+      { kind: 'library' },
+      [
+        { severity: 'high', name: 'Unsafe eval', file: 'deploy.skill.md', line: 4 },
+        { severity: 'high', name: 'Broad MCP scope', file: 'mcp.json' },
+      ],
+    );
     expect(v.status).toBe('unsafe');
-    expect(v.message).toContain('2 high');
+    expect(v.message).toContain('Unsafe eval in deploy.skill.md:4');
+    expect(v.message).toContain('+ 1 more');
   });
 
-  it('needs-fix verdict on medium+low', () => {
-    const v = buildVerdict({ critical: 0, high: 0, medium: 2, low: 3 }, { kind: 'library' });
+  it('needs-fix verdict names the lead medium/low finding', () => {
+    const v = buildVerdict(
+      { critical: 0, high: 0, medium: 2, low: 3 },
+      { kind: 'library' },
+      [
+        { severity: 'medium', name: 'Missing audit log', file: 'app.ts' },
+        { severity: 'medium', name: 'Weak rate limit', file: 'api.ts' },
+        { severity: 'low', name: 'Missing .gitignore', file: '.gitignore' },
+        { severity: 'low', name: 'Broad perms', file: 'config.json' },
+        { severity: 'low', name: 'No audit trail', file: 'log.ts' },
+      ],
+    );
     expect(v.status).toBe('needs-fix');
-    expect(v.message).toContain('2 medium');
-    expect(v.message).toContain('3 low');
+    expect(v.message).toContain('Missing audit log in app.ts');
+    expect(v.message).toContain('+ 4 more');
+    expect(v.message).toContain('secure --fix');
   });
 
   it('safe verdict on zero findings', () => {
@@ -122,6 +150,126 @@ describe('buildVerdict', () => {
   it('safe verdict falls back to "project" when kind is unknown', () => {
     const v = buildVerdict({ critical: 0, high: 0, medium: 0, low: 0 }, { kind: 'unknown' });
     expect(v.message).toContain('project');
+  });
+
+  it('falls back to severity-count when findings array not passed', () => {
+    const v = buildVerdict({ critical: 2, high: 0, medium: 0, low: 0 }, { kind: 'library' });
+    expect(v.status).toBe('unsafe');
+    expect(v.message).toContain('2 critical');
+  });
+
+  it('falls back to checkId when finding name is empty', () => {
+    const v = buildVerdict(
+      { critical: 1, high: 0, medium: 0, low: 0 },
+      { kind: 'library' },
+      [{ severity: 'critical', checkId: 'CRED-001', file: 'secret.ts' }],
+    );
+    expect(v.message).toContain('CRED-001 in secret.ts');
+  });
+
+  it('no extra count when there is exactly one finding', () => {
+    const v = buildVerdict(
+      { critical: 1, high: 0, medium: 0, low: 0 },
+      { kind: 'library' },
+      [{ severity: 'critical', name: 'API key exposed', file: '.env', line: 2 }],
+    );
+    expect(v.message).toContain('API key exposed in .env:2');
+    expect(v.message).not.toContain('+ ');
+  });
+});
+
+describe('renderObservationsBlock with artifacts', () => {
+  const base = {
+    surfaces: { kind: 'library', filesScanned: 4, artifactsCompiled: 2 },
+    checks: { staticCount: 209, semanticCount: 2 },
+    categories: buildCategorySummaries([]),
+    verdict: buildVerdict({ critical: 0, high: 0, medium: 0, low: 0 }, { kind: 'library' }),
+  };
+
+  it('artifacts block empty when no artifacts passed', () => {
+    const out = renderObservationsBlock(base);
+    expect(out.artifactLines).toEqual([]);
+  });
+
+  it('artifacts block empty when artifacts array is empty', () => {
+    const out = renderObservationsBlock({ ...base, artifacts: [] });
+    expect(out.artifactLines).toEqual([]);
+  });
+
+  it('renders one line per artifact', () => {
+    const out = renderObservationsBlock({
+      ...base,
+      artifacts: [
+        { path: 'deploy.skill.md', type: 'skill', intent: 'benign', capabilityLabels: ['fs-write', 'net-egress'], constraintCount: 3, weakConstraintCount: 0 },
+        { path: 'mcp.json', type: 'mcp_config', intent: 'suspicious', capabilityLabels: ['shell-exec'], constraintCount: 0, weakConstraintCount: 0 },
+      ],
+    });
+    // Output order: suspicious before benign (intent-ranked).
+    expect(out.artifactLines).toHaveLength(2);
+    const joined = out.artifactLines.join('\n');
+    expect(joined).toContain('deploy.skill.md');
+    expect(joined).toContain('skill');
+    expect(joined).toContain('benign');
+    expect(joined).toContain('fs-write + net-egress');
+    expect(joined).toContain('3 constraints');
+    expect(joined).toContain('mcp.json');
+    expect(joined).toContain('shell-exec');
+    expect(joined).toContain('no declared constraints');
+    // Suspicious comes first
+    expect(out.artifactLines[0]).toContain('mcp.json');
+  });
+
+  it('sorts artifacts by intent severity (malicious first) then capability count', () => {
+    const out = renderObservationsBlock({
+      ...base,
+      artifacts: [
+        { path: 'a.skill.md', type: 'skill', intent: 'benign', capabilityLabels: [], constraintCount: 0, weakConstraintCount: 0 },
+        { path: 'b.skill.md', type: 'skill', intent: 'malicious', capabilityLabels: ['fs-write'], constraintCount: 0, weakConstraintCount: 0 },
+        { path: 'c.skill.md', type: 'skill', intent: 'suspicious', capabilityLabels: ['net-egress'], constraintCount: 0, weakConstraintCount: 0 },
+      ],
+    });
+    expect(out.artifactLines[0]).toContain('b.skill.md');        // malicious
+    expect(out.artifactLines[1]).toContain('c.skill.md');        // suspicious
+    expect(out.artifactLines[2]).toContain('a.skill.md');        // benign
+  });
+
+  it('caps at 6 lines in default mode and appends "+ N more" tail', () => {
+    const arts = Array.from({ length: 10 }, (_, i) => ({
+      path: `skill-${i}.md`,
+      type: 'skill',
+      intent: 'benign' as const,
+      capabilityLabels: ['fs-read'],
+      constraintCount: 1,
+      weakConstraintCount: 0,
+    }));
+    const out = renderObservationsBlock({ ...base, artifacts: arts });
+    expect(out.artifactLines).toHaveLength(7); // 6 artifacts + 1 tail
+    expect(out.artifactLines[6]).toContain('+ 4 more');
+    expect(out.artifactLines[6]).toContain('--verbose');
+  });
+
+  it('verbose mode shows all artifacts with no tail', () => {
+    const arts = Array.from({ length: 10 }, (_, i) => ({
+      path: `skill-${i}.md`,
+      type: 'skill',
+      intent: 'benign' as const,
+      capabilityLabels: ['fs-read'],
+      constraintCount: 1,
+      weakConstraintCount: 0,
+    }));
+    const out = renderObservationsBlock({ ...base, artifacts: arts, verbose: true });
+    expect(out.artifactLines).toHaveLength(10);
+    expect(out.artifactLines.every(l => !l.includes('+ '))).toBe(true);
+  });
+
+  it('names weak constraints when present', () => {
+    const out = renderObservationsBlock({
+      ...base,
+      artifacts: [
+        { path: 'SOUL.md', type: 'soul', intent: 'benign', capabilityLabels: [], constraintCount: 5, weakConstraintCount: 2 },
+      ],
+    });
+    expect(out.artifactLines[0]).toContain('5 constraints, 2 weak');
   });
 });
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -318,6 +318,7 @@ Examples:
             compiledArtifacts: nmResult.compiledArtifacts,
             findings: issues as any[],
           },
+          artifactSummaries: nmResult.artifactSummaries,
           verbose: !!options.verbose,
           usedAnalm: resolveNanomindFlag(options),
           analystFindings: nmResult.analystFindings,
@@ -527,6 +528,19 @@ interface UnifiedCheckDisplayOptions {
     compiledArtifacts: number;
     findings: Array<{ severity: string; checkId?: string; description?: string; name?: string; message?: string; fix?: string; guidance?: string; file?: string; line?: number; passed?: boolean; attackClass?: string; category?: string }>;
   };
+  /** Per-artifact summaries for the Observations block. Skill/MCP/SOUL/A2A
+   *  detected and compiled by the semantic compiler. Shape mirrors
+   *  `ArtifactSummary` from nanomind-core/scanner-bridge. Top-level field
+   *  (not nested under nanomindScan) so both `check` and `secure` paths
+   *  populate it uniformly. */
+  artifactSummaries?: Array<{
+    path: string;
+    type: string;
+    intent: 'benign' | 'suspicious' | 'malicious' | 'unknown';
+    capabilityLabels: string[];
+    constraintCount: number;
+    weakConstraintCount: number;
+  }>;
   usedAnalm?: boolean;
   analystFindings?: Array<{
     taskType: string;
@@ -824,13 +838,24 @@ function displayUnifiedCheck(opts: UnifiedCheckDisplayOptions): void {
     const kind = rawKind && rawKind !== 'unknown' ? rawKind : 'local project';
 
     const categorySummaries = buildCategorySummaries(failed);
-    const verdictLine = buildVerdict({ critical, high, medium, low }, { kind, filesScanned });
+    const verdictLine = buildVerdict(
+      { critical, high, medium, low },
+      { kind, filesScanned },
+      failed.map(f => ({
+        severity: f.severity as 'critical' | 'high' | 'medium' | 'low',
+        name: f.name,
+        checkId: f.checkId,
+        file: f.file,
+        line: f.line,
+      })),
+    );
 
-    const { lines } = renderObservationsBlock({
+    const { lines, artifactLines } = renderObservationsBlock({
       surfaces: { kind, filesScanned, artifactsCompiled: semanticCount },
       checks: { staticCount, semanticCount },
       categories: categorySummaries,
       verdict: verdictLine,
+      artifacts: opts.artifactSummaries,
       verbose: !!verbose,
     });
 
@@ -843,11 +868,37 @@ function displayUnifiedCheck(opts: UnifiedCheckDisplayOptions): void {
     };
     // 11-char label width fits "Categories" + 1 space separator.
     const LABEL_WIDTH = 12;
-    for (const { label, value, tone } of lines) {
-      const labelPad = label.padEnd(LABEL_WIDTH, ' ');
-      const color = toneColor(tone);
-      const accent = label === 'Verdict' ? colors.bold : '';
-      console.log(`  ${colors.dim}${labelPad}${RESET()}${color}${accent}${value}${RESET()}`);
+
+    // Emit Surfaces + Checks, then Artifacts block (if any), then
+    // Categories + Verdict. Artifacts go between Checks and Categories
+    // because they answer "what's here" before Categories answers "where
+    // are the problems."
+    const surfacesLine = lines.find(l => l.label === 'Surfaces')!;
+    const checksLine = lines.find(l => l.label === 'Checks')!;
+    const categoriesLine = lines.find(l => l.label === 'Categories')!;
+    const verdictDisplay = lines.find(l => l.label === 'Verdict')!;
+
+    for (const line of [surfacesLine, checksLine]) {
+      const labelPad = line.label.padEnd(LABEL_WIDTH, ' ');
+      console.log(`  ${colors.dim}${labelPad}${RESET()}${toneColor(line.tone)}${line.value}${RESET()}`);
+    }
+
+    if (artifactLines.length > 0) {
+      // First artifact line gets the "Artifacts" label; subsequent lines
+      // are indented to align under the first artifact path.
+      const firstLabel = 'Artifacts'.padEnd(LABEL_WIDTH, ' ');
+      const contIndent = ' '.repeat(LABEL_WIDTH);
+      console.log(`  ${colors.dim}${firstLabel}${RESET()}${artifactLines[0]}`);
+      for (const extraLine of artifactLines.slice(1)) {
+        console.log(`  ${colors.dim}${contIndent}${RESET()}${extraLine}`);
+      }
+    }
+
+    for (const line of [categoriesLine, verdictDisplay]) {
+      const labelPad = line.label.padEnd(LABEL_WIDTH, ' ');
+      const color = toneColor(line.tone);
+      const accent = line.label === 'Verdict' ? colors.bold : '';
+      console.log(`  ${colors.dim}${labelPad}${RESET()}${color}${accent}${line.value}${RESET()}`);
     }
     console.log();
   }
@@ -3279,6 +3330,7 @@ Examples:
           ? nmResult.analystFindings
           : undefined,
         analystZeroState: nmResult.analystZeroState,
+        artifactSummaries: nmResult.artifactSummaries,
         nextStepsTarget: directory,
       });
 
@@ -8232,6 +8284,7 @@ async function checkGitHubRepo(
     // Run NanoMind semantic analysis and re-filter
     let analystFindings: any[] | undefined;
     let analystZeroState: { reason: 'clean-scan' | 'not-ready' | 'backend-unavailable'; modelLabel: string } | undefined;
+    let artifactSummaries: any[] | undefined;
     try {
       const { orchestrateNanoMind } = await import('./nanomind-core/orchestrate.js');
       const nmResult = await orchestrateNanoMind(repoDir, result.findings, { silent: true, nanomind: resolveNanomindFlag(options) });
@@ -8243,6 +8296,7 @@ async function checkGitHubRepo(
       result.score = scanner.calculateScore(result.findings.filter((f: any) => !f.passed && !f.fixed)).score;
       analystFindings = nmResult.analystFindings;
       analystZeroState = nmResult.analystZeroState;
+      artifactSummaries = nmResult.artifactSummaries;
     } catch {
       // NanoMind unavailable — surface this in the CLI output instead of going
       // silent when --nanomind was requested. Keeps the render path honest.
@@ -8289,6 +8343,7 @@ async function checkGitHubRepo(
       usedAnalm: resolveNanomindFlag(options),
       analystFindings,
       analystZeroState,
+      artifactSummaries,
     });
 
     // Community contribution
@@ -8427,6 +8482,7 @@ async function checkPyPiPackage(
     // Run NanoMind semantic analysis and re-filter
     let analystFindings: any[] | undefined;
     let analystZeroState: { reason: 'clean-scan' | 'not-ready' | 'backend-unavailable'; modelLabel: string } | undefined;
+    let artifactSummaries: any[] | undefined;
     try {
       const { orchestrateNanoMind } = await import('./nanomind-core/orchestrate.js');
       const nmResult = await orchestrateNanoMind(extractDir, result.findings, { silent: true, nanomind: resolveNanomindFlag(options) });
@@ -8438,6 +8494,7 @@ async function checkPyPiPackage(
       result.score = scanner.calculateScore(result.findings.filter((f: any) => !f.passed && !f.fixed)).score;
       analystFindings = nmResult.analystFindings;
       analystZeroState = nmResult.analystZeroState;
+      artifactSummaries = nmResult.artifactSummaries;
     } catch {
       // NanoMind unavailable -- use base scan results
     }
@@ -8482,6 +8539,7 @@ async function checkPyPiPackage(
       usedAnalm: resolveNanomindFlag(options),
       analystFindings,
       analystZeroState,
+      artifactSummaries,
     });
 
     if (critical.length > 0 || high.length > 0) process.exit(1);
@@ -8610,6 +8668,7 @@ async function checkRawUrl(
 
     let analystFindings: any[] | undefined;
     let analystZeroState: { reason: 'clean-scan' | 'not-ready' | 'backend-unavailable'; modelLabel: string } | undefined;
+    let artifactSummaries: any[] | undefined;
     try {
       const { orchestrateNanoMind } = await import('./nanomind-core/orchestrate.js');
       const nmResult = await orchestrateNanoMind(scanDir, result.findings, { silent: true, nanomind: resolveNanomindFlag(options) });
@@ -8621,6 +8680,7 @@ async function checkRawUrl(
       result.score = scanner.calculateScore(result.findings.filter((f: any) => !f.passed && !f.fixed)).score;
       analystFindings = nmResult.analystFindings;
       analystZeroState = nmResult.analystZeroState;
+      artifactSummaries = nmResult.artifactSummaries;
     } catch {
       // NanoMind unavailable — surface this in the CLI output instead of going
       // silent when --nanomind was requested. Keeps the render path honest.
@@ -8664,6 +8724,7 @@ async function checkRawUrl(
       usedAnalm: resolveNanomindFlag(options),
       analystFindings,
       analystZeroState,
+      artifactSummaries,
     });
 
     // Community contribution (auto-share if opted in, no first-time prompt for URLs)
@@ -8772,6 +8833,7 @@ async function checkNpmPackage(
     // Run NanoMind semantic analysis and re-filter (matches secure command pipeline)
     let analystFindings: any[] | undefined;
     let analystZeroState: { reason: 'clean-scan' | 'not-ready' | 'backend-unavailable'; modelLabel: string } | undefined;
+    let artifactSummaries: any[] | undefined;
     try {
       const { orchestrateNanoMind } = await import('./nanomind-core/orchestrate.js');
       const nmResult = await orchestrateNanoMind(packageDir, result.findings, { silent: true, nanomind: resolveNanomindFlag(options) });
@@ -8783,6 +8845,7 @@ async function checkNpmPackage(
       result.score = scanner.calculateScore(result.findings.filter((f: any) => !f.passed && !f.fixed)).score;
       analystFindings = nmResult.analystFindings;
       analystZeroState = nmResult.analystZeroState;
+      artifactSummaries = nmResult.artifactSummaries;
     } catch {
       // NanoMind unavailable — surface this in the CLI output instead of going
       // silent when --nanomind was requested. Keeps the render path honest.
@@ -8826,6 +8889,7 @@ async function checkNpmPackage(
       usedAnalm: resolveNanomindFlag(options),
       analystFindings,
       analystZeroState,
+      artifactSummaries,
     });
 
     // Community contribution (after 3 scans, interactive only)

--- a/src/nanomind-core/orchestrate.ts
+++ b/src/nanomind-core/orchestrate.ts
@@ -15,8 +15,10 @@
  */
 
 import type { SecurityFinding, ProjectType } from '../hardening/security-check.js';
-import type { NanoMindScanResult } from './scanner-bridge.js';
+import type { NanoMindScanResult, ArtifactSummary } from './scanner-bridge.js';
 import type { AnalystResponse } from './inference/security-analyst.js';
+
+export type { ArtifactSummary } from './scanner-bridge.js';
 
 export interface OrchestrationOptions {
   staticOnly?: boolean;
@@ -32,6 +34,9 @@ export interface OrchestrationResult {
   mergedFindings: SecurityFinding[];
   nanomindUsed: boolean;
   compiledArtifacts: number;
+  /** Compact per-artifact summaries (skills / MCPs / SOULs / A2A cards).
+   *  Empty when NanoMind is unavailable or only source code was scanned. */
+  artifactSummaries: ArtifactSummary[];
   newSemanticFindings: number;
   integrityStatus: string;
   /** NanoMind generative results (present when --nanomind is used and model is available). */
@@ -70,6 +75,7 @@ export async function orchestrateNanoMind(
       mergedFindings: [...existingFindings],
       nanomindUsed: false,
       compiledArtifacts: 0,
+      artifactSummaries: [],
       newSemanticFindings: 0,
       integrityStatus: 'SKIPPED',
     };
@@ -117,6 +123,7 @@ export async function orchestrateNanoMind(
       mergedFindings: nmResult.mergedFindings,
       nanomindUsed: nmResult.nanomindAvailable,
       compiledArtifacts: nmResult.compiledArtifacts,
+      artifactSummaries: nmResult.artifactSummaries,
       newSemanticFindings: newFindings,
       integrityStatus: nmResult.integrityStatus,
     };
@@ -194,6 +201,7 @@ export async function orchestrateNanoMind(
       mergedFindings: [...existingFindings],
       nanomindUsed: false,
       compiledArtifacts: 0,
+      artifactSummaries: [],
       newSemanticFindings: 0,
       integrityStatus: 'UNAVAILABLE',
     };

--- a/src/nanomind-core/scanner-bridge.ts
+++ b/src/nanomind-core/scanner-bridge.ts
@@ -69,11 +69,25 @@ const MAX_FILES_PER_SCAN = 200;
 // Public API
 // ============================================================================
 
+/** Compact summary of one compiled artifact, suitable for CLI rendering.
+ *  Populated during the scanner-bridge compile loop so the display layer
+ *  can describe what the project ACTUALLY CONTAINS (not just how many
+ *  findings fired). Avoids shipping full ASTs through the public API. */
+export interface ArtifactSummary {
+  path: string;                      // relative path from scan root
+  type: string;                      // artifactType (skill, mcp_config, soul, ...)
+  intent: 'benign' | 'suspicious' | 'malicious' | 'unknown';
+  capabilityLabels: string[];        // human-readable, up to 4 (e.g. "fs-write", "shell-exec")
+  constraintCount: number;           // # of declared constraints (0 = no governance)
+  weakConstraintCount: number;       // # of constraints with bypassRisk > 0.5
+}
+
 export interface NanoMindScanResult {
   mergedFindings: SecurityFinding[];
   astFindings: ASTFinding[];
   integrityStatus: IntegrityStatus;
   compiledArtifacts: number;
+  artifactSummaries: ArtifactSummary[];
   nanomindAvailable: boolean;
 }
 
@@ -101,6 +115,7 @@ export async function runNanoMindScan(
       astFindings: [],
       integrityStatus: 'QUARANTINE',
       compiledArtifacts: 0,
+      artifactSummaries: [],
       nanomindAvailable: false,
     };
   }
@@ -136,6 +151,7 @@ export async function runNanoMindScan(
 
   // Step 4: Compile each file and run analyzers
   const allASTFindings: ASTFinding[] = [];
+  const artifactSummaries: ArtifactSummary[] = [];
   let compiledCount = 0;
   let nanomindUsedAtLeastOnce = false;
 
@@ -159,6 +175,15 @@ export async function runNanoMindScan(
         result.ast.intentConfidence,
         result.ast.modelVersion,
       );
+
+      // Capture a compact summary for the CLI Observations block. Only
+      // security-relevant artifact types — skipping source_code / unknown /
+      // env_file avoids pollution from ordinary files that the compiler
+      // fingerprints but the user doesn't want enumerated.
+      const isAgentArtifact = ['skill', 'mcp_config', 'soul', 'system_prompt', 'agent_config', 'a2a_card'].includes(result.ast.artifactType);
+      if (isAgentArtifact) {
+        artifactSummaries.push(buildArtifactSummary(result.ast, relativePath));
+      }
 
       // Skip documentation and metadata files — these are not security artifacts.
       // URLs in package.json are not exfiltration, "should" in README is not governance.
@@ -216,8 +241,74 @@ export async function runNanoMindScan(
     astFindings: allASTFindings,
     integrityStatus: integrity.status,
     compiledArtifacts: compiledCount,
+    artifactSummaries,
     nanomindAvailable: nanomindUsedAtLeastOnce || useNanoMind,
   };
+}
+
+// ============================================================================
+// Artifact Summary Builder
+// ============================================================================
+
+/**
+ * Distill a SecurityAST into a compact summary suitable for CLI rendering.
+ *
+ * Capability names in the AST come from analyzer-internal taxonomy (e.g.
+ * `filesystem.write`, `network.http`, `shell.exec`). Those don't read well
+ * to a CISO — so we collapse them to short, readable phrases: "fs-write",
+ * "net-http", "shell-exec". The mapping is deterministic; no model inference.
+ */
+function buildArtifactSummary(ast: SecurityAST, relativePath: string): ArtifactSummary {
+  // Prefer inferred over declared — inferred reflects what the artifact
+  // ACTUALLY does, declared reflects what it claims to do. Divergence is a
+  // separate finding; here we describe behaviour.
+  const inferredLabels = ast.inferredCapabilities.map(c => humanizeCapability(c.name));
+  // Deduplicate (same capability can be inferred multiple times with different scopes)
+  const uniqueLabels = Array.from(new Set(inferredLabels)).filter(Boolean);
+
+  const weakConstraintCount = ast.declaredConstraints.filter(c => c.bypassRisk > 0.5).length;
+
+  return {
+    path: relativePath,
+    type: ast.artifactType,
+    intent: (ast.intentClassification ?? 'unknown') as ArtifactSummary['intent'],
+    capabilityLabels: uniqueLabels.slice(0, 4), // cap at 4 to keep the CLI line short
+    constraintCount: ast.declaredConstraints.length,
+    weakConstraintCount,
+  };
+}
+
+/**
+ * Collapse analyzer-internal capability names (dot-delimited,
+ * domain-first) into short display labels. Unknown names pass through
+ * as-is (better to show a raw name than a generic placeholder).
+ */
+function humanizeCapability(name: string): string {
+  const map: Record<string, string> = {
+    'filesystem.read': 'fs-read',
+    'filesystem.write': 'fs-write',
+    'filesystem.delete': 'fs-delete',
+    'network.http': 'net-http',
+    'network.egress': 'net-egress',
+    'shell.exec': 'shell-exec',
+    'shell.spawn': 'shell-spawn',
+    'process.kill': 'proc-kill',
+    'credential.read': 'creds-read',
+    'credential.write': 'creds-write',
+    'memory.read': 'mem-read',
+    'memory.write': 'mem-write',
+    'api.call': 'api-call',
+    'database.read': 'db-read',
+    'database.write': 'db-write',
+    'cron.schedule': 'cron',
+    'persistence.session': 'persistence',
+    'exfiltration.external': 'data-egress',
+    'injection.prompt': 'prompt-injection',
+  };
+  if (map[name]) return map[name];
+  // Fallback: take the last segment, e.g. "custom.foo.bar" -> "bar"
+  const segs = name.split('.');
+  return segs[segs.length - 1] || name;
 }
 
 // ============================================================================

--- a/src/output/observations.ts
+++ b/src/output/observations.ts
@@ -28,6 +28,19 @@ export interface SurfaceSummary {
   detected?: string[];
 }
 
+/** Per-artifact summary displayed in the Artifacts block.
+ *  Shape matches the one produced by the NanoMind scanner-bridge
+ *  `ArtifactSummary` — kept structurally compatible but defined here
+ *  so observations.ts has no import dependency on nanomind-core. */
+export interface ArtifactLine {
+  path: string;
+  type: string;
+  intent: 'benign' | 'suspicious' | 'malicious' | 'unknown';
+  capabilityLabels: string[];
+  constraintCount: number;
+  weakConstraintCount: number;
+}
+
 export interface ChecksSummary {
   /** Total static checks executed. */
   staticCount: number;
@@ -56,6 +69,10 @@ export interface ObservationsInput {
   checks: ChecksSummary;
   categories: CategorySummary[];
   verdict: { status: VerdictStatus; message: string };
+  /** Per-artifact summaries from NanoMind AST compiler. Empty array and
+   *  the Artifacts block is skipped — scans without agent artifacts
+   *  don't need a dedicated "what did we compile" block. */
+  artifacts?: ArtifactLine[];
   verbose?: boolean;
   /** Terminal width for wrapping (default 65). */
   width?: number;
@@ -155,45 +172,86 @@ export function buildCategorySummaries(findings: SecurityFinding[]): CategorySum
   return Array.from(byLabel.values());
 }
 
+/** Minimal finding shape the verdict builder consumes — a subset of SecurityFinding
+ *  so callers don't have to pass the whole object. Must include the fields
+ *  buildVerdict uses to name the lead finding. */
+export interface VerdictFinding {
+  severity: 'critical' | 'high' | 'medium' | 'low';
+  name?: string;
+  checkId?: string;
+  file?: string;
+  line?: number;
+}
+
 /**
- * Build a plain-English verdict from severity counts + surface context.
+ * Build a plain-English verdict from the actual failed findings.
  *
- * Never uses letter grades. Anchors to an action ("Safe to use",
- * "Fix X and rescan", "Not safe to ship") per CISO philosophy rule #10
- * (feedback_cli_ciso_philosophy.md).
+ * Old version counted severities and produced grammar like "1 low finding to
+ * address" — which told the reader nothing they couldn't count themselves.
+ * This version names the lead finding (worst severity, first by check-ID)
+ * so the Verdict line is action-oriented: the user learns WHAT to fix, not
+ * just HOW MANY exist.
+ *
+ * Never uses letter grades. Anchors to an action per CISO philosophy rule
+ * #10 (feedback_cli_ciso_philosophy.md).
  */
 export function buildVerdict(
   severity: { critical: number; high: number; medium: number; low: number },
   surface: SurfaceSummary,
+  findings?: VerdictFinding[],
 ): { status: VerdictStatus; message: string } {
   const { critical, high, medium, low } = severity;
   const total = critical + high + medium + low;
 
+  if (total === 0) {
+    const surfaceLabel = surface.kind && surface.kind !== 'unknown' ? surface.kind : 'project';
+    return {
+      status: 'safe',
+      message: `No security issues detected. This ${surfaceLabel} looks safe to use.`,
+    };
+  }
+
+  // Pick the leading finding to name in the verdict: worst severity first.
+  // If multiple findings at the top severity, the verdict describes the first
+  // one (stable ordering from the scanner) and says "+ N more" for the rest.
+  const leadSeverity: VerdictFinding['severity'] | null =
+    critical > 0 ? 'critical' : high > 0 ? 'high' : medium > 0 ? 'medium' : low > 0 ? 'low' : null;
+
+  const leaders = (findings ?? []).filter(f => f.severity === leadSeverity);
+  const lead = leaders[0];
+
+  /** Format a finding as "NAME in file:line" — falls back to checkId or name. */
+  const formatLead = (f: VerdictFinding): string => {
+    const label = f.name?.trim() || f.checkId?.trim() || 'finding';
+    if (f.file) {
+      const loc = f.line ? `${f.file}:${f.line}` : f.file;
+      return `${label} in ${loc}`;
+    }
+    return label;
+  };
+
+  const extraCount = Math.max(0, total - 1);
+  const extraSuffix = extraCount > 0 ? ` + ${extraCount} more` : '';
+
   if (critical > 0) {
+    const leadText = lead ? formatLead(lead) : `${critical} critical issue${critical > 1 ? 's' : ''}`;
     return {
       status: 'unsafe',
-      message: `Not safe to ship. Fix ${critical} critical issue${critical > 1 ? 's' : ''} before using this in production.`,
+      message: `Not safe to ship. ${leadText}${extraSuffix}. Fix before using in production.`,
     };
   }
   if (high > 0) {
+    const leadText = lead ? formatLead(lead) : `${high} high-severity issue${high > 1 ? 's' : ''}`;
     return {
       status: 'unsafe',
-      message: `Not safe as-is. Fix ${high} high-severity issue${high > 1 ? 's' : ''}, then rescan.`,
+      message: `Not safe as-is. ${leadText}${extraSuffix}. Fix, then rescan.`,
     };
   }
-  if (medium > 0 || low > 0) {
-    const parts: string[] = [];
-    if (medium > 0) parts.push(`${medium} medium`);
-    if (low > 0) parts.push(`${low} low`);
-    return {
-      status: 'needs-fix',
-      message: `Usable with caveats. ${parts.join(' + ')} finding${total > 1 ? 's' : ''} to address. Run \`secure --fix\` to auto-remediate where possible.`,
-    };
-  }
-  const surfaceLabel = surface.kind && surface.kind !== 'unknown' ? surface.kind : 'project';
+  // medium or low only
+  const leadText = lead ? formatLead(lead) : `${total} finding${total > 1 ? 's' : ''}`;
   return {
-    status: 'safe',
-    message: `No security issues detected. This ${surfaceLabel} looks safe to use.`,
+    status: 'needs-fix',
+    message: `Usable with caveats. ${leadText}${extraSuffix}. Run \`secure --fix\` to auto-remediate where possible.`,
   };
 }
 
@@ -248,6 +306,57 @@ function formatChecksLine(checks: ChecksSummary): string {
 }
 
 /**
+ * Format one artifact as a single compact line.
+ *
+ * Shape: `<path>  <type> · <intent> · <capabilities>  [<constraints>]`
+ *
+ * Example:
+ *   `deploy.skill.md  skill · benign · cron + fs-write + net-egress  (2 constraints, 1 weak)`
+ *   `mcp.json         mcp_config · suspicious · shell-exec + fs-write`
+ */
+function formatArtifactLine(a: ArtifactLine): string {
+  const capText = a.capabilityLabels.length > 0
+    ? a.capabilityLabels.join(' + ')
+    : 'no inferred capabilities';
+  const parts = [a.type, a.intent, capText];
+  const head = `${a.path}  ${parts.join(' · ')}`;
+
+  if (a.constraintCount > 0) {
+    const weakSuffix = a.weakConstraintCount > 0 ? `, ${a.weakConstraintCount} weak` : '';
+    return `${head}  (${a.constraintCount} constraint${a.constraintCount === 1 ? '' : 's'}${weakSuffix})`;
+  }
+  if (a.type === 'skill' || a.type === 'mcp_config' || a.type === 'a2a_card' || a.type === 'agent_config') {
+    // Agent artifacts without any declared constraints — this is itself a signal worth flagging
+    return `${head}  (no declared constraints)`;
+  }
+  return head;
+}
+
+/**
+ * Select + format artifact lines for the Observations block.
+ * Defaults to up to 6 lines; verbose mode shows all. Ordering: risky
+ * first (malicious > suspicious > benign), then by capability count
+ * (more capabilities = more surface = more worth naming first).
+ */
+function formatArtifactsBlock(artifacts: ArtifactLine[], verbose: boolean): string[] {
+  const intentRank: Record<ArtifactLine['intent'], number> = {
+    malicious: 0, suspicious: 1, benign: 2, unknown: 3,
+  };
+  const sorted = [...artifacts].sort((a, b) => {
+    const r = intentRank[a.intent] - intentRank[b.intent];
+    if (r !== 0) return r;
+    return b.capabilityLabels.length - a.capabilityLabels.length;
+  });
+  const cap = verbose ? Infinity : 6;
+  const shown = sorted.slice(0, cap).map(formatArtifactLine);
+  const extra = sorted.length - shown.length;
+  if (extra > 0) {
+    shown.push(`+ ${extra} more (run with --verbose to see all)`);
+  }
+  return shown;
+}
+
+/**
  * Format the Surfaces line. Always names the project kind; adds file
  * count + detected artifacts when present.
  */
@@ -274,11 +383,15 @@ function formatSurfacesLine(surface: SurfaceSummary): string {
  */
 export interface RenderedObservations {
   lines: Array<{ label: string; value: string; tone: 'default' | 'good' | 'warning' | 'critical' }>;
+  /** Multi-line Artifacts block. Each entry is rendered on its own line
+   *  (first entry gets the "Artifacts" label, rest are continuations).
+   *  Empty when no agent artifacts were compiled. */
+  artifactLines: string[];
   verdict: { status: VerdictStatus; message: string };
 }
 
 export function renderObservationsBlock(input: ObservationsInput): RenderedObservations {
-  const { surfaces, checks, categories, verdict, verbose } = input;
+  const { surfaces, checks, categories, verdict, artifacts, verbose } = input;
 
   const lines: RenderedObservations['lines'] = [
     { label: 'Surfaces', value: formatSurfacesLine(surfaces), tone: 'default' },
@@ -298,5 +411,9 @@ export function renderObservationsBlock(input: ObservationsInput): RenderedObser
     },
   ];
 
-  return { lines, verdict };
+  const artifactLines = artifacts && artifacts.length > 0
+    ? formatArtifactsBlock(artifacts, !!verbose)
+    : [];
+
+  return { lines, artifactLines, verdict };
 }


### PR DESCRIPTION
Follow-up to #110. Two user-feedback items that turn the Observations block from counts into content.

## Why

After #110 merged, review surfaced two concrete gaps:

1. **\`Usable with caveats. 1 low finding to address\`** — told the reader nothing they couldn't count themselves. The Verdict should name the actual thing.
2. **Scanner never described what skills / SOUL / A2A / MCP artifacts the project contains.** The most useful piece of CISO context — \"what does this agent actually do\" — wasn't rendered anywhere.

The data for both lives inside the NanoMind AST compiler (\`inferredCapabilities\`, \`declaredConstraints\`, \`intentClassification\`). It's deterministic — no SLM — so zero hallucination risk per \`project_nanomind_v05_intelreport_task_mismatch\`. We just weren't surfacing it.

## What changed

### Artifacts block (new)
Between Checks and Categories. One line per compiled agent artifact:

\`\`\`
  Artifacts   deploy.skill.md     skill · benign · fs-write + net-egress  (3 constraints)
              mcp.json            mcp_config · suspicious · shell-exec  (no declared constraints)
              SOUL.md             soul · benign · no inferred capabilities  (5 constraints, 1 weak)
\`\`\`

- Sorts malicious > suspicious > benign, then by capability count
- Caps at 6 lines; \`--verbose\` expands
- Names \"no declared constraints\" when an agent artifact has zero governance
- Flags weak constraints (bypassRisk > 0.5) inline

### Verdict enrichment
\`buildVerdict\` now accepts the failed findings array and names the lead finding by severity + file:line:

\`\`\`
  Old: \"Not safe to ship. Fix 3 critical issues before using this in production.\"
  New: \"Not safe to ship. Anthropic API key exposed in deploy.skill.md:12 + 2 more.
        Fix before using in production.\"
\`\`\`

Backward-compatible — falls back to severity count when findings array not passed.

## Verified on real fixtures

| Fixture | Artifacts rendered |
|---|---|
| \`test/hma\` (known-vulnerable) | 11 compiled artifacts: 5 system_prompt + 2 skill + 1 soul + more. All malicious intent. 2 skills called out as \"no declared constraints\" |
| \`/tmp/hma-clean-test\` (clean) | Artifacts block correctly omitted (no agent artifacts) |
| \`/tmp/hma-real-world/ibm-mcp\` (empty) | Same, omitted |

## Test plan

- [x] \`npm test\` — 1767 passing (+10 new: lead-finding tests + 6 Artifacts-render tests)
- [x] Verified on test/hma with new Artifacts block rendering
- [x] Verified --verbose expansion works (10-artifact test case)
- [x] Verified weak-constraint inline labeling
- [x] Verified graceful degradation when artifacts array is empty

## Known gap (filed as follow-up)

A2A \`agent-card.json\` files currently classify as \`unknown\` by the SemanticCompiler — pre-existing bug in the artifactType heuristic. The Artifacts block works correctly when the compiler returns the right type, so this PR doesn't block that fix.

## Not changing in this PR

- \`@opena2a/cli-ui\` extraction still pending per [CA-030] — helper stays inlined in HMA
- Publishing still HOLD per 2026-04-22 strategic frame