### PR TITLE
fix(deps): bump hono + override ip-address (closes remaining 6 dependabot alerts)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2067,9 +2067,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.12.15",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.15.tgz",
-      "integrity": "sha512-qM0jDhFEaCBb4TxoW7f53Qrpv9RBiayUHo0S52JudprkhvpjIrGoU1mnnr29Fvd1U335ZFPZQY1wlkqgfGXyLg==",
+      "version": "4.12.21",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.21.tgz",
+      "integrity": "sha512-uV63apnb0kyPtAUwoWgaGh9HyIFcv8lgmzPZSiTBQAFOFGIzka5EZ1dZocmGnn0XdX0+XTqJ6Tqv7selMuGLRQ==",
       "license": "MIT",
       "engines": {
         "node": ">=16.9.0"
@@ -2118,9 +2118,9 @@
       "license": "ISC"
     },
     "node_modules/ip-address": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.1.0.tgz",
-      "integrity": "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==",
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
+      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
       "license": "MIT",
       "engines": {
         "node": ">= 12"

--- a/package.json
+++ b/package.json
@@ -59,6 +59,9 @@
     "typescript": "^5.3.3",
     "vitest": "^3.0.0"
   },
+  "overrides": {
+    "ip-address": "^10.1.1"
+  },
   "keywords": [
     "ai",
     "agent",


### PR DESCRIPTION
## Summary

Bundle the remaining 6 open dependabot alerts on `main` (5 medium + 1 low):

- `hono` 4.12.15 → 4.12.21 (transitive via `@modelcontextprotocol/sdk`) — closes 5 alerts.
- `ip-address` override `^10.1.1` (lands 10.2.0) — closes 1 alert. Required because `express-rate-limit@8.4.1` exact-pins `ip-address@10.1.0` as a transitive; the npm `overrides` entry is narrower than forcing a parent-SDK bump. The latest upstream `express-rate-limit@8.5.2` already requires `ip-address ^10.2.0`, so this aligns with where upstream is heading.

## Alerts resolved

| # | Severity | Package | GHSA |
|---|---|---|---|
| 33 | medium | hono | CSS declaration injection via JSX style object values |
| 32 | low | hono | Improper NumericDate validation in JWT verify() |
| 31 | medium | hono | Cache middleware ignores Vary: Authorization / Vary: Cookie |
| 29 | medium | hono | bodyLimit() bypass for chunked / unknown-length requests |
| 28 | medium | hono | Unvalidated JSX tag names allowing HTML injection |
| 27 | medium | ip-address | XSS in Address6 HTML-emitting methods |

## Test plan

- [x] `npm audit` → 0 vulnerabilities
- [x] `npm test` → 2117/2117 pass
- [x] `npm run build` clean
- [x] `npm ls hono` → 4.12.21 deduped
- [x] `npm ls ip-address` → 10.2.0 (override applied)
- [x] Lockfile diff is surgical: only hono + ip-address resolutions changed