### PR TITLE
feat(check): consume cli-ui 0.3.0 + emit registry fields in --json (F1 close)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,19 @@ All notable changes to HackMyAgent are documented in this file.
 
 ## [Unreleased]
 
+## [0.18.3] - 2026-04-23
+
+### Added
+- **`check --json` now emits registry fields on registered packages (F1).** When the registry has trust data for the target, `hackmyagent check @pkg --json` (default local-scan path) emits `trustLevel`, `trustScore`, `verdict`, `scanStatus`, `packageType`, `lastScannedAt`, `communityScans`, and `cveCount` at the top level alongside the scan findings. Previously these fields only appeared on the `--no-scan` path. Closes the F1 parity gap from `briefs/check-command-divergence.md`; `opena2a check --json` (which spawn-delegates to hackmyagent) inherits the fix.
+
+### Changed
+- **`check` output consumes `@opena2a/cli-ui@0.3.0` primitives.** Exact-pinned the dependency. The registry-only render path (`check @pkg --no-scan`) now delegates to `renderCheckBlock` + `renderNextSteps` so the output structure matches `ai-trust@0.4.0` and the forthcoming parity fixtures in opena2a-parity. Trust-meter gating (`scanStatus === 'completed' | 'warnings'`) moves into the shared renderer — packages with `scanStatus: undefined` no longer render a score meter ("a number implies measurement", per F6).
+- **PyPI and GitHub not-found paths render via `renderNotFoundBlock`.** Replaces the raw `console.error` one-liners. Same shape as ai-trust's not-found block.
+- **`npm pack` `code 128` on git-style names translated to a did-you-mean hint.** `hackmyagent check user/repo` (no `@`) that slips past the GitHub classifier and fails at `npm pack`'s git fallback now renders `Looks like a git-style name. npm packages use "@scope/name" — did you mean "@user/repo"?` instead of leaking the raw exit code (F3).
+
+### Engineering
+- New `src/check-render.ts` extracts the pure helpers (`buildCheckJsonOutput`, `mapScanStatusForMeter`, `translateNpmPackError`) for unit testability. 18 new tests in `__tests__/check-render.test.ts` lock the F1 parity contract and F6 meter gate.
+
 ## [0.18.2] - 2026-04-22
 
 ### Fixed

