### PR TITLE
fix(credential-context): downgrade gitignored .env to MEDIUM (#208)

### DIFF
--- a/__tests__/semantic/credential-context-git-state.test.ts
+++ b/__tests__/semantic/credential-context-git-state.test.ts
@@ -1,0 +1,351 @@
+/**
+ * #208 regression: .env credential severity must consult git tracking state.
+ *
+ * Each test builds a real temp git repo, drops a `.env` with a fake API key,
+ * runs the StructuralAnalyzer, and asserts the SEM-CRED-002 finding has the
+ * right severity for that tracking state. Real `git` is invoked (no mocks)
+ * to match production behavior end-to-end.
+ *
+ * Severity table (from triage):
+ *   tracked OR has-add-history       -> HIGH (unchanged)
+ *   not a git repo                   -> HIGH (safe default, can't verify)
+ *   gitignored, never tracked        -> MEDIUM (local-only exposure)
+ *   on disk, untracked, not ignored  -> MEDIUM (at risk of accidental commit)
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, rmSync, writeFileSync, mkdirSync, symlinkSync, linkSync, realpathSync } from 'node:fs';
+import { spawnSync } from 'node:child_process';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { StructuralAnalyzer } from '../../src/semantic/structural';
+
+const FAKE_ENV_BODY = 'ANTHROPIC_API_KEY=sk-ant-FAKE1234567890abcdefghijklmnop\n';
+
+function git(cwd: string, ...args: string[]): void {
+  const r = spawnSync('git', args, {
+    cwd,
+    env: { ...process.env, GIT_AUTHOR_NAME: 't', GIT_AUTHOR_EMAIL: 't@t', GIT_COMMITTER_NAME: 't', GIT_COMMITTER_EMAIL: 't@t' },
+    stdio: ['ignore', 'pipe', 'pipe'],
+    encoding: 'utf-8',
+  });
+  if (r.status !== 0) {
+    throw new Error(`git ${args.join(' ')} failed (${r.status}): ${r.stderr}`);
+  }
+}
+
+function findEnvCred(findings: { id: string; file: string }[]): { id: string; file: string; severity: string; rationale: string; recommendation: string } | undefined {
+  return findings.find((f) => f.id === 'SEM-CRED-002' && f.file === '.env') as unknown as ReturnType<typeof findEnvCred>;
+}
+
+describe('#208: .env credential severity by git state', () => {
+  let dir: string;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'hma-208-'));
+  });
+
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it('tracked .env -> HIGH (gitignore does not untrack)', async () => {
+    git(dir, 'init', '-q');
+    writeFileSync(join(dir, '.env'), FAKE_ENV_BODY);
+    git(dir, 'add', '.env');
+    git(dir, 'commit', '-q', '-m', 'oops committed .env');
+
+    // Add to gitignore AFTER tracking; should still fire HIGH.
+    writeFileSync(join(dir, '.gitignore'), '.env\n');
+    git(dir, 'add', '.gitignore');
+    git(dir, 'commit', '-q', '-m', 'gitignore .env (still tracked)');
+
+    const analyzer = new StructuralAnalyzer();
+    const findings = await analyzer.analyze(dir);
+    const env = findEnvCred(findings);
+    expect(env, 'expected SEM-CRED-002 on .env').toBeDefined();
+    expect(env!.severity).toBe('high');
+  });
+
+  it('gitignored, never tracked -> MEDIUM (local-only, not in version control)', async () => {
+    git(dir, 'init', '-q');
+    writeFileSync(join(dir, '.gitignore'), '.env\n');
+    git(dir, 'add', '.gitignore');
+    git(dir, 'commit', '-q', '-m', 'gitignore .env from day 1');
+    writeFileSync(join(dir, '.env'), FAKE_ENV_BODY);
+
+    const analyzer = new StructuralAnalyzer();
+    const findings = await analyzer.analyze(dir);
+    const env = findEnvCred(findings);
+    expect(env, 'expected SEM-CRED-002 on .env').toBeDefined();
+    expect(env!.severity).toBe('medium');
+    expect(env!.rationale).not.toMatch(/If this file is committed/);
+    expect(env!.recommendation).toMatch(/opena2a protect/);
+  });
+
+  it('gitignored but with add-history -> HIGH (rm --cached does not erase history)', async () => {
+    git(dir, 'init', '-q');
+    writeFileSync(join(dir, '.env'), FAKE_ENV_BODY);
+    git(dir, 'add', '.env');
+    git(dir, 'commit', '-q', '-m', 'commit .env (leaked once)');
+    git(dir, 'rm', '--cached', '-q', '.env');
+    writeFileSync(join(dir, '.gitignore'), '.env\n');
+    git(dir, 'add', '.gitignore');
+    git(dir, 'commit', '-q', '-m', 'untrack .env, but reflog still has it');
+    // .env is still on disk
+    writeFileSync(join(dir, '.env'), FAKE_ENV_BODY);
+
+    const analyzer = new StructuralAnalyzer();
+    const findings = await analyzer.analyze(dir);
+    const env = findEnvCred(findings);
+    expect(env, 'expected SEM-CRED-002 on .env').toBeDefined();
+    expect(env!.severity).toBe('high');
+  });
+
+  it('not a git repo -> HIGH (safe default, can\'t verify)', async () => {
+    writeFileSync(join(dir, '.env'), FAKE_ENV_BODY);
+
+    const analyzer = new StructuralAnalyzer();
+    const findings = await analyzer.analyze(dir);
+    const env = findEnvCred(findings);
+    expect(env, 'expected SEM-CRED-002 on .env').toBeDefined();
+    expect(env!.severity).toBe('high');
+  });
+
+  it('untracked, not gitignored -> MEDIUM (at risk of accidental commit)', async () => {
+    git(dir, 'init', '-q');
+    // Commit an unrelated file to establish HEAD
+    writeFileSync(join(dir, 'README.md'), '# t\n');
+    git(dir, 'add', 'README.md');
+    git(dir, 'commit', '-q', '-m', 'init');
+    writeFileSync(join(dir, '.env'), FAKE_ENV_BODY);
+
+    const analyzer = new StructuralAnalyzer();
+    const findings = await analyzer.analyze(dir);
+    const env = findEnvCred(findings);
+    expect(env, 'expected SEM-CRED-002 on .env').toBeDefined();
+    expect(env!.severity).toBe('medium');
+  });
+
+  it('URL password in gitignored .env stays HIGH (#208 explicit out-of-scope)', async () => {
+    // Triage said URL-embedded credentials leak via proxies/logs/process
+    // listings even when the file is gitignored. SEM-CRED-001 stays HIGH.
+    git(dir, 'init', '-q');
+    writeFileSync(join(dir, '.gitignore'), '.env\n');
+    git(dir, 'add', '.gitignore');
+    git(dir, 'commit', '-q', '-m', 'gitignore .env');
+    writeFileSync(join(dir, '.env'), 'DATABASE_URL=postgres://u:realisticpassword@host/db\n');
+
+    const analyzer = new StructuralAnalyzer();
+    const findings = await analyzer.analyze(dir);
+    const url = findings.find((f) => f.id === 'SEM-CRED-001');
+    expect(url, 'expected SEM-CRED-001 (URL password)').toBeDefined();
+    expect(url!.severity).toBe('high');
+  });
+
+  it('symlinked .env -> tracked target stays HIGH (round-1 bypass)', async () => {
+    git(dir, 'init', '-q');
+    mkdirSync(join(dir, 'secrets'));
+    writeFileSync(join(dir, 'secrets', 'real.env'), FAKE_ENV_BODY);
+    writeFileSync(join(dir, '.gitignore'), '/.env\n');
+    git(dir, 'add', '.gitignore', 'secrets/real.env');
+    git(dir, 'commit', '-q', '-m', 'tracked real.env, link to follow');
+    symlinkSync('secrets/real.env', join(dir, '.env'));
+
+    const analyzer = new StructuralAnalyzer();
+    const findings = await analyzer.analyze(dir);
+    const env = findEnvCred(findings);
+    expect(env, 'expected SEM-CRED-002 via the .env symlink').toBeDefined();
+    // The link target is tracked -> the secret IS in version control -> HIGH.
+    expect(env!.severity).toBe('high');
+  });
+
+  it('deleted-branch add-history -> HIGH via reflog (round-1 bypass)', async () => {
+    git(dir, 'init', '-q', '--initial-branch=main');
+    writeFileSync(join(dir, '.gitignore'), '.env\n');
+    git(dir, 'add', '.gitignore');
+    git(dir, 'commit', '-q', '-m', 'init');
+    git(dir, 'checkout', '-q', '-b', 'draft');
+    writeFileSync(join(dir, '.env'), FAKE_ENV_BODY);
+    git(dir, 'add', '-f', '.env');
+    git(dir, 'commit', '-q', '-m', 'leaked-once on draft');
+    git(dir, 'checkout', '-q', 'main');
+    git(dir, 'branch', '-D', 'draft');
+    // .env on disk again with current secret. The deleted branch's add is
+    // unreachable from --all but recoverable via reflog.
+    writeFileSync(join(dir, '.env'), FAKE_ENV_BODY);
+
+    const analyzer = new StructuralAnalyzer();
+    const findings = await analyzer.analyze(dir);
+    const env = findEnvCred(findings);
+    expect(env, 'expected SEM-CRED-002 on .env').toBeDefined();
+    expect(env!.severity).toBe('high');
+  });
+
+  it('untracked + not gitignored: rationale tells the truth (no false "gitignored" claim)', async () => {
+    git(dir, 'init', '-q');
+    writeFileSync(join(dir, 'README.md'), '# t\n');
+    git(dir, 'add', 'README.md');
+    git(dir, 'commit', '-q', '-m', 'init');
+    writeFileSync(join(dir, '.env'), FAKE_ENV_BODY);
+
+    const analyzer = new StructuralAnalyzer();
+    const findings = await analyzer.analyze(dir);
+    const env = findEnvCred(findings);
+    expect(env, 'expected SEM-CRED-002 on .env').toBeDefined();
+    expect(env!.severity).toBe('medium');
+    // Must NOT claim "is gitignored" (it isn't); MUST acknowledge the file
+    // is on track for accidental commit.
+    expect(env!.rationale).not.toMatch(/is gitignored/);
+    expect(env!.rationale).toMatch(/not (gitignored|in version control)|NOT gitignored/);
+    expect(env!.recommendation).toMatch(/\.gitignore/);
+  });
+
+  it('.env.local untracked+gitignored downgrades just like .env', async () => {
+    git(dir, 'init', '-q');
+    writeFileSync(join(dir, '.gitignore'), '.env*\n');
+    git(dir, 'add', '.gitignore');
+    git(dir, 'commit', '-q', '-m', 'init');
+    writeFileSync(join(dir, '.env.local'), FAKE_ENV_BODY);
+
+    const analyzer = new StructuralAnalyzer();
+    const findings = await analyzer.analyze(dir);
+    const env = findings.find((f) => f.id === 'SEM-CRED-002' && f.file === '.env.local');
+    expect(env, 'expected SEM-CRED-002 on .env.local').toBeDefined();
+    expect(env!.severity).toBe('medium');
+  });
+
+  it('internal consistency: mixed-format secrets in same gitignored .env all downgrade', async () => {
+    // Round-1 found that JSON/YAML-pattern emit sites were hardcoding HIGH
+    // while the .env-format emit site downgraded, producing self-contradictory
+    // findings on adjacent lines of the same file.
+    git(dir, 'init', '-q');
+    writeFileSync(join(dir, '.gitignore'), '.env\n');
+    git(dir, 'add', '.gitignore');
+    git(dir, 'commit', '-q', '-m', 'init');
+    writeFileSync(
+      join(dir, '.env'),
+      'ANTHROPIC_API_KEY=sk-ant-FAKE1234567890abcdefghijklmnop\n' +
+        '"api_key": "sk-proj-FAKEabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstu"\n',
+    );
+
+    const analyzer = new StructuralAnalyzer();
+    const findings = await analyzer.analyze(dir);
+    const envFindings = findings.filter((f) => f.id === 'SEM-CRED-002' && f.file === '.env');
+    expect(envFindings.length, 'expected one finding per format match').toBeGreaterThanOrEqual(2);
+    for (const f of envFindings) {
+      expect(f.severity, `inconsistent severity on .env:${f.line}`).toBe('medium');
+    }
+  });
+
+  it('absolute-path symlink to tracked target stays HIGH (round-2 path-resolution bypass)', async () => {
+    // Round 2 found that path.resolve(rootDir) does not follow symlinks,
+    // so on macOS where /var/folders is a link to /private/var/folders,
+    // a symlink with an ABSOLUTE-path target produced an out-of-tree
+    // path.relative() result and slipped through.
+    git(dir, 'init', '-q');
+    mkdirSync(join(dir, 'secrets'));
+    writeFileSync(join(dir, 'secrets', 'real.env'), FAKE_ENV_BODY);
+    writeFileSync(join(dir, '.gitignore'), '/.env\n');
+    git(dir, 'add', '.gitignore', 'secrets/real.env');
+    git(dir, 'commit', '-q', '-m', 'tracked real.env');
+    // ABSOLUTE-path symlink target (realpath form -- the macOS bug case).
+    const absTarget = realpathSync(join(dir, 'secrets', 'real.env'));
+    symlinkSync(absTarget, join(dir, '.env'));
+
+    const analyzer = new StructuralAnalyzer();
+    const findings = await analyzer.analyze(dir);
+    const env = findEnvCred(findings);
+    expect(env, 'expected SEM-CRED-002 via the .env symlink').toBeDefined();
+    expect(env!.severity).toBe('high');
+  });
+
+  it('out-of-tree symlink target keeps HIGH (cannot verify tracking)', async () => {
+    // .env -> outside-repo file. We have no way to query that file's
+    // tracking state via this repo's git; default to HIGH.
+    const outside = mkdtempSync(join(tmpdir(), 'hma-208-outside-'));
+    try {
+      writeFileSync(join(outside, 'real.env'), FAKE_ENV_BODY);
+      git(dir, 'init', '-q');
+      writeFileSync(join(dir, '.gitignore'), '/.env\n');
+      git(dir, 'add', '.gitignore');
+      git(dir, 'commit', '-q', '-m', 'init');
+      symlinkSync(join(outside, 'real.env'), join(dir, '.env'));
+
+      const analyzer = new StructuralAnalyzer();
+      const findings = await analyzer.analyze(dir);
+      const env = findEnvCred(findings);
+      expect(env, 'expected SEM-CRED-002 via the .env symlink').toBeDefined();
+      expect(env!.severity).toBe('high');
+    } finally {
+      rmSync(outside, { recursive: true, force: true });
+    }
+  });
+
+  it('hardlinked .env stays HIGH (round-2 hardlink bypass)', async () => {
+    // ln (not ln -s) shares the inode; lstat reports a regular file with
+    // nlink > 1. We default HIGH because we can't cheaply prove the
+    // other path holding the same bytes isn't tracked.
+    git(dir, 'init', '-q');
+    mkdirSync(join(dir, 'secrets'));
+    writeFileSync(join(dir, 'secrets', 'real.env'), FAKE_ENV_BODY);
+    writeFileSync(join(dir, '.gitignore'), '/.env\n');
+    git(dir, 'add', '.gitignore', 'secrets/real.env');
+    git(dir, 'commit', '-q', '-m', 'tracked real.env');
+    linkSync(join(dir, 'secrets', 'real.env'), join(dir, '.env'));
+
+    const analyzer = new StructuralAnalyzer();
+    const findings = await analyzer.analyze(dir);
+    const env = findEnvCred(findings);
+    expect(env, 'expected SEM-CRED-002 on hardlinked .env').toBeDefined();
+    expect(env!.severity).toBe('high');
+    // Round-3: wording must explain hardlink, not parrot "Ensure .env is
+    // in .gitignore" (which is already satisfied here).
+    expect(env!.rationale).toMatch(/hardlink|shares its inode/i);
+    expect(env!.recommendation).toMatch(/find .* -inum|readlink/);
+  });
+
+  it('out-of-tree symlink wording calls out the link target (round-3 CISO Rule 11)', async () => {
+    const outside = mkdtempSync(join(tmpdir(), 'hma-208-outside-r3-'));
+    try {
+      writeFileSync(join(outside, 'real.env'), FAKE_ENV_BODY);
+      git(dir, 'init', '-q');
+      writeFileSync(join(dir, '.gitignore'), '/.env\n');
+      git(dir, 'add', '.gitignore');
+      git(dir, 'commit', '-q', '-m', 'init');
+      symlinkSync(join(outside, 'real.env'), join(dir, '.env'));
+
+      const analyzer = new StructuralAnalyzer();
+      const findings = await analyzer.analyze(dir);
+      const env = findEnvCred(findings);
+      expect(env, 'expected SEM-CRED-002 via the .env symlink').toBeDefined();
+      expect(env!.severity).toBe('high');
+      expect(env!.rationale).toMatch(/outside this repo|symlink/);
+      expect(env!.recommendation).toMatch(/readlink/);
+    } finally {
+      rmSync(outside, { recursive: true, force: true });
+    }
+  });
+
+  it('stale-cache regression: re-using StructuralAnalyzer reflects new git state', async () => {
+    // Round-1 flagged a process-lifetime module cache. Build, scan, then
+    // change tracking state, then scan AGAIN with the same analyzer instance.
+    git(dir, 'init', '-q');
+    writeFileSync(join(dir, '.gitignore'), '.env\n');
+    git(dir, 'add', '.gitignore');
+    git(dir, 'commit', '-q', '-m', 'init');
+    writeFileSync(join(dir, '.env'), FAKE_ENV_BODY);
+
+    const analyzer = new StructuralAnalyzer();
+    const first = await analyzer.analyze(dir);
+    const firstEnv = findEnvCred(first);
+    expect(firstEnv!.severity).toBe('medium');
+
+    // Now commit .env (force, since it's gitignored). Severity must flip to HIGH.
+    git(dir, 'add', '-f', '.env');
+    git(dir, 'commit', '-q', '-m', 'oops committed .env');
+
+    const second = await analyzer.analyze(dir);
+    const secondEnv = findEnvCred(second);
+    expect(secondEnv!.severity, 'stale cache served MEDIUM after .env became tracked').toBe('high');
+  });
+});

--- a/src/semantic/structural/credential-context.ts
+++ b/src/semantic/structural/credential-context.ts
@@ -9,6 +9,7 @@
  */
 
 import type { SemanticFinding, AnalysisFile } from '../types';
+import type { GitContext } from './git-context';
 
 /** Key names that indicate a secret value */
 const SECRET_KEY_PATTERN =
@@ -122,6 +123,107 @@ function severityForFile(filePath: string): 'critical' | 'high' {
 }
 
 /**
+ * #208 .env-specific severity that consults git tracking state.
+ *
+ * Only downgrades when the file is .env-like AND the gitContext can prove
+ * the credential is not in version control (not tracked, not in
+ * history reachable from --all + --reflog). All other paths keep HIGH so
+ * we do not weaken detection on credentials that ARE leaked.
+ *
+ * Order MUST be: index, then history, then ignored. A tracked file can
+ * match a gitignore pattern; downgrading on `isGitignored` alone would
+ * miss real leaks.
+ *
+ * Symlink defense: if the .env candidate is a symlink, the resolved
+ * target is checked too. A symlink to a tracked file stays HIGH.
+ *
+ * Returns the unchanged base severity for non-.env files (e.g. CLAUDE.md
+ * stays CRITICAL; MCP configs stay CRITICAL; generic config.json stays
+ * HIGH).
+ */
+function effectiveSeverityForEnvCredential(
+  filePath: string,
+  gitContext?: GitContext,
+): 'critical' | 'high' | 'medium' {
+  const base = severityForFile(filePath);
+  if (base === 'critical') return 'critical';
+
+  const lower = filePath.toLowerCase();
+  if (!lower.includes('.env')) return base;
+
+  // No git context (or not a git repo) -> can't verify -> keep HIGH.
+  if (!gitContext || !gitContext.isGitRepo) return 'high';
+
+  // Walk the symlink chain. If ANY resolved candidate is tracked or has
+  // history, keep HIGH. A symlinked .env pointing at a tracked file leaks
+  // the same bytes as if .env itself were tracked.
+  const resolved = gitContext.resolveCandidates(filePath);
+
+  // Out-of-tree symlink target OR hardlink: we can't verify tracking
+  // state of the other path holding the same bytes. Default HIGH.
+  if (resolved.outOfTree || resolved.hardlinked) return 'high';
+
+  for (const c of resolved.candidates) {
+    if (gitContext.hasFileInIndex(c)) return 'high';
+    if (gitContext.hasFileInHistory(c)) return 'high';
+  }
+
+  // Untracked AND not in history (any candidate). Local-only exposure.
+  return 'medium';
+}
+
+/**
+ * Build the rationale + recommendation strings for a downgraded .env
+ * SEM-CRED-002 finding. Branches on whether the file is actually
+ * gitignored vs just-untracked so the wording matches reality.
+ */
+function envDowngradeWording(
+  filePath: string,
+  gitContext?: GitContext,
+): { rationale: string; recommendation: string } {
+  const gitignored = gitContext?.isGitignored(filePath) ?? false;
+  if (gitignored) {
+    return {
+      rationale: `${filePath} is gitignored and not present in version control history. The credential is local-only on disk. Treat as MEDIUM until confirmed; the secret may still have been shared via other channels (logs, screen-share, copy-paste, backups).`,
+      recommendation: `Rotate this credential and migrate to opena2a protect (the Secretless vault keeps the value out of process memory and out of AI context, even on local disk).`,
+    };
+  }
+  return {
+    rationale: `${filePath} is not tracked in git and not in any add-history, but it is also NOT gitignored. The next \`git add .\` will commit this credential into version control. Treat as MEDIUM until \`.gitignore\` is updated; rotate the credential regardless.`,
+    recommendation: `Add ${filePath} to .gitignore, rotate this credential, and migrate to opena2a protect (the Secretless vault keeps the value out of process memory and out of AI context).`,
+  };
+}
+
+/**
+ * For .env findings that stayed HIGH because the file is hardlinked or
+ * points outside the repo (the bytes may be tracked under a path we can't
+ * verify), return tailored wording so the user gets an actionable
+ * verification step instead of the stock "Ensure .env is in .gitignore"
+ * which may already be satisfied. Returns undefined when neither flag
+ * applies; the caller should fall through to the standard wording.
+ */
+function envHighOverrideWording(
+  filePath: string,
+  gitContext?: GitContext,
+): { rationale: string; recommendation: string } | undefined {
+  if (!gitContext || !gitContext.isGitRepo) return undefined;
+  const resolved = gitContext.resolveCandidates(filePath);
+  if (resolved.hardlinked) {
+    return {
+      rationale: `${filePath} shares its inode with another path on disk (hardlinked). The other link may be tracked elsewhere in this repo, so the credential could be in version control under a different filename.`,
+      recommendation: `Find the other hardlinked path with: find . -inum $(stat -f '%i' ${filePath} 2>/dev/null || stat -c '%i' ${filePath}). Verify whether any of those paths are tracked, rotate the credential, and migrate to opena2a protect.`,
+    };
+  }
+  if (resolved.outOfTree) {
+    return {
+      rationale: `${filePath} is a symlink pointing outside this repo. The credential bytes live in a file this repo's git cannot inspect; treat as exposed until verified by checking the target's own repo (if any).`,
+      recommendation: `Inspect the link target with: readlink ${filePath}. Verify whether the target is tracked in its own repository, rotate the credential, and migrate to opena2a protect.`,
+    };
+  }
+  return undefined;
+}
+
+/**
  * Detect URL-embedded passwords
  */
 function detectUrlPasswords(file: AnalysisFile): SemanticFinding[] {
@@ -184,7 +286,7 @@ function detectUrlPasswords(file: AnalysisFile): SemanticFinding[] {
  * Skips MCP config and Claude settings files — detectMcpEnvSecrets handles those
  * with richer context (server name, env block path) to avoid duplicate findings.
  */
-function detectGenericTokens(file: AnalysisFile): SemanticFinding[] {
+function detectGenericTokens(file: AnalysisFile, gitContext?: GitContext): SemanticFinding[] {
   if (file.type === 'mcp_config' || file.type === 'claude_settings') {
     return [];
   }
@@ -202,17 +304,23 @@ function detectGenericTokens(file: AnalysisFile): SemanticFinding[] {
         // Ensure value looks like it could be a secret (min length, some entropy)
         if (value.length >= 8 && !/^[a-z]+$/i.test(value)) {
           const { type, masked } = classifySecret(key, value);
+          const sev = effectiveSeverityForEnvCredential(file.path, gitContext);
+          const downgraded = sev === 'medium';
+          const wording = downgraded
+            ? envDowngradeWording(file.path, gitContext)
+            : envHighOverrideWording(file.path, gitContext);
           findings.push({
             id: 'SEM-CRED-002',
             title: `${type} hardcoded in config`,
-            description: `"${key}": ${masked}  — ${type} hardcoded in ${file.path}. Visible to anyone with repo access or who can read the file.`,
-            rationale:
+            description: `"${key}": ${masked}  -- ${type} hardcoded in ${file.path}. Visible to anyone with repo access or who can read the file.`,
+            rationale: wording?.rationale ??
               'Config files with hardcoded secrets are commonly committed to version control. The key name and value prefix identify this as a real credential.',
             category: 'credential',
-            severity: severityForFile(file.path),
+            severity: sev,
             file: file.path,
             line: i + 1,
-            recommendation: 'opena2a protect .  — migrates hardcoded secrets into the Secretless vault (local, keychain, 1Password, or HashiCorp Vault). Keys are injected at runtime; source files reference them by name only.',
+            recommendation: wording?.recommendation ??
+              'opena2a protect .  -- migrates hardcoded secrets into the Secretless vault (local, keychain, 1Password, or HashiCorp Vault). Keys are injected at runtime; source files reference them by name only.',
             layer: 2,
             autoFixable: false,
           });
@@ -228,17 +336,23 @@ function detectGenericTokens(file: AnalysisFile): SemanticFinding[] {
       if (SECRET_KEY_PATTERN.test(key) && !isNonSecretValue(value)) {
         if (value.length >= 8 && !/^[a-z]+$/i.test(value)) {
           const { type, masked } = classifySecret(key, value);
+          const sev = effectiveSeverityForEnvCredential(file.path, gitContext);
+          const downgraded = sev === 'medium';
+          const wording = downgraded
+            ? envDowngradeWording(file.path, gitContext)
+            : envHighOverrideWording(file.path, gitContext);
           findings.push({
             id: 'SEM-CRED-002',
             title: `${type} hardcoded in config`,
-            description: `"${key}": ${masked}  — ${type} hardcoded in ${file.path}. Visible to anyone with repo access or who can read the file.`,
-            rationale:
+            description: `"${key}": ${masked}  -- ${type} hardcoded in ${file.path}. Visible to anyone with repo access or who can read the file.`,
+            rationale: wording?.rationale ??
               'Config files with hardcoded secrets are commonly committed to version control. The key name and value prefix identify this as a real credential.',
             category: 'credential',
-            severity: severityForFile(file.path),
+            severity: sev,
             file: file.path,
             line: i + 1,
-            recommendation: 'opena2a protect .  — migrates hardcoded secrets into the Secretless vault (local, keychain, 1Password, or HashiCorp Vault). Keys are injected at runtime; source files reference them by name only.',
+            recommendation: wording?.recommendation ??
+              'opena2a protect .  -- migrates hardcoded secrets into the Secretless vault (local, keychain, 1Password, or HashiCorp Vault). Keys are injected at runtime; source files reference them by name only.',
             layer: 2,
             autoFixable: false,
           });
@@ -253,17 +367,23 @@ function detectGenericTokens(file: AnalysisFile): SemanticFinding[] {
       const value = rawValue.trim().replace(/^["']|["']$/g, '');
       if (SECRET_KEY_PATTERN.test(key) && !isNonSecretValue(value)) {
         if (value.length >= 8 && !/^[a-z]+$/i.test(value)) {
+          const sev = effectiveSeverityForEnvCredential(file.path, gitContext);
+          const downgraded = sev === 'medium';
+          const wording = downgraded
+            ? envDowngradeWording(file.path, gitContext)
+            : envHighOverrideWording(file.path, gitContext);
           findings.push({
             id: 'SEM-CRED-002',
             title: 'Hardcoded secret in config',
             description: `Environment variable "${key}" contains a hardcoded secret value in ${file.path}.`,
-            rationale:
+            rationale: wording?.rationale ??
               '.env files with hardcoded secrets should be gitignored. If this file is committed, the secret is exposed in version control history.',
             category: 'credential',
-            severity: severityForFile(file.path),
+            severity: sev,
             file: file.path,
             line: i + 1,
-            recommendation: `Ensure ${file.path} is in .gitignore and rotate this credential.`,
+            recommendation: wording?.recommendation ??
+              `Ensure ${file.path} is in .gitignore and rotate this credential.`,
             layer: 2,
             autoFixable: false,
           });
@@ -390,12 +510,12 @@ function detectMcpEnvSecrets(file: AnalysisFile): SemanticFinding[] {
 }
 
 export class CredentialContextAnalyzer {
-  analyze(files: AnalysisFile[]): SemanticFinding[] {
+  analyze(files: AnalysisFile[], gitContext?: GitContext): SemanticFinding[] {
     const findings: SemanticFinding[] = [];
 
     for (const file of files) {
       findings.push(...detectUrlPasswords(file));
-      findings.push(...detectGenericTokens(file));
+      findings.push(...detectGenericTokens(file, gitContext));
       findings.push(...detectCredentialsInInstructions(file));
       findings.push(...detectMcpEnvSecrets(file));
     }

--- a/src/semantic/structural/git-context.ts
+++ b/src/semantic/structural/git-context.ts
@@ -1,0 +1,227 @@
+/**
+ * Git Context Helper (#208: gitignored .env severity downgrade)
+ *
+ * Provides a memoized per-rootDir view over `git ls-files`, `git log`, and
+ * `git check-ignore` so structural analyzers can downgrade severity on
+ * credentials that are gitignored AND never tracked.
+ *
+ * Calls return false on any error (missing git, non-zero exit, ENOENT). The
+ * "safe default" for callers is to treat a non-git-repo as HIGH severity per
+ * the #208 triage.
+ *
+ * Order matters when interpreting results:
+ *   1. `hasFileInIndex`: currently tracked
+ *   2. `hasFileInHistory`: added in ANY ref (--all + --reflog + --diff-filter=A)
+ *   3. `isGitignored`: only meaningful if the file is NOT tracked
+ *
+ * A tracked file can match a gitignore pattern (gitignore does not untrack),
+ * so a severity downgrade based on `isGitignored` alone would weaken
+ * detection. Callers MUST check index + history BEFORE acting on
+ * `isGitignored`.
+ */
+
+import { spawnSync } from 'node:child_process';
+import { lstatSync, readlinkSync, realpathSync, statSync } from 'node:fs';
+import * as path from 'node:path';
+
+export interface GitContext {
+  rootDir: string;
+  isGitRepo: boolean;
+  hasFileInIndex(relPath: string): boolean;
+  /**
+   * Returns true if the path has EVER been added in any ref reachable from
+   * --all OR appears in the reflog (covers deleted branches, `git reset
+   * --hard`, dropped stashes within the default 90-day reflog window).
+   * Does NOT cover dangling blobs after reflog expiry but before gc prune.
+   * A non-empty hit here MUST block any severity downgrade.
+   */
+  hasFileInHistory(relPath: string): boolean;
+  isGitignored(relPath: string): boolean;
+  /**
+   * Returns the list of in-tree candidate paths for relPath. For a regular
+   * file this is `[relPath]`. For a symlink it includes the literal
+   * readlink target plus the fully-resolved realpath, both expressed
+   * relative to a realpath'd rootDir so a path.relative call never crosses
+   * the repo boundary erroneously. Out-of-tree candidates are dropped.
+   *
+   * Returns `{ candidates, outOfTree, hardlinked }`:
+   *   - `outOfTree: true` means at least one resolved candidate was
+   *     outside the rootDir (e.g. symlink to /etc/secrets). Caller MUST
+   *     treat that as "could be tracked somewhere we can't verify" and
+   *     keep HIGH.
+   *   - `hardlinked: true` means lstat reports nlink > 1 (file has at
+   *     least one other path pointing at the same inode). Caller MUST
+   *     keep HIGH.
+   */
+  resolveCandidates(relPath: string): { candidates: string[]; outOfTree: boolean; hardlinked: boolean };
+}
+
+interface GitResult {
+  ok: boolean;
+  stdout: string;
+}
+
+function runGit(rootDir: string, args: string[]): GitResult {
+  try {
+    const result = spawnSync('git', args, {
+      cwd: rootDir,
+      stdio: ['ignore', 'pipe', 'pipe'],
+      encoding: 'utf-8',
+      timeout: 5000,
+    });
+    if (result.error || result.status === null) return { ok: false, stdout: '' };
+    return { ok: result.status === 0, stdout: result.stdout ?? '' };
+  } catch {
+    return { ok: false, stdout: '' };
+  }
+}
+
+/**
+ * Build a fresh GitContext for a single scan invocation.
+ *
+ * No module-level memoization: long-running consumers (MCP server) reuse
+ * the same StructuralAnalyzer across calls. Caching across calls would
+ * report stale tracking state for a path whose git status changed between
+ * scans (e.g. user committed the previously-gitignored .env). Intra-scan
+ * memoization is preserved via the per-instance Maps below.
+ *
+ * rootDir is realpath'd before anything else so candidate paths produced
+ * by `path.relative(abs, realpathSync(symlinkTarget))` land inside the
+ * repo on platforms where the working-tree path is itself a symlink
+ * (macOS `/var/folders` -> `/private/var/folders`, NFS mounts, container
+ * bind mounts).
+ */
+export function getGitContext(rootDir: string): GitContext {
+  let abs: string;
+  try {
+    abs = realpathSync(path.resolve(rootDir));
+  } catch {
+    abs = path.resolve(rootDir);
+  }
+
+  const isGitRepo =
+    runGit(abs, ['rev-parse', '--is-inside-work-tree']).stdout.trim() === 'true';
+
+  const indexCache = new Map<string, boolean>();
+  const historyCache = new Map<string, boolean>();
+  const ignoreCache = new Map<string, boolean>();
+  const candidateCache = new Map<string, { candidates: string[]; outOfTree: boolean; hardlinked: boolean }>();
+
+  const ctx: GitContext = {
+    rootDir: abs,
+    isGitRepo,
+    hasFileInIndex(relPath) {
+      if (!isGitRepo) return false;
+      const c = indexCache.get(relPath);
+      if (c !== undefined) return c;
+      const r = runGit(abs, ['ls-files', '--error-unmatch', '--', relPath]);
+      indexCache.set(relPath, r.ok);
+      return r.ok;
+    },
+    hasFileInHistory(relPath) {
+      if (!isGitRepo) return false;
+      const c = historyCache.get(relPath);
+      if (c !== undefined) return c;
+      // --all covers reachable refs; --reflog widens to deleted branches,
+      // dropped stashes, and `git reset --hard` survivors so a downgrade
+      // is not granted on a path that is only one `git fsck --lost-found`
+      // away from re-exposing the secret.
+      const r = runGit(abs, [
+        'log',
+        '--all',
+        '--reflog',
+        '--diff-filter=A',
+        '--format=%H',
+        '--',
+        relPath,
+      ]);
+      const hit = r.ok && r.stdout.trim().length > 0;
+      historyCache.set(relPath, hit);
+      return hit;
+    },
+    isGitignored(relPath) {
+      if (!isGitRepo) return false;
+      const c = ignoreCache.get(relPath);
+      if (c !== undefined) return c;
+      const r = runGit(abs, ['check-ignore', '-q', '--', relPath]);
+      ignoreCache.set(relPath, r.ok);
+      return r.ok;
+    },
+    resolveCandidates(relPath) {
+      const c = candidateCache.get(relPath);
+      if (c !== undefined) return c;
+
+      const candidates: string[] = [relPath];
+      let outOfTree = false;
+      let hardlinked = false;
+
+      const pushIfInTree = (absTarget: string): void => {
+        let resolved = absTarget;
+        try {
+          resolved = realpathSync(absTarget);
+        } catch {
+          // unreadable target; fall back to the literal path
+        }
+        const rel = path.relative(abs, resolved);
+        if (rel.length === 0) return;
+        // path.relative produces a leading `..` segment when the target
+        // escapes abs. On POSIX that's `../`; on Windows it can be a
+        // different drive letter (path.isAbsolute returns true). Either
+        // way it's out-of-tree as far as `git ls-files` is concerned.
+        if (rel.startsWith('..' + path.sep) || rel === '..' || path.isAbsolute(rel)) {
+          outOfTree = true;
+          return;
+        }
+        if (!candidates.includes(rel)) candidates.push(rel);
+      };
+
+      try {
+        const absPath = path.resolve(abs, relPath);
+        const st = lstatSync(absPath);
+
+        if (st.isSymbolicLink()) {
+          // Literal readlink (covers one hop, both relative + absolute
+          // link form). Even if realpathSync below resolves the chain,
+          // keeping the literal hop lets us match intermediate symlinks
+          // that are themselves tracked.
+          try {
+            const linkRaw = readlinkSync(absPath);
+            const linkAbs = path.isAbsolute(linkRaw)
+              ? linkRaw
+              : path.resolve(path.dirname(absPath), linkRaw);
+            pushIfInTree(linkAbs);
+          } catch {
+            // ignore unreadable link
+          }
+          // Realpath walks the full chain; captures multi-hop chains.
+          try {
+            const real = realpathSync(absPath);
+            pushIfInTree(real);
+          } catch {
+            // ignore broken realpath
+          }
+        } else {
+          // Hardlink defense: a regular file with nlink > 1 shares its
+          // inode with another path. We don't know that other path's git
+          // state without scanning the whole tree; flag and let the
+          // caller treat as HIGH.
+          try {
+            const realSt = statSync(absPath);
+            if (realSt.nlink > 1) hardlinked = true;
+          } catch {
+            // ignore
+          }
+        }
+      } catch {
+        // lstat failed (broken symlink, missing file); fall through with
+        // just the original path.
+      }
+
+      const result = { candidates, outOfTree, hardlinked };
+      candidateCache.set(relPath, result);
+      return result;
+    },
+  };
+
+  return ctx;
+}

--- a/src/semantic/structural/index.ts
+++ b/src/semantic/structural/index.ts
@@ -13,6 +13,7 @@ import { CredentialContextAnalyzer } from './credential-context';
 import { McpConfigAnalyzer } from './mcp-config';
 import { InstructionAnalyzer } from './instruction';
 import { PermissionModelAnalyzer } from './permission-model';
+import { getGitContext } from './git-context';
 
 /** Max file size to read (prevents OOM on huge files) */
 const MAX_FILE_SIZE = 512 * 1024; // 512KB
@@ -60,9 +61,11 @@ export class StructuralAnalyzer {
     const files = await this.discoverFiles(targetDir);
     if (files.length === 0) return [];
 
+    const gitContext = getGitContext(targetDir);
+
     const findings: SemanticFinding[] = [];
 
-    findings.push(...this.credentialAnalyzer.analyze(files));
+    findings.push(...this.credentialAnalyzer.analyze(files, gitContext));
     findings.push(...this.mcpAnalyzer.analyze(files));
     findings.push(...this.instructionAnalyzer.analyze(files));
     findings.push(...this.permissionAnalyzer.analyze(files));


### PR DESCRIPTION
## Summary

Closes #208. A gitignored .env that was never tracked and is not in any add-history (under `git log --all --reflog --diff-filter=A`) is local-only credential exposure, not committed exposure. Severity drops to MEDIUM with rationale + recommendation that match the actual risk surface. Tracked, in-history, hardlinked, out-of-tree symlinked, and non-git-repo cases all keep HIGH so detection is never weakened on real leaks.

## Coverage

16 regression tests in `__tests__/semantic/credential-context-git-state.test.ts` covering:

- tracked (HIGH)
- in-history via `rm --cached` then commit (HIGH, history detected via `--all --reflog --diff-filter=A`)
- not-a-git-repo (HIGH, can't verify)
- gitignored + never tracked (MEDIUM with gitignored rationale)
- untracked + not-ignored (MEDIUM with "next `git add .` will commit this" rationale)
- relative-symlink to tracked target (HIGH)
- absolute-symlink to tracked target including macOS `/var/folders` <-> `/private/var/folders` path-resolution case (HIGH)
- out-of-tree symlink (HIGH with CISO Rule 11 `readlink` verify + `opena2a protect` fix)
- hardlink with nlink > 1 (HIGH with CISO Rule 11 `find -inum` verify + `opena2a protect` fix)
- deleted-branch via reflog (HIGH, reflog still has the add)
- internal consistency on mixed-format same-file findings (.env, JSON, YAML all route through the same helper)
- stale-cache after analyzer re-use (fresh `getGitContext` per `analyze()` call)
- `.env.local` (MEDIUM when gitignored)
- truthful rationale on untracked-not-ignored (no false "is gitignored" claim)
- hardlink + out-of-tree wording satisfies CISO Rule 11

## Process

Three adversarial subagent rounds per `feedback_scanner_change_needs_two_adversarial_rounds`:

- Round 1: 5 HIGH (symlink-target, reflog/deleted-branch, stale module cache, JSON/YAML emit inconsistency, lying "is gitignored" rationale) -- all fixed.
- Round 2: 2 HIGH (macOS path-resolution, hardlink bypass) -- both fixed.
- Round 3: zero new HIGH/CRITICAL (stop signal).

## Verification

- `npx vitest run __tests__/semantic/credential-context-git-state.test.ts` -> 16 pass.
- `npm test` -> 2177 pass, 0 fail.
- HMA self-scan: 98/100 unchanged.
- Sibling ai-trust self-scan: 76/100 with 1 credential MEDIUM (the previously-HIGH `.env` download, correctly downgraded with new rationale).
- The original #208 repro shell snippet now reports MEDIUM with truthful rationale.
