### PR TITLE
docs(readme): mirror AIM README structure

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,65 +1,24 @@
-> **[OpenA2A](https://github.com/opena2a-org/opena2a)**: [CLI](https://github.com/opena2a-org/opena2a) · [HackMyAgent](https://github.com/opena2a-org/hackmyagent) · [Secretless](https://github.com/opena2a-org/secretless-ai) · [AIM](https://github.com/opena2a-org/agent-identity-management) · [Browser Guard](https://github.com/opena2a-org/AI-BrowserGuard) · [DVAA](https://github.com/opena2a-org/damn-vulnerable-ai-agent)
 # HackMyAgent
 
+> **[OpenA2A](https://github.com/opena2a-org/opena2a)**: [CLI](https://github.com/opena2a-org/opena2a) · [HackMyAgent](https://github.com/opena2a-org/hackmyagent) · [Secretless](https://github.com/opena2a-org/secretless-ai) · [AIM](https://github.com/opena2a-org/agent-identity-management) · [Browser Guard](https://github.com/opena2a-org/AI-BrowserGuard) · [DVAA](https://github.com/opena2a-org/damn-vulnerable-ai-agent)
+
+Security scanner, red-team toolkit, and behavioural simulator for AI agents. Apache 2.0.
+
 [![npm version](https://img.shields.io/npm/v/hackmyagent.svg)](https://www.npmjs.com/package/hackmyagent)
-[![License: Apache-2.0](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
+[![License: Apache-2.0](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](LICENSE)
 [![Tests](https://img.shields.io/badge/tests-2072%20passing-brightgreen)](https://github.com/opena2a-org/hackmyagent)
-[![NanoMind](https://img.shields.io/badge/NanoMind-semantic%20compiler-teal)](https://huggingface.co/opena2a/nanomind-security-classifier)
+[![NanoMind](https://img.shields.io/badge/NanoMind-semantic%20layer-teal)](https://huggingface.co/opena2a/nanomind-security-classifier)
 
-**209 static security checks + 29 NanoMind semantic checks + 164 adversarial payloads.**
+[Website](https://hackmyagent.com) · [Demos](https://opena2a.org/demos) · [Discord](https://discord.gg/uRZa3KXgEn)
 
-Security scanner, red-team toolkit, and behavioural simulation engine for AI agents. Every artifact (skill, MCP config, SOUL.md, system prompt) is compiled into an Abstract Security Tree before analysis -- semantic understanding, not regex.
+## Quick start
 
 ```bash
 npx hackmyagent secure
 ```
 
-No config files, no setup, no flags needed.
-
-![HackMyAgent Demo](docs/hackmyagent-demo.gif)
-
-[More demos](https://opena2a.org/demos)
-
-For a full security dashboard covering credentials, config integrity, shadow AI, and more:
-
-```bash
-npx opena2a-cli review
 ```
-
-[Website](https://hackmyagent.com) | [Security Checks Reference](docs/SECURITY_CHECKS.md) | [Use Cases](docs/USE-CASES.md) | [Demos](https://opena2a.org/demos) | [OpenA2A CLI](https://github.com/opena2a-org/opena2a)
-
----
-
-## What It Finds
-
-- **NanoMind Semantic Compiler** -- compiles every artifact into an Abstract Security Tree. 29 semantic checks query the AST instead of regex on raw text. Catches what pattern matching can't: undeclared capabilities, constraint weakness, scope mismatches, scanner evasion attempts.
-- **209 static checks across 44 categories** -- credentials, MCP configs, OpenClaw / NemoClaw, Unicode steganography, CVEs, governance, supply chain, memory / RAG poisoning, agent identity, sandbox escape.
-- **Adaptive red team** -- `hackmyagent red-team <file>` generates target-specific payloads, observes responses, adapts after failures, and maps every defence.
-- **164 adversarial payloads across 16 categories** -- prompt injection, jailbreak, data exfiltration, capability abuse, context manipulation, MCP / A2A exploitation, memory weaponisation, context window, supply chain, tool shadow, parser differential, persistent agent, fake tool, context lifecycle, policy enforcement.
-- **Behavioural simulation** -- 20-probe battery that observes what skills actually do (run with `--deep`).
-- **Self-securing** -- verifies its own binary on startup against an embedded SHA-256 manifest. Post-install tampered binaries enter QUARANTINE mode (exit code 3) with a per-file forensics report. Symlink-redirected manifests are rejected. For end-to-end supply-chain verification against rebuild attacks, every release ships SLSA v1 provenance via npm Trusted Publishing -- verify with `npm view hackmyagent@<version> dist.attestations --json`.
-
-Full catalogue in [`docs/SECURITY_CHECKS.md`](docs/SECURITY_CHECKS.md).
-
----
-
-## Quick Start
-
-```bash
-# Run without installing
-npx hackmyagent secure
-
-# Install globally
-npm install -g hackmyagent
-
-# Or add to your project
-npm install --save-dev hackmyagent
-```
-
-**Requirements:** Node.js 18+
-
-```
-  my-project  v1.0.0 · library
+  my-project  v1.0.0 · library · 47 files analyzed
   3 critical issues found
 
   Security  ━━━━━━━━━━━━━━━━━━━━ 42/100
@@ -68,74 +27,125 @@ npm install --save-dev hackmyagent
   Surfaces    library · 47 files
   Checks      209 static · 12 semantic (NanoMind AST) · 0 skipped
   Categories  credentials (3 critical) · MCP (2 high) · 18 others clear
-  Verdict     Not safe to ship. Fix 3 critical issues before using this
-              in production.
+  Verdict     Not safe to ship. Fix 3 critical issues before using this in production.
 
   ── Findings ────────────────────────────────────────────────
-  │ CRITICAL  Hardcoded API key in .env
+  │ CRITICAL  Exposed API key in .env
   │ .env:3
-  │ sk-ant-api03-**** (Anthropic API key detected)
-  │ →  hackmyagent secure --fix
+  │ Anthropic API key (sk-ant-api03-****) detected in plaintext.
+  │ Verify: sed -n '3p' '.env'
+  │ Fix: hackmyagent secure --fix
 ```
 
----
+No config files. No flags required. Exit code 1 if any critical or high finding fires.
 
-## Scan Anything
+![HackMyAgent Demo](docs/hackmyagent-demo.gif)
 
-`hackmyagent check <target>` accepts any of these. `secure` scans your own project. `scan-soul` scans governance.
+## What it finds
 
-| Surface                  | Command                                              | What gets scanned                                 |
-|--------------------------|------------------------------------------------------|---------------------------------------------------|
-| Your own project         | `hackmyagent secure`                                 | 209 static checks + NanoMind on current directory |
-| A local directory        | `hackmyagent check ./my-agent/`                      | tree + auto-detected artifacts                    |
-| An npm package           | `hackmyagent check express`                          | downloads tarball, scans before you install       |
-| A PyPI package           | `hackmyagent check pip:requests`                     | downloads sdist, scans before you install         |
-| A GitHub repo            | `hackmyagent check getsentry/sentry-mcp`             | clones, scans, reports                            |
-| A published skill        | `hackmyagent check @publisher/skill`                 | signature verification + 29 semantic checks       |
-| A local skill directory  | `hackmyagent check ./my-skill/`                      | skill files + SOUL.md + manifest                  |
-| An MCP server config     | `hackmyagent check ./my-mcp-server/`                 | MCP config + declared tools + scope + dependencies (point at the directory, not the single JSON file) |
-| An A2A agent card        | `hackmyagent check ./my-agent/`                      | agent-card capabilities + identity (point at the directory containing the card) |
-| A URL tarball            | `hackmyagent check https://ex.com/pkg.tar.gz`        | downloads, scans                                  |
-| External infrastructure  | `hackmyagent scan example.com`                       | external AI-endpoint inventory                    |
-| Governance (SOUL.md)     | `hackmyagent scan-soul`                              | SOUL.md against OASB v2 behavioural controls      |
+- **209 static checks across 44 categories.** Credentials, MCP configs, OpenClaw and NemoClaw, Unicode steganography, CVEs, governance, supply chain, memory and RAG poisoning, agent identity, sandbox escape.
+- **29 NanoMind semantic checks.** Every artifact (skill, MCP config, SOUL.md, system prompt) compiles into an Abstract Security Tree. The seven AST analyzers run against the tree: `capability`, `credential`, `governance`, `scope`, `prompt`, `code`, `stego`. Pattern matching misses undeclared capabilities, constraint weakness, scope mismatches, and scanner-evasion attempts. AST queries catch them.
+- **164 adversarial payloads across 16 categories.** Prompt injection, jailbreak, data exfiltration, capability abuse, context manipulation, MCP and A2A exploitation, memory weaponisation, context window, supply chain, tool shadow, parser differential, persistent agent, fake tool, context lifecycle, policy enforcement integrity.
+- **20-probe behavioural simulation** under `--deep`. Observes what a skill actually does, not only what it declares.
+- **Self-securing.** Every binary verifies itself on startup against an embedded SHA-256 manifest. Post-install tampered binaries enter QUARANTINE mode (exit code 3) with a per-file forensics report. Symlink-redirected manifests are rejected.
 
-### secure vs. check vs. red-team vs. attack
+Full catalogue: [`docs/SECURITY_CHECKS.md`](docs/SECURITY_CHECKS.md).
 
-- **`secure`** -- your own project. Full 209-check scan, auto-fix option, designed for recurring use and CI.
-- **`check`** -- something you don't own yet. Pre-install trust check for any surface above.
-- **`red-team`** -- generate adaptive attacks against a specific skill / MCP / SOUL. You've scanned it; now you want to see if it resists.
-- **`attack`** -- test a live endpoint or local simulation with 164 pre-built adversarial payloads.
+## Install
 
----
+### npm
+
+```bash
+npx hackmyagent secure          # run without installing
+npm install -g hackmyagent      # global install
+npm install --save-dev hackmyagent
+```
+
+Requires Node.js 18 or later.
+
+### Homebrew
+
+```bash
+brew install opena2a-org/tap/hackmyagent
+```
+
+### From source
+
+```bash
+git clone https://github.com/opena2a-org/hackmyagent.git
+cd hackmyagent
+npm install
+npm run build
+node dist/cli.js secure
+```
+
+### Verifying what was installed
+
+Every release publishes via npm Trusted Publishing with SLSA v1 provenance. No long-lived `NPM_TOKEN`. GitHub Actions exchanges its OIDC token with npm at publish time.
+
+```bash
+npm view hackmyagent dist.attestations --json
+# Expects non-empty result with predicateType "https://slsa.dev/provenance/v1"
+```
+
+## Scan anything
+
+`hackmyagent check <target>` accepts each of these surfaces. `secure` scans your own project. `scan-soul` scans governance.
+
+| Surface | Command | What gets scanned |
+|---|---|---|
+| Your own project | `hackmyagent secure` | 209 static checks + NanoMind on current directory |
+| A local directory | `hackmyagent check ./my-agent/` | tree + auto-detected artifacts |
+| An npm package | `hackmyagent check express` | downloads tarball, scans before you install |
+| A PyPI package | `hackmyagent check pip:requests` | downloads sdist, scans before you install |
+| A GitHub repo | `hackmyagent check getsentry/sentry-mcp` | clones, scans, reports |
+| A published skill | `hackmyagent check @publisher/skill` | signature verification + semantic checks |
+| A local skill directory | `hackmyagent check ./my-skill/` | skill files + SOUL.md + manifest |
+| An MCP server config | `hackmyagent check ./my-mcp-server/` | MCP config + declared tools + scope + dependencies |
+| An A2A agent card | `hackmyagent check ./my-agent/` | agent-card capabilities + identity |
+| A URL tarball | `hackmyagent check https://ex.com/pkg.tar.gz` | downloads, scans |
+| External infrastructure | `hackmyagent scan example.com` | external AI-endpoint inventory |
+| Governance (SOUL.md) | `hackmyagent scan-soul` | SOUL.md against OASB v2 behavioural controls |
+
+### secure vs check vs red-team vs attack
+
+- `secure`: your own project. Full static + semantic scan, auto-fix option, designed for CI and recurring use.
+- `check`: something you don't own yet. Pre-install trust check for any surface above.
+- `red-team`: adaptive attacks against a specific skill, MCP, or SOUL. You've scanned it; now see if it resists.
+- `attack`: test a live endpoint or local simulation with 164 pre-built adversarial payloads.
 
 ## Commands
 
-### `hackmyagent secure` -- Security Scan
+### `secure` (security scan)
 
 ```bash
 hackmyagent secure                            # scan current directory
-hackmyagent secure --fix                      # auto-fix issues (backups in .hackmyagent-backup/)
-hackmyagent secure --fix --dry-run            # preview fixes before applying
+hackmyagent secure --fix                      # auto-fix issues with rollback
+hackmyagent secure --fix --dry-run            # preview fixes
 hackmyagent secure --deep                     # full behavioural simulation (20 probes)
-hackmyagent secure --static-only              # static checks only (fast, CI mode)
-hackmyagent secure --ignore CRED-001,GIT-002  # skip specific checks
-hackmyagent secure --json                     # JSON output for CI/CD
-hackmyagent secure --publish                  # push anonymised results to OpenA2A Registry
-hackmyagent secure -b oasb-1                  # OASB-1 benchmark (46 controls, L1/L2/L3 levels)
+hackmyagent secure --static-only              # static checks only, faster
+hackmyagent secure --ignore CRED-001,GIT-002  # skip specific check IDs
+hackmyagent secure --json                     # JSON output for CI
+hackmyagent secure --ci                       # non-interactive, exit non-zero on findings
+hackmyagent secure --publish                  # push anonymised results to the OpenA2A Registry
+hackmyagent secure -b oasb-1                  # OASB-1 benchmark (L1, L2, L3)
 hackmyagent secure -b oasb-1 --fail-below 70  # CI gate
+hackmyagent secure --nanomind                 # per-finding AI threat narratives on HIGH or CRITICAL
 ```
 
-Output shows an Observations block (surfaces · checks · categories · verdict) and a per-finding list. Every HIGH / CRITICAL finding has a `file:line` location and a runnable `Fix:` command.
+Output shows an Observations block (surfaces, checks, categories, verdict) and a per-finding list. Every HIGH or CRITICAL finding has a `file:line` location and a runnable `Fix:` command.
 
-### NanoMind Semantic Analysis
+### NanoMind semantic analysis
 
-Runs automatically on every `secure` scan. On first use it downloads a ~5.5 MB ONNX classifier from HuggingFace and caches it locally.
+Runs automatically on every `secure` scan. On first use, HMA downloads a 5.5 MB ONNX classifier from HuggingFace ([`opena2a/nanomind-security-classifier`](https://huggingface.co/opena2a/nanomind-security-classifier), a 3M-parameter Mamba TME model) and caches it locally. No external calls after that.
 
-- **7 AST analysers**: `capability`, `credential`, `governance`, `scope`, `prompt`, `code`, `stego`.
-- **9 attack classes**: exfiltration, injection, privilege_escalation, persistence, credential_abuse, lateral_movement, social_engineering, policy_violation, benign.
-- **Flags**: `--deep` adds 20-probe behavioural simulation; `--static-only` disables the semantic layer; `--nanomind` opts into per-finding AI threat narratives (specialist model -- does not produce scan-wide summaries).
+- 7 AST analyzers: `capability`, `credential`, `governance`, `scope`, `prompt`, `code`, `stego`.
+- 9 attack classes: `exfiltration`, `injection`, `privilege_escalation`, `persistence`, `credential_abuse`, `lateral_movement`, `social_engineering`, `policy_violation`, `benign`.
+- `--deep` adds the 20-probe behavioural simulation.
+- `--static-only` disables the semantic layer.
+- `--nanomind` opts into per-finding AI threat narratives. This is the specialist analyst, not the classifier, and runs only on HIGH or CRITICAL findings.
 
-### `hackmyagent red-team` -- Adaptive Attack Engine
+### `red-team` (adaptive attack engine)
 
 ```bash
 hackmyagent red-team ./my-skill.md             # red-team a skill file
@@ -143,35 +153,36 @@ hackmyagent red-team ./SOUL.md --iterations 10 # more attack iterations
 hackmyagent red-team ./mcp-config.json --json  # JSON output
 ```
 
-Generates target-specific attacks from the artifact's own language and constraints. Iterates up to 5x per category, maps defences, produces specific remediation.
+Generates target-specific attacks from the artifact's own language and constraints. Iterates up to 5 times per category, maps defences, produces specific remediation.
 
-### `hackmyagent attack` -- Red-Team Payload Battery
+### `attack` (payload battery)
 
 ```bash
-hackmyagent attack --local                                              # local simulation
-hackmyagent attack --local --system-prompt "You are helpful"            # with custom system prompt
-hackmyagent attack https://api.example.com/v1/chat                      # test live endpoint
-hackmyagent attack --local --category prompt-injection                  # single category
-hackmyagent attack https://api.example.com --fail-on-vulnerable medium  # CI gate
+hackmyagent attack --local                                             # local simulation
+hackmyagent attack --local --system-prompt "You are helpful"           # with custom system prompt
+hackmyagent attack https://api.example.com/v1/chat                     # test a live endpoint
+hackmyagent attack --local --category prompt-injection                 # single category
+hackmyagent attack https://api.example.com --fail-on-vulnerable medium # CI gate
 ```
 
-164 payloads across 16 categories: `prompt-injection`, `jailbreak`, `data-exfiltration`, `capability-abuse`, `context-manipulation`, `mcp-exploitation`, `a2a-attack`, `memory-weaponization`, `context-window`, `supply-chain`, `tool-shadow`, `parser-differential`, `persistent-agent`, `fake-tool`, `context-lifecycle`, `policy-enforcement-integrity`. Full payload catalogue in [`docs/SECURITY_CHECKS.md`](docs/SECURITY_CHECKS.md).
+164 payloads across 16 categories. Intensity tiers: `passive` (28 payloads, observation only), `active` (111 payloads, default), `aggressive` (164 payloads, includes creative or risky probes).
 
-> Only test systems you own or have written authorisation to test.
+Only test systems you own or have written authorisation to test.
 
-### `hackmyagent scan-soul` / `harden-soul` -- Governance
+### `scan-soul` and `harden-soul` (governance)
 
 ```bash
 hackmyagent scan-soul                     # scan current directory for SOUL.md
 hackmyagent scan-soul --deep              # LLM semantic analysis (requires ANTHROPIC_API_KEY)
 hackmyagent scan-soul --fail-below 60     # CI gate
-hackmyagent harden-soul                   # generate / add missing governance sections
+hackmyagent scan-soul --explain           # print the 9-domain governance model and exit
+hackmyagent harden-soul                   # generate or update governance sections
 hackmyagent harden-soul --dry-run         # preview without writing
 ```
 
-Auto-detects governance file: `SOUL.md` > `system-prompt.md` > `CLAUDE.md` > `.cursorrules` > `agent-config.yaml`.
+Auto-detects governance file in this priority: `SOUL.md`, `system-prompt.md`, `CLAUDE.md`, `.cursorrules`, `agent-config.yaml`.
 
-### `hackmyagent detect` -- Shadow AI Audit
+### `detect` (shadow AI audit)
 
 ```bash
 hackmyagent detect                              # audit current directory
@@ -180,74 +191,34 @@ hackmyagent detect --json                       # machine-readable output
 hackmyagent detect --export-csv inventory.csv   # asset inventory for CMDB
 ```
 
-Inventory of AI tools, MCP servers, and governance gaps across your machine. Detects Claude Code / Cursor / Copilot, MCP configurations (project-local and machine-wide), AI config files with credential references or broad permission grants, and SOUL.md files.
+Inventory of AI tools, MCP servers, and governance gaps across your machine. Detects Claude Code, Cursor, Copilot, and similar tools; MCP configurations (project-local and machine-wide); AI config files with credential references or broad permission grants; and SOUL.md files.
 
-### `hackmyagent trust` / `explain` / `nanomind`
+### `trust`, `explain`, `nanomind`
 
 ```bash
-hackmyagent trust server-filesystem      # MCP shorthand trust lookup (Registry)
-hackmyagent trust --audit package.json   # audit all dependencies
+hackmyagent trust server-filesystem      # MCP shorthand trust lookup against the Registry
+hackmyagent trust --audit package.json   # audit every dependency
 hackmyagent explain CRED-001             # explain a check finding
-hackmyagent nanomind setup               # download optional generative model
-hackmyagent nanomind status              # check model + runtime status
+hackmyagent nanomind setup               # download the optional generative model
+hackmyagent nanomind status              # check model and runtime status
 ```
 
-### OpenClaw / NemoClaw Auto-detection
+### OpenClaw and NemoClaw auto-detection
 
-`hackmyagent secure` auto-detects OpenClaw / NemoClaw installations (`.openclaw/`, `.moltbot/`, `.nemoclaw/`, `openclaw.json`, `openclaw.plugin.json`). When detected, 28 NemoClaw + 34 OpenClaw checks run alongside the standard 209. No separate command needed.
-
-### Use-case walkthroughs
-
-- [Scan my agent](docs/use-cases/scan-my-agent.md) -- 209 checks + auto-fix (5 min)
-- [Red-team MCP servers](docs/use-cases/red-team-mcp.md) -- adversarial payloads (10 min)
-- [Secure OpenClaw](docs/use-cases/openclaw-security.md) -- CVE detection + ClawHavoc IOCs (10 min)
-- [CI/CD pipeline](docs/use-cases/ci-pipeline.md) -- GitHub Actions with JSON / SARIF (5 min)
-
-### Built-in help
-
-```bash
-hackmyagent --help          # All commands and flags
-hackmyagent --version       # Current version
-hackmyagent <command> -h    # Help for a specific command
-hackmyagent secure --ci     # Non-interactive mode for CI/CD
-```
-
-<details>
-<summary>Auto-fix catalogue</summary>
-
-| Check | Issue | Auto-fix |
-|-------|-------|----------|
-| CRED-001 | Exposed API keys | Replace with env var reference |
-| GIT-001 | Missing .gitignore | Create with secure defaults |
-| GIT-002 | Incomplete .gitignore | Add missing patterns |
-| PERM-001 | Overly permissive files | Set restrictive permissions |
-| MCP-001 | Root filesystem access | Scope to project directory |
-| NET-001 | Bound to 0.0.0.0 | Bind to 127.0.0.1 |
-| GATEWAY-001 | Gateway bound to 0.0.0.0 | Bind to 127.0.0.1 |
-| GATEWAY-003 | Plaintext token | Replace with `${OPENCLAW_AUTH_TOKEN}` |
-| GATEWAY-004 | Approvals disabled | Enable approvals |
-| GATEWAY-005 | Sandbox disabled | Enable sandbox |
-
-Use `--dry-run` to preview changes. Backups in `.hackmyagent-backup/`.
-
-</details>
-
----
+`hackmyagent secure` auto-detects OpenClaw and NemoClaw installations (`.openclaw/`, `.moltbot/`, `.nemoclaw/`, `openclaw.json`, `openclaw.plugin.json`). When detected, 28 NemoClaw plus 34 OpenClaw checks run alongside the standard suite. No separate command needed.
 
 ## Using with opena2a-cli
 
-[`opena2a-cli`](https://github.com/opena2a-org/opena2a) is the unified CLI for all OpenA2A security tools. HackMyAgent powers `opena2a review`, `opena2a scan`, `opena2a protect`, `opena2a benchmark`, and `opena2a scan-soul`.
+[`opena2a-cli`](https://github.com/opena2a-org/opena2a) is the unified CLI for the OpenA2A security tools. HackMyAgent powers `opena2a review`, `opena2a scan`, `opena2a protect`, `opena2a benchmark`, and `opena2a scan-soul`.
 
 ```bash
 npm install -g opena2a-cli
-opena2a review    # best place to start
+opena2a review
 ```
 
----
+## Runtime protection (ARP)
 
-## Runtime Protection (ARP)
-
-ARP monitors AI agents during execution with a 3-layer intelligence stack: rule-based pattern matching (40+ patterns), statistical anomaly detection, and LLM-assisted assessment.
+ARP monitors AI agents during execution with three intelligence layers: rule-based pattern matching (40+ patterns), statistical anomaly detection, and LLM-assisted assessment.
 
 ```bash
 opena2a runtime init     # generate config
@@ -255,11 +226,9 @@ opena2a runtime start    # start monitoring
 opena2a runtime status   # check status
 ```
 
-Also supports HTTP reverse-proxy mode for inspecting OpenAI API, MCP, and A2A protocol traffic. See `npx hackmyagent arp-guard proxy --help`.
+ARP also runs as an HTTP reverse proxy for inspecting OpenAI API, MCP, and A2A protocol traffic. Configure via `opena2a runtime`.
 
----
-
-## CI/CD Integration
+## CI/CD integration
 
 All commands support `--json` and `--ci` flags.
 
@@ -280,7 +249,7 @@ jobs:
 <details>
 <summary>SARIF output and pre-commit hook</summary>
 
-**SARIF (GitHub Security Tab)**
+SARIF for the GitHub Security tab:
 
 ```yaml
 - run: npx hackmyagent attack --local -f sarif -o results.sarif --fail-on-vulnerable medium
@@ -288,7 +257,7 @@ jobs:
   with: { sarif_file: results.sarif }
 ```
 
-**Pre-commit Hook**
+Pre-commit hook:
 
 ```bash
 #!/bin/sh
@@ -298,25 +267,42 @@ npx hackmyagent secure --ignore LOG-001,RATE-001
 
 </details>
 
----
-
-## Exit Codes
+## Exit codes
 
 | Code | Meaning |
-|------|---------|
-| `0` | Clean -- no critical / high issues |
-| `1` | Critical or high severity issues found |
-| `2` | Incomplete scan -- one or more plugins failed |
-| `3` | QUARANTINE -- binary integrity check failed (tampered installation) |
+|---|---|
+| 0 | Clean. No critical or high issues. |
+| 1 | Critical or high severity issues found. |
+| 2 | Incomplete scan. One or more plugins failed. |
+| 3 | QUARANTINE. Binary integrity check failed (tampered installation). |
 
----
+## Auto-fix catalogue
+
+<details>
+<summary>Checks fixable with <code>--fix</code></summary>
+
+| Check | Issue | Auto-fix |
+|---|---|---|
+| CRED-001 | Exposed API keys | Replace with env-var reference |
+| GIT-001 | Missing .gitignore | Create with secure defaults |
+| GIT-002 | Incomplete .gitignore | Add missing patterns |
+| PERM-001 | Overly permissive files | Set restrictive permissions |
+| MCP-001 | Root filesystem access | Scope to project directory |
+| NET-001 | Bound to 0.0.0.0 | Bind to 127.0.0.1 |
+| GATEWAY-001 | Gateway bound to 0.0.0.0 | Bind to 127.0.0.1 |
+| GATEWAY-003 | Plaintext token | Replace with `${OPENCLAW_AUTH_TOKEN}` |
+| GATEWAY-004 | Approvals disabled | Enable approvals |
+| GATEWAY-005 | Sandbox disabled | Enable sandbox |
+
+Use `--dry-run` to preview changes. Backups live in `.hackmyagent-backup/`. Rollback with `hackmyagent rollback`.
+
+</details>
 
 ## Programmatic API
 
 ```typescript
 import { HardeningScanner, AgentRuntimeProtection, AttackScanner } from 'hackmyagent';
 
-// NanoMind Semantic Compiler -- compile artifacts into Abstract Security Trees
 import {
   SemanticCompiler,
   analyzeCapabilities,
@@ -335,21 +321,41 @@ const { ast } = await compiler.compile(skillContent, 'my-skill.skill.md');
 const findings = analyzeCapabilities(ast);
 ```
 
-See [Plugin API documentation](docs/PLUGIN_API.md) for writing custom security plugins.
+Plugin authoring: [`docs/PLUGIN_API.md`](docs/PLUGIN_API.md).
 
----
+## Use cases
+
+| Guide | Time |
+|---|---|
+| [Scan my agent](docs/use-cases/scan-my-agent.md) | 5 min |
+| [Red-team MCP servers](docs/use-cases/red-team-mcp.md) | 10 min |
+| [Secure OpenClaw](docs/use-cases/openclaw-security.md) | 10 min |
+| [CI/CD pipeline](docs/use-cases/ci-pipeline.md) | 5 min |
+
+Full index: [`docs/USE-CASES.md`](docs/USE-CASES.md).
 
 ## Contributing
 
-Contributions welcome. See [CONTRIBUTING.md](CONTRIBUTING.md).
+Apache 2.0. PRs from outside the org welcome. [CONTRIBUTING.md](CONTRIBUTING.md) has the dev loop, test conventions, and pre-push review gates.
 
 ```bash
 git clone https://github.com/opena2a-org/hackmyagent.git
 cd hackmyagent && npm install && npm run build && npm test
 ```
 
+Security issues: `security@opena2a.org` (coordinated disclosure, response within 24 hours).
+
+## Links
+
+- [Website](https://hackmyagent.com)
+- [Security Checks Reference](docs/SECURITY_CHECKS.md)
+- [OpenA2A CLI](https://github.com/opena2a-org/opena2a)
+- [Demos](https://opena2a.org/demos)
+- [Documentation](https://opena2a.org/docs)
+- [Research](https://research.opena2a.org)
+
+Part of the [OpenA2A](https://opena2a.org) security platform.
+
 ## License
 
-Apache-2.0
-
-HackMyAgent is part of the [OpenA2A](https://opena2a.org) security platform. See all tools: [opena2a.org](https://opena2a.org)
+Apache-2.0. See [LICENSE](LICENSE).


### PR DESCRIPTION
## Summary

Reworks `README.md` to match the OpenA2A reference template (the AIM
README, merged via PR #124 over in `agent-identity-management`). Same
content, restructured so a new reader can move from "what is this" to
"how do I install it" to "how do I use it" in the same shape as every
other OpenA2A repo.

### What changed

- Title above the breadcrumb (was below).
- One-sentence product description directly under the title + Apache 2.0.
- Website / Demos / Discord links row.
- Quick start surfaces a single command, a realistic sample output, and the demo gif.
- Install paths split into npm, Homebrew, From source as their own H3.
- New "Verifying what was installed" section pointing to the SLSA v1 attestation lookup (`npm view hackmyagent dist.attestations --json`).
- "What it finds" tightened around the canonical breakdown: 209 static, 29 NanoMind semantic, 164 adversarial.
- Auto-fix table moved into a collapsed `<details>` block.
- Use cases pulled into a single table.
- Dead-end reference to `npx hackmyagent arp-guard proxy --help` removed (it was a Phase 7c violation: not a registered Commander subcommand).

### Hard constraints

- No em dashes anywhere in the new text.
- No marketing slogans (no "your call", "the local-first promise", no "you'll see…" hand-holding).
- camelCase JSON, no emojis.
- Every command and flag cited in the new README parses against the current `dist/cli.js`.

### Out of scope

- No code changes. README only.
- Stats unchanged (canonical 209 / 29 / 164). No website sweep required.

## Test plan

- [x] `grep -P "—" README.md` returns nothing (no em dashes)
- [x] Every `hackmyagent <command> --help` cited in the README parses
- [x] Self-scan (`secure --ci --static-only`) still 98/100 with no regression
- [x] Build clean, suite back to 2071 passing after `npm run build` refreshes the integrity manifest
- [x] Sensitive-file scan clean