### PR TITLE
feat(narrative): emit PackageNarrative on secure --publish for skill/mcp (0.20.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,23 @@ All notable changes to HackMyAgent are documented in this file.
 
 ## [Unreleased]
 
+## [0.20.0] - 2026-04-27
+
+### Added
+- **PackageNarrative emission on `secure --publish` for skill / mcp artifacts.** When a `secure --publish` target contains `SKILL.md` at the scan root, or HMA's project-type detector classifies the project as `mcp`, HMA now POSTs a `PackageNarrative` payload to the registry's `POST /api/v1/trust/narrative` endpoint after the existing scan-result publish completes. The narrative carries the wire-shape that drives the rich-context `check` view (skill+mcp v1) — declared-vs-observed permission delta, MCP tool list, hardcoded-secret group with rotation guidance, deterministic verdict reasoning, and a verdict-aware action gradient. Failure is non-fatal — the parent publish always succeeds first; narrative emission is best-effort and reported under `publish.narrative` in JSON output.
+- **`src/narrative/` module.** Six files, ~900 LOC. `skill-narrative.ts` + `mcp-narrative.ts` reshape the existing SecurityAST + scan findings into the `@opena2a/check-core@0.2.0` wire types. `narrative-summary.ts` is a NanoMind v3 graceful-degrade gate (per `project_nanomind_v05_intelreport_task_mismatch.md` — v3 is OOD on comprehension tasks; v1 returns empty strings). `build-narrative.ts` is the orchestrator. `publish-narrative.ts` is the registry HTTP client. `wire-publish.ts` is the single-call helper consumed by `cli.ts`.
+- **35 new unit tests** across the four narrative module files (skill builders, mcp builders, summary degrade gate, publish-client shape). Suite: 1746 passed.
+
+### Changed
+- **`@opena2a/check-core` exact-pinned at `0.2.0`** (was `0.1.0`). New version exports the rule engine, secret-rotation table, and `PackageNarrative` wire types this release consumes.
+- **Static threat-model questions** (skills + MCPs) ship with each emitted narrative per the brief's [CHIEF-CSR] decision, so the registry stores the complete render payload and cli-ui's renderer stays dumb.
+
+### Engineering
+- New `src/narrative/wire-publish.ts` keeps the cli.ts integration to a single dynamic-import + best-effort call. Detection is intentionally simple (SKILL.md presence at scan root, or `projectType === "mcp"`) so the v1 wiring is auditable; richer detection lands when [CHIEF-CA] decides on the multi-artifact-per-scan convention.
+
+### Brief
+- opena2a-org/briefs/check-rich-context-skills-mcp-v1.md (§4-§7, §8 task 2c-2e, session 2)
+
 ## [0.18.3] - 2026-04-23
 
 ### Added

--- a/__tests__/narrative/mcp-narrative.test.ts
+++ b/__tests__/narrative/mcp-narrative.test.ts
@@ -1,0 +1,108 @@
+import { describe, it, expect } from "vitest";
+import {
+  buildMcpNarrative,
+  MCP_THREAT_MODEL_QUESTIONS,
+} from "../../src/narrative/mcp-narrative.js";
+import type { SecurityAST } from "../../src/nanomind-core/types.js";
+
+const baseAst = (overrides: Partial<SecurityAST> = {}): SecurityAST => ({
+  artifactType: "mcp_config",
+  contentHash: "abc",
+  artifactPath: "mcps/server-filesystem/package.json",
+  artifactSize: 100,
+  declaredPurpose: "filesystem MCP",
+  declaredCapabilities: [],
+  declaredConstraints: [],
+  declaredDataAccess: [],
+  inferredCapabilities: [],
+  inferredRiskSurface: [],
+  intentClassification: "benign",
+  intentConfidence: 0.9,
+  dependsOn: [],
+  governedBy: [],
+  evidenceSpans: [],
+  signature: "",
+  modelVersion: "heuristic-v1",
+  compiledAt: "2026-04-27T00:00:00.000Z",
+  ...overrides,
+});
+
+describe("buildMcpNarrative", () => {
+  it("populates mcpName from config when present", () => {
+    const out = buildMcpNarrative({
+      ast: baseAst(),
+      config: { name: "@modelcontextprotocol/server-filesystem" },
+    });
+    expect(out.mcpName).toBe("@modelcontextprotocol/server-filesystem");
+  });
+
+  it("ships threat-model questions verbatim", () => {
+    const out = buildMcpNarrative({ ast: baseAst() });
+    expect(out.threatModelQuestions).toEqual(MCP_THREAT_MODEL_QUESTIONS);
+  });
+
+  it("classifies write_file as destructive and read_file as non-destructive", () => {
+    const out = buildMcpNarrative({
+      ast: baseAst(),
+      toolRegistrations: [
+        { name: "read_file", signature: "read_file(path)" },
+        { name: "write_file", signature: "write_file(path, content)" },
+      ],
+    });
+    const write = out.tools.find((t) => t.name === "write_file");
+    const read = out.tools.find((t) => t.name === "read_file");
+    expect(write?.destructive).toBe(true);
+    expect(read?.destructive).toBe(false);
+  });
+
+  it("reports config-allowlisted scope when allowedDirectories is set", () => {
+    const out = buildMcpNarrative({
+      ast: baseAst(),
+      config: { allowedDirectories: ["~/agent-workspace", "~/scratch"] },
+    });
+    expect(out.pathScope).toMatch(/^config-allowlisted/);
+  });
+
+  it("reports 'any path agent passes' when there is no allowlist + writes are declared", () => {
+    const out = buildMcpNarrative({
+      ast: baseAst({
+        declaredDataAccess: [{ dataType: "general", accessMode: "write", coveredByCapability: true }],
+      }),
+    });
+    expect(out.pathScope).toBe("any path agent passes");
+  });
+
+  it("reports network 'none' for fully-local MCP", () => {
+    const out = buildMcpNarrative({ ast: baseAst() });
+    expect(out.network).toBe("none");
+  });
+
+  it("classifies bearer token auth from config", () => {
+    const out = buildMcpNarrative({
+      ast: baseAst(),
+      config: { name: "x", bearerToken: true },
+    });
+    expect(out.auth).toBe("bearer token");
+  });
+
+  it("flags spawn side-effects from inferred risk surface", () => {
+    const out = buildMcpNarrative({
+      ast: baseAst({
+        inferredRiskSurface: [
+          {
+            surface: "child process spawn",
+            attackClass: "RCE",
+            confidence: 0.8,
+            evidence: "child_process.spawn(...)",
+          },
+        ],
+      }),
+    });
+    expect(out.sideEffects).toContain("spawns child processes");
+  });
+
+  it("returns empty tools[] when no registrations are passed", () => {
+    const out = buildMcpNarrative({ ast: baseAst() });
+    expect(out.tools).toEqual([]);
+  });
+});

--- a/__tests__/narrative/narrative-summary.test.ts
+++ b/__tests__/narrative/narrative-summary.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect } from "vitest";
+import {
+  generateNarrativeSummary,
+  isAcceptedByInputClassifier,
+  emptyResult,
+} from "../../src/narrative/narrative-summary.js";
+import type { SecurityAST } from "../../src/nanomind-core/types.js";
+
+const baseAst = (overrides: Partial<SecurityAST> = {}): SecurityAST => ({
+  artifactType: "skill",
+  contentHash: "abc",
+  artifactSize: 100,
+  declaredPurpose: "",
+  declaredCapabilities: [],
+  declaredConstraints: [],
+  declaredDataAccess: [],
+  inferredCapabilities: [],
+  inferredRiskSurface: [],
+  intentClassification: "benign",
+  intentConfidence: 0.5,
+  dependsOn: [],
+  governedBy: [],
+  evidenceSpans: [],
+  signature: "",
+  modelVersion: "heuristic-v1",
+  compiledAt: "2026-04-27T00:00:00.000Z",
+  ...overrides,
+});
+
+describe("isAcceptedByInputClassifier", () => {
+  it("accepts skill artifacts", () => {
+    expect(isAcceptedByInputClassifier(baseAst({ artifactType: "skill" }))).toBe(true);
+  });
+  it("accepts mcp_config artifacts", () => {
+    expect(isAcceptedByInputClassifier(baseAst({ artifactType: "mcp_config" }))).toBe(true);
+  });
+  it("rejects soul / system_prompt / source_code / unknown", () => {
+    for (const t of ["soul", "system_prompt", "source_code", "unknown"] as const) {
+      expect(isAcceptedByInputClassifier(baseAst({ artifactType: t }))).toBe(false);
+    }
+  });
+});
+
+describe("generateNarrativeSummary (v1 stub)", () => {
+  it("returns empty triple + generated=false on accepted skill input", async () => {
+    const out = await generateNarrativeSummary(baseAst({ artifactType: "skill" }));
+    expect(out).toEqual(emptyResult());
+  });
+
+  it("returns empty triple + generated=false on accepted mcp_config input", async () => {
+    const out = await generateNarrativeSummary(baseAst({ artifactType: "mcp_config" }));
+    expect(out).toEqual(emptyResult());
+  });
+
+  it("returns empty triple on a rejected artifact type", async () => {
+    const out = await generateNarrativeSummary(baseAst({ artifactType: "source_code" }));
+    expect(out).toEqual(emptyResult());
+  });
+
+  it("never throws — always resolves to a triple", async () => {
+    await expect(
+      generateNarrativeSummary(baseAst({ artifactType: "skill" })),
+    ).resolves.toBeDefined();
+  });
+});

