### PR TITLE
fix(deps): bump fast-uri 3.1.0 -> 3.1.2 (closes 2 HIGH dependabot alerts)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "hackmyagent",
-  "version": "0.22.2",
+  "version": "0.23.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "hackmyagent",
-      "version": "0.22.2",
+      "version": "0.23.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.12.1",
@@ -1815,9 +1815,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
-      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
+      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
       "funding": [
         {
           "type": "github",


### PR DESCRIPTION
## Summary

- Bump fast-uri transitive 3.1.0 → 3.1.2 via targeted `npm update fast-uri`.
- Resolves both HIGH dependabot alerts on `main`:
  - GHSA-v39h-62p7-jpjc / CVE-2026-6322 — host confusion via percent-encoded authority delimiters
  - GHSA-q3j6-qgpj-74h6 / CVE-2026-6321 — path traversal via percent-encoded dot segments
- Path: `@modelcontextprotocol/sdk@1.29.0 → ajv@8.20.0 → fast-uri`. No direct dep ranges changed.
- Side effect: lockfile's metadata `version` field was stale at 0.22.2; npm resynced to 0.23.0 (matches `package.json`).

## Test plan

- [x] `npm test` — 2117/2117 pass
- [x] `npm run build` clean
- [x] `npm ls fast-uri` confirms 3.1.2 in the tree
- [x] Lockfile diff is 10 lines, contained to fast-uri entry + metadata version