### PR TITLE
chore: bump to 0.22.3 — telemetry fix from #174

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hackmyagent",
-  "version": "0.22.2",
+  "version": "0.22.3",
   "description": "Find it. Break it. Fix it. The hacker's toolkit for AI agents.",
   "bin": {
     "hackmyagent": "dist/cli.js"


### PR DESCRIPTION
## Summary

Ships hackmyagent 0.22.3 to publish the telemetry success-heuristic fix from #174 (already on main). One-line version bump; no code change in this PR.

## What users get

- `hackmyagent secure` exits with code 1 when findings are detected; that's the deliberate convention. After the SDK fix on consumer side (#174 + @opena2a/telemetry 0.2.0), this is reported as `success: true` in telemetry. Prior to 0.22.3 the success rate showed 29% in production despite the CLI working correctly.

## Test plan

- [x] 2072/2098 tests pass locally (was 2072/2098 — no regression)
- [x] npm run build clean; integrity manifest regenerated at 0.22.3
- [x] @opena2a/telemetry 0.2.0 published with SLSA v1 provenance
- [ ] After merge: tag `v0.22.3` triggers GHA publish via OIDC
- [ ] Verify `npm view hackmyagent version` returns 0.22.3 with attestations