### PR TITLE
release: hackmyagent 0.18.2 — skip E2E-003 on CI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to HackMyAgent are documented in this file.
 
 ## [Unreleased]
 
+## [0.18.2] - 2026-04-22
+
+### Fixed
+- **E2E-003 live network detection skipped on CI (#119).** GHA ubuntu-latest runners don't reliably surface localhost TCP connections to `ss` polling within the 15s event window. Local dev on macOS and Linux continues to exercise the full detection path. Blocks the 0.18.1 publish workflow; 0.18.2 is the shippable bundle.
+
 ## [0.18.1] - 2026-04-22
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "hackmyagent",
-  "version": "0.18.1",
+  "version": "0.18.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "hackmyagent",
-      "version": "0.18.1",
+      "version": "0.18.2",
       "license": "Apache-2.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.12.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hackmyagent",
-  "version": "0.18.1",
+  "version": "0.18.2",
   "description": "Find it. Break it. Fix it. The hacker's toolkit for AI agents.",
   "bin": {
     "hackmyagent": "dist/cli.js"


### PR DESCRIPTION
Ships the PR #119 CI skip + all 0.18.0 / 0.18.1 feature content. 0.18.1 never published (release workflow failed on the same E2E-003 test). 0.18.2 is the shippable bundle.