### PR TITLE
chore: bump @opena2a/cli-ui pin to 0.5.1 + Node 24 actions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,6 +9,13 @@ permissions:
   contents: write
   id-token: write
 
+# Opt the v4-line JavaScript actions (checkout, setup-node) into Node 24
+# today. They run on Node 20 by default and emit a deprecation warning on
+# every release; the runner forces Node 24 on 2026-06-02. Setting this env
+# now silences the warning AND avoids surprise breakage in June.
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   release:
     runs-on: ubuntu-latest

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "@noble/post-quantum": "^0.2.1",
         "@opena2a/aim-core": "^0.1.2",
         "@opena2a/check-core": "0.2.0",
-        "@opena2a/cli-ui": "0.5.0",
+        "@opena2a/cli-ui": "0.5.1",
         "@opena2a/contribute": "^0.1.0",
         "@opena2a/credential-patterns": "0.1.1",
         "@opena2a/registry-client": "0.1.0",
@@ -599,9 +599,9 @@
       }
     },
     "node_modules/@opena2a/cli-ui": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/@opena2a/cli-ui/-/cli-ui-0.5.0.tgz",
-      "integrity": "sha512-c90/pOe/JiFe6WZnn9a8HVqOoaZ4cguI7Dkslh88FZM3Pqx8wP/9eaeoHFTKs/PrV9RYLj4GBC2OJ8srj7R7+g==",
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/@opena2a/cli-ui/-/cli-ui-0.5.1.tgz",
+      "integrity": "sha512-QfiZUEQS8HIHQKthZrXSGyO4OP3t2/AhR1/YDvglkbDstg6lG2GL5/O2UjH+8PlIBRhBzSvMpJt0OuCoVVuHoQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "chalk": "^5.3.0"

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "@noble/post-quantum": "^0.2.1",
     "@opena2a/aim-core": "^0.1.2",
     "@opena2a/check-core": "0.2.0",
-    "@opena2a/cli-ui": "0.5.0",
+    "@opena2a/cli-ui": "0.5.1",
     "@opena2a/contribute": "^0.1.0",
     "@opena2a/credential-patterns": "0.1.1",
     "@opena2a/registry-client": "0.1.0",


### PR DESCRIPTION
## Summary

Two unrelated maintenance bumps batched into one PR (both zero-behavior, workflow + lockfile only).

### 1. @opena2a/cli-ui pin 0.5.0 → 0.5.1

cli-ui 0.5.1 fixes two telemetry-command papercuts (caught by DVAA 0.9.0's release-test, fixed at root in opena2a#170):

- \`hackmyagent telemetry --help\` now prints proper usage instead of \`Unknown action '--help'\`.
- \`hackmyagent telemetry status\` toggle hint flips based on state instead of always suggesting \`off\`.

No HMA API depends on the patch diff; **2161 vitest tests still pass** after the bump.

### 2. FORCE_JAVASCRIPT_ACTIONS_TO_NODE24=true in release.yml

\`actions/checkout@v4\` and \`actions/setup-node@v4\` run on Node 20 by default and emit a deprecation warning on every release. GitHub forces them to Node 24 on **2026-06-02**. Setting this env at workflow level silences the warning today AND avoids any small risk on June 2nd.

No behavior change to the release-step itself — \`setup-node\` already installs \`node-version: 24\`; this is purely about the actions' internal Node runtime.

## Companion PRs

- damn-vulnerable-ai-agent#50 (Node 24 only — already on cli-ui 0.5.1 via v0.9.1)
- opena2a#172 (Node 24 + opena2a-cli cli-ui pin bump)
- ai-trust (in flight)

## Test plan

- [x] \`npm test\` → 2161 pass, 18 skipped, 10 todo
- [x] YAML parses cleanly
- [x] Diff is workflow + lockfile only
- [ ] On next HMA tag-push, deprecation warning gone from workflow log