### PR TITLE
fix(explainer): namespace `scan-soul --explain` citation with `hackmyagent` prefix

### DIFF
--- a/src/ui/concept-explainers.ts
+++ b/src/ui/concept-explainers.ts
@@ -43,7 +43,7 @@ export const CONCEPT_EXPLAINERS: Record<ConceptId, ConceptExplainer> = {
       '  SOUL.md  →  governs  →  SKILL.md / MCP  →  constrains  →  runtime input',
       '',
       '`harden-soul` generates the missing governance sections; existing content',
-      'is preserved. Run `scan-soul --explain` for the 9-domain model.',
+      'is preserved. Run `hackmyagent scan-soul --explain` for the 9-domain model.',
     ].join('\n'),
     oneLineRef: '(Why SOUL: see above)',
   },


### PR DESCRIPTION
## Summary

- Change the SOUL-governance concept-explainer citation from `Run \`scan-soul --explain\`` to `Run \`hackmyagent scan-soul --explain\``.
- One-line, defensive UX clarification. No detection / scoring / scanner changes.

## Why

The SOUL-governance explainer body (`src/ui/concept-explainers.ts:46`) is rendered inside *every* CLI that consumes HMA via spawn delegation — including `opena2a check` from opena2a-cli. The bare citation `scan-soul --explain` honors the user's reading context only when they invoke through `hackmyagent` directly. A user reading the same line through `opena2a check` will naturally prepend `opena2a`, hitting:

```
$ opena2a scan-soul --explain
error: unknown option '--explain'
# exit code 0
```

This is **not** an HMA-side bug — `hackmyagent scan-soul --explain` works (registered as a Commander option in `src/cli.ts:6278` since PR #166). The dead-end is in `opena2a-cli@0.10.4`'s wrapper, which has its own Commander definition of `scan-soul` and does not proxy `--explain` (filed separately).

This PR makes the citation unambiguous about which CLI honors it.

## Verification

- Lock-in test `__tests__/ui/concept-explainer-command-references.test.ts` (PR #163) continues to pass — Form 1 of the extractor matches `hackmyagent <verb>` directly and the asserted Usage-line shape is unchanged. Explicit regression for `scan-soul --explain` still passes.
- `npm test` — 2161 passed / 168 files.
- HMA self-scan: 98/100 (one pre-existing LOW on `CLAUDE.md`, no CRITICAL/HIGH).
- `node dist/cli.js scan-soul --explain` still prints the 9-domain model and exits 0.

## Related

- Closes opena2a-org/hackmyagent#207 (the report says the HMA-side `--explain` flag is missing — that is not accurate against 0.23.4; see comment on the issue with a full trace and the actual dead-end location in opena2a-cli).
- Follow-up issue against `opena2a-org/opena2a` to add `--explain` proxy to its scan-soul wrapper.

## Test plan

- [x] `npm test` green
- [x] `__tests__/ui/concept-explainer-command-references.test.ts` green
- [x] `node dist/cli.js scan-soul --explain` exits 0 with 9-domain printout
- [ ] Reviewer confirms the lock-in test would catch a re-introduction of a bare `<verb>` citation