### PR TITLE
docs: refresh test-count badge 1757 → 2072

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 
 [![npm version](https://img.shields.io/npm/v/hackmyagent.svg)](https://www.npmjs.com/package/hackmyagent)
 [![License: Apache-2.0](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
-[![Tests](https://img.shields.io/badge/tests-1757%20passing-brightgreen)](https://github.com/opena2a-org/hackmyagent)
+[![Tests](https://img.shields.io/badge/tests-2072%20passing-brightgreen)](https://github.com/opena2a-org/hackmyagent)
 [![NanoMind](https://img.shields.io/badge/NanoMind-semantic%20compiler-teal)](https://huggingface.co/opena2a/nanomind-security-classifier)
 
 **209 static security checks + 29 NanoMind semantic checks + 164 adversarial payloads.**


### PR DESCRIPTION
Trivial 1-line fix. The README's tests badge was stuck at 1757 from a pre-0.22 release. Current suite is 2072 passing / 2098 total per the 0.22.2 ship.

LF Open Source Summit demo (May 18) and Observability Summit (May 22) talks both link attendees to this README; the badge should reflect reality.

No code change.