### PR TITLE
release: 0.18.0 — Observations UX + Trusted Publishing provenance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,12 +4,23 @@ All notable changes to HackMyAgent are documented in this file.
 
 ## [Unreleased]
 
+## [0.18.0] - 2026-04-22
+
+First release of HackMyAgent published via npm Trusted Publishing — ships with SLSA v1 provenance attestations. Verify with `npm view hackmyagent dist.attestations --json`.
+
 ### Added
+- **Observations block in `secure` output (#110).** Scanner now emits a dedicated Observations section that groups per-finding context (file, severity, fix command, Verify line) separately from the verdict and artifact summary. Renders through `@opena2a/cli-ui@0.2.0` for cross-CLI parity with `opena2a review` and `ai-trust` output. Replaces the inlined `observations.ts` + `analyst-render.ts` implementations which have been removed from this repo and centralized in `@opena2a/cli-ui`.
+- **Artifacts block + Verdict names the lead finding (#111).** Verdict line now quotes the single highest-severity finding by name and check ID, followed by an Artifacts block enumerating what was scanned (files, paths, line counts). CISOs reading a one-screen verdict can identify the specific blocking issue without scrolling.
+- **`--nanomind` specialist gate.** NanoMind generative analysis is now invoked only on artifact types where the input-classifier v3.1 gate passes — reduces off-topic hallucinations on clean scans. Gate thresholds and model path live in `nanomind-core/orchestrate.ts`.
+- **Cross-CLI parity gate CI (#113).** New workflow in `.github/workflows/parity.yml` asserts that `hackmyagent secure`, `opena2a review`, and `ai-trust` produce identical Observations/Verdict blocks on a shared fixture set. Prevents rendering divergence between the three CLIs that all consume `@opena2a/cli-ui`.
 - **Scanner finds agent identity + DNA files in `.well-known/`.** `AIM-001` (no agent identity) and `DNA-001` (no behavioral fingerprint) now also recognize `.well-known/agent-card.json`, `.well-known/agent-dna.json`, and `.well-known/aim.json` alongside the existing root-level lookups. Additive — repos that keep their identity files at the project root continue to pass unchanged. Aligns with RFC 8615 well-known URI conventions and the A2A protocol spec.
 
 ### Changed
+- **Consumes `@opena2a/cli-ui@0.2.0` for Observations rendering (#112).** Inlined rendering code removed; all three CLIs now render through the shared package. Fixes a stale `semanticCount` on the `secure` path where the analyst-render output counted pre-dedupe findings.
 - **HMA's own agent identity files moved to `.well-known/`.** `agent-card.json` and `agent-dna.json` now live at `.well-known/agent-card.json` and `.well-known/agent-dna.json` to model the convention.
 - **Release playbook moved to `docs/release-playbook.md`.** Self-references and `.release/baselines.json` updated to match.
+- **Tag-triggered release workflow with npm provenance (#106).** Publishes now run via GitHub Actions OIDC exchange — no `NPM_TOKEN`, no long-lived credentials. Triggered by pushing a `v*` tag to `main`.
+- **Release workflow pinned to Node 24 (#107).** Required for npm Trusted Publishing OIDC flow. Legacy Node 20 workflows failed to exchange the OIDC token.
 
 ### Fixed
 - **`RAG-002` no longer fires on TypeScript data-catalog string literals (#108).** Property-value lines like `description: "...store and retrieve context..."` are now recognized as pure data rather than a retrieval call. The rule still fires on runtime retriever calls (`.retrieve(`, `retriever.invoke(`, `vectorStore.similaritySearch(`), Python f-string prompt assembly, template literals that embed retrieval calls, and any line containing a function call.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "hackmyagent",
-  "version": "0.17.11",
+  "version": "0.18.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "hackmyagent",
-      "version": "0.17.11",
+      "version": "0.18.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.12.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hackmyagent",
-  "version": "0.17.11",
+  "version": "0.18.0",
   "description": "Find it. Break it. Fix it. The hacker's toolkit for AI agents.",
   "bin": {
     "hackmyagent": "dist/cli.js"


### PR DESCRIPTION
## Summary

Cuts `hackmyagent@0.18.0` with SLSA v1 provenance via npm Trusted Publishing. Ships 18 commits of already-merged work since 0.17.11 — Observations block, Verdict + Artifacts block, consume `@opena2a/cli-ui@0.2.0`, cross-CLI parity gate, and context-gate FP fixes for RAG-002 + MEM-006.

Scope matches a minor bump: new user-visible output blocks and a new cross-CLI CI gate. Not a patch. The 2026-04-22 "HMA HOLD, batch 12 bugs into 0.18" framing is stale — 4 of the 12 already shipped (PR #100), 2 more shipped (PRs #108/#109), and the remaining 6 are preserved-detection FP-suppress (not detection gaps). Full rationale: `briefs/hma-0.18-publish-timing.md`.

First HMA release under Trusted Publishing — no `NPM_TOKEN`, no long-lived credentials. Verify after publish: `npm view hackmyagent dist.attestations --json` must return `predicateType: https://slsa.dev/provenance/v1`.

## What shipped since 0.17.11

See the 0.18.0 entry in `CHANGELOG.md` for full detail. Highlights:
- **Observations block** (#110) — new `secure` output section grouping per-finding context, rendered through shared `@opena2a/cli-ui`.
- **Verdict names the lead finding + Artifacts block** (#111) — CISO-friendly one-line verdict plus enumerated scan targets.
- **Consume `@opena2a/cli-ui@0.2.0`** (#112) — inlined rendering code removed; fixed stale `semanticCount` on secure path.
- **Cross-CLI parity gate CI** (#113) — asserts HMA / opena2a / ai-trust render identically on shared fixtures.
- **Context-gate RAG-002 + MEM-006** (#108, #109) — no longer flags TypeScript data-catalog string literals or DVAA-style adversarial test harnesses.
- **TP workflow** (#106, #107) — tag-triggered, Node 24, OIDC.

## Pre-push review

- **Phase 1 sensitive files:** clean.
- **Phase 2 build/test:** 1711 passed / 16 skipped / 10 todo across 128 test files.
- **Phase 3 code review:** no code changes — CHANGELOG + `package.json` + `package-lock.json` version-field update only. Entries trace to merged PRs #106–#113.
- **Phase 4 self-scan:** 1 LOW finding on `CLAUDE.md` size (baseline per `feedback_per_finding_review_protocol.md` — informational).
- **Phase 4.5 adversarial:** SKIPPED — this diff contains no scanner or detection logic changes. Scanner changes shipped in PRs #108/#109/#110/#111 already underwent adversarial review at merge time.
- **Phase 5 hma-hunter:** SKIPPED — HMA is a CLI-only tool.
- **Phase 6 new-user walkthrough:** ran `node dist/cli.js secure /tmp/…` and `secure test/hma/`. Observations / Findings / Top Issues blocks render with per-finding Verify/Fix. Verdict names the lead finding ("Not safe to ship. Dangerous npm Scripts in package.json + 111 more"). Per-finding protocol passes: specificity, action, severity coherence all intact.
- **Phase 7 version sweep (in-repo):** clean — only historical `0.17.11` references in CHANGELOG (correct).

## Post-merge steps (this PR does not tag)

1. `git tag v0.18.0` on main → `git push origin v0.18.0` → workflow publishes via OIDC.
2. Verify SLSA v1 attestations on npm (the workflow itself runs a 5-minute retry loop).
3. `gh release create v0.18.0 --generate-notes --title "v0.18.0"`; edit notes to reference TP + SLSA v1 verification command.
4. **Homebrew tap:** `curl -sL https://registry.npmjs.org/hackmyagent/-/hackmyagent-0.18.0.tgz | shasum -a 256` → update `homebrew-tap/Formula/hackmyagent.rb` url + sha256 + version table in README.
5. **Cross-repo version sweep:** opena2a-website, hackmyagent-web, oasb-website, opena2a-github-profile — replace any lingering `0.17.11` references. opena2a-cli's `MIN_HMA_VERSION` constant decides whether to bump.
6. **Downstream consumer bumps:** `opena2a-cli` and `ai-trust` exact-pin `hackmyagent` to `0.18.0` (separate PRs per repo, coordinated with the CLI-consolidation CA-034 M1 work).

## Remaining 0.18.x work (not blocking 0.18.0)

- Bug #3 AIM-002 severity on `examples/templates/` — [CA] decision PR
- Bug #5 UNICODE-STEGO-001 path exemption for `training/corpus/**` — [CSR] decision PR
- Bug #7 NEMO-007 severity on `*.test.*` — [CPO] decision PR
- Bug #9 `eval` in JSDoc comments + string literals (secretless case)
- Bug #10 `--help/` path corruption + `.claude/` exemption
- Bug #12 `token` word-match on ML-artifact filenames (nanomind case)

All six ship as `0.18.1` or later. Each is preserved-detection FP-suppress — they reduce noise without creating new detection gaps.