### PR TITLE
ci: rename parity.yml -> parity-gate.yml to force fresh GitHub workflow ID

### DIFF
--- a/.github/workflows/parity-gate.yml
+++ b/.github/workflows/parity-gate.yml
@@ -1,4 +1,4 @@
-name: parity
+name: parity-gate
 
 on:
   pull_request:
@@ -6,9 +6,10 @@ on:
       - "src/**"
       - "package.json"
       - "package-lock.json"
-      - ".github/workflows/parity.yml"
+      - ".github/workflows/parity-gate.yml"
   push:
     branches: [main]
+  workflow_dispatch:
 
 concurrency:
   group: parity-${{ github.ref }}


### PR DESCRIPTION
## Summary

Follow-up to #188 (SHA pin) which did not unblock the parity gate. Renames the workflow file to force GitHub to allocate a fresh workflow ID, bypassing what appears to be stale internal state on workflow ID 264824314.

## Symptoms

- PR #188 merged at 14:38; new push-to-main run 26364193911 still failed with empty `referenced_workflows` and "workflow file issue" / 0 jobs.
- The workflow's display name is stuck at the file path (".github/workflows/parity.yml") rather than the YAML `name: parity` field. That's the GitHub fallback when it can't parse the workflow.
- Yet the YAML parses fine via `python -c 'yaml.safe_load(...)'` and via `gh api`, and the file content is byte-identical to the version that successfully ran on PR #185 a couple of hours ago.

## Change

- `git mv .github/workflows/parity.yml .github/workflows/parity-gate.yml`
- Update workflow `name: parity` -> `name: parity-gate`
- Update path filter to match the new filename
- Add `workflow_dispatch:` trigger so we can smoke-test manually if the resolution issue recurs

## Verification

Watch a push-to-main run after this merges. If `referenced_workflows` is now populated and the parity job actually runs, this was a stale-state issue with the original workflow ID.

If this still fails the same way, the issue is upstream of any caller-side fix and warrants a GitHub Actions support ticket.