### PR TITLE
ci(parity): point uses: at opena2a-standards/opena2a-parity (org move)

### DIFF
--- a/.github/workflows/parity-gate.yml
+++ b/.github/workflows/parity-gate.yml
@@ -17,9 +17,10 @@ concurrency:
 
 jobs:
   parity:
-    # Pinned to opena2a-parity@main as of 2026-05-24. Bumping the SHA is
-    # an explicit, reviewable bump; tracking `@main` directly was flaky.
-    uses: opena2a-org/opena2a-parity/.github/workflows/parity.yml@093dbda7def691db3b2f860216a008b43f8affb0
+    # opena2a-parity moved from opena2a-org to opena2a-standards on 2026-05-24.
+    # Pinned to the current main SHA (untouched since 2026-05-12); bumps require
+    # an explicit, reviewable PR.
+    uses: opena2a-standards/opena2a-parity/.github/workflows/parity.yml@093dbda7def691db3b2f860216a008b43f8affb0
     with:
       hma_ref: ${{ github.event.pull_request.head.sha || github.sha }}
       opena2a_ref: main


### PR DESCRIPTION
## Summary

Root cause for today's parity failures: `opena2a-parity` was moved from the `opena2a-org` GitHub org to `opena2a-standards`. The old `uses:` reference stopped resolving for all three caller repos (hackmyagent, ai-trust, opena2a) at the moment of the move (~14:10 UTC).

## The real error message

Surfaced only via `gh workflow run` dispatch:

> `error parsing called workflow ... "opena2a-org/opena2a-parity/.github/workflows/parity.yml@<sha>" : workflow was not found.`

The normal `push`/`pull_request` failures hid this behind "workflow file issue" with empty `referenced_workflows` and 0 jobs.

## Change

`.github/workflows/parity-gate.yml`: `uses:` org owner `opena2a-org` -> `opena2a-standards`. SHA pin retained.

## Prior PRs this session (kept; net-positive defensive changes)

- #188: pinned the `uses:` ref to an explicit SHA (was `@main`)
- #189: renamed `parity.yml` -> `parity-gate.yml`, added `workflow_dispatch` trigger

Both were targeted at the wrong root cause but improve the workflow regardless.

## Verification

After merge, the push-to-main parity-gate run should finally resolve `referenced_workflows` and actually execute the parity job.