### PR TITLE
fix(cli): route uppercase bare names to npm not-found JSON (#161)

### DIFF
--- a/__tests__/checker/check-not-found-json.test.ts
+++ b/__tests__/checker/check-not-found-json.test.ts
@@ -134,6 +134,19 @@ describe('check --json not-found wired through dist/cli.js (smoke, local-only)',
     expect(parsed.errorHint).toBe(`Verify the URL: https://www.npmjs.com/package/${bareName}`);
   });
 
+  it.runIf(canRunSpawn())('#161: uppercase bare-name miss renders errorHint in plain (non-JSON) output', () => {
+    const bareName = 'NONEXISTENT-XYZ-9999';
+    const res = spawnSync('node', [CLI, 'check', bareName, '--no-scan', '--ci'], {
+      encoding: 'utf8',
+      timeout: 30_000,
+    });
+
+    expect(res.status).toBe(1);
+    const stderr = res.stderr || '';
+    expect(stderr).not.toContain('Invalid skill identifier');
+    expect(stderr).toContain(`Verify the URL: https://www.npmjs.com/package/${bareName}`);
+  });
+
   it.runIf(canRunSpawn())('F4: git-style miss populates errorHint in JSON output', () => {
     const target = 'anthropic/code-review';
     const res = spawnSync('node', [CLI, 'check', target, '--no-scan', '--json', '--ci'], {

--- a/__tests__/checker/check-not-found-json.test.ts
+++ b/__tests__/checker/check-not-found-json.test.ts
@@ -115,6 +115,25 @@ describe('check --json not-found wired through dist/cli.js (smoke, local-only)',
     expect(parsed.error.length).toBeGreaterThan(0);
   });
 
+  it.runIf(canRunSpawn())('#161: uppercase bare-name miss routes to npm (not skill-id parser) and emits valid JSON', () => {
+    const bareName = 'NONEXISTENT-XYZ-9999';
+    const res = spawnSync('node', [CLI, 'check', bareName, '--no-scan', '--json', '--ci'], {
+      encoding: 'utf8',
+      timeout: 30_000,
+    });
+
+    expect(res.status).toBe(1);
+    const stdout = (res.stdout || '').trim();
+    expect(stdout.length).toBeGreaterThan(0);
+    expect(res.stderr || '').not.toContain('Invalid skill identifier');
+
+    const parsed = JSON.parse(stdout);
+    expect(parsed.name).toBe(bareName);
+    expect(parsed.found).toBe(false);
+    expect(parsed.ecosystem).toBe('npm');
+    expect(parsed.errorHint).toBe(`Verify the URL: https://www.npmjs.com/package/${bareName}`);
+  });
+
   it.runIf(canRunSpawn())('F4: git-style miss populates errorHint in JSON output', () => {
     const target = 'anthropic/code-review';
     const res = spawnSync('node', [CLI, 'check', target, '--no-scan', '--json', '--ci'], {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -451,14 +451,16 @@ Examples:
           if (npmErr instanceof Error && npmErr.name === 'NpmNotFoundError') {
             const isScoped = skill.startsWith('@');
             if (!isScoped) {
+              const errorHint = `Verify the URL: https://www.npmjs.com/package/${skill}`;
               if (options.json) {
                 writeJsonStdout(buildNotFoundOutput({
                   name: skill,
                   ecosystem: 'npm',
                   error: `Package "${skill}" not found on npm.`,
+                  errorHint,
                 }));
               } else {
-                printNotFoundBlock({ pkg: skill, ecosystem: 'npm' });
+                printNotFoundBlock({ pkg: skill, ecosystem: 'npm', errorHint });
               }
               process.exit(1);
             }
@@ -7943,9 +7945,13 @@ function looksLikeNpmPackage(target: string): boolean {
   if (/^\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}$/.test(target)) return false;
   // Hostnames have dots (example.com, sub.domain.org)
   if (target.includes('.')) return false;
-  // What's left: bare names like express, lodash, hackmyagent
-  // npm names are lowercase, may contain hyphens and digits
-  return /^[a-z0-9][a-z0-9._-]*$/.test(target);
+  // What's left: bare names like express, lodash, hackmyagent.
+  // npm publishing requires lowercase, but accept uppercase here too —
+  // npm itself returns 404 for non-existent uppercase names, which we
+  // catch as NpmNotFoundError below and surface as the canonical
+  // NotFoundOutput JSON shape (closes #161). Rejecting uppercase here
+  // would fall through to the skill-id parser's dead-end error.
+  return /^[a-z0-9][a-z0-9._-]*$/i.test(target);
 }
 
 /**


### PR DESCRIPTION
## Summary

- Broaden `looksLikeNpmPackage` regex to accept uppercase. Previously, names like `NONEXISTENT-XYZ-9999` failed the lowercase-only regex and fell through to the skill-id parser dead-end, breaking the `--json` contract.
- Thread `errorHint: "Verify the URL: https://www.npmjs.com/package/<name>"` through both the JSON `buildNotFoundOutput` and the plain `printNotFoundBlock` for the bare-name 404 fall-through, matching the github-404 path's UX.
- Two spawned regression tests (JSON shape + plain stderr) cover the uppercase bare-name case.

Closes #161.

## What changed

| Before | After |
|---|---|
| `check NONEXISTENT-XYZ-9999` → stderr "Invalid skill identifier" | `check NONEXISTENT-XYZ-9999` → "Package not found: ... (npm)" + verify URL |
| `check NONEXISTENT-XYZ-9999 --json` → plain stderr error (jq parse error) | `check NONEXISTENT-XYZ-9999 --json` → valid `NotFoundOutput` JSON, exit 1 |

## Test plan

- [x] `npm test` — 2116/2116 tests pass.
- [x] Manual: `node dist/cli.js check NONEXISTENT-XYZ-9999 --no-scan --json --ci` emits canonical JSON, exit 1.
- [x] Manual: `node dist/cli.js check NONEXISTENT-XYZ-9999 --no-scan --ci` emits clean plain-text not-found block with hint URL.
- [x] Manual: `node dist/cli.js check left-pad --no-scan --ci` (lowercase happy path) — no regression.
- [x] Phase 4.5 adversarial subagent: no CRITICAL/HIGH; one MEDIUM test-depth gap fixed in 707f51f.