### PR TITLE
ci(parity): bump SHA to pick up check-not-found fixture (opena2a-parity#7)

### DIFF
--- a/.github/workflows/parity-gate.yml
+++ b/.github/workflows/parity-gate.yml
@@ -20,7 +20,7 @@ jobs:
     # opena2a-parity moved from opena2a-org to opena2a-standards on 2026-05-24.
     # Pinned to the current main SHA (untouched since 2026-05-12); bumps require
     # an explicit, reviewable PR.
-    uses: opena2a-standards/opena2a-parity/.github/workflows/parity.yml@093dbda7def691db3b2f860216a008b43f8affb0
+    uses: opena2a-standards/opena2a-parity/.github/workflows/parity.yml@1baab791b17880f44a927cb304c418ceb738988e
     with:
       hma_ref: ${{ github.event.pull_request.head.sha || github.sha }}
       opena2a_ref: main


### PR DESCRIPTION
## Summary

Bumps the parity reusable workflow SHA pin from `093dbda` to `1baab79` to pick up the new `check-not-found` fixture added in [opena2a-standards/opena2a-parity#7](https://github.com/opena2a-standards/opena2a-parity/pull/7).

Without this bump, hackmyagent's parity gate keeps running the prior 2-fixture harness and never exercises the new NOT_FOUND contract.

## Companion PRs

Same one-line SHA bump landing in lockstep on the two sister callers:

- ai-trust: TBD
- opena2a: TBD

## Verification

CI will re-run the parity gate against the new SHA; if green, the new fixture exercised live.