### PR TITLE
feat(help): two-bucket telemetry disclosure on --help

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -231,6 +231,15 @@ Quick start:
   $ hackmyagent secure --fix        Auto-fix with rollback
 `);
 
+// Two-bucket telemetry disclosure (briefs/scan-result-telemetry-policy.md §7,
+// [CHIEF-CSR-014] + [CHIEF-CPO-021]). Surfaces both consent rails on --help so
+// users see the boundary without reading the privacy policy.
+program.addHelpText('after', `
+Telemetry:
+  Anonymous usage telemetry is on. Disable: OPENA2A_TELEMETRY=off
+  Local scans may contribute to the OpenA2A Registry. Disable: --no-contribute or hackmyagent telemetry off
+`);
+
 program.hook('preAction', (thisCommand) => {
     const opts = thisCommand.opts();
     if (opts.color === false) {


### PR DESCRIPTION
## Summary

Closes the only remaining acceptance criterion in `briefs/scan-result-telemetry-policy.md` §10 for hackmyagent: a two-line `Telemetry:` block on `--help` that surfaces both the invocation-telemetry rail and the scan-result contribution rail, so users see the consent boundary without reading the privacy policy.

Brief reference: §7 disclosure form (locked under [CHIEF-CSR-014] + [CHIEF-CPO-021] on 2026-04-27).

## Diff

\`\`\`
+program.addHelpText('after', \`
+Telemetry:
+  Anonymous usage telemetry is on. Disable: OPENA2A_TELEMETRY=off
+  Local scans may contribute to the OpenA2A Registry. Disable: --no-contribute or hackmyagent telemetry off
+\`);
\`\`\`

9 lines in \`src/cli.ts\` alongside the existing \`addHelpText('beforeAll', ...)\` Quick-start block. Comment cites the brief + chief decisions.

## Verification

\`\`\`
$ node dist/cli.js --help | grep -A 3 ^Telemetry:
Telemetry:
  Anonymous usage telemetry is on. Disable: OPENA2A_TELEMETRY=off
  Local scans may contribute to the OpenA2A Registry. Disable: --no-contribute or hackmyagent telemetry off
\`\`\`

\`hackmyagent telemetry off\` subcommand is already registered (verified via \`hackmyagent telemetry --help\`).

## Test plan

- [x] \`npm run build\` — clean
- [x] \`npm test\` — 1791 passed (16 skipped, 10 todo)
- [x] \`--help\` renders the two-line disclosure verbatim
- [x] No detection logic / scanner / scoring changes (Phase 4.5 skip)

## Companion PRs

- opena2a #N+1 — same disclosure on opena2a-cli (`--no-contribute` only; no `telemetry` subcommand to reference)
- ai-trust #N+2 — same disclosure on ai-trust (`--no-contribute or ai-trust telemetry off`)

The three PRs together satisfy the brief's §10 acceptance criteria for the three CLIs. Privacy policy update on opena2a-website + spawn-delegation parity verification + OPENA2A_ENTERPRISE air-gapped default are explicitly out of scope here and tracked separately.