### PR TITLE
ci(parity): bump SHA to pick up scan-soul-hardened clamp re-baseline (#12)

### DIFF
--- a/.github/workflows/parity-gate.yml
+++ b/.github/workflows/parity-gate.yml
@@ -18,9 +18,12 @@ concurrency:
 jobs:
   parity:
     # opena2a-parity moved from opena2a-org to opena2a-standards on 2026-05-24.
-    # Pinned to the current main SHA (untouched since 2026-05-12); bumps require
-    # an explicit, reviewable PR.
-    uses: opena2a-standards/opena2a-parity/.github/workflows/parity.yml@5684cc3b0abfbf6eb1f1d66b637b095647f91830
+    # Pinned to the current main SHA; bumps require an explicit, reviewable PR.
+    # 2026-06-01: c861cf8 picks up scan-soul-hardened re-baseline for HMA 0.23.6
+    # scope-aware clamp (expected score 74/B/standard, was 100/A/hardened) and
+    # the parity workflow self-checkout owner-check fix (opena2a-standards
+    # owner now recognised on self-runs).
+    uses: opena2a-standards/opena2a-parity/.github/workflows/parity.yml@c861cf8bfe46522f30c048cb03f6303641e26301
     with:
       hma_ref: ${{ github.event.pull_request.head.sha || github.sha }}
       opena2a_ref: main


### PR DESCRIPTION
## Summary

Bumps `opena2a-standards/opena2a-parity` pin in `.github/workflows/parity-gate.yml` from `5684cc3` to `c861cf8`.

`c861cf8` ships [opena2a-standards/opena2a-parity#12](https://github.com/opena2a-standards/opena2a-parity/pull/12), which:

- Re-baselines the `scan-soul-hardened` expected JSON to HMA 0.23.6's scope-aware clamped verdict: score `74`, grade `B`, level `standard` (was `100/A/hardened`).
- Both shipped CLIs produce byte-identical output on the fixture: `hackmyagent 0.23.6` (PR #214) and `opena2a-cli 0.10.5` (`opena2a-org/opena2a#181`, bundled HMA 0.23.6).
- Widens the parity workflow's self-checkout owner-check to recognise the new `opena2a-standards` owner (the move from `opena2a-org` on 2026-05-28 left self-runs falling through to `main`).

This is the last step of the HMA 0.23.6 + opena2a-cli 0.10.5 coordinated ship arc. After merge, future HMA PRs will validate scan-soul output against the new clamped expected.

## Test plan

- [x] Parity SHA `c861cf8` verified merged on `opena2a-standards/opena2a-parity` main.
- [x] Both CLIs verified producing byte-identical 74/B/standard on the fixture.
- [ ] CI parity check on this PR passes (gates the merge).