--- a/__tests__/check-render.test.ts
+++ b/__tests__/check-render.test.ts
@@ -1,0 +1,220 @@
+/**
+ * Unit tests for the pure helpers behind `check` render + --json emission.
+ *
+ * Closes F1 / F3 test coverage for CA-034 M2 Day-2. The shape assertions
+ * are the parity contract consumers (opena2a-parity) rely on; changing
+ * them here is a breaking change for the F1 parity fixture.
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  buildCheckJsonOutput,
+  mapScanStatusForMeter,
+  translateNpmPackError,
+  type RegistryTrustDataLike,
+} from '../src/check-render';
+import type { SecurityFinding } from '../src/index';
+
+const EMPTY_FINDINGS: SecurityFinding[] = [];
+
+const MCP_REGISTRY: RegistryTrustDataLike = {
+  found: true,
+  name: '@modelcontextprotocol/server-filesystem',
+  trustScore: 0.824,
+  trustLevel: 3,
+  verdict: 'passed',
+  scanStatus: 'warnings',
+  packageType: 'mcp_server',
+  lastScannedAt: '2026-03-02T00:00:00Z',
+  communityScans: 1,
+};
+
+describe('buildCheckJsonOutput (F1)', () => {
+  it('emits registry fields at the top level when registry.found === true', () => {
+    const out = buildCheckJsonOutput({
+      name: '@modelcontextprotocol/server-filesystem',
+      type: 'npm-package',
+      projectType: 'library',
+      score: 100,
+      maxScore: 100,
+      findings: EMPTY_FINDINGS,
+      registry: MCP_REGISTRY,
+    });
+    expect(out.trustLevel).toBe(3);
+    expect(out.trustScore).toBe(0.824);
+    expect(out.verdict).toBe('passed');
+    expect(out.scanStatus).toBe('warnings');
+    expect(out.packageType).toBe('mcp_server');
+    expect(out.name).toBe('@modelcontextprotocol/server-filesystem');
+    expect(out.source).toBe('local-scan');
+    expect(out.score).toBe(100);
+  });
+
+  it('omits registry fields when registry is null', () => {
+    const out = buildCheckJsonOutput({
+      name: 'express',
+      type: 'npm-package',
+      projectType: 'library',
+      score: 100,
+      maxScore: 100,
+      findings: EMPTY_FINDINGS,
+      registry: null,
+    });
+    expect(out.trustLevel).toBeUndefined();
+    expect(out.trustScore).toBeUndefined();
+    expect(out.verdict).toBeUndefined();
+    expect(out.packageType).toBeUndefined();
+  });
+
+  it('omits registry fields when registry.found === false', () => {
+    const out = buildCheckJsonOutput({
+      name: 'new-package-xyz',
+      type: 'npm-package',
+      projectType: 'library',
+      score: 100,
+      maxScore: 100,
+      findings: EMPTY_FINDINGS,
+      registry: {
+        found: false,
+        name: 'new-package-xyz',
+        trustScore: 0,
+        trustLevel: 0,
+        verdict: 'unknown',
+      },
+    });
+    expect(out.trustLevel).toBeUndefined();
+    expect(out.verdict).toBeUndefined();
+  });
+
+  it('preserves the canonical top-level keys for the parity contract', () => {
+    const out = buildCheckJsonOutput({
+      name: '@modelcontextprotocol/server-filesystem',
+      type: 'npm-package',
+      projectType: 'library',
+      score: 100,
+      maxScore: 100,
+      findings: EMPTY_FINDINGS,
+      registry: MCP_REGISTRY,
+    });
+    // Parity fixture must_match keys — changing this list is a breaking
+    // change for opena2a-parity F1 golden fixtures.
+    for (const key of ['trustLevel', 'name', 'verdict', 'packageType', 'scanStatus']) {
+      expect(out).toHaveProperty(key);
+    }
+  });
+
+  it('passes through analyst findings when provided', () => {
+    const out = buildCheckJsonOutput({
+      name: 'express',
+      type: 'npm-package',
+      score: 90,
+      maxScore: 100,
+      findings: EMPTY_FINDINGS,
+      registry: null,
+      analystFindings: [{ taskType: 'threatAnalysis', result: {} }],
+    });
+    expect(Array.isArray(out.analystFindings)).toBe(true);
+    expect((out.analystFindings as unknown[]).length).toBe(1);
+  });
+
+  it('omits analystFindings when empty or absent', () => {
+    const out1 = buildCheckJsonOutput({
+      name: 'express',
+      type: 'npm-package',
+      score: 90,
+      maxScore: 100,
+      findings: EMPTY_FINDINGS,
+      registry: null,
+      analystFindings: [],
+    });
+    expect(out1.analystFindings).toBeUndefined();
+
+    const out2 = buildCheckJsonOutput({
+      name: 'express',
+      type: 'npm-package',
+      score: 90,
+      maxScore: 100,
+      findings: EMPTY_FINDINGS,
+      registry: null,
+    });
+    expect(out2.analystFindings).toBeUndefined();
+  });
+
+  it('includes version when provided (PyPI path)', () => {
+    const out = buildCheckJsonOutput({
+      name: 'requests',
+      type: 'pypi-package',
+      score: 100,
+      maxScore: 100,
+      findings: EMPTY_FINDINGS,
+      registry: null,
+      version: '2.32.0',
+    });
+    expect(out.version).toBe('2.32.0');
+    expect(out.type).toBe('pypi-package');
+  });
+});
+
+describe('mapScanStatusForMeter (F6 meter gate)', () => {
+  it('maps "completed" / "complete" / "passed" to "completed"', () => {
+    expect(mapScanStatusForMeter('completed')).toBe('completed');
+    expect(mapScanStatusForMeter('complete')).toBe('completed');
+    expect(mapScanStatusForMeter('passed')).toBe('completed');
+  });
+
+  it('maps "warnings" / "warning" to "warnings"', () => {
+    expect(mapScanStatusForMeter('warnings')).toBe('warnings');
+    expect(mapScanStatusForMeter('warning')).toBe('warnings');
+  });
+
+  it('suppresses the meter for pending / empty / unknown states', () => {
+    expect(mapScanStatusForMeter(undefined)).toBeUndefined();
+    expect(mapScanStatusForMeter('')).toBeUndefined();
+    expect(mapScanStatusForMeter('pending')).toBeUndefined();
+    expect(mapScanStatusForMeter('not_applicable')).toBeUndefined();
+    expect(mapScanStatusForMeter('mystery')).toBeUndefined();
+  });
+
+  it('suppresses the meter on error / failed (F6: no number without measurement)', () => {
+    expect(mapScanStatusForMeter('error')).toBeUndefined();
+    expect(mapScanStatusForMeter('failed')).toBeUndefined();
+  });
+
+  it('handles mixed-case input', () => {
+    expect(mapScanStatusForMeter('COMPLETED')).toBe('completed');
+    expect(mapScanStatusForMeter('  Warnings  ')).toBe('warnings');
+  });
+});
+
+describe('translateNpmPackError (F3)', () => {
+  it('translates `code 128` on a git-style name to a scoped did-you-mean', () => {
+    const translated = translateNpmPackError('anthropic/code-review', 'Command failed with code 128');
+    expect(translated).toBeDefined();
+    expect(translated?.suggestions).toEqual(['@anthropic/code-review']);
+    expect(translated?.errorHint).toContain('@anthropic/code-review');
+  });
+
+  it('returns undefined for scoped names (already npm-valid)', () => {
+    const translated = translateNpmPackError('@anthropic/code-review', 'Command failed with code 128');
+    expect(translated).toBeUndefined();
+  });
+
+  it('returns undefined for bare names (no slash)', () => {
+    const translated = translateNpmPackError('express', 'Command failed with code 128');
+    expect(translated).toBeUndefined();
+  });
+
+  it('returns undefined when the error is not code 128', () => {
+    const translated = translateNpmPackError('anthropic/code-review', '404 Not Found');
+    expect(translated).toBeUndefined();
+  });
+
+  it('handles variant `code128` / `code  128` spellings', () => {
+    expect(translateNpmPackError('foo/bar', 'code128')).toBeDefined();
+    expect(translateNpmPackError('foo/bar', 'error: code  128')).toBeDefined();
+  });
+
+  it('rejects names with characters that are not valid npm chars', () => {
+    // Disallows spaces, colons, etc. in either segment.
+    expect(translateNpmPackError('anthropic/code review', 'code 128')).toBeUndefined();
+  });
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@noble/ed25519": "^2.3.0",
         "@noble/post-quantum": "^0.2.1",
         "@opena2a/aim-core": "^0.1.2",
-        "@opena2a/cli-ui": "0.2.0",
+        "@opena2a/cli-ui": "0.3.0",
         "@opena2a/contribute": "^0.1.0",
         "@opena2a/registry-client": "0.1.0",
         "@opena2a/shared": "^0.1.0",
@@ -583,9 +583,9 @@
       }
     },
     "node_modules/@opena2a/cli-ui": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/@opena2a/cli-ui/-/cli-ui-0.2.0.tgz",
-      "integrity": "sha512-6woViVb94/1K0LV9gbvtF0Ko1yzKRu+FK9mirKDWdODlhxiIFKC7tXBAjlJYEpv1XmedPtxTw9sOMCkzJj3XQw==",
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@opena2a/cli-ui/-/cli-ui-0.3.0.tgz",
+      "integrity": "sha512-Rn2v4X15PhrTB5XwItZicV4cg1l56gMcYPZ1nvyXHJU6L/twdbc4m/gU9it8b22bn4/UhTgj6fYIXjDoS7E6tw==",
       "license": "Apache-2.0",
       "dependencies": {
         "chalk": "^5.3.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hackmyagent",
-  "version": "0.18.2",
+  "version": "0.18.3",
   "description": "Find it. Break it. Fix it. The hacker's toolkit for AI agents.",
   "bin": {
     "hackmyagent": "dist/cli.js"
@@ -39,7 +39,7 @@
     "@noble/ed25519": "^2.3.0",
     "@noble/post-quantum": "^0.2.1",
     "@opena2a/aim-core": "^0.1.2",
-    "@opena2a/cli-ui": "0.2.0",
+    "@opena2a/cli-ui": "0.3.0",
     "@opena2a/contribute": "^0.1.0",
     "@opena2a/registry-client": "0.1.0",
     "@opena2a/shared": "^0.1.0",

--- a/src/check-render.ts
+++ b/src/check-render.ts
@@ -1,0 +1,115 @@
+/**
+ * Pure helpers for the `check` command render + JSON emission paths.
+ *
+ * Lives outside cli.ts so it can be unit-tested without spinning up the
+ * commander entry point. The impure render functions (console.log-heavy)
+ * stay in cli.ts and import from here.
+ *
+ * Closes F1 (JSON emission consistency) and F3 (git-style not-found hint)
+ * from briefs/check-command-divergence.md.
+ */
+
+import type { SecurityFinding } from './index';
+
+/** Registry trust data shape as returned by queryRegistry() in cli.ts. */
+export interface RegistryTrustDataLike {
+  found: boolean;
+  name: string;
+  trustScore: number;
+  trustLevel: number;
+  verdict: string;
+  scanStatus?: string;
+  lastScannedAt?: string;
+  packageType?: string;
+  recommendation?: string;
+  cveCount?: number;
+  communityScans?: number;
+  dependencies?: {
+    totalDeps?: number;
+    vulnerableDeps?: number;
+    minTrustLevel?: number;
+    riskSummary?: Record<string, unknown>;
+  };
+}
+
+/**
+ * Map the registry's scanStatus vocabulary onto the renderCheckBlock meter
+ * gate ("completed" | "warnings" | undefined). Registry returns a wider
+ * set of states; collapse the "scan produced a usable score" ones and
+ * suppress the meter for everything else (F6: a number implies measurement).
+ */
+export function mapScanStatusForMeter(status?: string): string | undefined {
+  if (!status) return undefined;
+  const normalized = status.toLowerCase().trim();
+  if (normalized === '' || normalized === 'pending' || normalized === 'not_applicable') return undefined;
+  if (normalized === 'error' || normalized === 'failed') return undefined;
+  if (normalized === 'warnings' || normalized === 'warning') return 'warnings';
+  if (normalized === 'complete' || normalized === 'completed' || normalized === 'passed') return 'completed';
+  return undefined;
+}
+
+/**
+ * Build the top-level JSON shape for `check --json` when the caller has a
+ * local scan result. When registry data is also available and found, registry
+ * fields (trustLevel, trustScore, verdict, scanStatus, packageType) are
+ * merged at the top level so parity tools and consumers see one canonical
+ * shape across `hackmyagent check --json`, `opena2a check --json` (spawn
+ * delegation), and `ai-trust check --json`. Closes F1.
+ */
+export function buildCheckJsonOutput(params: {
+  name: string;
+  type: 'npm-package' | 'github-repo' | 'pypi-package';
+  projectType?: string;
+  score: number;
+  maxScore: number;
+  findings: SecurityFinding[];
+  registry?: RegistryTrustDataLike | null;
+  analystFindings?: Array<Record<string, unknown>>;
+  version?: string;
+}): Record<string, unknown> {
+  const { name, type, projectType, score, maxScore, findings, registry, analystFindings, version } = params;
+  const jsonOut: Record<string, unknown> = {
+    name,
+    type,
+    source: 'local-scan',
+    projectType,
+    score,
+    maxScore,
+    findings,
+  };
+  if (version !== undefined) jsonOut.version = version;
+  if (registry?.found) {
+    jsonOut.trustLevel = registry.trustLevel;
+    jsonOut.trustScore = registry.trustScore;
+    jsonOut.verdict = registry.verdict;
+    if (registry.scanStatus !== undefined) jsonOut.scanStatus = registry.scanStatus;
+    if (registry.packageType !== undefined) jsonOut.packageType = registry.packageType;
+    if (registry.lastScannedAt !== undefined) jsonOut.lastScannedAt = registry.lastScannedAt;
+    if (registry.communityScans !== undefined) jsonOut.communityScans = registry.communityScans;
+    if (registry.cveCount !== undefined) jsonOut.cveCount = registry.cveCount;
+  }
+  if (analystFindings && analystFindings.length) jsonOut.analystFindings = analystFindings;
+  return jsonOut;
+}
+
+/**
+ * Translate a raw npm downloader error message into a renderNotFoundBlock
+ * hint. F3 equivalent for hackmyagent — `anthropic/code-review` slipping
+ * past the GitHub classifier (rare but possible when the upstream look-up
+ * misclassifies) and failing with `code 128` from npm pack's git fallback.
+ * Returns hint + suggestions; caller passes them into renderNotFoundBlock.
+ */
+export function translateNpmPackError(
+  name: string,
+  message: string,
+): { errorHint?: string; suggestions?: string[] } | undefined {
+  const looksGitStyle = /^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/.test(name) && !name.startsWith('@');
+  if (looksGitStyle && /code\s*128/i.test(message)) {
+    const scoped = `@${name}`;
+    return {
+      errorHint: `Looks like a git-style name. npm packages use "@scope/name" — did you mean "${scoped}"?`,
+      suggestions: [scoped],
+    };
+  }
+  return undefined;
+}

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -52,6 +52,7 @@ import {
 } from './index';
 import { resolveAndLogMcpShorthand } from './resolve-mcp';
 import { WildScanner, type WildScanReport } from './wild';
