### PR TITLE
fix(credential-analyzer): gate AST-CRED-001 on credential-format substring (#164)

### DIFF
--- a/__tests__/nanomind-core/benign-fp-regression.test.ts
+++ b/__tests__/nanomind-core/benign-fp-regression.test.ts
@@ -533,4 +533,118 @@ Then ask the agent to provide a response.
       'AST-CRED-003 must fire on a real sk-ant- secret even in doc context',
     ).toBeGreaterThan(0);
   });
+
+  it('b15: .claude/settings.json with $VAR placeholder values must NOT fire AST-CRED-001 (#164)', async () => {
+    // Regression for #164: .claude/settings.json content that mentions
+    // "credentials" in defensive deny-rules (e.g. `"Read(.aws/credentials)"`)
+    // and only references credentials by env-var placeholder
+    // (`"OPENAI_API_KEY": "$OPENAI_API_KEY"`) was triggering MEDIUM
+    // AST-CRED-001 on every project that uses Claude Code's hook
+    // protection. The content-format gate at checkCredentialsInNonEnvContext
+    // requires a real credential-format substring before emitting.
+    const settingsJson = `{
+  "permissions": {
+    "deny": [
+      "Read(.env*)",
+      "Read(*.key)",
+      "Read(*.pem)",
+      "Read(.aws/credentials)",
+      "Read(.ssh/*)"
+    ]
+  },
+  "env": {
+    "OPENAI_API_KEY": "$OPENAI_API_KEY",
+    "ANTHROPIC_API_KEY": "$ANTHROPIC_API_KEY"
+  }
+}
+`;
+    const compiler = new SemanticCompiler({ useNanoMind: false });
+    const result = await compiler.compile(settingsJson, '.claude/settings.json');
+    const verifier = (ast: typeof result.ast) => compiler.verifyAST(ast);
+
+    const { analyzeCredentials } = await import('../../src/nanomind-core/analyzers/credential-analyzer');
+    const findings = analyzeCredentials(result.ast, verifier, undefined, settingsJson);
+
+    const cred001 = findings.filter(f => f.checkId === 'AST-CRED-001');
+    expect(
+      cred001,
+      `AST-CRED-001 must not fire on host-tool config with env-var placeholder values. Got: ${cred001.map(f => `${f.severity}: ${f.message}`).join(', ')}`,
+    ).toHaveLength(0);
+  });
+
+  it('b16: .claude/settings.json with ${VAR} brace placeholder values must NOT fire AST-CRED-001 (#164)', async () => {
+    // Same regression as b15 but with `${VAR}` brace-form placeholders.
+    // The shell/POSIX brace-substitution form is equally common in
+    // host-tool configs and must not be confused for a credential value.
+    const settingsJson = `{
+  "permissions": { "deny": ["Read(.env*)", "Read(.aws/credentials)"] },
+  "env": {
+    "OPENAI_API_KEY": "\${OPENAI_API_KEY}",
+    "ANTHROPIC_API_KEY": "\${ANTHROPIC_API_KEY}"
+  }
+}
+`;
+    const compiler = new SemanticCompiler({ useNanoMind: false });
+    const result = await compiler.compile(settingsJson, '.claude/settings.json');
+    const verifier = (ast: typeof result.ast) => compiler.verifyAST(ast);
+
+    const { analyzeCredentials } = await import('../../src/nanomind-core/analyzers/credential-analyzer');
+    const findings = analyzeCredentials(result.ast, verifier, undefined, settingsJson);
+
+    const cred001 = findings.filter(f => f.checkId === 'AST-CRED-001');
+    expect(
+      cred001,
+      `AST-CRED-001 must not fire on \${VAR}-form placeholders. Got: ${cred001.map(f => `${f.severity}: ${f.message}`).join(', ')}`,
+    ).toHaveLength(0);
+  });
+
+  it('b15-positive: real Slack token in agent-config.yaml WITH credential keyword MUST fire AST-CRED-001 with line (positive control for b15/b16)', async () => {
+    // Positive control: the FP suppression must not also suppress real
+    // hardcoded credentials. We construct a fixture whose content (a)
+    // includes the keyword "credentials" so the compiler emits a
+    // `dataType: 'credentials'` access pattern, (b) does NOT match the
+    // upstream credential_file classifier (whose triggers are sk-ant-,
+    // sk-proj-, AKIA, ghp_, PEM blocks), and (c) DOES contain a
+    // credential-format substring (a real Slack `xoxb-…` token).
+    //
+    // Without #164's content-format gate, this fixture would have fired
+    // AST-CRED-001 on the `dataType: 'credentials'` alone. With the gate,
+    // it still fires because the Slack token matches buildCredential-
+    // FormatRegex, AND it now carries a `file:line` populated from the
+    // token's match position.
+    const slackToken = ['xox', 'b-1234567890-1234567890-', 'AbCdEfGhIjKlMnOpQrStUvWx'].join('');
+    const yaml = `name: agent-config
+description: stores credentials for the bot
+slackBot:
+  webhookToken: ${slackToken}
+`;
+    const compiler = new SemanticCompiler({ useNanoMind: false });
+    const result = await compiler.compile(yaml, 'agent-config.yaml');
+    const verifier = (ast: typeof result.ast) => compiler.verifyAST(ast);
+
+    // Sanity check: the compiler must not have classified this as a
+    // `credential_file` (which would early-return AST-CRED-001).
+    expect(result.ast.artifactType, 'fixture must not be classified credential_file or env_file').not.toBe('credential_file');
+    expect(result.ast.artifactType).not.toBe('env_file');
+
+    const { analyzeCredentials } = await import('../../src/nanomind-core/analyzers/credential-analyzer');
+    const findings = analyzeCredentials(result.ast, verifier, undefined, yaml);
+
+    const cred001 = findings.filter(f => f.checkId === 'AST-CRED-001');
+    expect(
+      cred001.length,
+      `AST-CRED-001 MUST fire on a real Slack token in a non-credential_file context. All findings: ${findings.map(f => `${f.checkId}(${f.severity})`).join(', ') || '(none)'}; artifactType=${result.ast.artifactType}; declaredDataAccess=${JSON.stringify(result.ast.declaredDataAccess)}`,
+    ).toBeGreaterThan(0);
+
+    const finding = cred001[0];
+    expect(typeof finding.line, 'AST-CRED-001 must populate `line` from the credential-format match position').toBe('number');
+    expect(finding.line, 'line must be 1-based and match the slackBot.webhookToken line (4)').toBe(4);
+    // Evidence carries the masked prefix (per maskCredentialValue) — the raw
+    // token is never echoed back through HMA's output (R-Bonus from #164's
+    // adversarial review: a security tool must not leak the credential it
+    // detected).
+    expect(finding.evidence, 'evidence must preserve the recognizable prefix').toMatch(/^xoxb-/);
+    expect(finding.evidence, 'evidence body must be masked (no raw token bytes after prefix)').toMatch(/\*+$/);
+    expect(finding.evidence, 'masked evidence must not contain the raw token body').not.toMatch(/AbCdEfGhIjKl/);
+  });
 });

