### PR TITLE
release: hackmyagent 0.18.1 — E2E-003 timeout fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to HackMyAgent are documented in this file.
 
 ## [Unreleased]
 
+## [0.18.1] - 2026-04-22
+
+### Fixed
+- **E2E-003 live network detection no longer times out in CI (#117).** The test's internal `waitForEvent` uses a 15s polling budget, but vitest's default 10s test timeout was firing first on GHA ubuntu-latest runners (slower lsof/ss polling than local macOS). Bumped the test timeout to 30s. No product change; blocks previously-red 0.18.0 publish.
+
+Everything from the superseded 0.18.0 tag ships in 0.18.1. The v0.18.0 tag was force-published against a pre-fix commit and the workflow failed in CI; 0.18.1 is the shippable version.
+
 ## [0.18.0] - 2026-04-22
 
 First release of HackMyAgent published via npm Trusted Publishing — ships with SLSA v1 provenance attestations. Verify with `npm view hackmyagent dist.attestations --json`.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "hackmyagent",
-  "version": "0.18.0",
+  "version": "0.18.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "hackmyagent",
-      "version": "0.18.0",
+      "version": "0.18.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.12.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hackmyagent",
-  "version": "0.18.0",
+  "version": "0.18.1",
   "description": "Find it. Break it. Fix it. The hacker's toolkit for AI agents.",
   "bin": {
     "hackmyagent": "dist/cli.js"


### PR DESCRIPTION
## Summary

Bumps from 0.18.0 (workflow-blocked) to 0.18.1 so a fresh tag can trigger the release workflow against the fixed commit.

Why 0.18.1 not re-run 0.18.0:
- v0.18.0 tag is pinned at c14939a (pre-fix). Re-running the workflow fetches that commit, so the E2E test still fails.
- Moving a tag requires force-push (destructive). Bumping is safer and leaves a clean audit trail.
- 0.18.0 never published to npm — no conflict.

0.18.1 ships identical feature content to 0.18.0 plus PR #117's test timeout fix.

## Test plan

- [x] \`npm ci && npm run build && npm test\` — 1711/1711 pass locally.
- [ ] Post-merge: tag v0.18.1, \`gh run watch\`, \`npm view hackmyagent@0.18.1 dist.attestations --json\`.