### PR TITLE
fix(check): honor --no-scan for pip:/pypi: targets (closes #195)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,20 @@ All notable changes to HackMyAgent are documented in this file.
 
 ## [Unreleased]
 
+## [0.23.2] - 2026-05-25
+
+### Fixed
+
+- **`check pip:<pkg> --no-scan` now honors `--no-scan` and returns Registry-shape output instead of doing a full PyPI download + scan ([#195](https://github.com/opena2a-org/hackmyagent/issues/195)).** Prior to this release, `checkPyPiPackage` in `src/cli.ts` had no `--no-scan` branch, so the flag was silently dropped for `pip:`/`pypi:` targets. Every `check pip:<pkg> --no-scan` would still hit PyPI for metadata + tarball download (typically 5-30s) and emit scan-shape JSON (`findings`, `score`, `version`) that didn't match the Registry-shape output the npm path emits for the same flag combination. With this release, the pypi handler mirrors `checkNpmPackage`'s `--no-scan` early-return: kicks off the Registry lookup in parallel, awaits it on the no-scan branch, emits `{ ...registryData, source: 'registry' }` (or a `NotFoundOutput` with `ecosystem: 'pypi'` if the Registry has no record). Closes the contract gap that blocked the 3-way PyPI parity fixture at `opena2a-standards/opena2a-parity`. Discovered during fixture work for `scan-soul-hardened` ([opena2a-parity#9](https://github.com/opena2a-standards/opena2a-parity/pull/9)).
+
+### Tests
+
+- New spawn-smoke test in `__tests__/checker/check-not-found-json.test.ts` (`#195: pip:<missing> --no-scan honors --no-scan...`) gates the regression with a 5-second timeout. The fix completes in ~470ms; a pre-fix download + scan would have exceeded 5s on any real PyPI package.
+
+### Known follow-up
+
+- HMA queries the Registry with `pip:${name}` (prefix-preserved) while the Registry stores PyPI packages under their bare name. That mismatch means `--no-scan` against a Registry-indexed PyPI package still returns `found: false` today. Tracked separately; the fix in this release is scoped to the `--no-scan` lifecycle bug per [#195](https://github.com/opena2a-org/hackmyagent/issues/195).
+
 ## [0.23.1] - 2026-05-24
 
 ### Changed

--- a/__tests__/checker/check-not-found-json.test.ts
+++ b/__tests__/checker/check-not-found-json.test.ts
@@ -164,4 +164,33 @@ describe('check --json not-found wired through dist/cli.js (smoke, local-only)',
     expect(parsed.ecosystem).toBe('github');
     expect(parsed.errorHint).toBe(`Verify the URL: https://github.com/${target}`);
   });
+
+  it.runIf(canRunSpawn())('#195: pip:<missing> --no-scan honors --no-scan (no PyPI download), emits ecosystem:pypi not-found', () => {
+    // Closes hackmyagent#195: prior to the fix, `--no-scan` was silently
+    // dropped for pip:/pypi: targets — every check pip:<pkg> --no-scan
+    // would still hit PyPI for the metadata + tarball download. The
+    // 5-second timeout below is the regression gate: a real PyPI
+    // download + scan on a typical package easily exceeds it. A bare
+    // not-found early-return completes in <500ms.
+    const bareName = 'opena2a-fixture-pypi-nonexistent-xyz-do-not-publish-20260525';
+    const start = Date.now();
+    const res = spawnSync('node', [CLI, 'check', `pip:${bareName}`, '--no-scan', '--json', '--ci'], {
+      encoding: 'utf8',
+      timeout: 5_000,
+    });
+    const elapsedMs = Date.now() - start;
+
+    expect(res.status).toBe(2);
+    expect(elapsedMs).toBeLessThan(5_000);
+
+    const stdout = (res.stdout || '').trim();
+    expect(stdout.length).toBeGreaterThan(0);
+
+    const parsed = JSON.parse(stdout);
+    expect(parsed.name).toBe(bareName);
+    expect(parsed.found).toBe(false);
+    expect(parsed.ecosystem).toBe('pypi');
+    expect(typeof parsed.error).toBe('string');
+    expect(parsed.error.length).toBeGreaterThan(0);
+  });
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "hackmyagent",
-  "version": "0.23.1",
+  "version": "0.23.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "hackmyagent",
-      "version": "0.23.1",
+      "version": "0.23.2",
       "license": "Apache-2.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.12.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hackmyagent",
-  "version": "0.23.1",
+  "version": "0.23.2",
   "description": "Find it. Break it. Fix it. The hacker's toolkit for AI agents.",
   "bin": {
     "hackmyagent": "dist/cli.js"

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -8859,6 +8859,43 @@ async function checkPyPiPackage(
   // Strip prefix to get the bare package name
   const name = target.replace(/^(pip|pypi):/, '');
 
+  // Fetch registry data in parallel with download+scan (unless --no-registry).
+  // Mirrors the checkNpmPackage pattern (line ~9233) so both ecosystems share
+  // the same lifecycle for registry lookups.
+  const registryPromise = options.registry === false ? Promise.resolve(null) : queryRegistry(`pip:${name}`);
+
+  // Registry-only mode (--no-scan): skip the PyPI download + local scan,
+  // emit Registry-shape output instead. Mirrors checkNpmPackage's
+  // (line ~9236) behavior so `--no-scan` is honored consistently across
+  // ecosystems. Closes #195: prior to this, --no-scan was silently dropped
+  // for pip:/pypi: targets and the user got a full scan they didn't ask
+  // for, with scan-shape JSON (findings/score/etc.) that didn't match the
+  // Registry-shape output emitted by the npm path.
+  if (options.scan === false) {
+    const registryData = await registryPromise;
+    if (registryData?.found) {
+      if (options.json) {
+        writeJsonStdout({ ...registryData, source: 'registry' });
+        return;
+      }
+      displayUnifiedCheck({ name, registry: registryData, verbose: !!options.verbose, usedAnalm: resolveNanomindFlag(options) });
+      return;
+    }
+    // --no-scan with no Registry hit: emit a not-found block in the same
+    // shape as the PyPI 404 path below, then return without scanning.
+    if (options.json) {
+      writeJsonStdout(buildNotFoundOutput({
+        name,
+        ecosystem: 'pypi',
+        error: `Package "${name}" not found in the OpenA2A Registry.`,
+      }));
+    } else {
+      printNotFoundBlock({ pkg: name, ecosystem: 'pypi' });
+    }
+    process.exitCode = 2;
+    return;
+  }
+
   const { mkdtemp, rm, readdir } = await import('node:fs/promises');
   const { tmpdir } = await import('node:os');
   const { join } = await import('node:path');
@@ -8966,9 +9003,10 @@ async function checkPyPiPackage(
     const medium = failed.filter(f => f.severity === 'medium');
     const low = failed.filter(f => f.severity === 'low');
 
-    // Query registry for trust context (PyPI packages have pip: prefix in registry).
-    // Moved above the --json branch so JSON output can include registry fields (F1).
-    const registryData = options.registry === false ? null : await queryRegistry(`pip:${name}`);
+    // Await the registry lookup we kicked off in parallel above (line ~8866).
+    // Same query key (pip:${name}) to keep semantics identical to the prior
+    // sequential call.
+    const registryData = await registryPromise;
 
     if (options.json) {
       writeJsonStdout(buildCheckOutput({


### PR DESCRIPTION
## Summary

Closes [#195](https://github.com/opena2a-org/hackmyagent/issues/195).

`hackmyagent check pip:<pkg> --no-scan` silently dropped the `--no-scan` flag for `pip:`/`pypi:` targets. Every such command would still hit PyPI for metadata + tarball download (typically 5-30s) and emit scan-shape JSON (`findings`, `score`, `version`) that didn't match the Registry-shape output the npm path emits for the same flag combination.

## Fix

`checkPyPiPackage` now mirrors `checkNpmPackage`'s `--no-scan` early-return pattern:

1. Kick off the Registry lookup in parallel (right after stripping the prefix)
2. On `--no-scan`:
   - If Registry has a hit: emit `{ ...registryData, source: 'registry' }` (JSON) or `displayUnifiedCheck` (TTY), return
   - If Registry has no hit: emit a `NotFoundOutput` with `ecosystem: 'pypi'`, exit 2, return
3. Otherwise: continue to the existing download + scan path (now consuming the same `registryPromise` instead of re-querying)

## Behavior delta (live runtime)

**Before** (`check pip:requests --no-scan --json`):
```json
{
  "findings": [...],       // scan output
  "maxScore": 100,         // scan output
  "name": "requests",
  "projectType": "library",
  "score": 75,             // scan output
  "source": "local-scan",  // <-- gave away the bug
  "type": "pypi-package",
  "version": "2.31.0"
}
```
Runtime: multi-second PyPI download + tarball extract + scanner pipeline.

**After** (`check pip:opena2a-fixture-nonexistent --no-scan --json`):
```json
{
  "name": "opena2a-fixture-nonexistent",
  "found": false,
  "ecosystem": "pypi",
  "error": "Package \"opena2a-fixture-nonexistent\" not found in the OpenA2A Registry."
}
```
Runtime: 468ms (Registry round-trip only), exit 2.

## Diff scope

| File | Change |
|---|---|
| `src/cli.ts` | +~35 LOC (insert --no-scan early-return in checkPyPiPackage; reuse registryPromise in scan-path) |
| `__tests__/checker/check-not-found-json.test.ts` | +~30 LOC (new spawn-smoke regression test with 5s timeout) |
| `package.json` + `CHANGELOG.md` | 0.23.1 -> 0.23.2 |

## Verification

- `npm run build` clean
- `npm test`: 2118 pass / 16 skipped / 10 todo (was 2117 pre-fix; +1 new regression test)
- Live runtime checks above

## Known follow-up (NOT in this PR)

HMA queries the Registry with `pip:${name}` (prefix-preserved) while the Registry stores PyPI packages under their bare name. That mismatch means `--no-scan` against Registry-indexed PyPI packages still returns `found: false` today. Tracked separately; this PR is scoped strictly to the `--no-scan` lifecycle bug per #195.

## Test plan

- [x] Build + 2118 tests pass
- [x] New regression test gates the 5s timeout
- [x] Live runtime: pip: --no-scan returns Registry-shape in <500ms
- [ ] Reviewer: pull the branch, run `node dist/cli.js check pip:anything --no-scan --json`, confirm Registry-shape output (no `findings`, no `score`).