### PR TITLE
fix(cli): clean up scan workspace on every exit path

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -8769,7 +8769,14 @@ async function checkGitHubRepo(
       }
     }
 
-    if (critical.length > 0 || high.length > 0) process.exit(1);
+    if (critical.length > 0 || high.length > 0) {
+      // Set exit code and return so the `finally` block can clean up tempDir.
+      // process.exit() is synchronous and terminates immediately, leaving
+      // /tmp/hma-check-gh-* directories orphaned and eventually ENOSPC'ing
+      // the scanner container. See `finally { await rm(tempDir, ...) }` below.
+      process.exitCode = 1;
+      return;
+    }
   } catch (err: unknown) {
     const message = err instanceof Error ? err.message : String(err);
     if (message.includes('128') || message.includes('not found') || message.includes('Repository not found')) {
@@ -8796,7 +8803,7 @@ async function checkGitHubRepo(
     } else {
       console.error(`Error: ${message}`);
     }
-    process.exit(1);
+    process.exitCode = 1;
   } finally {
     await rm(tempDir, { recursive: true, force: true });
   }
@@ -8874,7 +8881,11 @@ async function checkPyPiPackage(
       } else {
         console.error(`Error: PyPI API returned ${metaRes.status} for "${name}".`);
       }
-      process.exit(1);
+      // Set exit code and return so `finally` can clean up tempDir (was already
+      // allocated above). process.exit() would skip the cleanup and orphan the
+      // /tmp/hma-check-pypi-* directory.
+      process.exitCode = 1;
+      return;
     }
 
     const meta = await metaRes.json() as {
@@ -8889,7 +8900,8 @@ async function checkPyPiPackage(
 
     if (!dist) {
       console.error(`Error: No downloadable distribution found for "${name}" on PyPI.`);
-      process.exit(1);
+      process.exitCode = 1;
+      return;
     }
 
     // Download the archive
@@ -8983,7 +8995,10 @@ async function checkPyPiPackage(
       artifactSummaries,
     });
 
-    if (critical.length > 0 || high.length > 0) process.exit(1);
+    if (critical.length > 0 || high.length > 0) {
+      process.exitCode = 1;
+      return;
+    }
   } catch (err: unknown) {
     const message = err instanceof Error ? err.message : String(err);
     if (message.includes('not found on PyPI')) {
@@ -8991,7 +9006,7 @@ async function checkPyPiPackage(
     } else {
       console.error(`Error scanning PyPI package "${name}": ${message}`);
     }
-    process.exit(1);
+    process.exitCode = 1;
   } finally {
     await rm(tempDir, { recursive: true, force: true });
   }
@@ -9043,7 +9058,11 @@ async function checkRawUrl(
       const headRes = await fetch(url, { method: 'HEAD', redirect: 'follow' });
       if (!headRes.ok) {
         console.error(`Error: HTTP ${headRes.status} fetching "${url}".`);
-        process.exit(1);
+        // Set exit code and return so `finally` can clean up tempDir (was
+        // already allocated above). process.exit() would skip the cleanup
+        // and orphan the /tmp/hma-check-url-* directory.
+        process.exitCode = 1;
+        return;
       }
 
       const contentType = headRes.headers.get('content-type') || '';
@@ -9059,7 +9078,8 @@ async function checkRawUrl(
       const bodyRes = await fetch(finalUrl, { redirect: 'follow' });
       if (!bodyRes.ok || !bodyRes.body) {
         console.error(`Error: Failed to download "${url}" (HTTP ${bodyRes.status}).`);
-        process.exit(1);
+        process.exitCode = 1;
+        return;
       }
       const buffer = Buffer.from(await bodyRes.arrayBuffer());
 
@@ -9177,7 +9197,10 @@ async function checkRawUrl(
       }
     }
 
-    if (critical.length > 0 || high.length > 0) process.exit(1);
+    if (critical.length > 0 || high.length > 0) {
+      process.exitCode = 1;
+      return;
+    }
   } catch (err: unknown) {
     const message = err instanceof Error ? err.message : String(err);
     if (message.includes('128') || message.includes('not found') || message.includes('Repository not found')) {
@@ -9190,7 +9213,7 @@ async function checkRawUrl(
     } else {
       console.error(`Error scanning URL: ${message}`);
     }
-    process.exit(1);
+    process.exitCode = 1;
   } finally {
     await rm(tempDir, { recursive: true, force: true });
   }
@@ -9369,7 +9392,10 @@ async function checkNpmPackage(
       }
     }
 
-    if (critical.length > 0 || high.length > 0) process.exit(1);
+    if (critical.length > 0 || high.length > 0) {
+      process.exitCode = 1;
+      return;
+    }
   } catch (err: unknown) {
     const message = err instanceof Error ? err.message : String(err);
     // Clean npm error messages
@@ -9404,11 +9430,40 @@ async function checkNpmPackage(
         console.error(`Error: ${message}`);
       }
     }