+import { buildCheckJsonOutput, mapScanStatusForMeter, translateNpmPackError } from './check-render';
 import {
   isRenderableAnalystFinding,
   formatAnalystDescription,
@@ -60,6 +61,12 @@ import {
   renderObservationsBlock,
   buildCategorySummaries,
   buildVerdict,
+  renderCheckBlock,
+  renderNotFoundBlock,
+  renderNextSteps,
+  type CheckTone,
+  type NotFoundTone,
+  type NextStepsCta,
 } from '@opena2a/cli-ui';
 import { getTaxonomyMap } from './hardening/taxonomy';
 const program = new Command();
@@ -706,8 +713,148 @@ function uiScoreMeter(value: number, max: number = 100): string {
   return `${meterColor}${'━'.repeat(pct)}${RESET()}${colors.dim}${'━'.repeat(UI_METER_WIDTH - pct)}${RESET()} ${meterColor}${colors.bold}${value}${RESET()}${colors.dim}/${max}${RESET()}`;
 }
 
+// ── cli-ui 0.3.0 tone painters ────────────────────────────────────────
+// The cli-ui renderers return structured { value, tone } pairs; each
+// CLI owns its own chalk palette per the contract.
+function paintCheckTone(tone: CheckTone, s: string): string {
+  if (tone === 'good') return `${colors.green}${s}${RESET()}`;
+  if (tone === 'warning') return `${colors.yellow}${s}${RESET()}`;
+  if (tone === 'critical') return `${colors.red}${s}${RESET()}`;
+  if (tone === 'dim') return `${colors.dim}${s}${RESET()}`;
+  return s;
+}
+
+function paintNotFoundTone(tone: NotFoundTone, s: string): string {
+  if (tone === 'good') return `${colors.green}${s}${RESET()}`;
+  if (tone === 'warning') return `${colors.yellow}${s}${RESET()}`;
+  if (tone === 'critical') return `${colors.red}${s}${RESET()}`;
+  if (tone === 'dim') return `${colors.dim}${s}${RESET()}`;
+  return s;
+}
+
+/** Next-steps CTAs for the registry-only render path. */
+function buildRegistryCheckCtas(registry: RegistryTrustData): NextStepsCta[] {
+  const ctas: NextStepsCta[] = [];
+  const normalized = normalizeTrustVerdict(registry.verdict);
+  const meterGate = mapScanStatusForMeter(registry.scanStatus);
+  const isUnscanned = meterGate === undefined;
+
+  if (isUnscanned || registry.trustLevel <= 2 || normalized === 'blocked' || normalized === 'warning') {
+    ctas.push({
+      label: 'Fresh scan',
+      command: `${CLI_PREFIX} check ${registry.name}`,
+      primary: true,
+    });
+  } else {
+    ctas.push({
+      label: 'Fresh scan',
+      command: `${CLI_PREFIX} check ${registry.name}`,
+      primary: true,
+    });
+  }
+  ctas.push({
+    label: 'All commands',
+    command: `${CLI_PREFIX} --help`,
+  });
+  return ctas;
+}
+
+/**
+ * Render the registry-only "check" path via cli-ui renderCheckBlock +
+ * renderNextSteps. Returns nothing; prints directly.
+ *
+ * Used when the CLI has a registry answer but no local scan or NanoMind
+ * output (i.e. --no-scan hits, skill-adjacent targets with trust metadata).
+ * Local-scan and NanoMind paths continue to use renderObservationsBlock +
+ * printCheckNextSteps (shipped in cli-ui 0.2.0, stable in 0.3.0).
+ */
+function renderRegistryOnlyCheck(
+  name: string,
+  registry: RegistryTrustData,
+  sourceLabel?: string,
+  version?: string,
+): void {
+  const CHECK_LABEL_WIDTH = 10;
+  const scanStatusForMeter = mapScanStatusForMeter(registry.scanStatus);
+  const block = renderCheckBlock({
+    name,
+    packageType: registry.packageType,
+    version,
+    trustLevel: registry.trustLevel,
+    trustScore: registry.trustScore,
+    verdict: registry.verdict,
+    scanStatus: scanStatusForMeter,
+    communityScans: registry.communityScans,
+    lastScannedAt: registry.lastScannedAt,
+  });
+
+  // Header
+  console.log();
+  const meta = [...block.header.meta];
+  if (sourceLabel) meta.push(sourceLabel);
+  const metaSuffix = meta.length > 0 ? `  ${colors.dim}${meta.join(' · ')}${RESET()}` : '';
+  console.log(`  ${colors.bold}${colors.white}${block.header.name}${RESET()}${metaSuffix}`);
+
+  // Verdict
+  const verdictColor =
+    block.verdict.tone === 'good' ? colors.green
+    : block.verdict.tone === 'warning' ? colors.yellow
+    : block.verdict.tone === 'critical' ? colors.brightRed
+    : colors.dim;
+  console.log(`  ${verdictColor}${colors.bold}${block.verdict.text}${RESET()}`);
+
+  // Body lines
+  console.log();
+  for (const line of block.lines) {
+    const label = line.label.padEnd(CHECK_LABEL_WIDTH);
+    console.log(`  ${colors.dim}${label}${RESET()}${paintCheckTone(line.tone, line.value)}`);
+  }
+
+  // Dependencies (registry-sourced — adjacent to the Trust block)
+  if (registry.dependencies && (registry.dependencies.totalDeps ?? 0) > 0) {
+    const d = registry.dependencies;
+    const depParts: string[] = [];
+    if (d.totalDeps !== undefined) depParts.push(`${d.totalDeps} total`);
+    if (d.vulnerableDeps !== undefined && d.vulnerableDeps > 0) {
+      depParts.push(`${colors.red}${d.vulnerableDeps} vulnerable${RESET()}`);
+    }
+    if (d.minTrustLevel !== undefined) depParts.push(`min trust ${d.minTrustLevel}/4`);
+    if (depParts.length > 0) {
+      console.log(`  ${colors.dim}${'Deps'.padEnd(CHECK_LABEL_WIDTH)}${RESET()}${depParts.join(`${colors.dim} · ${RESET()}`)}`);
+    }
+  }
+
+  // CVEs
+  if (registry.cveCount !== undefined && registry.cveCount > 0) {
+    console.log(`  ${colors.dim}${'CVEs'.padEnd(CHECK_LABEL_WIDTH)}${RESET()}${colors.brightRed}${colors.bold}${registry.cveCount}${RESET()}`);
+  }
+
+  // Next steps
+  if (!globalCiMode) {
+    console.log(`\n  ${colors.dim}──${RESET()} ${colors.bold}Next Steps${RESET()} ${colors.dim}${'─'.repeat(49)}${RESET()}`);
+    const { lines } = renderNextSteps({ ctas: buildRegistryCheckCtas(registry) });
+    for (const l of lines) {
+      const bullet = l.tone === 'good' ? `${colors.green}${l.bullet}${RESET()}` : `${colors.cyan}${l.bullet}${RESET()}`;
+      const label = l.tone === 'good' ? `${colors.bold}${l.label}${RESET()}` : `${colors.cyan}${l.label}${RESET()}`;
+      console.log(`  ${bullet} ${label}  ${colors.dim}${l.command}${RESET()}`);
+    }
+    console.log();
+  }
+}
+
 function displayUnifiedCheck(opts: UnifiedCheckDisplayOptions): void {
   const { name, sourceLabel, projectType, localScan, registry, verbose, version, nanomindScan, usedAnalm } = opts;
+
+  // ── Registry-only render path (cli-ui 0.3.0 renderCheckBlock) ────────
+  // When we have registry trust data and nothing scanned locally, delegate
+  // to the shared renderer so `hackmyagent check --no-scan @pkg` shows the
+  // same structure as `ai-trust check --no-scan @pkg` and `opena2a check`
+  // (which spawns HMA). Closes F5 for this path; the Trust meter gating
+  // (F6) lives inside renderCheckBlock itself.
+  if (registry?.found && !localScan && !nanomindScan) {
+    renderRegistryOnlyCheck(name, registry, sourceLabel, version);
+    return;
+  }
 
   // ── Visual helpers ──────────────────────────────────────────────────
   const METER_WIDTH = 20;
@@ -8304,23 +8451,23 @@ async function checkGitHubRepo(
     const medium = failed.filter(f => f.severity === 'medium');
     const low = failed.filter(f => f.severity === 'low');
 
+    // Await registry data (started in parallel with clone) before emitting
+    // any output so --json can include registry fields (F1).
+    const registryData = await registryPromise;
+
     if (options.json) {
-      const jsonOut: Record<string, any> = {
+      writeJsonStdout(buildCheckJsonOutput({
         name: displayName,
         type: 'github-repo',
-        source: 'local-scan',
         projectType: result.projectType,
         score: result.score,
         maxScore: result.maxScore,
         findings: result.findings,
-      };
-      if (analystFindings?.length) jsonOut.analystFindings = analystFindings;
-      writeJsonStdout(jsonOut);
+        registry: registryData,
+        analystFindings,
+      }));
       return;
     }
-
-    // Await registry data (started in parallel with clone)
-    const registryData = await registryPromise;
 
     // Display results using unified display
     displayUnifiedCheck({
@@ -8373,8 +8520,15 @@ async function checkGitHubRepo(
   } catch (err: unknown) {
     const message = err instanceof Error ? err.message : String(err);
     if (message.includes('128') || message.includes('not found') || message.includes('Repository not found')) {
-      console.error(`Error: Repository "${displayName}" not found on GitHub.`);
-      console.error(`\nVerify the URL: https://github.com/${displayName}`);
+      if (options.json) {
+        writeJsonStdout({ name: displayName, ecosystem: 'github', found: false, error: `Repository "${displayName}" not found on GitHub.` });
+      } else {
+        printNotFoundBlock({
+          pkg: displayName,
+          ecosystem: 'github',
+          errorHint: `Verify the URL: https://github.com/${displayName}`,
+        });
+      }
     } else if (message.includes('timeout') || message.includes('Timeout')) {
       console.error(`Error: Cloning "${displayName}" timed out (120s). The repo may be too large.`);
       console.error(`\nTry cloning manually and scanning the local path:`);
@@ -8387,6 +8541,35 @@ async function checkGitHubRepo(
   } finally {
     await rm(tempDir, { recursive: true, force: true });
   }
+}
+
+/**
+ * Print a renderNotFoundBlock using the hackmyagent chalk palette. Used by
+ * the PyPI / GitHub / npm-code-128 paths so they share the cli-ui shape
+ * instead of emitting raw console.error lines.
+ */
+function printNotFoundBlock(input: {
+  pkg: string;
+  ecosystem?: string;
+  suggestions?: string[];
+  skillFallback?: { available: boolean; command: string };
+  errorHint?: string;
+}): void {
+  const { header, lines } = renderNotFoundBlock(input);
+  const LABEL_WIDTH = 10;
+  console.error();
+  console.error(`  ${colors.yellow}${colors.bold}${header.text}${RESET()}`);
+  if (lines.length > 0) {
+    console.error();
+    for (const l of lines) {
+      if (l.label) {
+        console.error(`  ${colors.dim}${l.label.padEnd(LABEL_WIDTH)}${RESET()}${paintNotFoundTone(l.tone, l.value)}`);
+      } else {
+        console.error(`  ${paintNotFoundTone(l.tone, l.value)}`);
+      }
+    }
+  }
+  console.error();
 }
 
 /**
@@ -8420,7 +8603,11 @@ async function checkPyPiPackage(
     const metaRes = await fetch(`https://pypi.org/pypi/${encodeURIComponent(name)}/json`);
     if (!metaRes.ok) {
       if (metaRes.status === 404) {
-        console.error(`Error: Package "${name}" not found on PyPI.`);
+        if (options.json) {
+          writeJsonStdout({ name, ecosystem: 'pypi', found: false, error: `Package "${name}" not found on PyPI.` });
+        } else {
+          printNotFoundBlock({ pkg: name, ecosystem: 'pypi' });
+        }
       } else {
         console.error(`Error: PyPI API returned ${metaRes.status} for "${name}".`);
       }
@@ -8498,25 +8685,24 @@ async function checkPyPiPackage(
     const medium = failed.filter(f => f.severity === 'medium');
     const low = failed.filter(f => f.severity === 'low');
 
+    // Query registry for trust context (PyPI packages have pip: prefix in registry).
+    // Moved above the --json branch so JSON output can include registry fields (F1).
+    const registryData = options.registry === false ? null : await queryRegistry(`pip:${name}`);
+
     if (options.json) {
-      const jsonOut: Record<string, any> = {
+      writeJsonStdout(buildCheckJsonOutput({
         name,
         type: 'pypi-package',
-        source: 'local-scan',
-        version: meta.info.version,
         projectType: result.projectType,
         score: result.score,
         maxScore: result.maxScore,
         findings: result.findings,
-      };
-      if (analystFindings?.length) jsonOut.analystFindings = analystFindings;
-      writeJsonStdout(jsonOut);
+        registry: registryData,
+        analystFindings,
+        version: meta.info.version,
+      }));
       return;
     }
-
-    // Display results using unified display
-    // Query registry for trust context (PyPI packages have pip: prefix in registry)
-    const registryData = options.registry === false ? null : await queryRegistry(`pip:${name}`);
 
     displayUnifiedCheck({
       name,
@@ -8851,23 +9037,23 @@ async function checkNpmPackage(
     const critical = failed.filter(f => f.severity === 'critical');
     const high = failed.filter(f => f.severity === 'high');
 
+    // Await registry data (started in parallel with download) before emitting
+    // any output so --json can include registry fields (F1).
+    const registryData = await registryPromise;
+
     if (options.json) {
-      const jsonOut: Record<string, any> = {
+      writeJsonStdout(buildCheckJsonOutput({
         name,
         type: 'npm-package',
-        source: 'local-scan',
         projectType: result.projectType,
         score: result.score,
         maxScore: result.maxScore,
         findings: result.findings,
-      };
-      if (analystFindings?.length) jsonOut.analystFindings = analystFindings;
-      writeJsonStdout(jsonOut);
+        registry: registryData,
+        analystFindings,
+      }));
       return;
     }
-
-    // Await registry data (started in parallel with download)
-    const registryData = await registryPromise;
 
     // Display results using unified display
     displayUnifiedCheck({
@@ -8926,7 +9112,24 @@ async function checkNpmPackage(
       notFound.name = 'NpmNotFoundError';
       throw notFound;
     } else {
-      console.error(`Error: ${message}`);
+      // Git-style shorthand (user/repo) slipping past the npm classifier
+      // and failing with `code 128` from npm pack's git fallback — render
+      // a did-you-mean block instead of leaking the raw exit code.
+      const translated = translateNpmPackError(name, message);
+      if (translated && (translated.errorHint || translated.suggestions)) {
+        if (options.json) {
+          writeJsonStdout({ name, ecosystem: 'npm', found: false, error: translated.errorHint, suggestions: translated.suggestions });
+        } else {
+          printNotFoundBlock({
+            pkg: name,
+            ecosystem: 'npm',
+            errorHint: translated.errorHint,
+            suggestions: translated.suggestions,
+          });
+        }
+      } else {
+        console.error(`Error: ${message}`);
+      }
     }
     process.exit(1);
   } finally {


### PR DESCRIPTION
## Summary

- Migrates the `check` command's registry-only render path to `@opena2a/cli-ui@0.3.0`'s `renderCheckBlock` + `renderNextSteps` so hackmyagent, `opena2a check` (spawn delegation), and `ai-trust check` share one output structure.
- Fixes `check --json`: when the registry has data for the target, the default local-scan JSON now emits `trustLevel`, `trustScore`, `verdict`, `scanStatus`, `packageType`, `lastScannedAt`, `communityScans`, and `cveCount` at the top level alongside the scan findings. Previously these fields only appeared on the `--no-scan` path, blocking opena2a from being a participant in the F1 parity fixture (since `opena2a check --json` defaults to local scan via HMA spawn).
- PyPI and GitHub 404 paths render via `renderNotFoundBlock`; `npm pack` `code 128` on git-style names (`user/repo` without `@`) now produces a translated did-you-mean hint instead of leaking the raw exit code (F3).

**Primary Day-2 outcome (F1 parity):** `opena2a-parity/fixtures/check-registered-ai` can drop its `opena2a.skip` sentinel once this lands.

## Scope

- `src/cli.ts` — new cli-ui imports, `displayUnifiedCheck` early-return for registry-only path, JSON emission fix in `checkNpmPackage` / `checkGitHubRepo` / `checkPyPiPackage`, not-found migrations.
- `src/check-render.ts` (new) — pure helpers `buildCheckJsonOutput`, `mapScanStatusForMeter`, `translateNpmPackError`.
- `__tests__/check-render.test.ts` (new) — 18 unit tests locking the F1 parity contract and F6 meter gate.
- `package.json` — exact-pin `@opena2a/cli-ui: 0.3.0`; version 0.18.2 → 0.18.3.
- `CHANGELOG.md`.
- `package-lock.json` regenerated outside the workspace (zero `link: true` entries confirmed).

Scanner detection logic NOT touched. 1729 tests green (1711 pre-existing + 18 new), HMA self-scan 100/100.

## Test plan
- [x] Unit tests — 18 new, 1729 total, all green
- [x] Full build via `npm run build`
- [x] Pre-push review gate (Phase 1 sensitive files / Phase 2 build+tests / Phase 3 AI review / Phase 4 HMA self-scan 100/100 / Phase 4.5 adversarial / Phase 6 new-user walkthrough across 7 surfaces / Phase 7 cross-repo version sweep)
- [x] F1 verification: `hackmyagent check @modelcontextprotocol/server-filesystem --json` emits `trustLevel / trustScore / verdict / scanStatus / packageType` at top level
- [x] Registry-only text render: `--no-scan` output uses `renderCheckBlock` shape
- [x] Not-found parity: GitHub 404 + git-style miss render via `renderNotFoundBlock`
- [x] No regressions in `secure` path (Observations block + verdict + artifacts intact on self-scan)
- [ ] After merge: tag `v0.18.3`, publish via Trusted Publishing workflow, verify SLSA v1
- [ ] After publish: flip `opena2a-parity/fixtures/check-registered-ai/expected/opena2a.skip` and add opena2a to participants (separate PR)
- [ ] Housekeeping: update `homebrew-tap/Formula/hackmyagent.rb` from 0.17.11 → 0.18.3 (stale since before 0.18.0; bundle with the publish workflow)

## Related
- Brief: `briefs/check-command-divergence.md` §F1
- Pickup: `todo/2026-04-23-cli-consolidation-m2-day2-pickup.md`
- Day-1 shipped: `@opena2a/cli-ui@0.3.0` (opena2a#96)
- Parallel consumer: `ai-trust@0.4.0` (ai-trust#33, 47d26aa)