### PR TITLE
fix(check): honor --no-scan for GitHub repo targets (closes test F4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to HackMyAgent are documented in this file.
 
 ## [Unreleased]
 
+### Fixed
+
+- **`hackmyagent check <org>/<repo> --no-scan` no longer attempts a `git clone` when the Registry has no record of the target.** USER_VISIBLE_IMPACT: previously, `hackmyagent check anthropic/code-review --no-scan --json` (a private repo) fell through to `git clone` and surfaced an opaque `Authentication failed` to stderr with empty stdout instead of the intended not-found JSON. The fix mirrors the PyPI #195 / PR #197 pattern for the GitHub path: emit a `buildNotFoundOutput`-shaped block with `ecosystem: "github"` and a `Verify the URL: …` hint, then return with exit 1 before any clone. This was masquerading as a flaky-test cluster — the hung `git clone` subprocess held resources during parallel vitest execution and caused collateral timing failures in `__tests__/semantic/credential-context-git-state.test.ts` and `__tests__/cli/check-skill-quick-scan-label.test.ts`. With the fix in place the full suite is 2251/2251 green across 5 consecutive runs.
+
 ### Added
 
 - **`hackmyagent trust --grant <ref> --atx <path>`**: opt-in Agent Authorization Protocol gate. Before any Registry lookup, `trust` presents an ATX to the local Secretless broker and proceeds only if the broker authorizes the grant. Second TypeScript AAP consumer (after `opena2a protect --grant` in opena2a-org/opena2a#179). Defends T-3002, T-3003, T-3006, T-8002 at the CLI surface.

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -8765,9 +8765,26 @@ async function checkGitHubRepo(
       displayUnifiedCheck({ name: displayName, sourceLabel: 'GitHub', registry: registryData, verbose: !!options.verbose, usedAnalm: resolveNanomindFlag(options) });
       return;
     }
-    if (!options.json && !globalCiMode) {
-      console.error(`No registry data found for ${displayName}. Running local scan...`);
+    // --no-scan with no Registry hit: emit a not-found block in the same
+    // shape as the GitHub 404 path below, then return without cloning.
+    // Mirrors checkPyPiPackage's #195 fix so --no-scan is honored
+    // consistently across ecosystems. Previously this fell through to
+    // `git clone` -- which on a private repo (e.g. anthropic/code-review)
+    // surfaces an opaque "Authentication failed" instead of the
+    // intended not-found JSON, leaving stdout empty.
+    const errorHint = `Verify the URL: https://github.com/${displayName}`;
+    if (options.json) {
+      writeJsonStdout(buildNotFoundOutput({
+        name: displayName,
+        ecosystem: 'github',
+        error: `Repository "${displayName}" not found in the OpenA2A Registry.`,
+        errorHint,
+      }));
+    } else {
+      printNotFoundBlock({ pkg: displayName, ecosystem: 'github', errorHint });
     }
+    process.exitCode = 1;
+    return;
   }
 
   // Step 2: Clone and scan


### PR DESCRIPTION
## Summary

`hackmyagent check <org>/<repo> --no-scan --json` falls through to `git clone` when the Registry has no record of the target, contradicting the `--no-scan` contract. On a private repo (e.g. `anthropic/code-review`) the clone surfaces an opaque `Authentication failed` instead of the intended not-found JSON, leaving stdout empty.

Mirror the PyPI fix ([#195 / PR #197](https://github.com/opena2a-org/hackmyagent/pull/197)) for the GitHub path: emit a `buildNotFoundOutput`-shaped block with `ecosystem: "github"` and a `Verify the URL: ...` hint, then return with exit 1 before the clone. Exit 1 matches the existing GitHub 404 catch branch a few lines below.

## Why this matters beyond the contract

This was masquerading as a flaky-test cluster. The deterministic F4 failure spawned a hung `git clone` subprocess that held resources during parallel vitest execution, causing collateral timing failures in `__tests__/semantic/credential-context-git-state.test.ts` and `__tests__/cli/check-skill-quick-scan-label.test.ts`. With F4 fixed (no clone attempted), the full suite is 2251/2251 green across 5 consecutive runs.

## Diff scope

19 lines added in `src/cli.ts` + a CHANGELOG entry. Behavioral change: a fall-through path now emits documented JSON instead of triggering an external `git clone`. Strictly safer — no new code paths, no new input handling.

## Test plan

- [x] `npx vitest run __tests__/checker/check-not-found-json.test.ts` — 9/9 passing (F4 included)
- [x] `npm test` — 2251/2251 across 5 consecutive runs (was deterministically 1 failing before)
- [x] Smoke: `check anthropic/code-review --no-scan --json --ci` → clean JSON with errorHint, exit 1
- [x] Smoke: `check anthropic/code-review --no-scan --ci` (text) → "Package not found" + URL hint
- [x] Regression: `check opena2a-org/opena2a --no-scan --json --ci` → still returns Registry data (unchanged behavior on the registered path)
- [x] 8-phase `/pre-push-review` PASSED