-    process.exit(1);
+    process.exitCode = 1;
   } finally {
     await rm(tempDir, { recursive: true, force: true });
   }
 }
+
+// Defense-in-depth: best-effort cleanup of stale scan workspaces from prior
+// CLI invocations that crashed or were SIGKILL'd before their `finally` could
+// run. The process.exit() leak that wedged the scanner container in May 2026
+// (ENOSPC on /tmp/hma-check-*) is fixed upstream in this commit, but a
+// fire-and-forget sweep on startup protects against future regressions or
+// non-graceful exits we can't intercept (OOM, SIGKILL, host eviction).
+//
+// Never blocks, never throws. Runs concurrently with the integrity check below.
+(async () => {
+  try {
+    const { readdir, rm, stat } = await import('node:fs/promises');
+    const { tmpdir } = await import('node:os');
+    const { join } = await import('node:path');
+    const root = tmpdir();
+    const cutoffMs = Date.now() - 24 * 60 * 60 * 1000; // 24h
+    const entries = await readdir(root);
+    for (const entry of entries) {
+      if (!entry.startsWith('hma-check-') && !entry.startsWith('arp-lab-')) continue;
+      const full = join(root, entry);
+      try {
+        const s = await stat(full);
+        if (s.mtimeMs < cutoffMs) {
+          await rm(full, { recursive: true, force: true });
+        }
+      } catch { /* swallow per-entry errors */ }
+    }
+  } catch { /* swallow root errors — cleanup is best-effort */ }
+})().catch(() => { /* never propagates */ });
 
 // Self-securing: verify own integrity before running any command
 // A security tool that doesn't verify itself is worse than no security tool


### PR DESCRIPTION
## Summary

- The four `check*` functions (`checkGithubRepo` / `checkPyPiPackage` / `checkRawUrl` / `checkNpmPackage`) allocate `/tmp/hma-check-*` workspaces via `mkdtemp` and rely on `try/finally { await rm(tempDir, ...) }` for cleanup. Twelve `process.exit(1)` calls inside `try` and `catch` blocks were terminating the Node process synchronously and skipping the `finally`. Every scan with critical/high findings AND every error path orphaned its workspace.
- Production impact (`ca-scanner-prod`, May 2026): **214,106** `ENOSPC: no space left on device, mkdir '/tmp/scan-*'` failures in 14 days. The container's ephemeral `/tmp` filled within days; scans wedged at workspace creation. Each ENOSPC also wrote two rows to `registry_scan_requests` (`scanning` → `failed`), amplifying the Supabase DiskIO + CPU pressure on aim-registry.
- Fix: replace `process.exit(1)` with `process.exitCode = 1` (plus explicit `return` inside `try` blocks). Node exits with the set code after the stack unwinds — the `finally` runs and `rm(tempDir, ...)` actually executes.
- Defense in depth: added a startup IIFE that sweeps `/tmp/hma-check-*` and `/tmp/arp-lab-*` older than 24h, fire-and-forget, swallowing all errors. Catches future regressions, `SIGKILL` / OOM scenarios where `finally` can't run, and any host-eviction edge cases.

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npm test` — 2,115 pass, 1 file skipped (expected)
- [x] `npm run build` clean
- [x] `node dist/cli.js secure --ci` self-scan: 98/100, 0 CRITICAL/HIGH/MEDIUM, 1 LOW (pre-existing on `CLAUDE.md` size)
- [x] `node dist/cli.js check pip:requests --ci` happy path: scan completes, exit 0, **0 leftover `/tmp/hma-check-*` directories** after scan
- [x] `/pre-push-review` 8-phase gate: PASS
- [ ] After merge: confirm `ca-scanner-prod` no longer accumulates `/tmp/hma-check-*` entries over 24h (operator check)
- [ ] After merge: confirm `scan submission failed` rate on `ca-registry-backend-prod` drops once `AUTO_QUEUE_ENABLED=true` is restored (separate ticket — registry pipeline is currently paused pending risk-tiered cadence redesign)

## Context

This is one of two root causes identified in the 2026-05-14 Supabase resource-exhaustion investigation (`opena2a-org/todo/2026-05-14-supabase-registry-resource-exhaustion.md`). The other (auto-queue saturation retry loop in `opena2a-registry`) is paused via `AUTO_QUEUE_ENABLED=false` + GHA curation cron disable while the tier-cadence redesign is in progress.