### PR TITLE
feat(schema): Finding type v2 — evidence/rationale/concept fields (#140)

### DIFF
--- a/__tests__/semantic/credential-context.test.ts
+++ b/__tests__/semantic/credential-context.test.ts
@@ -46,6 +46,25 @@ describe('CredentialContextAnalyzer', () => {
       const findings = analyzer.analyze([file]);
       expect(findings.filter((f) => f.id === 'SEM-CRED-001')).toHaveLength(0);
     });
+
+    it('redacts every occurrence of the password from evidence content (regression: H1)', () => {
+      // Adversarial reviewer found that an earlier split-on-`:pw@` redaction
+      // missed bare-password substrings appearing on the same line as the URL
+      // (e.g., a comment or sibling assignment). Verify the password is
+      // redacted EVERYWHERE in evidence.lines[].content, not just the URL slot.
+      const file = makeFile(
+        'config.yaml',
+        'DATABASE_URL=postgres://admin:supersecret123@host  # password is supersecret123',
+        'config_file'
+      );
+      const findings = analyzer.analyze([file]);
+      const sem = findings.find((f) => f.id === 'SEM-CRED-001');
+      expect(sem).toBeDefined();
+      const content = sem?.evidence?.kind === 'positive' ? sem.evidence.lines[0]?.content : undefined;
+      expect(content).toBeDefined();
+      expect(content).not.toContain('supersecret123');
+      expect(content).toContain('[REDACTED]');
+    });
   });
 
   describe('generic tokens via key-name heuristics', () => {

--- a/__tests__/types/finding-evidence.test.ts
+++ b/__tests__/types/finding-evidence.test.ts
@@ -1,0 +1,106 @@
+import { describe, it, expect } from 'vitest';
+import {
+  type Evidence,
+  type ConceptId,
+  isPositiveEvidence,
+  isAbsenceEvidence,
+  isMixedEvidence,
+  isValidEvidence,
+  isConceptId,
+} from '../../src/types/finding-evidence';
+
+describe('Evidence discriminated union', () => {
+  it('narrows to PositiveEvidence on kind="positive"', () => {
+    const e: Evidence = {
+      kind: 'positive',
+      lines: [{ n: 3, content: 'evil line', why: 'because' }],
+    };
+    if (isPositiveEvidence(e)) {
+      expect(e.lines[0].n).toBe(3);
+      expect(e.lines[0].content).toBe('evil line');
+    } else {
+      throw new Error('expected PositiveEvidence narrowing');
+    }
+  });
+
+  it('narrows to AbsenceEvidence on kind="absence"', () => {
+    const e: Evidence = {
+      kind: 'absence',
+      observed: {
+        lines: [{ n: 1, content: 'shell:*' }],
+        summary: 'grants shell wildcard',
+      },
+      expected: [{ constraint: 'override-resistance', rationale: 'must reject runtime injection' }],
+    };
+    if (isAbsenceEvidence(e)) {
+      expect(e.expected[0].constraint).toBe('override-resistance');
+    } else {
+      throw new Error('expected AbsenceEvidence narrowing');
+    }
+  });
+
+  it('narrows to MixedEvidence on kind="mixed"', () => {
+    const e: Evidence = {
+      kind: 'mixed',
+      positive: { lines: [{ n: 3, content: 'exfil', why: 'sends to webhook.site' }] },
+      absence: {
+        observed: { lines: [{ n: 1, content: 'shell:*' }], summary: 'wildcard shell' },
+        expected: [{ constraint: 'trust-hierarchy', rationale: 'no source ranking' }],
+      },
+    };
+    if (isMixedEvidence(e)) {
+      expect(e.positive.lines).toHaveLength(1);
+      expect(e.absence.expected).toHaveLength(1);
+    } else {
+      throw new Error('expected MixedEvidence narrowing');
+    }
+  });
+});
+
+describe('isValidEvidence runtime guard', () => {
+  it('accepts positive', () => {
+    expect(isValidEvidence({ kind: 'positive', lines: [] })).toBe(true);
+  });
+
+  it('accepts absence', () => {
+    expect(isValidEvidence({ kind: 'absence', observed: { lines: [], summary: '' }, expected: [] })).toBe(true);
+  });
+
+  it('accepts mixed', () => {
+    expect(isValidEvidence({ kind: 'mixed', positive: { lines: [] }, absence: { observed: { lines: [], summary: '' }, expected: [] } })).toBe(true);
+  });
+
+  it('rejects unknown kind', () => {
+    expect(isValidEvidence({ kind: 'magic', whatever: true })).toBe(false);
+  });
+
+  it('rejects null and primitives', () => {
+    expect(isValidEvidence(null)).toBe(false);
+    expect(isValidEvidence(undefined)).toBe(false);
+    expect(isValidEvidence('positive')).toBe(false);
+    expect(isValidEvidence(42)).toBe(false);
+  });
+});
+
+describe('isConceptId runtime guard', () => {
+  it('accepts every ConceptId in the union', () => {
+    const concepts: ConceptId[] = [
+      'soul-governance',
+      'secretless-vault',
+      'mcp-tool-isolation',
+      'injection-resistance',
+      'trust-hierarchy',
+      'signing-and-pinning',
+    ];
+    for (const c of concepts) {
+      expect(isConceptId(c)).toBe(true);
+    }
+  });
+
+  it('rejects unknown strings', () => {
+    expect(isConceptId('made-up-concept')).toBe(false);
+    expect(isConceptId('')).toBe(false);
+    expect(isConceptId(null)).toBe(false);
+    expect(isConceptId(123)).toBe(false);
+  });
+});

--- a/__tests__/ui/concept-explainers.test.ts
+++ b/__tests__/ui/concept-explainers.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect } from 'vitest';
+import { CONCEPT_EXPLAINERS, getConceptExplainer } from '../../src/ui/concept-explainers';
+import type { ConceptId } from '../../src/types/finding-evidence';
+
+const ALL_CONCEPTS: ConceptId[] = [
+  'soul-governance',
+  'secretless-vault',
+  'mcp-tool-isolation',
+  'injection-resistance',
+  'trust-hierarchy',
+  'signing-and-pinning',
+];
+
+describe('CONCEPT_EXPLAINERS registry', () => {
+  it('has an entry for every ConceptId in the union', () => {
+    for (const id of ALL_CONCEPTS) {
+      const entry = CONCEPT_EXPLAINERS[id];
+      expect(entry, `missing entry for ${id}`).toBeDefined();
+      expect(entry.id).toBe(id);
+    }
+  });
+
+  it('every entry has a non-empty title, body, and oneLineRef', () => {
+    for (const id of ALL_CONCEPTS) {
+      const entry = CONCEPT_EXPLAINERS[id];
+      expect(entry.title.length).toBeGreaterThan(0);
+      expect(entry.body.length).toBeGreaterThan(0);
+      expect(entry.oneLineRef.length).toBeGreaterThan(0);
+    }
+  });
+
+  it('oneLineRef references the concept by name (helps the user follow back-refs)', () => {
+    // Don't enforce exact wording — just sanity-check that the back-ref isn't generic
+    for (const id of ALL_CONCEPTS) {
+      const ref = CONCEPT_EXPLAINERS[id].oneLineRef;
+      expect(ref.length).toBeGreaterThan(5);
+    }
+  });
+});
+
+describe('getConceptExplainer', () => {
+  it('returns the registered entry for a known id', () => {
+    const entry = getConceptExplainer('soul-governance');
+    expect(entry).toBeDefined();
+    expect(entry?.id).toBe('soul-governance');
+  });
+});

--- a/__tests__/ui/concept-explainers.test.ts
+++ b/__tests__/ui/concept-explainers.test.ts
@@ -1,38 +1,44 @@
 import { describe, it, expect } from 'vitest';
 import { CONCEPT_EXPLAINERS, getConceptExplainer } from '../../src/ui/concept-explainers';
-import type { ConceptId } from '../../src/types/finding-evidence';
+import { isConceptId, type ConceptId } from '../../src/types/finding-evidence';
 
-const ALL_CONCEPTS: ConceptId[] = [
-  'soul-governance',
-  'secretless-vault',
-  'mcp-tool-isolation',
-  'injection-resistance',
-  'trust-hierarchy',
-  'signing-and-pinning',
-];
+/**
+ * Note on enforcement: the canonical "every ConceptId has a registry entry"
+ * rule is enforced at COMPILE TIME by the `Record<ConceptId, ConceptExplainer>`
+ * type annotation on `CONCEPT_EXPLAINERS`. Adding a new ConceptId without an
+ * entry fails `tsc`. These runtime tests are belt-and-suspenders: they iterate
+ * the registry's actual keys (not a hardcoded list) so they also fail loudly
+ * if a key is added that ISN'T a valid ConceptId, or if the registry is
+ * pruned in a way the type system can't catch.
+ */
 
 describe('CONCEPT_EXPLAINERS registry', () => {
-  it('has an entry for every ConceptId in the union', () => {
-    for (const id of ALL_CONCEPTS) {
-      const entry = CONCEPT_EXPLAINERS[id];
-      expect(entry, `missing entry for ${id}`).toBeDefined();
-      expect(entry.id).toBe(id);
+  const registeredKeys = Object.keys(CONCEPT_EXPLAINERS) as ConceptId[];
+
+  it('every registered key is a valid ConceptId', () => {
+    for (const key of registeredKeys) {
+      expect(isConceptId(key), `registry key ${key} is not a valid ConceptId`).toBe(true);
     }
   });
 
   it('every entry has a non-empty title, body, and oneLineRef', () => {
-    for (const id of ALL_CONCEPTS) {
-      const entry = CONCEPT_EXPLAINERS[id];
+    for (const key of registeredKeys) {
+      const entry = CONCEPT_EXPLAINERS[key];
       expect(entry.title.length).toBeGreaterThan(0);
       expect(entry.body.length).toBeGreaterThan(0);
       expect(entry.oneLineRef.length).toBeGreaterThan(0);
     }
   });
 
-  it('oneLineRef references the concept by name (helps the user follow back-refs)', () => {
-    // Don't enforce exact wording — just sanity-check that the back-ref isn't generic
-    for (const id of ALL_CONCEPTS) {
-      const ref = CONCEPT_EXPLAINERS[id].oneLineRef;
+  it('every entry id matches its registry key', () => {
+    for (const key of registeredKeys) {
+      expect(CONCEPT_EXPLAINERS[key].id).toBe(key);
+    }
+  });
+
+  it('oneLineRef back-references are non-generic', () => {
+    for (const key of registeredKeys) {
+      const ref = CONCEPT_EXPLAINERS[key].oneLineRef;
       expect(ref.length).toBeGreaterThan(5);
     }
   });

--- a/src/hardening/security-check.ts
+++ b/src/hardening/security-check.ts
@@ -2,6 +2,8 @@
  * Security check types and interfaces
  */
 
+import type { Evidence, Rationale, ConceptId } from '../types/finding-evidence';
+
 export type Severity = 'critical' | 'high' | 'medium' | 'low';
 
 /**
@@ -67,6 +69,15 @@ export interface SecurityFinding {
   /** Attack taxonomy class this finding maps to (e.g., "CRED-HARVEST") */
   attackClass?: string;
   details?: Record<string, unknown>;
+  /**
+   * Structured evidence (positive | absence | mixed). Optional in v0.21.x;
+   * mandatory in v0.22+. See `src/types/finding-evidence.ts`.
+   */
+  evidence?: Evidence;
+  /** Plain-English rationale grounded in the evidence. Optional in v0.21.x. */
+  rationale?: Rationale;
+  /** Tag for an unfamiliar primitive the fix recommends (renderer dedupes per scan). */
+  concept?: ConceptId;
 }
 
 export interface ScanResult {

--- a/src/plugins/core.ts
+++ b/src/plugins/core.ts
@@ -1,6 +1,7 @@
 export const VERSION = '0.1.0';
 
 import type { AIMCore } from '@opena2a/aim-core';
+import type { Evidence, Rationale, ConceptId } from '../types/finding-evidence';
 
 // --- Plugin Interface ---
 
@@ -23,6 +24,15 @@ export interface Finding {
   oasbControl?: string;
   /** Whether this finding can be auto-fixed */
   autoFixable: boolean;
+  /**
+   * Structured evidence (positive | absence | mixed). Optional in v0.21.x;
+   * mandatory in v0.22+. See `src/types/finding-evidence.ts`.
+   */
+  evidence?: Evidence;
+  /** Plain-English rationale grounded in the evidence. Optional in v0.21.x. */
+  rationale?: Rationale;
+  /** Tag for an unfamiliar primitive the fix recommends (renderer dedupes per scan). */
+  concept?: ConceptId;
 }
 
 export interface FixOptions {

--- a/src/semantic/integration/finding-adapter.ts
+++ b/src/semantic/integration/finding-adapter.ts
@@ -6,10 +6,15 @@
  */
 
 import type { SemanticFinding } from '../types';
+import type { Evidence, Rationale, ConceptId } from '../../types/finding-evidence';
 
 /**
  * SecurityFinding shape duplicated here to avoid a circular dependency —
  * the semantic engine has zero runtime dependencies.
+ *
+ * Keep this interface in sync with the canonical `SecurityFinding` in
+ * `src/hardening/security-check.ts`. Drift here causes silently-stripped
+ * fields when SemanticFinding → SecurityFinding conversion happens.
  */
 export interface SecurityFinding {
   checkId: string;
@@ -26,6 +31,9 @@ export interface SecurityFinding {
   fix?: string;
   guidance?: string;
   attackClass?: string;
+  evidence?: Evidence;
+  rationale?: Rationale;
+  concept?: ConceptId;
 }
 
 const CATEGORY_LABELS: Record<string, string> = {
@@ -53,6 +61,8 @@ export function toSecurityFinding(finding: SemanticFinding): SecurityFinding {
     fix: finding.recommendation,
     guidance: finding.rationale,
     attackClass: finding.attackClass,
+    evidence: finding.evidence,
+    concept: finding.concept,
   };
 }
 

--- a/src/semantic/integration/finding-adapter.ts
+++ b/src/semantic/integration/finding-adapter.ts
@@ -62,6 +62,7 @@ export function toSecurityFinding(finding: SemanticFinding): SecurityFinding {
     guidance: finding.rationale,
     attackClass: finding.attackClass,
     evidence: finding.evidence,
+    rationale: { plainEnglish: finding.rationale },
     concept: finding.concept,
   };
 }

--- a/src/semantic/structural/credential-context.ts
+++ b/src/semantic/structural/credential-context.ts
@@ -141,6 +141,9 @@ function detectUrlPasswords(file: AnalysisFile): SemanticFinding[] {
       if (password.length < 3) continue;
 
       const urlPwMasked = password.length > 5 ? password.slice(0, 5) + '****' : '****';
+      // Redact the password before putting the line into structured evidence so the
+      // raw secret never reaches JSON output or terminal rendering.
+      const safeContent = line.split(`:${password}@`).join(`:${urlPwMasked}@`);
       findings.push({
         id: 'SEM-CRED-001',
         title: 'Password embedded in URL',
@@ -155,6 +158,17 @@ function detectUrlPasswords(file: AnalysisFile): SemanticFinding[] {
           'opena2a protect .  — migrates hardcoded secrets into the Secretless vault (local, keychain, 1Password, or HashiCorp Vault). Keys are injected at runtime; source files reference them by name only.',
         layer: 2,
         autoFixable: false,
+        evidence: {
+          kind: 'positive',
+          lines: [
+            {
+              n: i + 1,
+              content: safeContent.trim(),
+              why: `URL contains inline password (${urlPwMasked}). Connection strings with embedded passwords are logged by proxies, shell history, and process listings, and bypass .env file protections.`,
+            },
+          ],
+        },
+        concept: 'secretless-vault',
       });
     }
   }

--- a/src/semantic/structural/credential-context.ts
+++ b/src/semantic/structural/credential-context.ts
@@ -141,9 +141,12 @@ function detectUrlPasswords(file: AnalysisFile): SemanticFinding[] {
       if (password.length < 3) continue;
 
       const urlPwMasked = password.length > 5 ? password.slice(0, 5) + '****' : '****';
-      // Redact the password before putting the line into structured evidence so the
-      // raw secret never reaches JSON output or terminal rendering.
-      const safeContent = line.split(`:${password}@`).join(`:${urlPwMasked}@`);
+      // Redact every occurrence of the raw password from the line before placing it
+      // into structured evidence. Split-on-`:pw@` only catches the URL slot, but
+      // the same secret can appear in comments, sibling assignments, or doc strings
+      // on the same line. split/join catches all occurrences without partial-leak
+      // and stays ES2020-safe (replaceAll is ES2021).
+      const safeContent = line.split(password).join('[REDACTED]');
       findings.push({
         id: 'SEM-CRED-001',
         title: 'Password embedded in URL',

--- a/src/semantic/types.ts
+++ b/src/semantic/types.ts
@@ -6,6 +6,8 @@
  * converts SemanticFinding → SecurityFinding for the core scanner.
  */
 
+import type { Evidence, ConceptId } from '../types/finding-evidence';
+
 export type SemanticSeverity = 'critical' | 'high' | 'medium' | 'low' | 'info';
 
 export type SemanticCategory =
@@ -38,6 +40,17 @@ export interface SemanticFinding {
   autoFixable: boolean;
   /** Attack class for oracle label mapping (e.g. 'MCP-PRIV-ESC', 'SOUL-CONSENT') */
   attackClass?: string;
+  /**
+   * Structured evidence (positive | absence | mixed). Optional in v0.21.x;
+   * mandatory in v0.22+. See `src/types/finding-evidence.ts`.
+   *
+   * Note: SemanticFinding's existing `rationale: string` field is kept as-is
+   * for back-compat. The integration layer wraps it into the new
+   * `Rationale` shape when converting to `SecurityFinding`.
+   */
+  evidence?: Evidence;
+  /** Tag for an unfamiliar primitive the recommendation references. */
+  concept?: ConceptId;
 }
 
 export interface AnalysisContext {

--- a/src/types/finding-evidence.ts
+++ b/src/types/finding-evidence.ts
@@ -1,0 +1,117 @@
+/**
+ * Finding evidence schema (v2 spine).
+ *
+ * Standard: every finding emitted by HMA must carry structured evidence,
+ * a plain-English rationale, and (when applicable) a concept tag for an
+ * unfamiliar primitive the user is being asked to adopt. See
+ * `~/.claude/instructions/cli-finding-ux-standard.md` for the contract.
+ *
+ * This module is the type-level spine. Population at emit sites and the
+ * renderer behavior (per-scan dedupe, first-occurrence-expanded explainer)
+ * land in #138 / #141 / #142.
+ */
+
+/** Positive evidence — "we saw X bad thing at line N." */
+export interface PositiveEvidence {
+  kind: 'positive';
+  lines: Array<{
+    /** 1-based line number in the artifact. */
+    n: number;
+    /** Verbatim line content as the detector saw it. */
+    content: string;
+    /** What makes this line dangerous in context. Finding-specific, not boilerplate. */
+    why: string;
+  }>;
+}
+
+/** Absence-of-defense evidence — "the artifact does Z but lacks Y." */
+export interface AbsenceEvidence {
+  kind: 'absence';
+  observed: {
+    lines: Array<{
+      /** 1-based line number in the artifact. */
+      n: number;
+      /** Verbatim line content showing the high-risk capability. */
+      content: string;
+    }>;
+    /** Plain-English summary of what the artifact does that requires constraint. */
+    summary: string;
+  };
+  expected: Array<{
+    /** Constraint name (e.g., "trust-hierarchy", "override-resistance"). */
+    constraint: string;
+    /** Why this constraint matters given the observed behavior. */
+    rationale: string;
+  }>;
+}
+
+/** Mixed — both positive evidence and absence-of-defense apply. */
+export interface MixedEvidence {
+  kind: 'mixed';
+  positive: Omit<PositiveEvidence, 'kind'>;
+  absence: Omit<AbsenceEvidence, 'kind'>;
+}
+
+/** Discriminated union — narrow on `kind`. */
+export type Evidence = PositiveEvidence | AbsenceEvidence | MixedEvidence;
+
+/**
+ * Plain-English rationale grounded in the evidence.
+ *
+ * For deterministic detectors this is templated from the evidence.
+ * For NanoMind behavioral findings this is generated and grounded in the
+ * cited lines. Either way the value must be finding-specific — not
+ * byte-identical across siblings in the same scan.
+ */
+export interface Rationale {
+  plainEnglish: string;
+}
+
+/**
+ * Concept identifier for an unfamiliar primitive a fix recommends.
+ *
+ * The renderer dedupes by concept per scan: first occurrence shows the
+ * curated explainer (from `src/ui/concept-explainers.ts`), subsequent
+ * occurrences collapse to a one-line back-reference.
+ */
+export type ConceptId =
+  | 'soul-governance'
+  | 'secretless-vault'
+  | 'mcp-tool-isolation'
+  | 'injection-resistance'
+  | 'trust-hierarchy'
+  | 'signing-and-pinning';
+
+/** Type guard — narrow `Evidence` to `PositiveEvidence`. */
+export function isPositiveEvidence(e: Evidence): e is PositiveEvidence {
+  return e.kind === 'positive';
+}
+
+/** Type guard — narrow `Evidence` to `AbsenceEvidence`. */
+export function isAbsenceEvidence(e: Evidence): e is AbsenceEvidence {
+  return e.kind === 'absence';
+}
+
+/** Type guard — narrow `Evidence` to `MixedEvidence`. */
+export function isMixedEvidence(e: Evidence): e is MixedEvidence {
+  return e.kind === 'mixed';
+}
+
+/** Runtime validation — useful for JSON deserialization boundaries. */
+export function isValidEvidence(value: unknown): value is Evidence {
+  if (typeof value !== 'object' || value === null) return false;
+  const v = value as { kind?: unknown };
+  return v.kind === 'positive' || v.kind === 'absence' || v.kind === 'mixed';
+}
+
+/** Runtime validation — useful for JSON deserialization boundaries. */
+export function isConceptId(value: unknown): value is ConceptId {
+  return (
+    value === 'soul-governance' ||
+    value === 'secretless-vault' ||
+    value === 'mcp-tool-isolation' ||
+    value === 'injection-resistance' ||
+    value === 'trust-hierarchy' ||
+    value === 'signing-and-pinning'
+  );
+}

--- a/src/ui/concept-explainers.ts
+++ b/src/ui/concept-explainers.ts
@@ -1,0 +1,74 @@
+/**
+ * Concept-explainer registry (skeleton).
+ *
+ * Curated, human-written copy for unfamiliar primitives that finding
+ * fixes recommend (SOUL.md, Secretless vault, MCP tool isolation, etc.).
+ *
+ * The renderer dedupes by `ConceptId` per scan: first occurrence shows
+ * the expanded `body`; subsequent occurrences collapse to `oneLineRef`.
+ *
+ * This file is the SKELETON — full body copy lands in #142 along with
+ * the renderer dedupe logic. Every `ConceptId` must have an entry here
+ * so a future finding tagged with that concept always resolves.
+ */
+
+import type { ConceptId } from '../types/finding-evidence';
+
+export interface ConceptExplainer {
+  id: ConceptId;
+  /** Heading shown above the expanded body (first occurrence). */
+  title: string;
+  /** Expanded multi-line explainer rendered on first occurrence per scan. */
+  body: string;
+  /** One-line back-reference rendered on subsequent occurrences. */
+  oneLineRef: string;
+}
+
+/**
+ * Registry of all known concepts. Body copy is stubbed pending #142.
+ * Adding a new `ConceptId` to the union requires adding an entry here —
+ * `concept-explainers.test.ts` enforces this.
+ */
+export const CONCEPT_EXPLAINERS: Record<ConceptId, ConceptExplainer> = {
+  'soul-governance': {
+    id: 'soul-governance',
+    title: 'Why SOUL.md',
+    body: 'TODO — see hackmyagent#142. SOUL.md is the agent constitution; it governs SKILL/MCP capabilities and constrains runtime input.',
+    oneLineRef: '(Why SOUL: see above)',
+  },
+  'secretless-vault': {
+    id: 'secretless-vault',
+    title: 'Why the Secretless vault',
+    body: 'TODO — see hackmyagent#142. Hardcoded credentials live in source, configs, and version control history. The Secretless vault keeps them out of process memory and out of AI context.',
+    oneLineRef: '(Why Secretless: see above)',
+  },
+  'mcp-tool-isolation': {
+    id: 'mcp-tool-isolation',
+    title: 'Why MCP tool isolation',
+    body: 'TODO — see hackmyagent#142. Wildcard MCP tool grants give the agent everything; an explicit allowlist scopes capability to legitimate use.',
+    oneLineRef: '(Why MCP isolation: see above)',
+  },
+  'injection-resistance': {
+    id: 'injection-resistance',
+    title: 'Why injection resistance',
+    body: 'TODO — see hackmyagent#142. Without an immutability clause, instructions in user input, tool output, or retrieved documents can hijack the agent.',
+    oneLineRef: '(Why injection resistance: see above)',
+  },
+  'trust-hierarchy': {
+    id: 'trust-hierarchy',
+    title: 'Why a trust hierarchy',
+    body: 'TODO — see hackmyagent#142. The agent must rank sources: system prompt > user input > tool output > retrieved documents.',
+    oneLineRef: '(Why trust hierarchy: see above)',
+  },
+  'signing-and-pinning': {
+    id: 'signing-and-pinning',
+    title: 'Why hash-pinning + signing',
+    body: 'TODO — see hackmyagent#142. Pinned sha256 hashes prevent skill substitution; Ed25519 signatures bind a skill to a publisher.',
+    oneLineRef: '(Why signing: see above)',
+  },
+};
+
+/** Look up an explainer by concept id. Returns `undefined` if not registered. */
+export function getConceptExplainer(id: ConceptId): ConceptExplainer | undefined {
+  return CONCEPT_EXPLAINERS[id];
+}


### PR DESCRIPTION
Closes #140.

## Summary

The schema-spine PR for the OpenA2A CLI Finding-Output UX Standard. Adds three optional fields (\`evidence\`, \`rationale\`, \`concept\`) to all three Finding type definitions, a new \`Evidence\` discriminated union module, a stubbed concept-explainer registry, and one PoC emit site populated end-to-end. **No behavior change in this PR** — terminal output on the corpus is byte-identical pre/post; JSON gains additive fields only.

This is the spine #138, #141, and #142 plug into.

## What's in the diff

- **NEW** \`src/types/finding-evidence.ts\` — \`Evidence\` union (positive | absence | mixed), \`Rationale\`, \`ConceptId\` enum, runtime guards
- **NEW** \`src/ui/concept-explainers.ts\` — registry skeleton with all 6 concepts (body copy stubbed, lands in #142)
- **EXTEND** \`src/plugins/core.ts\` \`Finding\`, \`src/hardening/security-check.ts\` \`SecurityFinding\`, \`src/semantic/types.ts\` \`SemanticFinding\` — three optional fields each
- **EXTEND** \`src/semantic/integration/finding-adapter.ts\` — pass \`evidence\` and \`concept\` through; wrap legacy \`rationale: string\` into \`{ plainEnglish: string }\`
- **PoC** \`src/semantic/structural/credential-context.ts\` SEM-CRED-001 (URL passwords) populates \`evidence: { kind: 'positive', lines: [...] }\` and \`concept: 'secretless-vault'\`. Passwords are fully redacted (\`[REDACTED]\` marker, every occurrence) before being put in evidence content.
- **TESTS** \`__tests__/types/finding-evidence.test.ts\` (10 tests) + \`__tests__/ui/concept-explainers.test.ts\` (5 tests) + 1 H1-regression test in \`__tests__/semantic/credential-context.test.ts\`

## Migration plan

| Version | State |
|---|---|
| v0.21.x (this PR) | 3 fields optional. 1 PoC site populated. Renderer falls back when absent. |
| v0.21.x + #138 | Every emit site populates \`attackClass\` + \`evidence\` together (single pass). |
| v0.21.x + #142 | Stubbed concept registry replaced with curated copy. Renderer dedupe activates. |
| v0.21.x + #141 | \`generateVerifyCommand()\` rewired to consume \`evidence.lines[0]\`. |
| v0.22.0 | Fields flipped to mandatory. Type-compile fails for any unmigrated site. |

## Verification

- 1840 tests pass (15 new across types/ui/semantic regression)
- \`npm run release-smoke:corpus\`: 12/12 fixtures green, 0 failed, 2 skipped (a2a + npm Phase 3)
- Terminal output on \`~/.opena2a/corpus/repo/malicious/kitchen-sink\` and \`~/.opena2a/corpus/repo/benign/tiny-clean-repo\`: byte-identical pre/post (\`diff\` is empty)
- JSON output gains \`evidence\` + \`concept\` on the 3 PoC findings (\`evidence.kind=positive\`, \`evidence.lines[0].n=5\`, \`concept=secretless-vault\`); gains \`rationale: { plainEnglish: ... }\` on ~95 semantic-derived findings (M1 fix). Both additive.
- Pre-push gate: 8 phases run. Phase 4.5 adversarial review surfaced H1 (HIGH redaction leak), M1 (comment vs behavior mismatch), M3 (test claim vs enforcement). All three closed in commit \`4704f8b\`. Re-run adversarial review confirmed all closed, no new regressions.

## Test plan

- [x] \`npm run build\` — clean
- [x] \`npm test\` — 1840 pass
- [x] \`npm run release-smoke:corpus\` — 12/12
- [x] Snapshot test: kitchen-sink + tiny-clean text output byte-identical
- [x] Direct repro of H1 fix: postgres URL with password \`supersecret123\` AND comment \`# password is supersecret123\` on same line → both occurrences redact to \`[REDACTED]\`
- [x] Adversarial review (general-purpose subagent, two rounds) — all surfaced issues closed

## Scope notes

- Pre-existing HIGH on \`src/check/rich-block-adapter.ts:292\` ("Memory store without input sanitization") is a false positive on a pure data-validation function. File untouched by this PR. Same finding waived through #126 → #131 → #133. Not introduced here.
- Two pre-existing LOW notes carry forward (5-char masked-preview leak in \`why:\`/\`description:\`; triple-storage of rationale text across \`message\`/\`guidance\`/\`rationale.plainEnglish\`). Neither introduced by this PR.

## Standard reference

\`~/.claude/instructions/cli-finding-ux-standard.md\` (joint chief decision [CHIEF-CPO-022 / CHIEF-CDS-028, 2026-04-28]).