### PR TITLE
fix(test): bump E2E-003 network-detection timeout to 30s

### DIFF
--- a/__tests__/oasb/e2e/E2E-003.live-network-detection.test.ts
+++ b/__tests__/oasb/e2e/E2E-003.live-network-detection.test.ts
@@ -84,7 +84,7 @@ describe('E2E-003: Live Network Detection', () => {
     });
   });
 
-  it('should detect a new outbound TCP connection', async () => {
+  it('should detect a new outbound TCP connection', { timeout: 30000 }, async () => {
     if (!networkAvailable) {
       console.log('SKIP: lsof/ss not available — network E2E test requires system tools');
       return;


### PR DESCRIPTION
## Summary

The E2E network-detection test was failing on GHA ubuntu-latest runners because vitest's default 10s test timeout fired before the test's internal \`waitForEvent(..., 15000)\` polling could complete. lsof/ss polling is slower on GHA than on local macOS.

30s gives 2x headroom on the existing internal timeout. No product change; same code passes 1711/1711 locally on Darwin.

**Blocks hackmyagent 0.18.0 publish.** The v0.18.0 tag is pushed; merge + retag (or rerun workflow) to re-trigger publish with the fix.

## Test plan

- [x] \`npm test __tests__/oasb/e2e/E2E-003\` locally — passes.
- [ ] GHA CI passes on this PR.
- [ ] Post-merge: retag v0.18.0 (delete + re-push) or bump to 0.18.1 and tag.