### PR TITLE
fix(telemetry): treat exit 1 as success (findings detected ≠ failure)

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -9486,7 +9486,10 @@ async function checkNpmPackage(
       if (startedAt === undefined) return;
       telemetryStartedAt.delete(name);
       void tele.track(name, {
-        success: (process.exitCode ?? 0) === 0,
+        // Exit 1 = findings detected (security-tool convention — see
+        // line ~3535 where critHigh.length > 0 sets exitCode=1). The
+        // command did its job. Only exit >=2 is a real crash.
+        success: ((process.exitCode ?? 0) as number) <= 1,
         durationMs: Date.now() - startedAt,
       });
     });


### PR DESCRIPTION
## Summary

HMA secure exits 1 when CRITICAL or HIGH findings are detected (`src/cli.ts:3535`: `if (critHigh.length > 0) process.exitCode = 1`) — that's the security tool doing its job. The telemetry dispatcher (`src/cli.ts:9489`) was tagging it as failure, producing **29% success rate** for `hackmyagent secure` in production (856 events across 6 installs, Apr 27 – May 11) — the dominant command on the most-used CLI.

Change dispatcher heuristic from `=== 0` to `<= 1` (security-tool convention, matches npm audit / eslint). Exit ≥ 2 still records as failure. Cast handles Node 22+'s widened `process.exitCode` type.

Companion PR in `opena2a` (#144) ships `@opena2a/telemetry@0.2.0` exposing a centralised `successFromExitCode()` helper. When this repo's `@opena2a/telemetry` pin bumps to `0.2.0`, the inline `<= 1` here can be replaced with `tele.successFromExitCode(process.exitCode)`. Keeping the fix inline in this PR so it merges independently.

Sister PRs landing the same fix in secretless-ai, ai-trust, and damn-vulnerable-ai-agent.

## Test plan

- [x] `npm run build` clean
- [x] `npm test` — 2072/2098 (16 skipped, 10 todo) — unchanged from main
- [x] `hackmyagent secure --ci` self-scan on this branch — 98/100, 1 LOW (CLAUDE.md size), 0 CRITICAL/HIGH, 0 new findings introduced
- [x] Diff is 1 functional line (`=== 0` → `<= 1`) with comment

## Why the OpenA2A `/admin/cli-usage` dashboard now exists to catch this

Production dashboard surfaced this anomaly: `hackmyagent secure` 29% success, `hackmyagent scan-soul` 100% success, `hackmyagent check` 100% success — same SDK, same dispatcher, different commands. The pattern (high-volume scan commands inverted-success while one-shot lookups OK) pointed straight at the exit-code interpretation in the postAction hook.

Audit doc: `~/workspace/opena2a-org/todo/2026-05-10-cli-telemetry-anomalies.md`