### PR TITLE
ci(parity): bump SHA to pick up check-registered-ai-pypi fixture (opena2a-parity#10)

### DIFF
--- a/.github/workflows/parity-gate.yml
+++ b/.github/workflows/parity-gate.yml
@@ -20,7 +20,7 @@ jobs:
     # opena2a-parity moved from opena2a-org to opena2a-standards on 2026-05-24.
     # Pinned to the current main SHA (untouched since 2026-05-12); bumps require
     # an explicit, reviewable PR.
-    uses: opena2a-standards/opena2a-parity/.github/workflows/parity.yml@0c2a98f0fd4572652ba3955caf6b4b6536e24260
+    uses: opena2a-standards/opena2a-parity/.github/workflows/parity.yml@1d7b792a65985e0f9449f3895d1a86e22b218e9c
     with:
       hma_ref: ${{ github.event.pull_request.head.sha || github.sha }}
       opena2a_ref: main


### PR DESCRIPTION
Bumps the opena2a-parity workflow SHA to `1d7b792` ([opena2a-standards/opena2a-parity#10](https://github.com/opena2a-standards/opena2a-parity/pull/10)).

Adds the `check-registered-ai-pypi` 2-way fixture (hma + ai-trust) that exercises HMA's bare-name PyPI Registry query introduced in [#198](https://github.com/opena2a-org/hackmyagent/pull/198) (v0.23.4). This is the 4th SHA-bump in the established lockstep series alongside ai-trust + opena2a.