### PR TITLE
chore(telemetry): migrate to @opena2a/telemetry 0.2.0 successFromExitCode helper

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
         "@opena2a/credential-patterns": "0.1.1",
         "@opena2a/registry-client": "0.1.0",
         "@opena2a/shared": "^0.1.0",
-        "@opena2a/telemetry": "0.1.2",
+        "@opena2a/telemetry": "0.2.0",
         "ai-trust": "^0.2.6",
         "commander": "^12.0.0",
         "js-yaml": "^4.1.1",
@@ -647,9 +647,9 @@
       }
     },
     "node_modules/@opena2a/telemetry": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/@opena2a/telemetry/-/telemetry-0.1.2.tgz",
-      "integrity": "sha512-lMbNtwDfrXvrPWyEMXBY3ttU/RXWhQ2/xzSfCaosVvujFbqxtWuyq8YY725IEpQ9owa7uJ+PCp4mkxZ8UKW3wA==",
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@opena2a/telemetry/-/telemetry-0.2.0.tgz",
+      "integrity": "sha512-Du55/lKlEAaz0bZNmvPcnksnExzevUom8+Had0vGkCqHND9Umrab2jcObPQcPDxHjG278dEf7Afd6aWkI4BCqA==",
       "license": "Apache-2.0",
       "engines": {
         "node": ">=18.0.0"

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "@opena2a/credential-patterns": "0.1.1",
     "@opena2a/registry-client": "0.1.0",
     "@opena2a/shared": "^0.1.0",
-    "@opena2a/telemetry": "0.1.2",
+    "@opena2a/telemetry": "0.2.0",
     "ai-trust": "^0.2.6",
     "commander": "^12.0.0",
     "js-yaml": "^4.1.1",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -9556,7 +9556,7 @@ async function checkNpmPackage(
         // Exit 1 = findings detected (security-tool convention — see
         // line ~3535 where critHigh.length > 0 sets exitCode=1). The
         // command did its job. Only exit >=2 is a real crash.
-        success: ((process.exitCode ?? 0) as number) <= 1,
+        success: tele.successFromExitCode(process.exitCode),
         durationMs: Date.now() - startedAt,
       });
     });


### PR DESCRIPTION
## Summary

Replaces the inline `((process.exitCode ?? 0) as number) <= 1` cast at `src/cli.ts:9559` with the centralized `tele.successFromExitCode(process.exitCode)` helper shipped in `@opena2a/telemetry@0.2.0`.

PR #174 landed the original exit-1-as-success fix; this PR adopts the helper here so the subsequent SDK upgrade (0.3.0 ships `semanticSuccessCodes`) plugs in cleanly without re-touching the inline cast.

Pin bumps `@opena2a/telemetry` from `0.1.2` to `0.2.0` (exact pin per org convention).

## Diff

- `package.json`: 1 line (pin)
- `src/cli.ts`: 1 line (inline cast -> helper)
- `package-lock.json`: 8 lines (regenerated by `npm install`)

## Verification

- `npm install` clean
- `npm run build` (tsc + integrity-manifest gen) clean
- `npm test`: 2117 pass / 16 skipped / 10 todo (167 files)

## Stacked

A follow-up PR (`chore/telemetry-0.3.0-integrity-error`, commit `056f4cb`) bumps to 0.3.0 and migrates the binary integrity-failure path at `src/cli.ts:9494` to `tele.error('startup', 'INTEGRITY_FAIL')` per [CHIEF-CSR-018]. Lands after this merges.