### PR TITLE
chore(deps): audit fix - qs DoS (closes Dependabot #35)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2502,9 +2502,9 @@
       }
     },
     "node_modules/qs": {
-      "version": "6.15.1",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.1.tgz",
-      "integrity": "sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg==",
+      "version": "6.15.2",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.2.tgz",
+      "integrity": "sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "side-channel": "^1.1.0"


### PR DESCRIPTION
## Summary

Closes [Dependabot #35](https://github.com/opena2a-org/hackmyagent/security/dependabot/35).

Resolves the qs DoS transitive vulnerability ([GHSA-q8mj-m7cp-5q26](https://github.com/advisories/GHSA-q8mj-m7cp-5q26)) via `npm audit fix`. qs.stringify crashes with TypeError on null/undefined entries in comma-format arrays when encodeValuesOnly is set.

## Diff

Lockfile-only. package.json untouched. hackmyagent npm tarball is unaffected (lockfile is dev-only).

## Verification

- `npm audit`: 0 vulnerabilities (was 1 moderate)
- `npm run build` (tsc + integrity-manifest gen) clean
- `npm test`: 2117 pass / 16 skipped / 10 todo (167 files)

Closes #35.