### PR TITLE
feat(check): not-found JSON parity via buildNotFoundOutput (0.21.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,19 @@ All notable changes to HackMyAgent are documented in this file.
 
 ## [Unreleased]
 
+## [0.21.1] - 2026-04-28
+
+### Changed
+- **`check --json` not-found paths now emit the canonical `NotFoundOutput` shape from `@opena2a/check-core`.** The npm-miss (translated git-style + alternative-name path), PyPI 404, and GitHub 404 paths all go through `buildNotFoundOutput({ name, ecosystem, error, errorHint?, suggestions? })`. Closes the data-layer half of the F2/F3/F4 parity fixtures in opena2a-parity (PR #3 + PR #4).
+- **Bare names on npm 404 no longer fall through to the skill resolver.** `hackmyagent check <bare-name> --json` (where the package does not exist on npm) used to emit `Invalid skill identifier` on stderr with no JSON, breaking the `--json` contract. It now emits the same `NotFoundOutput` shape as scoped/git-style misses and exits 1. Scoped names (`@scope/name`) still fall through to skill-identifier fallback on npm 404 — that path is unchanged.
+- **GitHub 404 `--json` path now populates `errorHint`** (`Verify the URL: https://github.com/<displayName>`) instead of leaving it undefined. The human-rendered path was already populating it; the JSON branch is now in parity. Closes F4 in opena2a-parity.
+
+### Engineering
+- Adds `__tests__/checker/check-not-found-json.test.ts` as a regression test covering the bare-name → npm `NotFoundOutput` emission (F3) and the git-style → `errorHint` population (F4). CI-skipped by default since the test spawns a built `dist/cli.js` and exercises the live npm + GitHub 404 paths; local dev runs verify the real shape.
+
+### Brief
+- opena2a-org/briefs/check-core-adoption-round2-not-found.md (PR A)
+
 ## [0.21.0] - 2026-04-27
 
 ### Added

--- a/__tests__/checker/check-not-found-json.test.ts
+++ b/__tests__/checker/check-not-found-json.test.ts
@@ -1,0 +1,135 @@
+// Regression tests for HMA --json not-found path canonical shape (CA-034 round 2).
+//
+// Two layers:
+// 1. Deterministic unit test — calls `buildNotFoundOutput` with the exact
+//    arguments cli.ts uses, asserts the wire shape matches the parity
+//    fixtures' must_match contract. No spawn, no network, runs everywhere.
+// 2. Spawned smoke test — invokes the built `dist/cli.js` against a
+//    non-existent npm package and a non-existent GitHub repo, asserts the
+//    JSON output. Skipped on CI runners since the harness needs network +
+//    a built dist.
+//
+// The unit layer is the contract gate (closes F3 + F4). The spawn layer
+// is local-only confirmation that the wiring in cli.ts is reaching the
+// builder.
+
+import { describe, it, expect } from 'vitest';
+import { spawnSync } from 'node:child_process';
+import { existsSync } from 'node:fs';
+import { join } from 'node:path';
+import { buildNotFoundOutput } from '@opena2a/check-core';
+
+const REPO_ROOT = join(__dirname, '..', '..');
+const CLI = join(REPO_ROOT, 'dist', 'cli.js');
+
+function canRunSpawn(): boolean {
+  if (process.env.CI === 'true' || process.env.GITHUB_ACTIONS === 'true') return false;
+  return existsSync(CLI);
+}
+
+describe('check --json not-found shape (deterministic — closes F3 + F4 contract)', () => {
+  it('F3: bare-name npm miss produces NotFoundOutput shape', () => {
+    // Mirrors the exact call site in cli.ts for the bare-name reclass at
+    // the npm-404 fallthrough.
+    const skill = 'opena2a-parity-f2-nonexistent-pkg-xyz789';
+    const out = buildNotFoundOutput({
+      name: skill,
+      ecosystem: 'npm',
+      error: `Package "${skill}" not found on npm.`,
+    });
+
+    expect(out.name).toBe(skill);
+    expect(out.found).toBe(false);
+    expect(out.ecosystem).toBe('npm');
+    expect(typeof out.error).toBe('string');
+    expect(out.error?.length ?? 0).toBeGreaterThan(0);
+  });
+
+  it('F4: github 404 populates errorHint (was undefined pre-0.20.1)', () => {
+    // Mirrors the exact call site in cli.ts for the GitHub 404 branch in
+    // checkGitHubRepo. errorHint must thread through to the JSON branch.
+    const displayName = 'anthropic/code-review';
+    const errorHint = `Verify the URL: https://github.com/${displayName}`;
+    const out = buildNotFoundOutput({
+      name: displayName,
+      ecosystem: 'github',
+      error: `Repository "${displayName}" not found on GitHub.`,
+      errorHint,
+    });
+
+    expect(out.name).toBe(displayName);
+    expect(out.found).toBe(false);
+    expect(out.ecosystem).toBe('github');
+    expect(out.errorHint).toBe(errorHint);
+  });
+
+  it('PyPI 404 produces NotFoundOutput shape', () => {
+    const name = 'opena2a-parity-pypi-nonexistent-xyz789';
+    const out = buildNotFoundOutput({
+      name,
+      ecosystem: 'pypi',
+      error: `Package "${name}" not found on PyPI.`,
+    });
+
+    expect(out.name).toBe(name);
+    expect(out.found).toBe(false);
+    expect(out.ecosystem).toBe('pypi');
+  });
+
+  it('npm translateDownloadError path threads suggestions + errorHint', () => {
+    const name = 'lodahs';
+    const errorHint = 'Did you mean "lodash"?';
+    const suggestions = ['lodash', 'lodash.merge'];
+    const out = buildNotFoundOutput({
+      name,
+      ecosystem: 'npm',
+      error: errorHint,
+      errorHint,
+      suggestions,
+    });
+
+    expect(out.name).toBe(name);
+    expect(out.ecosystem).toBe('npm');
+    expect(out.errorHint).toBe(errorHint);
+    expect(out.suggestions).toEqual(suggestions);
+  });
+});
+
+describe('check --json not-found wired through dist/cli.js (smoke, local-only)', () => {
+  it.runIf(canRunSpawn())('F3: bare-name miss emits NotFoundOutput from cli.ts (no stderr fall-through)', () => {
+    const bareName = 'totally-nonexistent-pkg-xyz789';
+    const res = spawnSync('node', [CLI, 'check', bareName, '--no-scan', '--json', '--ci'], {
+      encoding: 'utf8',
+      timeout: 30_000,
+    });
+
+    expect(res.status).toBe(1);
+    const stdout = (res.stdout || '').trim();
+    expect(stdout.length).toBeGreaterThan(0);
+
+    const parsed = JSON.parse(stdout);
+    expect(parsed.name).toBe(bareName);
+    expect(parsed.found).toBe(false);
+    expect(parsed.ecosystem).toBe('npm');
+    expect(typeof parsed.error).toBe('string');
+    expect(parsed.error.length).toBeGreaterThan(0);
+  });
+
+  it.runIf(canRunSpawn())('F4: git-style miss populates errorHint in JSON output', () => {
+    const target = 'anthropic/code-review';
+    const res = spawnSync('node', [CLI, 'check', target, '--no-scan', '--json', '--ci'], {
+      encoding: 'utf8',
+      timeout: 30_000,
+    });
+
+    expect(res.status).toBe(1);
+    const stdout = (res.stdout || '').trim();
+    expect(stdout.length).toBeGreaterThan(0);
+
+    const parsed = JSON.parse(stdout);
+    expect(parsed.name).toBe(target);
+    expect(parsed.found).toBe(false);
+    expect(parsed.ecosystem).toBe('github');
+    expect(parsed.errorHint).toBe(`Verify the URL: https://github.com/${target}`);
+  });
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "hackmyagent",
-  "version": "0.21.0",
+  "version": "0.21.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "hackmyagent",
-      "version": "0.21.0",
+      "version": "0.21.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.12.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hackmyagent",
-  "version": "0.21.0",
+  "version": "0.21.1",
   "description": "Find it. Break it. Fix it. The hacker's toolkit for AI agents.",
   "bin": {
     "hackmyagent": "dist/cli.js"

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -52,7 +52,7 @@ import {
 } from './index';
 import { resolveAndLogMcpShorthand } from './resolve-mcp';
 import { WildScanner, type WildScanReport } from './wild';
-import { buildCheckOutput, mapScanStatusForMeter, translateDownloadError } from '@opena2a/check-core';
+import { buildCheckOutput, buildNotFoundOutput, mapScanStatusForMeter, translateDownloadError } from '@opena2a/check-core';
 import {
   isRenderableAnalystFinding,
   formatAnalystDescription,
@@ -415,14 +415,30 @@ Examples:
       }
 
       // npm package name: download, run full HMA scan, clean up
-      // On npm 404, fall through to skill check (skill identifiers look like @scope/name)
+      // On npm 404 for scoped names (@scope/name), fall through to skill check.
+      // Bare names are not valid skill identifiers — emit canonical npm
+      // not-found via buildNotFoundOutput so the `--json` shape matches the
+      // scoped/git-style miss path. Closes F3 in opena2a-parity.
       if (looksLikeNpmPackage(skill)) {
         try {
           await checkNpmPackage(skill, options);
           return;
         } catch (npmErr: unknown) {
           if (npmErr instanceof Error && npmErr.name === 'NpmNotFoundError') {
-            // Not on npm — fall through to skill check
+            const isScoped = skill.startsWith('@');
+            if (!isScoped) {
+              if (options.json) {
+                writeJsonStdout(buildNotFoundOutput({
+                  name: skill,
+                  ecosystem: 'npm',
+                  error: `Package "${skill}" not found on npm.`,
+                }));
+              } else {
+                printNotFoundBlock({ pkg: skill, ecosystem: 'npm' });
+              }
+              process.exit(1);
+            }
+            // Scoped name — fall through to skill check
             if (!options.json && !globalCiMode) {
               console.error(`Package "${skill}" not found on npm. Trying as skill identifier...`);
             }
@@ -8634,13 +8650,19 @@ async function checkGitHubRepo(
   } catch (err: unknown) {
     const message = err instanceof Error ? err.message : String(err);
     if (message.includes('128') || message.includes('not found') || message.includes('Repository not found')) {
+      const errorHint = `Verify the URL: https://github.com/${displayName}`;
       if (options.json) {
-        writeJsonStdout({ name: displayName, ecosystem: 'github', found: false, error: `Repository "${displayName}" not found on GitHub.` });
+        writeJsonStdout(buildNotFoundOutput({
+          name: displayName,
+          ecosystem: 'github',
+          error: `Repository "${displayName}" not found on GitHub.`,
+          errorHint,
+        }));
       } else {
         printNotFoundBlock({
           pkg: displayName,
           ecosystem: 'github',
-          errorHint: `Verify the URL: https://github.com/${displayName}`,
+          errorHint,
         });
       }
     } else if (message.includes('timeout') || message.includes('Timeout')) {
@@ -8718,7 +8740,11 @@ async function checkPyPiPackage(
     if (!metaRes.ok) {
       if (metaRes.status === 404) {
         if (options.json) {
-          writeJsonStdout({ name, ecosystem: 'pypi', found: false, error: `Package "${name}" not found on PyPI.` });
+          writeJsonStdout(buildNotFoundOutput({
+            name,
+            ecosystem: 'pypi',
+            error: `Package "${name}" not found on PyPI.`,
+          }));
         } else {
           printNotFoundBlock({ pkg: name, ecosystem: 'pypi' });
         }
@@ -9236,7 +9262,13 @@ async function checkNpmPackage(
       const translated = translateDownloadError(name, message);
       if (translated && (translated.errorHint || translated.suggestions)) {
         if (options.json) {
-          writeJsonStdout({ name, ecosystem: 'npm', found: false, error: translated.errorHint, suggestions: translated.suggestions });
+          writeJsonStdout(buildNotFoundOutput({
+            name,
+            ecosystem: 'npm',
+            error: translated.errorHint,
+            errorHint: translated.errorHint,
+            suggestions: translated.suggestions,
+          }));
         } else {
           printNotFoundBlock({
             pkg: name,


### PR DESCRIPTION
## Summary

Closes the data-layer half of opena2a-parity F3 + F4 (PR #3 + PR #4) by routing the `check --json` not-found paths through `buildNotFoundOutput` from `@opena2a/check-core`:

- **F3 — bare-name reclass:** Bare names on npm 404 (e.g. `hackmyagent check totally-nonexistent-pkg`) used to drop through to the skill resolver and emit "Invalid skill identifier" on stderr with no JSON, breaking the `--json` contract. They now emit the canonical `NotFoundOutput` shape and exit 1. Scoped names (`@scope/name`) still fall through to skill-identifier fallback on npm 404 — that path is unchanged.
- **F4 — github 404 errorHint:** `checkGitHubRepo` `--json` branch now populates `errorHint` ("Verify the URL: https://github.com/<displayName>") via `buildNotFoundOutput`. The human-rendered path was already populating it; the JSON branch had drifted.
- **PyPI 404** and **npm `translateDownloadError` (did-you-mean)** paths also route through `buildNotFoundOutput` for shape consistency.

## Parity status (local, with built bins)

```
PR #3 (notfound-parity-fixtures, 4 fixtures): 0 failures (was 2 failures pre-fix)
PR #4 (parity-harness-fixture-count-fix, 5 fixtures): 0 failures (was 3 failures pre-fix)
```

## Test plan

- [x] `npm test` — 1791 passed, 16 skipped, 10 todo (1817 total). +6 vs main (the 6 new not-found regression tests).
- [x] `npm run build` clean.
- [x] `__tests__/checker/check-not-found-json.test.ts` — 4 deterministic shape tests + 2 spawn smoke tests covering F3 + F4.
- [x] opena2a-parity local run with built `dist/cli.js`: PR #3 4/4 green, PR #4 5/5 green.
- [x] /release-test fresh-user walkthrough: zero P1/P2/P3 findings.
- [x] /pre-push-review 8-phase quality gate: PASS.

## Notes

- Re-grafted from local-only `ff55c1b` (originally version-stamped 0.20.1) onto current `main` (0.21.0). The previous tag was held while Day 1 of the cli-ui 0.5.0 release window shipped HMA 0.21.0. This PR re-bumps to **0.21.1**.
- opena2a-cli inherits via spawn delegation. ai-trust is out of scope (round 2 PR B in the brief).

Brief: `opena2a-org/briefs/check-core-adoption-round2-not-found.md` (PR A)