### PR TITLE
feat(telemetry): fire INTEGRITY_FAIL telemetry event per [CHIEF-CSR-018] + [CHIEF-CPO-022] (0.23.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,19 @@ All notable changes to HackMyAgent are documented in this file.
 
 ## [Unreleased]
 
+## [0.23.1] - 2026-05-24
+
+### Changed
+- **Integrity-failure path now fires `tele.error('startup', 'INTEGRITY_FAIL')` before exit-3.** Per [CHIEF-CSR-018] + [CHIEF-CPO-022] (`briefs/cli-telemetry-success-semantics.md`), supply-chain integrity violations are a distinct dashboard event class — not a generic command failure — and warrant per-event paging (threshold = 1). Telemetry initialization moved to before the integrity check at `src/cli.ts:9476` so the error event can fire during the QUARANTINE branch; `tele.flush()` is called explicitly because `process.exit()` does not trigger Node's beforeExit drain. The duplicate `const tele = await import('@opena2a/telemetry')` later in the file is removed. No change to user-facing behavior: exit code is still 3, stderr message unchanged, telemetry remains opt-out via `OPENA2A_TELEMETRY=off`.
+
+- **Main-dispatcher `successFromExitCode` call left at the single-argument form.** Per [CHIEF-CSR-018]'s per-tool mapping, HMA does NOT pass `semanticSuccessCodes`. Exit 2 in HMA represents partial/incomplete scan or plugin errors — both genuinely degraded outcomes that the dashboard should surface as failure. Only ai-trust receives `[2]`; HMA stays POSIX-strict.
+
+### Pinned
+- `@opena2a/telemetry` bumped from `0.2.0` to `0.3.0` (exact). 0.3.0 is API-additive — HMA does not consume the new optional argument but pins ahead so the fleet stays on a single SDK major across release windows.
+
+### Brief
+- opena2a-org/briefs/cli-telemetry-success-semantics.md
+
 ## [0.23.0] - 2026-05-11
 
 ### Changed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "hackmyagent",
-  "version": "0.23.0",
+  "version": "0.23.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "hackmyagent",
-      "version": "0.23.0",
+      "version": "0.23.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.12.1",
@@ -19,7 +19,7 @@
         "@opena2a/credential-patterns": "0.1.1",
         "@opena2a/registry-client": "0.1.0",
         "@opena2a/shared": "^0.1.0",
-        "@opena2a/telemetry": "0.2.0",
+        "@opena2a/telemetry": "0.3.0",
         "ai-trust": "^0.2.6",
         "commander": "^12.0.0",
         "js-yaml": "^4.1.1",
@@ -647,9 +647,9 @@
       }
     },
     "node_modules/@opena2a/telemetry": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/@opena2a/telemetry/-/telemetry-0.2.0.tgz",
