### PR TITLE
chore: merge 0.23.3 release commits back to main

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to HackMyAgent are documented in this file.
 
 ## [Unreleased]
 
-## [0.23.3] - 2026-05-26
+## [0.23.3] - 2026-05-27
 
 ### Fixed
 - **Scanner false-positive class on NEMO-009 (eval/Function/JSON5) and AST-CRED-001/002/003.** Three FPs that surfaced on the nanomind tree (`opena2a-org/nanomind#26`) are now suppressed by preserved-detection refinements:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to HackMyAgent are documented in this file.
 
 ## [Unreleased]
 
+## [0.23.3] - 2026-05-26
+
 ### Fixed
 - **Scanner false-positive class on NEMO-009 (eval/Function/JSON5) and AST-CRED-001/002/003.** Three FPs that surfaced on the nanomind tree (`opena2a-org/nanomind#26`) are now suppressed by preserved-detection refinements:
   - **NEMO-009 string-literal gating.** New exported `isMatchInsideStringLiteral(line, matchIndex)` walker tracks single, double, and backtick quote state plus `//` line comments and `/* ... */` block comments. Template-literal interpolation (`${...}` inside a backtick) is brace-counted: a match inside the interpolation expression returns false (real code); a match outside the interpolation but still inside the backtick keeps in-string state. NEMO-009 calls this helper on every TS/JS match (bareEval, indirectEval, newFunction, JSON5.parse) so `screenInput('eval(atob("malicious"))', 'piped')` no longer fires.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "hackmyagent",
-  "version": "0.23.2",
+  "version": "0.23.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "hackmyagent",
-      "version": "0.23.2",
+      "version": "0.23.3",
       "license": "Apache-2.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.12.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hackmyagent",
-  "version": "0.23.2",
+  "version": "0.23.3",
   "description": "Find it. Break it. Fix it. The hacker's toolkit for AI agents.",
   "bin": {
     "hackmyagent": "dist/cli.js"


### PR DESCRIPTION
Merges the three commits made on \`release/0.23.3\` (CHANGELOG Unreleased -> [0.23.3] promotion, \`npm version patch\` version bump, CHANGELOG ship-date correction) back into main so the version bump is reachable from main's history.

The tag \`v0.23.3\` is already pushed and the package is published on npm with SLSA v1 provenance attached. Homebrew tap bumped to 0.23.3 in [\`08c3f1a\`](https://github.com/opena2a-org/homebrew-tap/commit/08c3f1a). opena2a-architecture site bumped to 0.23.3 in [\`1f12c05\`](https://github.com/opena2a-org/opena2a-architecture/commit/1f12c05).

Three commits:
- \`37dbdfc\` docs(changelog): promote Unreleased nanomind#26 block to [0.23.3]
- \`92f7c27\` chore(release): 0.23.3
- \`439adac\` docs(changelog): correct 0.23.3 ship date to 2026-05-27