### PR TITLE
ci(parity): bump SHA to pick up scan-soul-hardened fixture (opena2a-parity#9)

### DIFF
--- a/.github/workflows/parity-gate.yml
+++ b/.github/workflows/parity-gate.yml
@@ -20,7 +20,7 @@ jobs:
     # opena2a-parity moved from opena2a-org to opena2a-standards on 2026-05-24.
     # Pinned to the current main SHA (untouched since 2026-05-12); bumps require
     # an explicit, reviewable PR.
-    uses: opena2a-standards/opena2a-parity/.github/workflows/parity.yml@00a32d9caf701fd2b83f19c6c65e3fdcbf253883
+    uses: opena2a-standards/opena2a-parity/.github/workflows/parity.yml@0c2a98f0fd4572652ba3955caf6b4b6536e24260
     with:
       hma_ref: ${{ github.event.pull_request.head.sha || github.sha }}
       opena2a_ref: main


### PR DESCRIPTION
Bumps the parity reusable workflow SHA pin from `00a32d9` to `0c2a98f` to pick up the new `scan-soul-hardened` fixture added in [opena2a-standards/opena2a-parity#9](https://github.com/opena2a-standards/opena2a-parity/pull/9).

Companion PRs (same lockstep bump): ai-trust + opena2a (forthcoming).