-      "integrity": "sha512-Du55/lKlEAaz0bZNmvPcnksnExzevUom8+Had0vGkCqHND9Umrab2jcObPQcPDxHjG278dEf7Afd6aWkI4BCqA==",
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@opena2a/telemetry/-/telemetry-0.3.0.tgz",
+      "integrity": "sha512-gp3sVuPv5IJQVQWM9VgEYImHOYHnzAyMeAt9RMevY9NaYkSnq4KYnSsWPRizBAPsR0yGIGPyMdv+hh/k/LlUCg==",
       "license": "Apache-2.0",
       "engines": {
         "node": ">=18.0.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hackmyagent",
-  "version": "0.23.0",
+  "version": "0.23.1",
   "description": "Find it. Break it. Fix it. The hacker's toolkit for AI agents.",
   "bin": {
     "hackmyagent": "dist/cli.js"
@@ -46,7 +46,7 @@
     "@opena2a/credential-patterns": "0.1.1",
     "@opena2a/registry-client": "0.1.0",
     "@opena2a/shared": "^0.1.0",
-    "@opena2a/telemetry": "0.2.0",
+    "@opena2a/telemetry": "0.3.0",
     "ai-trust": "^0.2.6",
     "commander": "^12.0.0",
     "js-yaml": "^4.1.1",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -9474,6 +9474,15 @@ async function checkNpmPackage(
 // Self-securing: verify own integrity before running any command
 // A security tool that doesn't verify itself is worse than no security tool
 (async () => {
+  // Initialize telemetry FIRST so an integrity failure can fire a distinct
+  // INTEGRITY_FAIL event before the process exits. Per [CHIEF-CSR-018] +
+  // [CHIEF-CPO-022], supply-chain integrity violations get their own
+  // dashboard event row (not a generic command failure) and a per-event
+  // pager threshold of 1. tele.init() is silent on file-I/O failures
+  // (sandboxed envs) so this never blocks startup.
+  const tele = await import('@opena2a/telemetry');
+  await tele.init({ tool: TELEMETRY_TOOL, version: VERSION });
+
   try {
     const { verifyAll } = await import('./nanomind-core/security/integrity-verifier.js');
     const integrity = await verifyAll();
@@ -9491,6 +9500,14 @@ async function checkNpmPackage(
       for (const check of integrity.checks.filter(c => !c.passed)) {
         process.stderr.write(`  Failed: ${check.name} -- ${check.reason}\n`);
       }
+      // Fire INTEGRITY_FAIL telemetry event before exit.
+      // process.exit() does NOT trigger Node's beforeExit drain, so we
+      // flush explicitly. tele.flush is bounded by the SDK's 2s per-event
+      // timeout — worst-case CLI delay is small and capped.
+      try {
+        tele.error('startup', 'INTEGRITY_FAIL');
+        await tele.flush();
+      } catch { /* never block integrity exit on a telemetry failure */ }
       process.exit(3); // Exit code 3 = integrity failure
     }
 
@@ -9525,11 +9542,11 @@ async function checkNpmPackage(
   // Tier-1 anonymous usage telemetry — default ON; opt-out via
   // OPENA2A_TELEMETRY=off or `hackmyagent telemetry off`. See README §Telemetry.
   // Disclosure surfaces: README, --version line, telemetry subcommand,
-  // opena2a.org/telemetry. CommonJS / ESM bridge: dynamic import inside async
-  // main, type-only `TelemetryAction` import with resolution-mode: 'import'.
-  const tele = await import('@opena2a/telemetry');
+  // opena2a.org/telemetry. The `tele` import + init happened above (before
+  // the integrity check) so INTEGRITY_FAIL can fire. CommonJS / ESM bridge:
+  // dynamic import inside async main, type-only `TelemetryAction` import
+  // with resolution-mode: 'import'.
   const { versionLine, runTelemetryCommand } = await import('@opena2a/cli-ui');
-  await tele.init({ tool: TELEMETRY_TOOL, version: VERSION });
 
   // Set the --version line now that we have live telemetry status.
   program.version(


### PR DESCRIPTION
## Summary

Migrates the binary integrity-failure dispatcher path at `src/cli.ts:9476` to fire a distinct `tele.error('startup', 'INTEGRITY_FAIL')` event with an explicit `tele.flush()` before `process.exit(3)`. Supply-chain integrity violations are now a dedicated dashboard event class rather than a generic command failure.

Per the locked brief at `opena2a-org/briefs/cli-telemetry-success-semantics.md` (chief decisions [CHIEF-CSR-018] + [CHIEF-CPO-022]).

Bumps `@opena2a/telemetry` from 0.2.0 to 0.3.0.

## Why explicit flush

`process.exit()` does NOT trigger Node's `beforeExit` drain, so the SDK's normal lifecycle-flush hook does not fire. The explicit `await tele.flush()` ensures the INTEGRITY_FAIL event reaches the registry within the SDK's 2s timeout before the process terminates with exit code 3.

## Main dispatcher: unchanged

`successFromExitCode` is left at the single-argument form. Per the brief's per-tool mapping, HMA does NOT pass `semanticSuccessCodes` because exit 2 in HMA represents partial/incomplete scan or plugin errors, both of which are degraded outcomes the dashboard should surface as failure. Only ai-trust receives `[2]`.

## Public CLI contract: unchanged

Exit codes unchanged. stderr message unchanged. Telemetry opt-out unchanged. No user-facing shell-level change.

## Diff

- `CHANGELOG.md`: +13 lines (0.23.1 entry)
- `package.json`: 0.23.0 -> 0.23.1 + telemetry pin 0.2.0 -> 0.3.0 (exact)
- `src/cli.ts`: +21 -4 (telemetry hoisted before integrity check; INTEGRITY_FAIL path; duplicate import removed)
- `package-lock.json`: 6 lines (regenerated against published SDK 0.3.0)

## Verification

- `npm view @opena2a/telemetry@0.3.0 version` returns 0.3.0 (live on npm with SLSA v1 provenance)
- `npm install` resolves SDK 0.3.0 cleanly
- `npm run build` (tsc + integrity-manifest gen) clean
- `npm test`: 2117 pass / 16 skipped / 10 todo (167 files); no regression vs main

## Stacked on

#185 (helper migration to @opena2a/telemetry@0.2.0). That PR landed first; this PR rebased onto the new main.

## Follow-up not in this PR

[CHIEF-CSR-018] §8.3 commits to Slack pager wiring for the new INTEGRITY_FAIL event (per-event threshold = 1). That's [CHIEF-CA] scope, separate PR.