### PR TITLE
ci: cross-CLI parity gate workflow (M0)

### DIFF
--- a/.github/workflows/parity.yml
+++ b/.github/workflows/parity.yml
@@ -1,0 +1,23 @@
+name: parity
+
+on:
+  pull_request:
+    paths:
+      - "src/**"
+      - "package.json"
+      - "package-lock.json"
+      - ".github/workflows/parity.yml"
+  push:
+    branches: [main]
+
+concurrency:
+  group: parity-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  parity:
+    uses: opena2a-org/opena2a-parity/.github/workflows/parity.yml@main
+    with:
+      hma_ref: ${{ github.event.pull_request.head.sha || github.sha }}
+      opena2a_ref: main
+      ai_trust_ref: main


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/parity.yml` that invokes the reusable workflow in `opena2a-org/opena2a-parity`.
- On every PR touching `src/**`, the gate checks out this PR's SHA alongside `main` from `opena2a` and `ai-trust`, builds all three CLIs on Node 24, and runs the parity harness against the `secure-dirty-skill` fixture.
- Includes an intentional-drift self-test — drift mode must exit non-zero, otherwise the gate itself is broken and CI fails.

This is one of four coordinated PRs delivering M0 of the CLI consolidation plan (CA-034 / CPO-019, committed 2026-04-22). See `opena2a-org/todo/2026-04-22-cli-consolidation-sequenced.md` for the full milestone chain.

Companion PRs:
- `opena2a-org/opena2a` — `feat/parity-gate-mvp` (monorepo caller workflow with path filter on `packages/cli/**` and `packages/cli-ui/**`)
- `opena2a-org/ai-trust` — `feat/parity-gate-mvp` (caller workflow)
- `opena2a-org/opena2a-architecture` — `feat/parity-gate-mvp` (docs entry under Shared Packages)

The harness itself lives at `opena2a-org/opena2a-parity` (new private repo, `main`).

## Contract for this fixture

`secure-dirty-skill` exercises `hackmyagent secure --format json` against the existing `test/hma/` corpus. Must-match fields for M0: `platform`, `projectType`, `score`, `maxScore`. Findings-count drift (HMA 112 vs opena2a scan 231) is a known gap tracked for M3/M4 to close via `hackmyagent/core` extraction.

`ai-trust` skips dir-scan fixtures per contract — its `check` command takes a package name. Three-way parity arrives with `check-*` fixtures in follow-up PRs.

## Test plan

- [ ] Chief review (CA-034 primary, CPO-019 acceptance).
- [ ] Watch the first CI run after merge — the workflow only triggers on `src/**` changes, so a trivial follow-up PR will prove it fires.
- [ ] Merge after companion PRs in `opena2a` + `ai-trust` + `opena2a-architecture` are ready (so the reusable workflow can locate peer repos at HEAD).

## Notes

- Node 24 in the reusable workflow — matches the Trusted Publishing requirement.
- Local harness run against this branch passes: `[OK] secure-dirty-skill × hma: 4 must-match fields byte-identical`.
- `parity:drift-demo` correctly returns exit 1 with `at platform: expected ... actual ...+drift-demo`.

Do not merge. Chief sign-off required.