### PR TITLE
docs: add STATUS.md (stable)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # HackMyAgent
 
+[![Status: stable](https://img.shields.io/badge/status-stable-green)](./STATUS.md)
+
 > **[OpenA2A](https://github.com/opena2a-org/opena2a)**: [CLI](https://github.com/opena2a-org/opena2a) · [HackMyAgent](https://github.com/opena2a-org/hackmyagent) · [Secretless](https://github.com/opena2a-org/secretless-ai) · [AIM](https://github.com/opena2a-org/agent-identity-management) · [Browser Guard](https://github.com/opena2a-org/AI-BrowserGuard) · [DVAA](https://github.com/opena2a-org/damn-vulnerable-ai-agent)
 
 Security scanner, red-team toolkit, and behavioural simulator for AI agents. Apache 2.0.

--- a/STATUS.md
+++ b/STATUS.md
@@ -1,0 +1,18 @@
+# Status: stable
+
+**Stage:** stable
+**Maintenance horizon:** actively maintained through 2026-12-31, status reviewed quarterly
+**Maintainer wanted:** no
+
+## Stage definitions
+
+- **stable**: production-ready, semver honored, breaking changes documented, security patches triaged within 24 hours.
+- **beta**: feature-complete or near, breaking changes possible with notice, actively developed.
+- **experimental**: early stage, breaking changes expected, use at your own risk.
+- **reference-only**: spec or reference implementation, not intended for production use.
+
+## Status changes
+
+| Date | Stage | Reason |
+|---|---|---|
+| 2026-05-24 | stable | initial STATUS.md (org lifecycle introduction) |


### PR DESCRIPTION
## Summary

Adds a top-level `STATUS.md` and a status-line badge in the README header. Part of the org-wide STATUS sweep so downstream consumers can read repo lifecycle at a glance.

Stage: **stable**.

## What changed

- `STATUS.md` (new): stage, maintenance horizon, maintainer-wanted flag, stage definitions, status-change log
- `README.md` (line 3): status badge linking to STATUS.md

## Why this matters

Downstream tools, packagers, and contributors need a one-line signal of whether a repo is stable, beta, experimental, or reference-only. STATUS.md is the canonical place for that signal plus the maintenance horizon.

## Scope

Part of the 16-repo non-honey sweep. The four honey-fleet bait repos (agent-hardening-guide, mcp-security-checklist, ai-credential-safety, a2a-security-examples) are intentionally excluded.

## Test plan

- [x] Pre-push gate passed (build, 2117 tests, docs-only phases skipped per skill)
- [x] STATUS.md renders correctly on GitHub
- [x] Badge links to STATUS.md