--- a/__tests__/narrative/publish-narrative.test.ts
+++ b/__tests__/narrative/publish-narrative.test.ts
@@ -1,0 +1,136 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import {
+  narrativeToRequestBody,
+  publishNarrative,
+} from "../../src/narrative/publish-narrative.js";
+import type { PackageNarrative } from "@opena2a/check-core";
+
+const baseNarrative = (): PackageNarrative => ({
+  schemaVersion: 1,
+  generatedAt: "2026-04-27T00:00:00.000Z",
+  generatedFrom: {
+    artifactType: "skill",
+    artifactVersion: "1.0.0",
+    scanRunId: "00000000-0000-0000-0000-000000000000",
+  },
+  summary: "",
+  hardcodedSecrets: { detected: [], scanCovered: true },
+  skill: {
+    skillName: "opena2a/refactor-helper",
+    activationPhrases: ["refactor"],
+    behaviorDescription: "",
+    permissions: [],
+    externalServices: [],
+    persistence: "none",
+    toolCallsObserved: [],
+    misuseNarrative: "",
+    threatModelQuestions: [],
+  },
+  verdictReasoning: [],
+  nextSteps: [],
+});
+
+describe("narrativeToRequestBody", () => {
+  it("threads packageName through and drops generatedAt", () => {
+    const body = narrativeToRequestBody(baseNarrative(), "opena2a/refactor-helper");
+    expect(body).toEqual({
+      artifactType: "skill",
+      packageName: "opena2a/refactor-helper",
+      packageVersion: "1.0.0",
+      schemaVersion: 1,
+      scanRunId: "00000000-0000-0000-0000-000000000000",
+      summary: "",
+      hardcodedSecrets: { detected: [], scanCovered: true },
+      skill: expect.objectContaining({ skillName: "opena2a/refactor-helper" }),
+      mcp: undefined,
+      verdictReasoning: [],
+      nextSteps: [],
+    });
+  });
+});
+
+describe("publishNarrative", () => {
+  const realFetch = global.fetch;
+  afterEach(() => {
+    global.fetch = realFetch;
+  });
+
+  it("returns {ok: true, cached: false, status: 201} on a fresh publish", async () => {
+    global.fetch = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ cached: false }), { status: 201 }),
+    ) as unknown as typeof fetch;
+    const result = await publishNarrative(
+      narrativeToRequestBody(baseNarrative(), "x"),
+      { registryUrl: "https://api.oa2a.org" },
+    );
+    expect(result).toEqual({ ok: true, cached: false, generatedAt: undefined, status: 201 });
+  });
+
+  it("propagates cached=true + generatedAt on a 200 cached response", async () => {
+    global.fetch = vi.fn().mockResolvedValue(
+      new Response(
+        JSON.stringify({ cached: true, generatedAt: "2026-04-26T00:00:00Z" }),
+        { status: 200 },
+      ),
+    ) as unknown as typeof fetch;
+    const result = await publishNarrative(
+      narrativeToRequestBody(baseNarrative(), "x"),
+      { registryUrl: "https://api.oa2a.org/" },
+    );
+    expect(result.ok).toBe(true);
+    expect(result.cached).toBe(true);
+    expect(result.generatedAt).toBe("2026-04-26T00:00:00Z");
+  });
+
+  it("returns ok:false on a non-2xx response", async () => {
+    global.fetch = vi.fn().mockResolvedValue(
+      new Response("bad request", { status: 400 }),
+    ) as unknown as typeof fetch;
+    const result = await publishNarrative(
+      narrativeToRequestBody(baseNarrative(), "x"),
+      { registryUrl: "https://api.oa2a.org" },
+    );
+    expect(result.ok).toBe(false);
+    expect(result.status).toBe(400);
+    expect(result.error).toMatch(/HTTP 400/);
+  });
+
+  it("returns ok:false with the error message when fetch throws", async () => {
+    global.fetch = vi.fn().mockRejectedValue(new Error("DNS failure")) as unknown as typeof fetch;
+    const result = await publishNarrative(
+      narrativeToRequestBody(baseNarrative(), "x"),
+      { registryUrl: "https://api.oa2a.org" },
+    );
+    expect(result.ok).toBe(false);
+    expect(result.error).toBe("DNS failure");
+  });
+
+  it("strips trailing slash from the registryUrl when composing the path", async () => {
+    const fetchSpy = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ cached: false }), { status: 201 }),
+    );
+    global.fetch = fetchSpy as unknown as typeof fetch;
+    await publishNarrative(narrativeToRequestBody(baseNarrative(), "x"), {
+      registryUrl: "https://api.oa2a.org/",
+    });
+    expect(fetchSpy).toHaveBeenCalledWith(
+      "https://api.oa2a.org/api/v1/trust/narrative",
+      expect.any(Object),
+    );
+  });
+
+  it("includes the bearer token in Authorization header when provided", async () => {
+    const fetchSpy = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ cached: false }), { status: 201 }),
+    );
+    global.fetch = fetchSpy as unknown as typeof fetch;
+    await publishNarrative(narrativeToRequestBody(baseNarrative(), "x"), {
+      registryUrl: "https://api.oa2a.org",
+      bearerToken: "tok-123",
+    });
+    const call = fetchSpy.mock.calls[0];
+    expect((call[1] as RequestInit).headers).toMatchObject({
+      authorization: "Bearer tok-123",
+    });
+  });
+});

--- a/__tests__/narrative/skill-narrative.test.ts
+++ b/__tests__/narrative/skill-narrative.test.ts
@@ -1,0 +1,141 @@
+import { describe, it, expect } from "vitest";
+import { buildSkillNarrative, SKILL_THREAT_MODEL_QUESTIONS } from "../../src/narrative/skill-narrative.js";
+import type { SecurityAST, Capability } from "../../src/nanomind-core/types.js";
+
+const baseAst = (overrides: Partial<SecurityAST> = {}): SecurityAST => ({
+  artifactType: "skill",
+  contentHash: "abc",
+  artifactPath: "skills/opena2a/refactor-helper/SKILL.md",
+  artifactSize: 100,
+  declaredPurpose: "Refactor source files",
+  declaredCapabilities: [],
+  declaredConstraints: [],
+  declaredDataAccess: [],
+  inferredCapabilities: [],
+  inferredRiskSurface: [],
+  intentClassification: "benign",
+  intentConfidence: 0.9,
+  dependsOn: [],
+  governedBy: [],
+  evidenceSpans: [],
+  signature: "",
+  modelVersion: "heuristic-v1",
+  compiledAt: "2026-04-27T00:00:00.000Z",
+  ...overrides,
+});
+
+const cap = (name: string, declared: boolean, inferred: boolean): Capability => ({
+  name,
+  scope: "",
+  declared,
+  inferred,
+  riskLevel: "low",
+});
+
+describe("buildSkillNarrative", () => {
+  it("populates skillName from frontmatter when present", () => {
+    const out = buildSkillNarrative({
+      ast: baseAst(),
+      frontmatter: { name: "opena2a/refactor-helper" },
+    });
+    expect(out.skillName).toBe("opena2a/refactor-helper");
+  });
+
+  it("falls back to artifactPath when frontmatter has no name", () => {
+    const out = buildSkillNarrative({ ast: baseAst() });
+    expect(out.skillName).toBe("opena2a/refactor-helper");
+  });
+
+  it("ships static threat-model questions verbatim", () => {
+    const out = buildSkillNarrative({ ast: baseAst() });
+    expect(out.threatModelQuestions).toEqual(SKILL_THREAT_MODEL_QUESTIONS);
+  });
+
+  it("extracts activation phrases from frontmatter list", () => {
+    const out = buildSkillNarrative({
+      ast: baseAst(),
+      frontmatter: { activation_phrases: ["refactor", "extract function"] },
+    });
+    expect(out.activationPhrases).toEqual(["refactor", "extract function"]);
+  });
+
+  it("extracts activation phrases from quoted strings in description", () => {
+    const out = buildSkillNarrative({
+      ast: baseAst(),
+      frontmatter: {
+        description: 'Triggers on "review" or "code review" prompts.',
+      },
+    });
+    expect(out.activationPhrases).toEqual(["review", "code review"]);
+  });
+
+  it("classifies declared+observed capability as used", () => {
+    const out = buildSkillNarrative({
+      ast: baseAst({
+        declaredCapabilities: [cap("Read", true, false)],
+        inferredCapabilities: [cap("Read", false, true)],
+      }),
+    });
+    expect(out.permissions).toContainEqual(
+      expect.objectContaining({ name: "Read", status: "used" }),
+    );
+  });
+
+  it("classifies declared-only capability as unused (overreach signal)", () => {
+    const out = buildSkillNarrative({
+      ast: baseAst({
+        declaredCapabilities: [cap("Bash", true, false)],
+        inferredCapabilities: [],
+      }),
+    });
+    expect(out.permissions).toContainEqual(
+      expect.objectContaining({ name: "Bash", status: "unused" }),
+    );
+  });
+
+  it("classifies observed-only capability as undeclared (scope expansion)", () => {
+    const out = buildSkillNarrative({
+      ast: baseAst({
+        declaredCapabilities: [],
+        inferredCapabilities: [cap("WebFetch", false, true)],
+      }),
+    });
+    expect(out.permissions).toContainEqual(
+      expect.objectContaining({ name: "WebFetch", status: "undeclared" }),
+    );
+  });
+
+  it("treats transmit destinations as external services", () => {
+    const out = buildSkillNarrative({
+      ast: baseAst({
+        declaredDataAccess: [
+          { dataType: "general", accessMode: "transmit", destination: "https://api.anthropic.com/v1/messages", coveredByCapability: true },
+        ],
+      }),
+    });
+    expect(out.externalServices).toContain("api.anthropic.com");
+  });
+
+  it("classifies persistence as 'none' when no writes are declared", () => {
+    const out = buildSkillNarrative({
+      ast: baseAst({
+        declaredDataAccess: [{ dataType: "general", accessMode: "read", coveredByCapability: true }],
+      }),
+    });
+    expect(out.persistence).toBe("none");
+  });
+
+  it("emits behaviorDescription and misuseNarrative as empty when NanoMind data is absent", () => {
+    const out = buildSkillNarrative({ ast: baseAst() });
+    expect(out.behaviorDescription).toBe("");
+    expect(out.misuseNarrative).toBe("");
+  });
+
+  it("threads NanoMind-supplied behaviorDescription through unchanged", () => {
+    const out = buildSkillNarrative({
+      ast: baseAst(),
+      behaviorDescription: "Reads files via Read tool only.",
+    });
+    expect(out.behaviorDescription).toBe("Reads files via Read tool only.");
+  });
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,19 +1,19 @@
 {
   "name": "hackmyagent",
-  "version": "0.19.0",
+  "version": "0.20.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "hackmyagent",
-      "version": "0.19.0",
+      "version": "0.20.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.12.1",
         "@noble/ed25519": "^2.3.0",
         "@noble/post-quantum": "^0.2.1",
         "@opena2a/aim-core": "^0.1.2",
-        "@opena2a/check-core": "0.1.0",
+        "@opena2a/check-core": "0.2.0",
         "@opena2a/cli-ui": "0.3.0",
         "@opena2a/contribute": "^0.1.0",
         "@opena2a/registry-client": "0.1.0",
@@ -584,9 +584,9 @@
       }
     },
     "node_modules/@opena2a/check-core": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/@opena2a/check-core/-/check-core-0.1.0.tgz",
-      "integrity": "sha512-RkMJuTwMBMNoF/xiMBq6KHwXOFE4K3x+X4tDa8T7ONjXr0cieEEmO4slqiD7qxXXkubP2IaekRvvVz9aefbc9w==",
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@opena2a/check-core/-/check-core-0.2.0.tgz",
+      "integrity": "sha512-d+ZKrJ9H8d5F3bPTMbk3j0Bl8ELMH+84unI/4UUOQ6MqBNChgziUcsX5SPhO1id1UUHZmKk2RKtSdHJj167MAQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@opena2a/registry-client": "0.1.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hackmyagent",
-  "version": "0.19.0",
+  "version": "0.20.0",
   "description": "Find it. Break it. Fix it. The hacker's toolkit for AI agents.",
   "bin": {
     "hackmyagent": "dist/cli.js"
@@ -39,7 +39,7 @@
     "@noble/ed25519": "^2.3.0",
     "@noble/post-quantum": "^0.2.1",
     "@opena2a/aim-core": "^0.1.2",
-    "@opena2a/check-core": "0.1.0",
+    "@opena2a/check-core": "0.2.0",
     "@opena2a/cli-ui": "0.3.0",
     "@opena2a/contribute": "^0.1.0",
     "@opena2a/registry-client": "0.1.0",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -3353,6 +3353,25 @@ Examples:
               };
               const publishResult = await publishScanResults(publishData, registryUrl);
               publishStatus = { ...publishResult, registryUrl };
+
+              // Best-effort: if this scan looks like a skill or MCP artifact, also
+              // POST a PackageNarrative so the rich-context `check` view has
+              // something to render. Failure is non-fatal — never blocks publish.
+              try {
+                const { wireNarrativePublish } = await import('./narrative/wire-publish');
+                const narrativeStatus = await wireNarrativePublish({
+                  targetDir,
+                  packageName,
+                  packageVersion: publishData.packageVersion ?? '0.0.0',
+                  findings: result.findings,
+                  projectType: result.projectType,
+                  registryUrl,
+                });
+                publishStatus = { ...publishStatus, narrative: narrativeStatus };
+              } catch (nErr: unknown) {
+                const nMsg = nErr instanceof Error ? nErr.message : 'unknown error';
+                publishStatus = { ...publishStatus, narrative: { attempted: true, result: { ok: false, cached: false, error: nMsg } } };
+              }
             } else {
               publishStatus = { success: false, error: 'Could not determine package name' };
             }
