### PR TITLE
Rename composite assessment label to OASB Composite

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to HackMyAgent are documented in this file.
 
 ## [Unreleased]
 
+### Changed
+
+- **`secure -b oasb-2` composite output is relabeled "OASB Composite Security Assessment"** (was "OASB-2 Composite"). The composite spans both layers, so labeling it "OASB-2" collided with the "Governance Score (OASB-2)" leg now that OASB-2 denotes behavioral governance specifically. The unified composite is now named OASB; the two legs remain "Infrastructure Score (OASB-1)" and "Governance Score (OASB-2)". The `--json` `benchmark` field changes from `"OASB-2"` to `"OASB"` accordingly. The `-b oasb-2` flag value is unchanged.
+
 ## [0.23.7] - 2026-06-04
 
 ### Changed

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -3079,7 +3079,7 @@ Performs ${CHECK_COUNT} security checks across ${CATEGORY_COUNT} categories:
 Benchmark mode (--benchmark):
   oasb-1   OASB-1 infrastructure compliance (L1/L2/L3 levels)
            L1 = Essential (baseline), L2 = Standard, L3 = Hardened
-  oasb-2   OASB-2 composite: infrastructure (50%) + governance (50%)
+  oasb-2   OASB composite: infrastructure (50%) + governance (50%)
            Combines OASB-1 scan with scan-soul for a unified score
 
 Output formats (--format):
@@ -3100,7 +3100,7 @@ Examples:
   $ hackmyagent secure -b oasb-1 -f sarif        SARIF for GitHub
   $ hackmyagent secure -b oasb-1 -f html -o report.html
   $ hackmyagent secure -b oasb-1 --fail-below 80 CI threshold
-  $ hackmyagent secure -b oasb-2               OASB-2 composite (infra + governance)
+  $ hackmyagent secure -b oasb-2               OASB composite (infra + governance)
   $ hackmyagent secure ./my-agent --publish    Scan and publish results to registry`)
   .argument('[directory]', 'Directory to scan (defaults to current directory)', '.')
   .option('--fix', 'Automatically fix issues where possible')
@@ -3417,7 +3417,7 @@ Examples:
         }
       }
 
-      // OASB-2 composite mode: infrastructure (50%) + governance (50%)
+      // OASB composite mode: infrastructure (50%) + governance (50%)
       if (isOasb2) {
         const infraResult = generateBenchmarkReport(
           result.allFindings || result.findings,
@@ -3435,7 +3435,7 @@ Examples:
 
         if (format === 'json') {
           const jsonOutput = JSON.stringify({
-            benchmark: 'OASB-2',
+            benchmark: 'OASB',
             infraScore,
             govScore,
             compositeScore,
@@ -3451,7 +3451,7 @@ Examples:
             fs.writeFileSync(1, jsonOutput + '\n');
           }
         } else {
-          process.stdout.write('\nOASB-2 Composite Security Assessment\n');
+          process.stdout.write('\nOASB Composite Security Assessment\n');
           process.stdout.write('----------------------------------------------------\n');
           process.stdout.write(`Infrastructure Score (OASB-1): ${infraScore}%\n`);
           process.stdout.write(`Governance Score (OASB-2):     ${govScore}/100\n`);


### PR DESCRIPTION
Resolves the composite-naming contradiction surfaced in the 0.23.7 release test.

`secure -b oasb-2` produces a composite that spans both layers (infrastructure + governance). Labeling that composite "OASB-2 Composite" collided with the "Governance Score (OASB-2)" leg in the same output, now that OASB-2 denotes behavioral governance specifically.

## Change
The composite is renamed **OASB Composite**; the two legs are unchanged:

```
OASB Composite Security Assessment
Infrastructure Score (OASB-1): 44%
Governance Score (OASB-2):     74/100
Composite Score:               59/100
```

- Header text, `-b` help description, example, and an internal comment: "OASB-2 composite" → "OASB composite".
- `--json` `benchmark` field: `"OASB-2"` → `"OASB"`.
- The `-b oasb-2` flag value is **unchanged** (CLI contract).

## Verification
- `tsc` clean; cli + benchmark tests green (32 passed).
- Smoke: `secure -b oasb-2` prints "OASB Composite Security Assessment"; `--json` emits `"benchmark": "OASB"`.

Follow-up to #223.