--- a/__tests__/nanomind-core/source-code-preprocessor.test.ts
+++ b/__tests__/nanomind-core/source-code-preprocessor.test.ts
@@ -269,7 +269,10 @@ func LeakCreds() {
     expect(result.ast.inferredRiskSurface.length).toBeGreaterThan(0);
     expect(result.ast.inferredRiskSurface[0].attackClass).toBe('CRED-HARVEST');
 
-    const findings = analyzeCredentials(result.ast, (a) => compiler.verifyAST(a));
+    // Pass artifact content so AST-CRED-001's content-format gate (#164)
+    // can verify a credential-format substring exists. Production callers
+    // (scanner-bridge.ts) always pass content; only earlier tests omitted it.
+    const findings = analyzeCredentials(result.ast, (a) => compiler.verifyAST(a), undefined, src);
     // AST-CRED-001 (context) and AST-CRED-003 (hardcoded secret) must fire
     expect(findings.length).toBeGreaterThanOrEqual(2);
     expect(findings.some(f => f.checkId === 'AST-CRED-003')).toBe(true);

--- a/src/nanomind-core/analyzers/credential-analyzer.ts
+++ b/src/nanomind-core/analyzers/credential-analyzer.ts
@@ -41,7 +41,7 @@ export function analyzeCredentials(
 
   const findings: ASTFinding[] = [];
 
-  findings.push(...checkCredentialsInNonEnvContext(ast, projectType));
+  findings.push(...checkCredentialsInNonEnvContext(ast, projectType, artifactContent));
   findings.push(...checkCredentialForwarding(ast, projectType, artifactContent));
   findings.push(...checkHardcodedSecrets(ast, artifactContent));
 
@@ -60,7 +60,11 @@ export function analyzeCredentials(
  * Uses AST.declaredDataAccess to find credential-type data patterns
  * and checks whether the artifact type is an appropriate context.
  */
-function checkCredentialsInNonEnvContext(ast: SecurityAST, projectType?: ProjectType): ASTFinding[] {
+function checkCredentialsInNonEnvContext(
+  ast: SecurityAST,
+  projectType?: ProjectType,
+  artifactContent?: string,
+): ASTFinding[] {
   const findings: ASTFinding[] = [];
   const isSDK = projectType === 'sdk';
 
@@ -80,6 +84,26 @@ function checkCredentialsInNonEnvContext(ast: SecurityAST, projectType?: Project
 
   // Check if evidence spans suggest these are documentation examples or test fixtures
   const isDocOrTest = isDocumentationOrTestContext(ast);
+
+  // Content-format gate (#164): the upstream compiler tags any artifact
+  // whose lowercased content includes the substring "credential" or
+  // "session" with a `dataType: 'credentials'` data-access pattern. That
+  // is too noisy on host-tool config files like `.claude/settings.json`,
+  // which mention credentials in *defensive* deny-rules ("Read(.aws/
+  // credentials)") without containing any credential value. Require an
+  // actual credential-format substring in the artifact content before
+  // emitting AST-CRED-001 — vendor prefixes (`sk-`, `sk_live_`, `ghp_`,
+  // `gho_`, `github_pat_`, `xox[abprs]-`, `eyJ` JWT, `AKIA…`, `AIza…`)
+  // OR a high-entropy 40+ word-character run. Placeholder/reference
+  // values (`$OPENAI_API_KEY`, `${OPENAI_API_KEY}`) deliberately do NOT
+  // match. SDKs are also gated — flagging an SDK source file that only
+  // mentions the word "credential" was the same false-positive shape.
+  const credLocation = artifactContent !== undefined
+    ? findFirstCredentialFormat(artifactContent)
+    : undefined;
+  if (!credLocation) {
+    return findings;
+  }
 
   for (const access of credentialAccess) {
     // Credential reads in skills/configs/source code are suspicious
@@ -110,6 +134,7 @@ function checkCredentialsInNonEnvContext(ast: SecurityAST, projectType?: Project
       message: `Credential ${access.accessMode} in ${ast.artifactType} context`,
       fixable: false,
       file: ast.artifactPath,
+      line: credLocation.line,
       fix: isSDK
         ? 'Expected behavior for an SDK. Credentials are read from environment variables and sent to the service API.'
         : 'opena2a protect .  — scans for hardcoded secrets and encrypts them into a secure vault. Keys are injected at runtime, never stored as plaintext.',
@@ -119,6 +144,7 @@ function checkCredentialsInNonEnvContext(ast: SecurityAST, projectType?: Project
           'logs, or prompt injection attacks that extract artifact content.',
       attackClass: 'CRED-EXPOSURE',
       confidence: isSDK ? 0.3 : isDocOrTest ? 0.3 : 0.8,
+      evidence: credLocation.match,
     });
   }
 
@@ -516,23 +542,111 @@ function isDocumentationOrTestContext(ast: SecurityAST): boolean {
  * actual hardcoded secrets.
  */
 function evidenceShowsCredentialFormat(evidenceTexts: string[]): boolean {
-  return evidenceTexts.some(t =>
-    new RegExp(
-      [
-        'sk-[a-zA-Z0-9_-]{20,}',
-        'sk_live_[a-zA-Z0-9]{20,}',
-        'sk_test_[a-zA-Z0-9]{20,}',
-        'ghp_[a-zA-Z0-9]{20,}',
-        'gho_[a-zA-Z0-9]{20,}',
-        'github_pat_[a-zA-Z0-9_]{20,}',
-        'AKIA[0-9A-Z]{16}',
-        'AIza[0-9A-Za-z_-]{35}',
-        'xox[abprs]-[0-9A-Za-z-]{10,}',
-        'eyJ[A-Za-z0-9_-]+\\.[A-Za-z0-9_-]+\\.[A-Za-z0-9_-]+',
-        '\\b[A-Za-z0-9+=_]{40,}\\b',
-      ].join('|'),
-    ).test(t),
+  const re = buildCredentialFormatRegex();
+  return evidenceTexts.some(t => re.test(t));
+}
+
+/**
+ * Build the credential-format detector. The regex is shared between the
+ * AST-CRED-003 evidence-text gate and the AST-CRED-001 content-scanning
+ * gate (#164) so both code paths agree on what counts as a credential.
+ *
+ * Curated multi-vendor prefixes — Anthropic / OpenAI (`sk-`), Stripe
+ * (`sk_live_` / `sk_test_`), GitHub PAT (`ghp_` / `gho_` / `github_pat_`),
+ * AWS access key IDs (`AKIA…`), Google API keys (`AIza…`), Slack
+ * (`xox[abprs]-…`), and JWTs (`eyJ…header.payload.sig`) — plus a
+ * high-entropy 40+ word-character fallback (anchored on word boundaries,
+ * excluding `-` and `/` so URL slugs and slug-style identifiers do not
+ * match). Bare-keyword mentions ("credentials", "API key", "token") in
+ * descriptive text do NOT count.
+ *
+ * Placeholder / env-var reference values (`$OPENAI_API_KEY`,
+ * `${OPENAI_API_KEY}`, `<YOUR_KEY>`) deliberately fail the entropy gate
+ * because the leading `$`/`<` characters are not in the word-character
+ * class, and the all-uppercase env-var convention rarely produces 40+
+ * consecutive characters anyway.
+ */
+function buildCredentialFormatRegex(): RegExp {
+  return new RegExp(
+    [
+      'sk-[a-zA-Z0-9_-]{20,}',
+      'sk_live_[a-zA-Z0-9]{20,}',
+      'sk_test_[a-zA-Z0-9]{20,}',
+      'ghp_[a-zA-Z0-9]{20,}',
+      'gho_[a-zA-Z0-9]{20,}',
+      'github_pat_[a-zA-Z0-9_]{20,}',
+      'AKIA[0-9A-Z]{16}',
+      'AIza[0-9A-Za-z_-]{35}',
+      'xox[abprs]-[0-9A-Za-z-]{10,}',
+      'eyJ[A-Za-z0-9_-]+\\.[A-Za-z0-9_-]+\\.[A-Za-z0-9_-]+',
+      '\\b[A-Za-z0-9+=_]{40,}\\b',
+    ].join('|'),
   );
+}
+
+/**
+ * Scan `content` for the first credential-format substring (per
+ * `buildCredentialFormatRegex`). Returns the 1-based line number of the
+ * match and the masked matched substring, or undefined when no match
+ * exists. The match is masked at this layer so callers cannot
+ * accidentally leak the raw credential value into a finding's
+ * `evidence` field — HMA must never echo a real credential back to the
+ * user, JSON output, telemetry, or Registry sync.
+ */
+function findFirstCredentialFormat(content: string): { line: number; match: string } | undefined {
+  const re = buildCredentialFormatRegex();
+  const m = re.exec(content);
+  if (!m) return undefined;
+  // Count newlines before the match index — 1-based line number.
+  let line = 1;
+  for (let i = 0; i < m.index; i++) {
+    if (content.charCodeAt(i) === 10 /* \n */) line++;
+  }
+  return { line, match: maskCredentialValue(m[0]) };
+}
+
+/**
+ * Mask a matched credential value for safe inclusion in finding
+ * `evidence`, JSON output, and telemetry. Mirrors the prefix-preserving
+ * scheme used by `src/narrative/build-narrative.ts:maskCredential`.
+ *
+ * - For curated vendor prefixes, preserve the prefix and replace the
+ *   remaining body with up to 16 asterisks. The user can still
+ *   recognize the credential format and the match line, but the value
+ *   itself never appears in scanner output.
+ * - For unknown shapes, expose the first 8 characters and mask up to 16
+ *   more.
+ */
+function maskCredentialValue(value: string): string {
+  if (value.length === 0) return '';
+  const knownPrefixes = [
+    'sk-ant-api03-',
+    'sk-ant-api02-',
+    'sk-proj-',
+    'sk_live_',
+    'sk_test_',
+    'github_pat_',
+    'ghp_',
+    'gho_',
+    'ghs_',
+    'AKIA',
+    'AIza',
+    'xoxb-',
+    'xoxa-',
+    'xoxp-',
+    'xoxr-',
+    'xoxs-',
+    'eyJ',
+  ];
+  for (const prefix of knownPrefixes) {
+    if (value.startsWith(prefix)) {
+      const remaining = Math.max(0, value.length - prefix.length);
+      return `${prefix}${'*'.repeat(Math.min(remaining, 16))}`;
+    }
+  }
+  // Unknown shape — show first 8 chars then asterisks. Cap so the
+  // masked output never exceeds 24 chars regardless of input length.
+  return `${value.slice(0, 8)}${'*'.repeat(Math.min(Math.max(value.length - 8, 0), 16))}`;
 }
 
 /**

--- a/src/nanomind-core/fix-generator.ts
+++ b/src/nanomind-core/fix-generator.ts
@@ -612,8 +612,13 @@ function generateGuidance(finding: ASTFinding, ast: SecurityAST, projectConstrai
 
   // If the artifact has few effective constraints (artifact-level + project-level), note the
   // compounding risk. Use effective count so that adding a SOUL.md clears this message.
+  // Skip on host-tool config files (.json / .yaml / .yml) where inline
+  // governance constraints are not a meaningful concept (#164): a Claude
+  // Code or Cursor settings file is a tool-host config, not an agent
+  // definition, and the prose "this artifact has no inline governance
+  // constraints" is unactionable on those paths.
   const effectiveConstraintCount = ast.declaredConstraints.length + (projectConstraints?.length ?? 0);
-  if (effectiveConstraintCount < 2 && finding.attackClass !== 'SOUL-MISSING') {
+  if (effectiveConstraintCount < 2 && finding.attackClass !== 'SOUL-MISSING' && !isStructuredConfigPath(ast.artifactPath)) {
     const constraintWord = ast.declaredConstraints.length === 0 ? 'no' : `only ${ast.declaredConstraints.length}`;
     parts.push(`This artifact has ${constraintWord} inline governance constraints, amplifying the risk of this finding.`);
   }
@@ -628,6 +633,52 @@ function generateGuidance(finding: ASTFinding, ast: SecurityAST, projectConstrai
 function verifyCommand(ast: SecurityAST): string {
   const dir = ast.artifactPath ? ast.artifactPath.split('/').slice(0, -1).join('/') || '.' : '.';
   return `Verify: hackmyagent secure ${dir}`;
+}
+
+/**
+ * True when the artifact is a host-tool config file where the
+ * governance-amplifier prose ("This artifact has no inline governance
+ * constraints, amplifying the risk of this finding") is unactionable
+ * because the file does not define agent behavior — it configures the
+ * host application (Claude Code, Cursor, VS Code, package manager).
+ *
+ * Curated allowlist of basenames + path patterns. Deliberately does NOT
+ * match `.cursor/mcp.json` / `agent.json` / `agent-card.json` /
+ * `agent-config.yaml` etc. — those ARE agent-definition surfaces and
+ * the amplifier text is meaningful on them. See #164.
+ */
+function isStructuredConfigPath(artifactPath?: string): boolean {
+  if (!artifactPath) return false;
+  const lower = artifactPath.toLowerCase();
+  // Path-suffix matches: host-tool settings + standard repo configs that
+  // are not agent-definition surfaces.
+  const hostToolPaths = [
+    '.claude/settings.json',
+    '.claude/settings.local.json',
+    '.vscode/settings.json',
+    '.cursor/settings.json',
+    '.idea/workspace.xml',
+  ];
+  if (hostToolPaths.some((p) => lower.endsWith(p))) return true;
+
+  // Exact basename matches.
+  const basename = lower.split('/').pop() ?? '';
+  const repoConfigBasenames = new Set([
+    'package.json',
+    'package-lock.json',
+    'tsconfig.json',
+    'tsconfig.build.json',
+    'jest.config.json',
+    'vitest.config.json',
+    '.eslintrc.json',
+    '.prettierrc.json',
+    '.babelrc.json',
+    'renovate.json',
+    'commitlint.config.json',
+    '.npmrc.json',
+    '.nvmrc.json',
+  ]);
+  return repoConfigBasenames.has(basename);
 }
 
 function truncate(text: string, maxLen: number): string {


### PR DESCRIPTION
Closes #164.

## Summary

`.claude/settings.json` was firing AST-CRED-001 MEDIUM ("Credentials in Non-Environment Context") on every project that uses Claude Code's hook protection. The upstream compiler tags any artifact whose lowercased content includes the word "credential" or "session" with a `dataType: 'credentials'` access pattern, so a defensive `.claude/settings.json` containing `"Read(.aws/credentials)"` deny-rules and `$VAR` placeholder env values was being flagged despite holding no credential value.

## Implementation

1. **Content-format gate** in `checkCredentialsInNonEnvContext`: only fire when the artifact content contains a credential-format substring per a curated regex (vendor prefixes `sk-`, `sk_live_`, `ghp_`, `gho_`, `github_pat_`, `xox[abprs]-`, `eyJ` JWT, `AKIA…`, `AIza…`, plus a high-entropy 40+ word-character fallback). The regex is shared with AST-CRED-003's evidence-text gate.
2. **`file:line` + `evidence` population** from the credential-format match position, with the `evidence` field **masked at the analyzer layer** so the raw token never reaches finding output, JSON, telemetry, or Registry sync. Mask preserves recognizable prefixes (`sk-ant-api03-` → `sk-ant-api03-****************`).
3. **Governance-amplifier suppression** on a curated host-tool config allowlist (`.claude/settings.json`, `.vscode/settings.json`, `package.json`, `tsconfig.json`, `.eslintrc.json`, etc.) — NOT every `.json`/`.yaml` file. MCP configs and A2A agent cards still get the amplifier text because they ARE agent-definition surfaces.

## Phase 4.5 adversarial review

A general-purpose subagent investigated 8 risk categories pre-merge. Three findings actioned in this PR:

- **R-Bonus (HIGH)**: raw credential value was leaking into `evidence` — fixed by masking in `findFirstCredentialFormat`.
- **R4 (MEDIUM)**: governance-amplifier extension-match was over-suppressing on `.cursor/mcp.json` / `agent.json` / `agent-config.yaml` — replaced with curated host-tool basename allowlist.
- **R2 (HIGH)**: malicious `.clinerules` in adversarial corpus no longer fires AST-CRED-001 (used to fire on credential-keyword narrative alone). **Accepted with rationale**: the same fixture still fires `AST-CRED-002 CRITICAL` ("credential forwarding to external endpoint") and `SEM-INST-001` / `SEM-INST-002 HIGH` on lines 1–3. System-level detection of the malicious artifact is preserved (release-smoke corpus 12/12 unchanged).

Out of scope (filed as follow-ups):

- R1/R7 regex gaps (Stripe `pk_live_`, Twilio `AC…`, Mailgun `key-`, Heroku UUID, short `sk-` < 20 chars, URL-safe base64 with `-`/`/`). Pre-existing in `evidenceShowsCredentialFormat` shared regex.
- Migrate the credential-format regex into `@opena2a/credential-patterns` for cross-tool sync.

## Verification

- `npm test` 2025/2051 pass (was 2022/2048; +3 new b15 / b16 / b15-positive tests).
- `npm run release-smoke:corpus` 12/12.
- HMA self-scan 84 → 89 (FP at `.claude/settings.json` suppressed).
- `secure ./hackmyagent/` no longer fires MEDIUM on `.claude/settings.json`.
- AST-CRED-001 still fires on `.cursorrules:7` in the adversarial kitchen-sink corpus, with masked `sk-ant-api03-****************` evidence.
- `analyzeCredentials` Go-source regression test (`source-code-preprocessor.test.ts:272`) updated to pass `artifactContent` so AST-CRED-001 still fires on a real `sk-ant-api03-…` value.

## Phase 4.5 score-jump classification

84 → 89 (+5):
- At the `.claude/settings.json` suppression site: **(a) preserved-detection FP-suppress** (real credentials still fire; only keyword-only mentions in host-tool configs are suppressed).
- At the `.clinerules` unit-level site: **(b) narrowed-detection** at the AST-CRED-001 layer, but `.clinerules` malicious fixtures are still flagged CRITICAL via AST-CRED-002 + HIGH via SEM-INST-* — system-level detection preserved; documented above as "accepted with rationale."

## Test plan

- [x] `npm test` green (2025/2051)
- [x] `npm run release-smoke:corpus` 12/12
- [x] `secure ./hackmyagent/` does not fire MEDIUM on `.claude/settings.json`
- [x] `secure ~/.opena2a/corpus/repo/malicious/kitchen-sink` still fires AST-CRED-001 on `.cursorrules:7` (masked evidence) AND AST-CRED-002 / SEM-INST-* on `.clinerules` lines 1–3
- [x] b15-positive: real Slack token in `agent-config.yaml` fires with `line: 4` + masked `xoxb-****…` evidence
- [x] Go-source AST-CRED-001 regression test still passes after passing `artifactContent`

## Related

Bundled with #162 / #163 fixes for the 0.22.1 release.