### PR TITLE
ci(parity): pin opena2a-parity workflow ref from @main to SHA

### DIFF
--- a/.github/workflows/parity.yml
+++ b/.github/workflows/parity.yml
@@ -16,7 +16,9 @@ concurrency:
 
 jobs:
   parity:
-    uses: opena2a-org/opena2a-parity/.github/workflows/parity.yml@main
+    # Pinned to opena2a-parity@main as of 2026-05-24. Bumping the SHA is
+    # an explicit, reviewable bump; tracking `@main` directly was flaky.
+    uses: opena2a-org/opena2a-parity/.github/workflows/parity.yml@093dbda7def691db3b2f860216a008b43f8affb0
     with:
       hma_ref: ${{ github.event.pull_request.head.sha || github.sha }}
       opena2a_ref: main


### PR DESCRIPTION
## Summary

Replaces `uses: opena2a-org/opena2a-parity/.github/workflows/parity.yml@main` with `@093dbda7def691db3b2f860216a008b43f8affb0` (the current opena2a-parity main SHA, untouched since 2026-05-12).

## Investigation

5 parity runs failed today with "workflow file issue" / 0 jobs / empty `referenced_workflows`:

| Run | Event | Conclusion |
|---|---|---|
| 26363462762 (PR #185) | pull_request | **success** |
| 26363506722 (push to main, post #185) | push | failure |
| 26363552530 (PR #186) | pull_request | failure |
| 26363573169 (push to main, post #186) | push | failure |
| 26364021621 (PR #187) | pull_request | failure |
| 26364055475 (push to main, post #187) | push | failure |

- The hackmyagent parity.yml content is identical across all runs (verified via `git show eff040b:.github/workflows/parity.yml` vs `git show 66aa9eb:.github/workflows/parity.yml`).
- The opena2a-parity main branch hasn't moved in 12 days; its workflow YAML parses correctly (verified via `gh api`).
- hackmyagent has `allowed_actions: all` and `enabled: true`; reusable workflow access is unrestricted.
- The failing runs show no `referenced_workflows` resolution, meaning GitHub never even got to dispatching the called workflow.

## Fix

Pinning to an explicit SHA matches GitHub Actions' recommended practice for third-party (and inter-repo first-party) reusable workflows. It removes the `@main` resolution ambiguity, gives an explicit reviewable bump path, and bounds the blast radius if upstream main goes sideways.

## Verification

Once merged, parity should re-resolve on the push-to-main event. If failures persist, the issue is deeper (likely a GitHub-side regression) and should be raised with support.