### PR TITLE
fix(check): query Registry with bare PyPI name (drop pip: prefix) [0.23.4]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to HackMyAgent are documented in this file.
 
 ## [Unreleased]
 
+## [0.23.4] - 2026-05-27
+
+### Fixed
+
+- **`check pip:<pkg>` Registry lookups now use the bare package name instead of a `pip:` prefix.** The OpenA2A Registry stores PyPI packages under their bare names (e.g. `anthropic`), not under a `pip:` / `pypi:` prefix. Until this release, `checkPyPiPackage` in `src/cli.ts` queried `queryRegistry(\`pip:${name}\`)`, which always missed for Registry-indexed PyPI packages and returned `found: false` even for stably-registered records. Combined with the `--no-scan` fix in 0.23.2 ([#195](https://github.com/opena2a-org/hackmyagent/issues/195)), the CLI returned a not-found block for `pip:anthropic --no-scan --json` despite the canonical record being live in the Registry. With this release the PyPI path mirrors `checkNpmPackage`'s bare-name query, so `--no-scan` against any Registry-indexed PyPI package now returns the canonical record (`found: true`, `packageType`, `trustLevel`, `trustScore`, `dependencies`). Closes the "known follow-up" called out in the 0.23.2 entry and unblocks the 3-way PyPI parity fixture at `opena2a-standards/opena2a-parity`.
+
+### Tests
+
+- New test file `__tests__/checker/check-pip-prefix-registry-query.test.ts` with two layers (matching the `check-not-found-json.test.ts` pattern): a deterministic source-level lock-in that asserts `checkPyPiPackage` does not call `queryRegistry` with a `pip:` / `pypi:` prefix (CI-safe; catches the exact regression class), plus a local-only spawn smoke test that invokes the built `dist/cli.js` against a Registry-known PyPI package and asserts `found: true` + `packageType: "ai_tool"`.
+
 ## [0.23.3] - 2026-05-27
 
 ### Fixed

--- a/__tests__/checker/check-pip-prefix-registry-query.test.ts
+++ b/__tests__/checker/check-pip-prefix-registry-query.test.ts
@@ -1,0 +1,93 @@
+// Regression tests for HMA Registry-query key in the PyPI check path.
+//
+// Background: the Registry stores PyPI packages under their bare name
+// (e.g. `anthropic`), not under a `pip:` / `pypi:` prefix. Until this
+// PR, `checkPyPiPackage` called `queryRegistry(\`pip:${name}\`)`, which
+// always missed for Registry-indexed PyPI packages. Combined with
+// hackmyagent#197 (which honors --no-scan for pip:/pypi: targets), the
+// CLI returned `found: false` for known packages like `anthropic` when
+// run as `hma check pip:anthropic --no-scan --json`.
+//
+// Two layers, matching the pattern in check-not-found-json.test.ts:
+//
+// 1. Deterministic lock-in: read src/cli.ts and assert the PyPI path
+//    calls queryRegistry with the bare name. Catches the exact
+//    regression class deterministically on CI. (Lock-in tests are the
+//    discipline from MEMORY's "ai pr reviewers hallucinate" entry —
+//    future reviewers shouldn't re-add the prefix on a flawed reading
+//    of "make pip: queries explicit.")
+//
+// 2. Spawned smoke test: invokes the built dist/cli.js against a
+//    Registry-known PyPI package, asserts the JSON output reports
+//    found:true. Local-only; skipped on CI runners.
+
+import { describe, it, expect } from 'vitest';
+import { spawnSync } from 'node:child_process';
+import { existsSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+const REPO_ROOT = join(__dirname, '..', '..');
+const CLI_TS = join(REPO_ROOT, 'src', 'cli.ts');
+const CLI = join(REPO_ROOT, 'dist', 'cli.js');
+
+function canRunSpawn(): boolean {
+  if (process.env.CI === 'true' || process.env.GITHUB_ACTIONS === 'true') return false;
+  return existsSync(CLI);
+}
+
+describe('PyPI Registry-query key (lock-in: closes pip-prefix bug)', () => {
+  it('checkPyPiPackage queries Registry with bare name, not pip:-prefixed', () => {
+    const src = readFileSync(CLI_TS, 'utf8');
+
+    // Locate checkPyPiPackage. Its body owns the only queryRegistry call
+    // in the PyPI path.
+    const startIdx = src.indexOf('async function checkPyPiPackage');
+    expect(startIdx, 'checkPyPiPackage function not found in src/cli.ts').toBeGreaterThan(-1);
+
+    // Slice through the end of the function. The next top-level
+    // `async function ` declaration marks the boundary.
+    const afterStart = src.slice(startIdx + 'async function checkPyPiPackage'.length);
+    const nextFnRel = afterStart.search(/\nasync function /);
+    const body = nextFnRel === -1 ? afterStart : afterStart.slice(0, nextFnRel);
+
+    // Forbidden: prefixed queries. These would route to a Registry key
+    // that doesn't exist (Registry stores PyPI under bare names).
+    expect(body, 'queryRegistry call must not use pip:${name} (Registry stores PyPI under bare name)').not.toMatch(/queryRegistry\(\s*`pip:\$\{/);
+    expect(body, 'queryRegistry call must not use pypi:${name} either').not.toMatch(/queryRegistry\(\s*`pypi:\$\{/);
+
+    // Required: at least one queryRegistry call passing bare `name`.
+    expect(body, 'checkPyPiPackage must call queryRegistry(name) with the bare package name').toMatch(/queryRegistry\(\s*name\s*\)/);
+  });
+});
+
+describe('PyPI Registry-query end-to-end (smoke, local-only)', () => {
+  it.runIf(canRunSpawn())(
+    'check pip:anthropic --no-scan returns Registry record (found:true)',
+    () => {
+      // Live-Registry test. `anthropic` is stably indexed in the
+      // OpenA2A Registry under its bare PyPI name. Pre-fix this would
+      // return found:false because HMA queried `pip:anthropic`, a key
+      // the Registry doesn't store.
+      const res = spawnSync(
+        'node',
+        [CLI, 'check', 'pip:anthropic', '--no-scan', '--json', '--ci'],
+        { encoding: 'utf8', timeout: 10_000 },
+      );
+
+      // --no-scan + Registry hit = exit 0 (mirrors the npm path).
+      expect(res.status, `unexpected exit ${res.status}; stderr: ${res.stderr}`).toBe(0);
+
+      const stdout = (res.stdout || '').trim();
+      expect(stdout.length).toBeGreaterThan(0);
+
+      const parsed = JSON.parse(stdout);
+      expect(parsed.found).toBe(true);
+      expect(parsed.name).toBe('anthropic');
+      // packageType for `anthropic` is `ai_tool` per the Registry's
+      // canonical record. If this assertion ever flakes, treat as a
+      // Registry-data drift signal rather than masking it with a
+      // looser match.
+      expect(parsed.packageType).toBe('ai_tool');
+    },
+  );
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "hackmyagent",
-  "version": "0.23.3",
+  "version": "0.23.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "hackmyagent",
-      "version": "0.23.3",
+      "version": "0.23.4",
       "license": "Apache-2.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.12.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hackmyagent",
-  "version": "0.23.3",
+  "version": "0.23.4",
   "description": "Find it. Break it. Fix it. The hacker's toolkit for AI agents.",
   "bin": {
     "hackmyagent": "dist/cli.js"

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -8860,9 +8860,11 @@ async function checkPyPiPackage(
   const name = target.replace(/^(pip|pypi):/, '');
 
   // Fetch registry data in parallel with download+scan (unless --no-registry).
-  // Mirrors the checkNpmPackage pattern (line ~9233) so both ecosystems share
-  // the same lifecycle for registry lookups.
-  const registryPromise = options.registry === false ? Promise.resolve(null) : queryRegistry(`pip:${name}`);
+  // Mirrors the checkNpmPackage pattern (line ~9271) so both ecosystems share
+  // the same lifecycle for registry lookups. The Registry stores PyPI
+  // packages under their bare names (not `pip:` / `pypi:` prefixed), so the
+  // query key is the stripped `name`, matching the npm path.
+  const registryPromise = options.registry === false ? Promise.resolve(null) : queryRegistry(name);
 
   // Registry-only mode (--no-scan): skip the PyPI download + local scan,
   // emit Registry-shape output instead. Mirrors checkNpmPackage's
@@ -9003,9 +9005,8 @@ async function checkPyPiPackage(
     const medium = failed.filter(f => f.severity === 'medium');
     const low = failed.filter(f => f.severity === 'low');
 
-    // Await the registry lookup we kicked off in parallel above (line ~8866).
-    // Same query key (pip:${name}) to keep semantics identical to the prior
-    // sequential call.
+    // Await the registry lookup we kicked off in parallel above (line ~8867).
+    // Bare-name query key, matching the Registry's PyPI storage convention.
     const registryData = await registryPromise;
 
     if (options.json) {


### PR DESCRIPTION
## Summary

- `checkPyPiPackage` in `src/cli.ts` was querying the Registry with `pip:${name}`, but the Registry stores PyPI packages under their bare names. `check pip:anthropic --no-scan --json` returned `found: false` despite the canonical record being live.
- Mirror the npm path's bare-name query (`queryRegistry(name)`). Closes the "known follow-up" called out in the 0.23.2 CHANGELOG entry and unblocks the 3-way PyPI parity fixture at `opena2a-standards/opena2a-parity`.
- Bumps `0.23.3` -> `0.23.4`.

## Why 0.23.4 (not 0.23.3)

This PR originally targeted `0.23.3`. While the PR was open, `0.23.3` was cut from a separate `release/0.23.3` branch for the scanner false-positive suppression work (PR #192 + release-merge-back #199), shipped to npm, and updated Homebrew + the architecture site. The pip-prefix fix was not included in that release. Verified post-publish:

```
$ npm view hackmyagent dist-tags
{ latest: '0.23.3' }
$ npm pack hackmyagent@0.23.3 && grep "queryRegistry" package/dist/cli.js
async function queryRegistry(name) { ... }
const registryPromise = ... queryRegistry(`pip:${name}`);   ← still buggy
const registryPromise = ... queryRegistry(name);            ← npm path (correct)
```

This PR has been rebased onto current main (post-#199), CHANGELOG conflict resolved (kept the scanner-FP 0.23.3 entry intact, added a new 0.23.4 entry above it), and the version bumped to 0.23.4.

## Registry storage convention (verified)

```
$ curl -s "https://api.oa2a.org/api/v1/trust/query?name=anthropic&includeProfile=true" | head -c 200
{"packageId":"41627a5f-1322-4217-911d-57d9ccb4d418","name":"anthropic","packageType":"ai_tool","trustLevel":2,"trustScore":0.3533333333333334,"verdict":"listed",...

$ curl -s "https://api.oa2a.org/api/v1/trust/query?name=pip:anthropic&includeProfile=true"
{"error":"Package not found","verdict":"unknown"}
```

Bare-name is canonical; the `pip:` prefix is an HMA-side artifact and was never sent to the Registry by `ai-trust` (which calls `client.checkTrust(name)` with the bare name).

## End-to-end (after fix)

```
$ node dist/cli.js check pip:anthropic --no-scan --json --ci
{ "found": true, "name": "anthropic", "packageType": "ai_tool", "trustLevel": 2,
  "trustScore": 0.3533333333333334, "verdict": "listed", "scanStatus": "pending", ... }
$ echo $?
0
```

## Tests

New file: `__tests__/checker/check-pip-prefix-registry-query.test.ts`. Two layers (matching the `check-not-found-json.test.ts` pattern):

1. **Deterministic lock-in (CI-safe).** Reads `src/cli.ts` and asserts that `checkPyPiPackage` does not contain ``queryRegistry(`pip:${...`` or ``queryRegistry(`pypi:${...``, and that the function does call `queryRegistry(name)` with the bare name. Catches the exact regression class even when no network or built dist is available.
2. **Spawn smoke (local-only).** Invokes the built `dist/cli.js` against `pip:anthropic --no-scan --json`, asserts `found: true`, `name: "anthropic"`, `packageType: "ai_tool"`, exit 0. Skipped on CI runners (`canRunSpawn()` gates on `CI` env + presence of `dist/cli.js`).

Verified pre-fix: lock-in fails on `697c1f6` (the 0.23.2 commit) AND on the published 0.23.3 (which still has the bug). Post-fix: both layers pass.

## Test plan

- [x] Full vitest suite: 2161 passed, 18 skipped, 10 todo (168 files), post-rebase onto main
- [x] New test passes both layers (lock-in + spawn) locally with built dist
- [x] `tsc` clean (via `npm run build`)
- [x] Live Registry round-trip for `pip:anthropic --no-scan --json` returns `found:true`, exit 0
- [x] Rebased onto current main; CHANGELOG conflict resolved (kept scanner-FP 0.23.3 entry; added 0.23.4 entry)
- [ ] After merge: arch-site sweep -> release-test -> tag-push `v0.23.4` (under daily-publish cap)
- [ ] After publish: Homebrew tap update + retarget [opena2a-parity#10](https://github.com/opena2a-standards/opena2a-parity/pull/10) and [opena2a#169](https://github.com/opena2a-org/opena2a/pull/169) to point at `0.23.4`