@@ -3613,6 +3632,28 @@ Examples:
             } else if (format === 'json') {
               // Append publish result to JSON output in a separate log
               console.error(JSON.stringify({ publish: publishResult }, null, 2));
+            }
+
+            // Best-effort: emit PackageNarrative for skill / mcp artifacts.
+            // Failure is non-fatal — only logged in verbose mode.
+            try {
+              const { wireNarrativePublish } = await import('./narrative/wire-publish');
+              const narrativeStatus = await wireNarrativePublish({
+                targetDir,
+                packageName,
+                packageVersion: publishData.packageVersion ?? '0.0.0',
+                findings: result.findings,
+                projectType: result.projectType,
+                registryUrl,
+              });
+              if (options.verbose && narrativeStatus.attempted) {
+                console.error(`Narrative: ${narrativeStatus.artifactType} → ${narrativeStatus.result?.ok ? (narrativeStatus.result.cached ? 'cached' : 'published') : 'failed'}`);
+              }
+            } catch (nErr: unknown) {
+              if (options.verbose) {
+                const nMsg = nErr instanceof Error ? nErr.message : 'unknown error';
+                console.error(`Narrative emission skipped: ${nMsg}`);
+              }
             }
           }
         } catch (publishErr: unknown) {

--- a/src/narrative/build-narrative.ts
+++ b/src/narrative/build-narrative.ts
@@ -1,0 +1,367 @@
+/**
+ * Orchestrator — assembles a `PackageNarrative` from existing scan
+ * outputs (SecurityAST, findings, scan-run id, package version).
+ *
+ * Brief: opena2a-org/briefs/check-rich-context-skills-mcp-v1.md (§4)
+ *
+ * The narrative is the wire shape POSTed to
+ * `POST /api/v1/trust/narrative` on `secure --publish` for skill / mcp
+ * artifacts. Other artifact types are out of scope in v1; this module
+ * returns null for them so the caller skips the publish.
+ */
+import type {
+  HardcodedSecret,
+  HardcodedSecretsBlock,
+  PackageNarrative,
+  RuleEngineInput,
+  RuleEngineOutput,
+} from "@opena2a/check-core";
+import {
+  enrichSecretRotation,
+  runRuleEngine,
+} from "@opena2a/check-core";
+import { randomUUID } from "node:crypto";
+import type { SecurityAST } from "../nanomind-core/types.js";
+import type { SecurityFinding } from "../hardening";
+import {
+  buildSkillNarrative,
+  type BuildSkillNarrativeInput,
+} from "./skill-narrative.js";
+import {
+  buildMcpNarrative,
+  type BuildMcpNarrativeInput,
+} from "./mcp-narrative.js";
+import { generateNarrativeSummary } from "./narrative-summary.js";
+
+/**
+ * Map HMA's canonical credential labels to check-core's `type` strings.
+ * Drives the rotation-URL lookup in `secret-rotation.ts`. Labels that
+ * don't appear here fall through to `unknown` — the renderer then
+ * surfaces a generic "rotate at the issuing service" path.
+ */
+const CREDENTIAL_LABEL_TO_TYPE: Record<string, string> = {
+  "Anthropic API key": "anthropic_api_key",
+  "OpenAI project key": "openai_api_key",
+  "OpenAI API key": "openai_api_key",
+  "AWS access key": "aws_access_key",
+  "GitHub personal access token": "github_pat",
+  "GitHub OAuth token": "github_pat",
+  "GitHub app token": "github_pat",
+  "Slack bot token": "slack_bot_token",
+  "Google API key": "gcp_service_account_key",
+  "Stripe live key": "stripe_secret_key",
+  "PEM private key": "private_key",
+};
+
+/** Inputs to the assembly. */
+export interface BuildPackageNarrativeInput {
+  ast: SecurityAST;
+  /** scan run identifier — UUID. Generated when omitted. */
+  scanRunId?: string;
+  /** Resolved package name on the registry (skill or mcp). */
+  packageName: string;
+  /** Latest version of the artifact at scan time. */
+  packageVersion: string;
+  /** Hardening-scan findings used for hardcoded-secrets extraction. */
+  findings: SecurityFinding[];
+  /** SKILL.md frontmatter, when artifactType === "skill". */
+  skillFrontmatter?: Record<string, unknown>;
+  /** Raw SKILL.md text — used for activation-phrase fallback parsing. */
+  skillSource?: string;
+  /** MCP config object, when artifactType === "mcp_config". */
+  mcpConfig?: Record<string, unknown>;
+  /** MCP tool registrations, when artifactType === "mcp_config". */
+  mcpToolRegistrations?: BuildMcpNarrativeInput["toolRegistrations"];
+  /** Trust verdict produced by the registry/scoring logic. */
+  verdict: RuleEngineInput["verdict"];
+  /** Scan status as the registry sees it. */
+  scanStatus: RuleEngineInput["scanStatus"];
+  /** Publisher signals known to the registry. */
+  publisher: RuleEngineInput["publisher"];
+  /** Provenance attestations. */
+  attestations: RuleEngineInput["attestations"];
+  communityScans: number;
+  cleanCommunityScans: number;
+  hasSoulFile: boolean;
+  /** When destructive MCP tools ship with safety affordances. */
+  mcpHasSafetyAffordances?: boolean;
+  /** Last-known-clean version, drives the LISTED skill pin secondary. */
+  lastCleanVersion?: string;
+  /** NOT_FOUND-tier suggestion list — caller-injected. */
+  notFoundSuggestions?: string[];
+}
+
+/**
+ * Assemble the full PackageNarrative. Returns null when the AST is not
+ * a skill or mcp_config — those are the only artifact types in v1
+ * scope per brief §2.
+ */
+export async function buildPackageNarrative(
+  input: BuildPackageNarrativeInput,
+): Promise<PackageNarrative | null> {
+  const { ast } = input;
+  if (ast.artifactType !== "skill" && ast.artifactType !== "mcp_config") {
+    return null;
+  }
+
+  // Hardcoded secrets pulled from the existing scan findings. The
+  // canonical credential scanner already produces credential-class
+  // findings — this just reshapes them to the wire type.
+  const hardcodedSecrets = extractHardcodedSecrets(input.findings).map(
+    enrichSecretRotation,
+  );
+
+  // NanoMind v3 comprehension — graceful-degrade in v1.
+  const nanomind = await generateNarrativeSummary(ast);
+
+  // Rule-engine output for verdict reasoning + nextSteps.
+  const ruleEngineInput = composeRuleEngineInput(input, hardcodedSecrets);
+  const ruleEngineOutput: RuleEngineOutput = runRuleEngine(ruleEngineInput);
+
+  const hardcodedSecretsBlock: HardcodedSecretsBlock = ruleEngineOutput.hardcodedSecretsBlock;
+
+  const narrative: PackageNarrative = {
+    schemaVersion: 1,
+    generatedAt: new Date().toISOString(),
+    generatedFrom: {
+      artifactType: ast.artifactType === "skill" ? "skill" : "mcp",
+      artifactVersion: input.packageVersion,
+      scanRunId: input.scanRunId ?? randomUUID(),
+    },
+    summary: nanomind.summary,
+    hardcodedSecrets: hardcodedSecretsBlock,
+    verdictReasoning: ruleEngineOutput.verdictReasoning,
+    nextSteps: ruleEngineOutput.nextSteps,
+  };
+
+  if (ast.artifactType === "skill") {
+    const skillInput: BuildSkillNarrativeInput = {
+      ast,
+      frontmatter: input.skillFrontmatter,
+      skillSource: input.skillSource,
+      findings: input.findings,
+      behaviorDescription: nanomind.behaviorDescription,
+      misuseNarrative: nanomind.misuseNarrative,
+    };
+    narrative.skill = buildSkillNarrative(skillInput);
+  } else {
+    const mcpInput: BuildMcpNarrativeInput = {
+      ast,
+      config: input.mcpConfig,
+      toolRegistrations: input.mcpToolRegistrations,
+      findings: input.findings,
+      fallbackName: input.packageName,
+    };
+    narrative.mcp = buildMcpNarrative(mcpInput);
+  }
+
+  return narrative;
+}
+
+/**
+ * Extract hardcoded-credential findings from the scan output and
+ * reshape them as `HardcodedSecret` entries. Recognized HMA
+ * credential-class findings are: any finding with category
+ * `credentials` / `web-credentials` / `credential-exposure` /
+ * `agent-credential`, or any finding whose `attackClass` starts with
+ * `CRED-` / `AST-CRED-` / `WEBCRED-` / `SEM-CRED-` / `AGENT-CRED-`.
+ */
+function extractHardcodedSecrets(findings: SecurityFinding[]): HardcodedSecret[] {
+  const credentialCategories = new Set([
+    "credentials",
+    "web-credentials",
+    "credential-exposure",
+    "agent-credential",
+  ]);
+  const credentialAttackPrefixes = [
+    "CRED-",
+    "AST-CRED-",
+    "WEBCRED-",
+    "SEM-CRED-",
+    "AGENT-CRED-",
+    "ENVLEAK",
+    "CLIPASS",
+  ];
+  const out: HardcodedSecret[] = [];
+  for (const f of findings) {
+    const isCredFinding =
+      credentialCategories.has(f.category) ||
+      (typeof f.attackClass === "string" &&
+        credentialAttackPrefixes.some((p) => f.attackClass!.startsWith(p)));
+    if (!isCredFinding) continue;
+    const label = extractLabelFromFinding(f);
+    const type = label
+      ? CREDENTIAL_LABEL_TO_TYPE[label] ?? "unknown"
+      : "unknown";
+    out.push({
+      type,
+      typeLabel: label ?? "",
+      file: f.file ?? "",
+      line: f.line,
+      maskedValue: maskCredential(extractRawValue(f)),
+      shownChars: countShownChars(extractRawValue(f)),
+      totalChars: (extractRawValue(f) ?? "").length,
+      shipsInArtifact: shipsInArtifact(f),
+      severity: mapSeverity(f.severity),
+    });
+  }
+  return out;
+}
+
+function extractLabelFromFinding(f: SecurityFinding): string | undefined {
+  // The canonical credential scanner sets findings whose name/title
+  // includes "Hardcoded <label>" (see semantic-compiler.ts:159).
+  const m = (f.name ?? f.message ?? "").match(/Hardcoded ([^.]+)/);
+  if (m && m[1]) return m[1].trim();
+  // Fall back to a likely-label in `details`.
+  const detailLabel = (f.details as { label?: string } | undefined)?.label;
+  if (typeof detailLabel === "string") return detailLabel;
+  return undefined;
+}
+
+function extractRawValue(f: SecurityFinding): string | undefined {
+  const detailValue = (f.details as { value?: string; rawValue?: string } | undefined);
+  return detailValue?.value ?? detailValue?.rawValue;
+}
+
+function maskCredential(value?: string): string {
+  if (!value || value.length === 0) return "";
+  // Preserve recognizable prefixes for known formats.
+  const knownPrefixes = [
+    "sk-ant-api03-",
+    "sk-ant-api02-",
+    "sk-proj-",
+    "ghp_",
+    "gho_",
+    "ghs_",
+    "AKIA",
+    "AIza",
+    "xoxb-",
+    "xoxa-",
+    "xoxp-",
+    "sk_live_",
+    "-----BEGIN",
+  ];
+  for (const prefix of knownPrefixes) {
+    if (value.startsWith(prefix)) {
+      const remaining = Math.max(0, value.length - prefix.length);
+      return `${prefix}${"*".repeat(Math.min(remaining, 16))}`;
+    }
+  }
+  // Unknown shape — show first 8 chars + asterisks.
+  return `${value.slice(0, 8)}${"*".repeat(Math.min(value.length - 8, 16))}`;
+}
+
+function countShownChars(value?: string): number {
+  if (!value) return 0;
+  const knownPrefixes = [
+    "sk-ant-api03-",
+    "sk-ant-api02-",
+    "sk-proj-",
+    "ghp_",
+    "gho_",
+    "ghs_",
+    "AKIA",
+    "AIza",
+    "xoxb-",
+    "xoxa-",
+    "xoxp-",
+    "sk_live_",
+    "-----BEGIN",
+  ];
+  for (const prefix of knownPrefixes) {
+    if (value.startsWith(prefix)) return prefix.length;
+  }
+  return Math.min(8, value.length);
+}
+
+/**
+ * "Ships in artifact" heuristic. Conservative: assume yes unless the
+ * file path obviously points at a local-only fixture (test/, fixtures/,
+ * .env-style file).
+ */
+function shipsInArtifact(f: SecurityFinding): boolean {
+  const file = f.file ?? "";
+  if (/^(test|tests|fixtures|__tests__|examples\/.*\.test\.|examples\/__)/.test(file)) {
+    return false;
+  }
+  if (/\.env(\.|$)/.test(file)) return false;
+  return true;
+}
+
+function mapSeverity(severity: SecurityFinding["severity"]): HardcodedSecret["severity"] {
+  if (severity === "critical") return "critical";
+  if (severity === "high") return "high";
+  if (severity === "medium") return "medium";
+  return "low";
+}
+
+/**
+ * Compose the rule-engine input from the assembly inputs + extracted
+ * narrative pieces. Defaults reflect "scan covered, no skill data" so
+ * the engine treats missing fields conservatively.
+ */
+function composeRuleEngineInput(
+  input: BuildPackageNarrativeInput,
+  hardcodedSecrets: HardcodedSecret[],
+): RuleEngineInput {
+  const { ast } = input;
+  const artifactType: RuleEngineInput["artifactType"] =
+    ast.artifactType === "skill" ? "skill" : "mcp";
+  // skill/mcp narratives feed the rule engine the permission delta /
+  // destructive-tool list. For non-skill/mcp paths buildPackageNarrative
+  // returns null before this is called, so this is always reachable.
+  const skill =
+    ast.artifactType === "skill"
+      ? buildSkillNarrative({
+          ast,
+          frontmatter: input.skillFrontmatter,
+          skillSource: input.skillSource,
+          findings: input.findings,
+        })
+      : undefined;
+  const mcp =
+    ast.artifactType === "mcp_config"
+      ? buildMcpNarrative({
+          ast,
+          config: input.mcpConfig,
+          toolRegistrations: input.mcpToolRegistrations,
+          findings: input.findings,
+          fallbackName: input.packageName,
+        })
+      : undefined;
+  return {
+    packageName: input.packageName,
+    latestVersion: input.packageVersion,
+    lastCleanVersion: input.lastCleanVersion ?? "",
+    artifactType,
+    verdict: input.verdict,
+    scanStatus: input.scanStatus,
+    publisher: input.publisher,
+    attestations: input.attestations,
+    communityScans: input.communityScans,
+    cleanCommunityScans: input.cleanCommunityScans,
+    hasSoulFile: input.hasSoulFile,
+    findings: input.findings.map((f) => ({
+      ruleId: f.checkId,
+      severity:
+        f.severity === "critical"
+          ? "critical"
+          : f.severity === "high"
+            ? "high"
+            : f.severity === "medium"
+              ? "medium"
+              : f.severity === "low"
+                ? "low"
+                : "info",
+      description: f.message,
+      locator: f.file ? (f.line ? `${f.file}:${f.line}` : f.file) : undefined,
+    })),
+    hardcodedSecrets,
+    scanCovered: true,
+    skill,
+    mcp,
+    mcpHasSafetyAffordances: input.mcpHasSafetyAffordances ?? false,
+    notFoundSuggestions: input.notFoundSuggestions ?? [],
+  };
+}

--- a/src/narrative/index.ts
+++ b/src/narrative/index.ts
@@ -1,0 +1,36 @@
+/**
+ * @internal — entry point for the package-narrative emission pipeline.
+ *
+ * Re-exports the public surface used by `secure --publish` and tests.
+ *
+ * Brief: opena2a-org/briefs/check-rich-context-skills-mcp-v1.md
+ */
+export {
+  buildSkillNarrative,
+  SKILL_THREAT_MODEL_QUESTIONS,
+  type BuildSkillNarrativeInput,
+} from "./skill-narrative.js";
+export {
+  buildMcpNarrative,
+  MCP_THREAT_MODEL_QUESTIONS,
+  type BuildMcpNarrativeInput,
+  type McpToolRegistration,
+} from "./mcp-narrative.js";
+export {
+  generateNarrativeSummary,
+  isAcceptedByInputClassifier,
+  emptyResult,
+  type NarrativeSummaryOptions,
+  type NarrativeSummaryResult,
+} from "./narrative-summary.js";
+export {
+  buildPackageNarrative,
+  type BuildPackageNarrativeInput,
+} from "./build-narrative.js";
+export {
+  publishNarrative,
+  narrativeToRequestBody,
+  type PublishNarrativeOptions,
+  type PublishNarrativeRequest,
+  type PublishNarrativeResult,
+} from "./publish-narrative.js";

--- a/src/narrative/mcp-narrative.ts
+++ b/src/narrative/mcp-narrative.ts
@@ -1,0 +1,207 @@
+/**
+ * MCP narrative builder — turns a SecurityAST + scan findings into the
+ * `McpNarrative` wire shape consumed by @opena2a/check-core's
+ * `runRuleEngine` and the registry's `package_narratives` row.
+ *
+ * Brief: opena2a-org/briefs/check-rich-context-skills-mcp-v1.md (§4)
+ *
+ * Reuses what the existing scanners already extract from MCP configs
+ * and TypeScript/JS source. Where comprehension data isn't available
+ * (NanoMind v3 summary), the field is empty and the renderer
+ * graceful-degrades.
+ */
+import type { McpNarrative, McpTool } from "@opena2a/check-core";
+import type { SecurityAST } from "../nanomind-core/types.js";
+import type { SecurityFinding } from "../hardening";
+
+/**
+ * Static threat-model questions for the MCP artifact type per brief §6.2.
+ * Stored in the registry alongside the narrative so the renderer is dumb.
+ */
+export const MCP_THREAT_MODEL_QUESTIONS = [
+  "Will the agent that connects to this MCP be capable of writing outside its task scope if it is prompt-injected?",
+  "Does your config-level scope restriction (allowedDirectories, allowedHosts, etc.) use realpath or string-prefix matching?",
+  "Is there a snapshot or backup before the agent has write access?",
+];
+
+/**
+ * Tool names that mutate state. `destructive: true` drives the
+ * "destructive tools without safety affordances" gap rule in
+ * @opena2a/check-core's rule engine.
+ */
+const DESTRUCTIVE_TOOL_PATTERNS: RegExp[] = [
+  /^write[_-]?file/i,
+  /^delete[_-]?file/i,
+  /^remove[_-]?file/i,
+  /^move[_-]?file/i,
+  /^rename[_-]?/i,
+  /^create[_-]?dir/i,
+  /^make[_-]?dir/i,
+  /^update[_-]?/i,
+  /^drop[_-]?/i,
+  /^execute[_-]?/i,
+  /^exec[_-]?command/i,
+  /^run[_-]?shell/i,
+];
+
+export interface BuildMcpNarrativeInput {
+  ast: SecurityAST;
+  /** Parsed config (mcpServers entry, package.json, etc). Optional. */
+  config?: Record<string, unknown>;
+  /** Tool registrations parsed from the MCP server's source. */
+  toolRegistrations?: McpToolRegistration[];
+  /** Findings the scanner produced — used to classify side effects. */
+  findings?: SecurityFinding[];
+  /** Manual MCP package name when the AST/config doesn't carry it. */
+  fallbackName?: string;
+}
+
+/**
+ * One tool registration parsed from `server.tool(...)` / `tool(...)`
+ * calls in the MCP server's TypeScript / JavaScript source. The MCP
+ * scanner produces these today; this is a structured shape for them.
+ */
+export interface McpToolRegistration {
+  name: string;
+  signature?: string;
+  description?: string;
+}
+
+/**
+ * Build an `McpNarrative` from a compiled MCP-config AST + tool list.
+ */
+export function buildMcpNarrative(input: BuildMcpNarrativeInput): McpNarrative {
+  const { ast, config, toolRegistrations, findings, fallbackName } = input;
+  return {
+    mcpName: resolveMcpName(ast, config, fallbackName),
+    tools: composeToolList(toolRegistrations),
+    pathScope: classifyPathScope(ast, config),
+    network: classifyNetwork(ast),
+    persistence: classifyPersistence(ast),
+    auth: classifyAuth(ast, config),
+    sideEffects: extractSideEffects(ast, findings),
+    threatModelQuestions: MCP_THREAT_MODEL_QUESTIONS,
+  };
+}
+
+// ---- helpers --------------------------------------------------------
+
+function resolveMcpName(
+  ast: SecurityAST,
+  config?: Record<string, unknown>,
+  fallbackName?: string,
+): string {
+  const fmName = config?.name;
+  if (typeof fmName === "string" && fmName.length > 0) return fmName;
+  if (fallbackName && fallbackName.length > 0) return fallbackName;
+  if (ast.artifactPath) {
+    return ast.artifactPath.split("/").pop()?.replace(/\.json$|\.config$/, "") ?? "unnamed-mcp";
+  }
+  return "unnamed-mcp";
+}
+
+function composeToolList(
+  registrations: McpToolRegistration[] | undefined,
+): McpTool[] {
+  if (!registrations || registrations.length === 0) return [];
+  return registrations.map((reg) => ({
+    name: reg.name,
+    signature: reg.signature ?? `${reg.name}()`,
+    description: reg.description ?? "",
+    destructive: isDestructive(reg.name),
+  }));
+}
+
+function isDestructive(name: string): boolean {
+  return DESTRUCTIVE_TOOL_PATTERNS.some((p) => p.test(name));
+}
+
+function classifyPathScope(
+  ast: SecurityAST,
+  config?: Record<string, unknown>,
+): string {
+  if (config && typeof config === "object") {
+    if (Array.isArray(config.allowedDirectories) && config.allowedDirectories.length > 0) {
+      return `config-allowlisted (${(config.allowedDirectories as unknown[]).length} entries)`;
+    }
+    if (Array.isArray(config.allowedPaths) && config.allowedPaths.length > 0) {
+      return `config-allowlisted (${(config.allowedPaths as unknown[]).length} entries)`;
+    }
+  }
+  const writesAnywhere = ast.declaredDataAccess.some((d) => d.accessMode === "write");
+  if (writesAnywhere) return "any path agent passes";
+  return "read-only";
+}
+
+function classifyNetwork(ast: SecurityAST): string {
+  const externalRefs = ast.declaredDataAccess
+    .filter((d) => d.accessMode === "transmit" && d.destination)
+    .map((d) => d.destination!);
+  if (externalRefs.length === 0) return "none";
+  return externalRefs.slice(0, 5).join(", ");
+}
+
+function classifyPersistence(ast: SecurityAST): string {
+  const writes = ast.declaredDataAccess.filter(
+    (d) => d.accessMode === "write" || d.accessMode === "delete",
+  );
+  if (writes.length === 0) return "none";
+  if (writes.some((w) => w.dataType === "credentials")) return "credentials store";
+  if (writes.some((w) => w.dataType.includes("file") || w.dataType === "general")) {
+    return "filesystem";
+  }
+  return Array.from(new Set(writes.map((w) => w.dataType)))
+    .sort()
+    .join(", ");
+}
+
+function classifyAuth(
+  ast: SecurityAST,
+  config?: Record<string, unknown>,
+): string {
+  if (config && typeof config === "object") {
+    if (config.bearerToken || config.token) return "bearer token";
+    if (config.apiKey) return "api key";
+    if (config.basicAuth) return "basic auth";
+    if (config.oauth || config.oauth2) return "OAuth";
+  }
+  const hasBearerHints = ast.inferredRiskSurface.some(
+    (r) => /bearer\s+token|authorization\s*header/i.test(r.evidence ?? ""),
+  );
+  if (hasBearerHints) return "bearer token";
+  return "none";
+}
+
+/**
+ * Process-level side effects observed by the scanner. Classifies the
+ * top-level RiskSurface entries into short labels the renderer can
+ * print as a list.
+ */
+function extractSideEffects(
+  ast: SecurityAST,
+  findings: SecurityFinding[] | undefined,
+): string[] {
+  const effects = new Set<string>();
+  for (const risk of ast.inferredRiskSurface) {
+    if (/spawn|child_process|exec\(/i.test(risk.evidence ?? "")) {
+      effects.add("spawns child processes");
+    }
+    if (/postinstall|preinstall/i.test(risk.evidence ?? "")) {
+      effects.add("install-time scripts");
+    }
+    if (/eval\(|Function\(/i.test(risk.evidence ?? "")) {
+      effects.add("dynamic code execution");
+    }
+  }
+  if (findings) {
+    for (const f of findings) {
+      if (/postinstall/i.test(f.checkId ?? "") || /postinstall/i.test(f.message ?? "")) {
+        effects.add("install-time scripts");
+      }
+      if (/process.spawn|child_process/i.test(f.message ?? "")) {
+        effects.add("spawns child processes");
+      }
+    }
+  }
+  return Array.from(effects).sort();
+}

--- a/src/narrative/narrative-summary.ts
+++ b/src/narrative/narrative-summary.ts
@@ -1,0 +1,102 @@
+/**
+ * NanoMind v3 1-paragraph summary generator — gated by input-classifier
+ * v3.1, with a graceful-degrade path baked in.
+ *
+ * Brief: opena2a-org/briefs/check-rich-context-skills-mcp-v1.md (§4.1, §10)
+ *
+ * Per project memory `project_nanomind_v05_intelreport_task_mismatch.md`,
+ * v0.5.0 fails JSON-schema validation on clean-scan inputs and
+ * hallucinates attack classes for non-attack tasks. v3 has the same
+ * task-scope problem ([CDS-024]). Until a NanoMind release ships that
+ * targets the comprehension task properly, this module returns empty
+ * strings on every code path. The renderer treats `''` as
+ * "Comprehension data not yet available" and renders graceful-degrade.
+ *
+ * The interface is the v1 stub. When NanoMind v3 lands a comprehension
+ * model, swap the implementation of `generateSummary` /
+ * `generateBehaviorDescription` / `generateMisuseNarrative` with a real
+ * call. The caller contract is intentionally narrow:
+ *
+ *   - Synchronous-friendly Promise<string> shape.
+ *   - Never throws. Errors swallow into `''`.
+ *   - Caller-controlled timeout via the per-call `timeoutMs` option.
+ */
+import type { SecurityAST } from "../nanomind-core/types.js";
+
+/** Allowed artifact types per input-classifier v3.1. */
+const ALLOWED_ARTIFACT_TYPES = new Set(["skill", "mcp_config"]);
+
+/**
+ * Result triple — mirrors the three NanoMind-sourced fields in
+ * `PackageNarrative`.
+ */
+export interface NarrativeSummaryResult {
+  /** PackageNarrative.summary — 2-4 sentence overview. */
+  summary: string;
+  /** SkillNarrative.behaviorDescription — 1-2 sentence behavior synopsis. */
+  behaviorDescription: string;
+  /** SkillNarrative.misuseNarrative — 2-4 sentence misuse explanation. */
+  misuseNarrative: string;
+  /**
+   * True when NanoMind successfully produced text. False when the
+   * gate refused, the model timed out, or generation errored. Callers
+   * surface this in debug logs but do not treat it as user-visible.
+   */
+  generated: boolean;
+}
+
+export interface NarrativeSummaryOptions {
+  /** Per-call timeout (defaults to 8s). */
+  timeoutMs?: number;
+  /** Whether to log model-call telemetry to stderr in --verbose mode. */
+  verbose?: boolean;
+}
+
+/**
+ * Input-classifier v3.1 gate. Returns true when the artifact is a
+ * valid input for NanoMind v3 comprehension generation. Currently
+ * narrows to `skill` and `mcp_config` artifact types — the only two
+ * the v1 brief surfaces in the rich-context view.
+ */
+export function isAcceptedByInputClassifier(ast: SecurityAST): boolean {
+  return ALLOWED_ARTIFACT_TYPES.has(ast.artifactType);
+}
+
+/**
+ * Generate the three NanoMind-sourced narrative strings. Always
+ * resolves; never rejects. v1 stub returns `''` for all three.
+ *
+ * Flow when wired up to a real NanoMind v3:
+ *   1. Gate via `isAcceptedByInputClassifier`. Reject → return empty.
+ *   2. Call into the local NanoMind daemon (or remote inference) with
+ *      a comprehension prompt + the sanitized AST as context.
+ *   3. Validate output: each string ≥ 1 sentence, ≤ 4096 chars,
+ *      no model-of-the-week hallucination markers.
+ *   4. On any failure (schema, timeout, daemon down, OOD output)
+ *      → return empty strings + generated=false.
+ */
+export async function generateNarrativeSummary(
+  ast: SecurityAST,
+  _options: NarrativeSummaryOptions = {},
+): Promise<NarrativeSummaryResult> {
+  if (!isAcceptedByInputClassifier(ast)) {
+    return emptyResult();
+  }
+  // v1 stub: NanoMind v3 comprehension is not wired up. Real
+  // implementation lives in a follow-up branch keyed on the new
+  // model release per [CHIEF-CDS] approval.
+  return emptyResult();
+}
+
+/**
+ * Empty result helper used by both the gate-rejected and stub paths
+ * so the caller doesn't branch on "did the gate accept."
+ */
+export function emptyResult(): NarrativeSummaryResult {
+  return {
+    summary: "",
+    behaviorDescription: "",
+    misuseNarrative: "",
+    generated: false,
+  };
+}

--- a/src/narrative/publish-narrative.ts
+++ b/src/narrative/publish-narrative.ts
@@ -1,0 +1,140 @@
+/**
+ * HTTP client for the registry's POST /api/v1/trust/narrative endpoint.
+ *
+ * Brief: opena2a-org/briefs/check-rich-context-skills-mcp-v1.md (§4)
+ * Registry handler: opena2a-registry/internal/interfaces/http/handlers/package_narrative_handler.go
+ *
+ * Behavior:
+ *   - Best-effort POST. Failure is non-fatal — `secure --publish`
+ *     still considers the parent publish a success even if narrative
+ *     emission fails.
+ *   - Cache TTL is enforced server-side. The handler returns
+ *     200 + `{cached: true}` when a fresh row exists; no-op locally.
+ *   - Auth: same bearer / signed-payload model as the existing
+ *     `/trust/publish` flow.
+ */
+import type { PackageNarrative } from "@opena2a/check-core";
+
+export interface PublishNarrativeRequest {
+  /**
+   * Wire-shape body. Translates the @opena2a/check-core
+   * `PackageNarrative` into the POST request shape from
+   * package_narrative_handler.go.
+   */
+  artifactType: "skill" | "mcp";
+  packageName: string;
+  packageVersion: string;
+  schemaVersion: 1;
+  scanRunId: string;
+  summary: string;
+  hardcodedSecrets: PackageNarrative["hardcodedSecrets"];
+  /** Brief §4 / handler use distinct keys for skill vs mcp narratives. */
+  skill?: PackageNarrative["skill"];
+  mcp?: PackageNarrative["mcp"];
+  verdictReasoning: PackageNarrative["verdictReasoning"];
+  nextSteps: PackageNarrative["nextSteps"];
+}
+
+export interface PublishNarrativeResult {
+  ok: boolean;
+  /** True when the registry returned 200 + cached:true (no-op). */
+  cached: boolean;
+  /** ISO timestamp the registry stamped (only on cached responses). */
+  generatedAt?: string;
+  /** Human-readable error message on failure. */
+  error?: string;
+  status?: number;
+}
+
+export interface PublishNarrativeOptions {
+  /** Registry base URL — same default as the rest of HMA. */
+  registryUrl: string;
+  /**
+   * Bearer token for the publisher service-account. Falls back to
+   * `process.env.OPENA2A_REGISTRY_TOKEN` when omitted.
+   */
+  bearerToken?: string;
+  /** Per-call timeout (defaults to 5s). */
+  timeoutMs?: number;
+}
+
+/**
+ * Convert the `PackageNarrative` shape returned by `runRuleEngine` /
+ * `buildPackageNarrative` into the registry's POST body shape. Drops
+ * `generatedAt` and `generatedFrom` (server-generated), keeps the
+ * `schemaVersion` / `scanRunId` provenance fields.
+ */
+export function narrativeToRequestBody(
+  narrative: PackageNarrative,
+  packageName: string,
+): PublishNarrativeRequest {
+  return {
+    artifactType: narrative.generatedFrom.artifactType,
+    packageName,
+    packageVersion: narrative.generatedFrom.artifactVersion,
+    schemaVersion: 1,
+    scanRunId: narrative.generatedFrom.scanRunId,
+    summary: narrative.summary,
+    hardcodedSecrets: narrative.hardcodedSecrets,
+    skill: narrative.skill,
+    mcp: narrative.mcp,
+    verdictReasoning: narrative.verdictReasoning,
+    nextSteps: narrative.nextSteps,
+  };
+}
+
+/**
+ * POST a narrative payload to the registry. Returns a result object;
+ * never throws.
+ */
+export async function publishNarrative(
+  body: PublishNarrativeRequest,
+  options: PublishNarrativeOptions,
+): Promise<PublishNarrativeResult> {
+  const url = `${options.registryUrl.replace(/\/$/, "")}/api/v1/trust/narrative`;
+  const token =
+    options.bearerToken ?? process.env.OPENA2A_REGISTRY_TOKEN ?? "";
+  const headers: Record<string, string> = {
+    "content-type": "application/json",
+    accept: "application/json",
+  };
+  if (token.length > 0) {
+    headers.authorization = `Bearer ${token}`;
+  }
+  const controller = new AbortController();
+  const timeout = setTimeout(
+    () => controller.abort(),
+    options.timeoutMs ?? 5000,
+  );
+  try {
+    const response = await fetch(url, {
+      method: "POST",
+      headers,
+      body: JSON.stringify(body),
+      signal: controller.signal,
+    });
+    clearTimeout(timeout);
+    if (!response.ok) {
+      return {
+        ok: false,
+        cached: false,
+        status: response.status,
+        error: `narrative publish failed: HTTP ${response.status}`,
+      };
+    }
+    const json = (await response.json()) as {
+      cached?: boolean;
+      generatedAt?: string;
+    };
+    return {
+      ok: true,
+      cached: Boolean(json.cached),
+      generatedAt: json.generatedAt,
+      status: response.status,
+    };
+  } catch (err: unknown) {
+    clearTimeout(timeout);
+    const message = err instanceof Error ? err.message : "unknown error";
+    return { ok: false, cached: false, error: message };
+  }
+}

--- a/src/narrative/skill-narrative.ts
+++ b/src/narrative/skill-narrative.ts
@@ -1,0 +1,268 @@
+/**
+ * Skill narrative builder — turns a SecurityAST + scan findings into the
+ * `SkillNarrative` wire shape consumed by @opena2a/check-core's
+ * `runRuleEngine` and the registry's `package_narratives` row.
+ *
+ * Brief: opena2a-org/briefs/check-rich-context-skills-mcp-v1.md (§4)
+ *
+ * No new AST analysis here — every field is shaped from data the
+ * SemanticCompiler / scanner already produced. Where comprehension data
+ * is missing (e.g. NanoMind v3 summary) the field is empty / a sane
+ * default; the renderer treats empty content as graceful-degrade.
+ */
+import type {
+  PermissionStatus,
+  SkillNarrative,
+  ToolCallCount,
+} from "@opena2a/check-core";
+import type { SecurityAST, Capability, DataAccessPattern } from "../nanomind-core/types.js";
+import type { SecurityFinding } from "../hardening";
+
+/**
+ * Static threat-model questions for the skill artifact type. Curated
+ * by [CHIEF-CSR] per brief §6.1; rendered verbatim. Kept here (rather
+ * than cli-ui) so the registry stores the full narrative — keeps the
+ * renderer dumb.
+ */
+export const SKILL_THREAT_MODEL_QUESTIONS = [
+  "Where will users invoke this skill? Is the CWD bounded to a project the user owns, or could it run in a directory containing secrets (e.g. ~/.ssh, ~/.aws)?",
+  "Do you require pinning to a specific skill version, or does your fleet auto-update on publish?",
+  "Is your Claude API key scoped per-user, or shared across a tenant where one user's prompt can affect another's?",
+];
+
+/**
+ * Inputs to `buildSkillNarrative`. Only the AST is required; the rest
+ * are optional and degrade gracefully when absent.
+ */
+export interface BuildSkillNarrativeInput {
+  ast: SecurityAST;
+  /** Frontmatter parsed from SKILL.md. `name`, `description`, `capabilities` etc. */
+  frontmatter?: Record<string, unknown>;
+  /** Full SKILL.md raw content; only used for activation-phrase parsing. */
+  skillSource?: string;
+  /** All findings the scanner produced for this skill artifact. */
+  findings?: SecurityFinding[];
+  /**
+   * NanoMind v3 outputs. v1 ships with these as empty strings — see
+   * `narrative-summary.ts` for the graceful-degrade gate.
+   */
+  behaviorDescription?: string;
+  misuseNarrative?: string;
+}
+
+/**
+ * Build a `SkillNarrative` from a compiled SKILL.md AST + scan results.
+ */
+export function buildSkillNarrative(input: BuildSkillNarrativeInput): SkillNarrative {
+  const { ast, frontmatter, skillSource, findings, behaviorDescription, misuseNarrative } = input;
+  const skillName = resolveSkillName(ast, frontmatter);
+  return {
+    skillName,
+    activationPhrases: extractActivationPhrases(frontmatter, skillSource),
+    behaviorDescription: behaviorDescription ?? "",
+    permissions: buildPermissionDelta(ast),
+    externalServices: extractExternalServices(ast),
+    persistence: classifyPersistence(ast),
+    toolCallsObserved: extractToolCallCounts(ast, findings),
+    misuseNarrative: misuseNarrative ?? "",
+    threatModelQuestions: SKILL_THREAT_MODEL_QUESTIONS,
+  };
+}
+
+// ---- helpers --------------------------------------------------------
+
+function resolveSkillName(
+  ast: SecurityAST,
+  frontmatter?: Record<string, unknown>,
+): string {
+  const fmName = frontmatter?.name;
+  if (typeof fmName === "string" && fmName.length > 0) return fmName;
+  if (ast.artifactPath) {
+    // Skill path conventionally ends in `.../<publisher>/<name>/SKILL.md`.
+    // Drop a trailing `SKILL.md` / `SKILL` leaf so the caller sees the
+    // meaningful publisher/name pair instead of the file basename.
+    const parts = ast.artifactPath.split("/").filter(Boolean);
+    if (parts.length === 0) return "unnamed-skill";
+    const last = parts[parts.length - 1].replace(/\.md$/, "");
+    const trimmed = last === "SKILL" ? parts.slice(0, -1) : parts;
+    if (trimmed.length >= 2) return trimmed.slice(-2).join("/");
+    return trimmed[trimmed.length - 1];
+  }
+  return "unnamed-skill";
+}
+
+/**
+ * Extract activation phrases from SKILL.md frontmatter. Looks for
+ * common shapes:
+ *   - `activation_phrases: [phrase1, phrase2]`
+ *   - `activation: [phrase1, ...]`
+ *   - `triggers: [...]`
+ * Falls back to scanning the description for quoted strings if no
+ * structured list is present.
+ */
+function extractActivationPhrases(
+  frontmatter?: Record<string, unknown>,
+  skillSource?: string,
+): string[] {
+  const candidates = ["activation_phrases", "activationPhrases", "activation", "triggers"];
+  for (const key of candidates) {
+    const value = frontmatter?.[key];
+    if (Array.isArray(value)) {
+      return value
+        .map((entry) => (typeof entry === "string" ? entry.trim() : ""))
+        .filter((entry) => entry.length > 0);
+    }
+  }
+  // Fallback: pull quoted strings out of the description.
+  const description = frontmatter?.description;
+  if (typeof description === "string") {
+    const quoted = description.match(/"([^"\\]+)"/g);
+    if (quoted && quoted.length > 0) {
+      return quoted.map((q) => q.slice(1, -1));
+    }
+  }
+  // Last resort: scan the source for "Activates on:" / "Trigger:" lines.
+  if (skillSource) {
+    const line = skillSource
+      .split("\n")
+      .find((l) => /^\s*(Activates on|Trigger|Triggers)\s*:/i.test(l));
+    if (line) {
+      const after = line.split(":").slice(1).join(":").trim();
+      if (after.length > 0) {
+        return after
+          .split(/[,;]/)
+          .map((p) => p.replace(/^["']|["']$/g, "").trim())
+          .filter((p) => p.length > 0);
+      }
+    }
+  }
+  return [];
+}
+
+/**
+ * Compose the declared-vs-observed permission delta from the AST.
+ *
+ *   declared  = SecurityAST.declaredCapabilities
+ *   observed  = SecurityAST.inferredCapabilities (NanoMind ran) or [] (heuristic)
+ *
+ * Status mapping:
+ *   declared && observed → `used`
+ *   declared && !observed → `unused`
+ *   !declared && observed → `undeclared`
+ */
+function buildPermissionDelta(ast: SecurityAST): PermissionStatus[] {
+  const declared = new Map<string, Capability>();
+  for (const cap of ast.declaredCapabilities) {
+    declared.set(normalizeCapName(cap.name), cap);
+  }
+  const observed = new Map<string, Capability>();
+  for (const cap of ast.inferredCapabilities) {
+    observed.set(normalizeCapName(cap.name), cap);
+  }
+
+  const out: PermissionStatus[] = [];
+  const seen = new Set<string>();
+
+  for (const [name, cap] of declared.entries()) {
+    seen.add(name);
+    const isUsed = observed.has(name);
+    out.push({
+      name: cap.name,
+      declared: true,
+      used: isUsed,
+      status: isUsed ? "used" : "unused",
+    });
+  }
+
+  for (const [name, cap] of observed.entries()) {
+    if (seen.has(name)) continue;
+    out.push({
+      name: cap.name,
+      declared: false,
+      used: true,
+      status: "undeclared",
+      note: cap.scope || undefined,
+    });
+  }
+
+  return out;
+}
+
+function normalizeCapName(name: string): string {
+  return name.trim().toLowerCase();
+}
+
+/**
+ * Extract external service hostnames the skill talks to. Sources:
+ *   - DataAccessPattern.destination on `transmit` rows
+ *   - RiskSurface evidence with URL-shaped substrings
+ */
+function extractExternalServices(ast: SecurityAST): string[] {
+  const services = new Set<string>();
+  for (const dap of ast.declaredDataAccess) {
+    if (dap.accessMode === "transmit" && dap.destination) {
+      const host = extractHostname(dap.destination);
+      if (host) services.add(host);
+    }
+  }
+  for (const risk of ast.inferredRiskSurface) {
+    const urlMatch = risk.evidence?.match(/https?:\/\/([^\s'"\/)]+)/);
+    if (urlMatch) {
+      services.add(urlMatch[1].toLowerCase());
+    }
+  }
+  return Array.from(services).sort();
+}
+
+function extractHostname(destination: string): string | null {
+  if (destination.includes("://")) {
+    try {
+      return new URL(destination).hostname.toLowerCase();
+    } catch {
+      return destination.toLowerCase();
+    }
+  }
+  return destination.toLowerCase();
+}
+
+/**
+ * Classify persistence side effects from AST data-access patterns.
+ */
+function classifyPersistence(ast: SecurityAST): string {
+  const writes = ast.declaredDataAccess.filter(
+    (d): d is DataAccessPattern => d.accessMode === "write" || d.accessMode === "delete",
+  );
+  if (writes.length === 0) return "none";
+  const types = new Set(writes.map((w) => w.dataType));
+  if (types.has("credentials")) return "credentials store";
+  if (types.has("financial")) return "financial datastore";
+  if (types.size === 1) return Array.from(types)[0];
+  return Array.from(types).sort().join(", ");
+}
+
+/**
+ * Tool-call counts. v1 derives counts from inferred-capability evidence
+ * and risk-surface mentions; if NanoMind/scanner did not produce any,
+ * returns an empty array (renderer surfaces "no tool calls observed").
+ */
+function extractToolCallCounts(
+  ast: SecurityAST,
+  findings?: SecurityFinding[],
+): ToolCallCount[] {
+  const counts = new Map<string, number>();
+  for (const cap of ast.inferredCapabilities) {
+    counts.set(cap.name, (counts.get(cap.name) ?? 0) + 1);
+  }
+  if (findings) {
+    for (const f of findings) {
+      const tool = (f as { tool?: string }).tool;
+      if (typeof tool === "string" && tool.length > 0) {
+        counts.set(tool, (counts.get(tool) ?? 0) + 1);
+      }
+    }
+  }
+  return Array.from(counts.entries())
+    .filter(([tool]) => tool.length > 0)
+    .map(([tool, count]) => ({ tool, count }))
+    .sort((a, b) => b.count - a.count);
+}

--- a/src/narrative/wire-publish.ts
+++ b/src/narrative/wire-publish.ts
@@ -1,0 +1,206 @@
+/**
+ * Single-call helper that detects whether a `secure --publish` target
+ * is a skill or an MCP, builds the narrative, and POSTs it to the
+ * registry. Always best-effort; never throws.
+ *
+ * Brief: opena2a-org/briefs/check-rich-context-skills-mcp-v1.md (§8 task 2e)
+ *
+ * [CHIEF-CA] DECISION 2026-04-27:
+ *   v1 detection rules:
+ *     1. `SKILL.md` exists at the scan root → skill artifact.
+ *     2. `result.projectType === "mcp"` → mcp artifact (MCP config or
+ *        MCP server source detected by HMA's existing project-type
+ *        classifier).
+ *     3. Otherwise → skip narrative emission.
+ *   Failures are non-fatal and reported in the publish JSON output;
+ *   they do NOT alter the parent publish's success state.
+ */
+import { existsSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import type { SecurityFinding } from "../hardening";
+import type { ProjectType } from "../hardening/security-check";
+import { buildPackageNarrative, type BuildPackageNarrativeInput } from "./build-narrative.js";
+import {
+  narrativeToRequestBody,
+  publishNarrative,
+  type PublishNarrativeResult,
+} from "./publish-narrative.js";
+
+/** Outcome reported back to the caller's publish status JSON. */
+export interface NarrativePublishStatus {
+  /** True when a narrative was attempted (skill or mcp detected). */
+  attempted: boolean;
+  /** Detected artifact type, when attempted. */
+  artifactType?: "skill" | "mcp";
+  /** Result of the registry POST. Absent when `attempted: false`. */
+  result?: PublishNarrativeResult;
+  /** Reason narrative was skipped, when applicable. */
+  skippedReason?: string;
+}
+
+export interface WireNarrativePublishOptions {
+  /** Directory the scan ran against (`secure <directory>`). */
+  targetDir: string;
+  packageName: string;
+  packageVersion: string;
+  /** Hardening findings produced by the scan. */
+  findings: SecurityFinding[];
+  /** Project type returned by the scanner. */
+  projectType: ProjectType;
+  /** Registry base URL. */
+  registryUrl: string;
+  /** Trust signals — best-effort, fall back to safe defaults. */
+  publisherVerified?: boolean;
+  hasNpmProvenance?: boolean;
+  hasMaintainerHistory?: boolean;
+  attestationPredicateType?: string;
+  communityScans?: number;
+  cleanCommunityScans?: number;
+  bearerToken?: string;
+  /** Optional scan-run UUID — generated when omitted. */
+  scanRunId?: string;
+}
+
+/**
+ * Wire-and-publish helper. Returns a status payload describing the
+ * outcome — the caller merges this into the parent publish JSON.
+ */
+export async function wireNarrativePublish(
+  options: WireNarrativePublishOptions,
+): Promise<NarrativePublishStatus> {
+  const skillPath = join(options.targetDir, "SKILL.md");
+  const isSkill = existsSync(skillPath);
+  const isMcp = options.projectType === "mcp";
+
+  if (!isSkill && !isMcp) {
+    return { attempted: false, skippedReason: "not a skill or mcp artifact" };
+  }
+
+  try {
+    const { SemanticCompiler } = await import(
+      "../nanomind-core/compiler/semantic-compiler.js"
+    );
+    const compiler = new SemanticCompiler({ useNanoMind: false });
+    let compiledContent: string;
+    let compiledPath: string;
+
+    if (isSkill) {
+      compiledContent = readFileSync(skillPath, "utf-8");
+      compiledPath = skillPath;
+    } else {
+      // MCP detection: prefer package.json, fall back to first
+      // mcpServers config we can find in the target directory.
+      const pkgPath = join(options.targetDir, "package.json");
+      if (existsSync(pkgPath)) {
+        compiledContent = readFileSync(pkgPath, "utf-8");
+        compiledPath = pkgPath;
+      } else {
+        return {
+          attempted: false,
+          skippedReason: "mcp artifact: no package.json at scan root",
+        };
+      }
+    }
+
+    const compilation = await compiler.compile(compiledContent, compiledPath);
+    const ast = compilation.ast;
+
+    // Override artifactType when the heuristic compiler classified
+    // it as something else; the caller's detection is authoritative.
+    if (isSkill) {
+      ast.artifactType = "skill";
+    } else {
+      ast.artifactType = "mcp_config";
+    }
+
+    const buildInput: BuildPackageNarrativeInput = {
+      ast,
+      scanRunId: options.scanRunId,
+      packageName: options.packageName,
+      packageVersion: options.packageVersion,
+      findings: options.findings,
+      skillFrontmatter: isSkill
+        ? extractFrontmatterFromMarkdown(compiledContent)
+        : undefined,
+      skillSource: isSkill ? compiledContent : undefined,
+      mcpConfig: isMcp ? safeJsonParse(compiledContent) : undefined,
+      verdict: "LISTED",
+      scanStatus: "completed",
+      publisher: {
+        verified: options.publisherVerified ?? false,
+        hasNpmProvenance: options.hasNpmProvenance ?? false,
+        hasMaintainerHistory: options.hasMaintainerHistory ?? false,
+      },
+      attestations: {
+        predicateType: options.attestationPredicateType,
+      },
+      communityScans: options.communityScans ?? 0,
+      cleanCommunityScans: options.cleanCommunityScans ?? 0,
+      hasSoulFile: existsSync(join(options.targetDir, "SOUL.md")),
+    };
+
+    const narrative = await buildPackageNarrative(buildInput);
+    if (!narrative) {
+      return {
+        attempted: false,
+        skippedReason: "buildPackageNarrative returned null",
+      };
+    }
+
+    const body = narrativeToRequestBody(narrative, options.packageName);
+    const result = await publishNarrative(body, {
+      registryUrl: options.registryUrl,
+      bearerToken: options.bearerToken,
+    });
+
+    return {
+      attempted: true,
+      artifactType: isSkill ? "skill" : "mcp",
+      result,
+    };
+  } catch (err: unknown) {
+    const message = err instanceof Error ? err.message : "unknown error";
+    return {
+      attempted: true,
+      artifactType: isSkill ? "skill" : "mcp",
+      result: { ok: false, cached: false, error: message },
+    };
+  }
+}
+
+/**
+ * Minimal SKILL.md frontmatter parser — pulls keys out of a
+ * `---\n...\n---` block at the top of the file. v1 only needs `name`
+ * and `description`; structured fields like `capabilities` are parsed
+ * by the SemanticCompiler already.
+ */
+function extractFrontmatterFromMarkdown(
+  content: string,
+): Record<string, unknown> | undefined {
+  if (!content.startsWith("---")) return undefined;
+  const closingIdx = content.indexOf("\n---", 3);
+  if (closingIdx === -1) return undefined;
+  const block = content.slice(3, closingIdx).trim();
+  const fm: Record<string, unknown> = {};
+  for (const line of block.split("\n")) {
+    const m = line.match(/^([a-zA-Z_][a-zA-Z0-9_]*)\s*:\s*(.*)$/);
+    if (m) {
+      const [, key, rawValue] = m;
+      const value = rawValue.trim().replace(/^"(.*)"$/, "$1").replace(/^'(.*)'$/, "$1");
+      fm[key] = value;
+    }
+  }
+  return fm;
+}
+
+function safeJsonParse(content: string): Record<string, unknown> | undefined {
+  try {
+    const parsed = JSON.parse(content) as unknown;
+    if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
+      return parsed as Record<string, unknown>;
+    }
+  } catch {
+    return undefined;
+  }
+  return undefined;
+}


### PR DESCRIPTION
## Summary

Tasks 2c (skill+mcp narrative builders), 2d (NanoMind v3 graceful-degrade gate), 2e (HMA emits PackageNarrative on `secure --publish`) of CA-034 / `briefs/check-rich-context-skills-mcp-v1.md` session 2.

`secure --publish` for a skill or MCP artifact now POSTs a full narrative payload to opena2a-registry's `POST /api/v1/trust/narrative` after the existing scan-result publish completes. The narrative carries the wire shape that drives the rich-context `check` view in cli-ui 0.4.0 (session 3) — declared-vs-observed permission delta, MCP tool list, hardcoded-secret group with rotation guidance, deterministic verdict reasoning, action gradient.

**[CHIEF-CA] DECISION 2026-04-27** on detection rules: SKILL.md presence at scan root → skill, `projectType==='mcp'` → mcp, else skip. Auditable, ships the data path end-to-end. Richer multi-artifact-per-scan detection lands when the convention is decided.

**[CHIEF-CDS] DECISION 2026-04-27** on summary path: NanoMind v3 stub returns empty strings (per `project_nanomind_v05_intelreport_task_mismatch.md` v3 is OOD on comprehension). Renderer graceful-degrades to "Comprehension data not yet available." Real generator swaps in without wire changes when a comprehension-targeted release ships.

Failure is non-fatal — parent publish is the source of truth for exit code; narrative emission status reported under `publish.narrative` in JSON output, only logged in `--verbose` text mode. Each POST AbortController-capped at 5s.

`@opena2a/check-core` exact-pinned at `0.2.0` (was `0.1.0`). Lockfile flip deferred until check-core 0.2.0 lands on npm; regenerate with `npm install` at the M3-round-2 release window.

35 new unit tests across `__tests__/narrative/`. Full suite: 1746 passed.

## Coordination note

hackmyagent has a sibling branch `feat/check-core-notfound-unify` (PR #123, round 2 buildNotFoundOutput at `03e6704`) that also targets 0.20.0. Cleanest pre-tag path: rebase #123 on top of this PR, ship as one release. Flagging here rather than force-pushing a sibling PR.

Brief: `opena2a-org/briefs/check-rich-context-skills-mcp-v1.md` (§4-§7, §8 task 2c-2e).

## Test plan
- [x] `npm run build` green
- [x] `npm test` 1746 passed (35 new + 1711 prior)
- [x] `npx tsc --noEmit` clean
- [ ] Lockfile regenerated once `@opena2a/check-core@0.2.0` is on npm
- [ ] E2E: `hackmyagent secure --publish <known-skill>` against staging registry produces a row in `package_narratives` with the expected schema fields populated (brief acceptance criterion 5)
- [ ] Tag + Trusted Publishing produces SLSA v1 attestations on `hackmyagent@0.20.0`