### PR TITLE
Sign first-party scanner provenance on publish

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
         "@opena2a/cli-ui": "0.5.1",
         "@opena2a/contribute": "^0.1.0",
         "@opena2a/credential-patterns": "0.1.1",
-        "@opena2a/registry-client": "0.1.0",
+        "@opena2a/registry-client": "0.2.0",
         "@opena2a/shared": "^0.1.0",
         "@opena2a/telemetry": "0.3.0",
         "ai-trust": "^0.2.6",
@@ -651,6 +651,15 @@
         "node": ">=18.0.0"
       }
     },
+    "node_modules/@opena2a/check-core/node_modules/@opena2a/registry-client": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@opena2a/registry-client/-/registry-client-0.1.0.tgz",
+      "integrity": "sha512-1x9OIxMLlFM4XouRoIoCPidh0moAYcE4F44pL0D7/y8a2MiSrUoE8B7KxMRvHitplmYnZ+hma5JM53mpQ13mCw==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
     "node_modules/@opena2a/cli-ui": {
       "version": "0.5.1",
       "resolved": "https://registry.npmjs.org/@opena2a/cli-ui/-/cli-ui-0.5.1.tgz",
@@ -673,10 +682,13 @@
       "license": "Apache-2.0"
     },
     "node_modules/@opena2a/registry-client": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/@opena2a/registry-client/-/registry-client-0.1.0.tgz",
-      "integrity": "sha512-1x9OIxMLlFM4XouRoIoCPidh0moAYcE4F44pL0D7/y8a2MiSrUoE8B7KxMRvHitplmYnZ+hma5JM53mpQ13mCw==",
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@opena2a/registry-client/-/registry-client-0.2.0.tgz",
+      "integrity": "sha512-F+txNbir/owap6TyIHlEW9kQRIufGEDYKmXi2VzflCQB7IAroe4sa/tPGTTnigrLsoWK+AleOdCuZDQW0YEZjQ==",
       "license": "Apache-2.0",
+      "dependencies": {
+        "tweetnacl": "^1.0.3"
+      },
       "engines": {
         "node": ">=18.0.0"
       }

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "@opena2a/cli-ui": "0.5.1",
     "@opena2a/contribute": "^0.1.0",
     "@opena2a/credential-patterns": "0.1.1",
-    "@opena2a/registry-client": "0.1.0",
+    "@opena2a/registry-client": "0.2.0",
     "@opena2a/shared": "^0.1.0",
     "@opena2a/telemetry": "0.3.0",
     "ai-trust": "^0.2.6",

--- a/src/registry/client.ts
+++ b/src/registry/client.ts
@@ -103,10 +103,21 @@ export interface UnifiedPublishPayload {
   version?: string;
   /** Ed25519 signature (base64) — moved from headers to body */
   signature?: string;
-  /** Public key (PEM) of the signer */
+  /** Public key of the signer. PEM for the legacy claimed-agent path; raw base64 for
+   *  the first-party scanner path (the registry allowlist expects a raw 32-byte key). */
   publicKey?: string;
   /** Agent identity ID */
   agentId?: string;
+  /**
+   * Provenance class. Privileged values (first_party_scanner|ci|partner) are honored by
+   * the registry ONLY when signature/publicKey/nonce/signedAt prove an allowlisted
+   * first-party key signed the strong canonical. Unset → community (fail-closed).
+   */
+  source?: string;
+  /** Single-use anti-replay nonce (first-party scanner path). */
+  nonce?: string;
+  /** Unix time in seconds at signing (first-party scanner path). */
+  signedAt?: number;
   /** Sub-reports from different scan types (hardening, attack, soul, oasb) */
   subReports?: Record<string, unknown>;
   /** CAAT tree hash for deduplication */

--- a/src/registry/publish.test.ts
+++ b/src/registry/publish.test.ts
@@ -415,14 +415,18 @@ describe('buildPublishPayload', () => {
 describe('publishScanResults', () => {
   let tmpHome: string;
   let originalEnv: string | undefined;
+  let originalScannerKey: string | undefined;
 
   beforeEach(() => {
     tmpHome = createTempDir();
     originalEnv = process.env.OPENA2A_HOME;
     process.env.OPENA2A_HOME = tmpHome;
+    // Default every test to "no scanner key" so a leaked env value can never
+    // silently mis-tag a community scan as first_party. The one first-party
+    // test sets it explicitly; afterEach restores the original.
+    originalScannerKey = process.env.HMA_SCANNER_SIGNING_KEY;
+    delete process.env.HMA_SCANNER_SIGNING_KEY;
   });
-
-  let originalScannerKey: string | undefined;
 
   afterEach(() => {
     if (originalEnv === undefined) {
@@ -472,6 +476,9 @@ describe('publishScanResults', () => {
     expect(body.name).toBe('@test/agent');
     expect(body.tool).toBe('hackmyagent');
     expect(body.findings).toBeDefined();
+    // No scanner key → never claim privileged provenance. This is the one
+    // invariant the feature must guarantee: a community scan is never mis-tagged.
+    expect(body.source).toBeUndefined();
   });
 
   it('publishes as claimed agent when keypair exists', async () => {
@@ -511,10 +518,12 @@ describe('publishScanResults', () => {
     expect(body.publicKey).toBeDefined();
     expect(body.agentId).toBe('test-agent-123');
     expect(fetchCalls[1][1].headers['X-Scan-Token']).toBe('tok-123');
+    // The per-user claimed-agent identity is NOT our first-party scanner.
+    expect(body.source).toBeUndefined();
   });
 
   it('self-tags first_party_scanner with a strong-canonical signature when HMA_SCANNER_SIGNING_KEY is set', async () => {
-    originalScannerKey = process.env.HMA_SCANNER_SIGNING_KEY;
+    // beforeEach already captured + cleared the original; set the scanner key for this test only.
     // A fixed 32-byte seed (base64), the way our batch orchestration would supply it.
     const seed = Buffer.alloc(32, 9);
     process.env.HMA_SCANNER_SIGNING_KEY = seed.toString('base64');

--- a/src/registry/publish.test.ts
+++ b/src/registry/publish.test.ts
@@ -422,11 +422,18 @@ describe('publishScanResults', () => {
     process.env.OPENA2A_HOME = tmpHome;
   });
 
+  let originalScannerKey: string | undefined;
+
   afterEach(() => {
     if (originalEnv === undefined) {
       delete process.env.OPENA2A_HOME;
     } else {
       process.env.OPENA2A_HOME = originalEnv;
+    }
+    if (originalScannerKey === undefined) {
+      delete process.env.HMA_SCANNER_SIGNING_KEY;
+    } else {
+      process.env.HMA_SCANNER_SIGNING_KEY = originalScannerKey;
     }
     vi.unstubAllGlobals();
     cleanupDir(tmpHome);
@@ -504,6 +511,61 @@ describe('publishScanResults', () => {
     expect(body.publicKey).toBeDefined();
     expect(body.agentId).toBe('test-agent-123');
     expect(fetchCalls[1][1].headers['X-Scan-Token']).toBe('tok-123');
+  });
+
+  it('self-tags first_party_scanner with a strong-canonical signature when HMA_SCANNER_SIGNING_KEY is set', async () => {
+    originalScannerKey = process.env.HMA_SCANNER_SIGNING_KEY;
+    // A fixed 32-byte seed (base64), the way our batch orchestration would supply it.
+    const seed = Buffer.alloc(32, 9);
+    process.env.HMA_SCANNER_SIGNING_KEY = seed.toString('base64');
+
+    const tokenResponse = {
+      ok: true,
+      status: 200,
+      json: async () => ({ scanToken: 'tok-fp', tokenId: 'tid-fp', expiresIn: '300s' }),
+    };
+    const publishResponse = {
+      ok: true,
+      json: async () => ({ accepted: true, publishId: 'pub-fp', consensusStatus: 'pending', weight: 1.0 }),
+    };
+    vi.stubGlobal('fetch', vi.fn()
+      .mockResolvedValueOnce(tokenResponse)
+      .mockResolvedValueOnce(publishResponse));
+
+    const data: PublishScanData = {
+      packageName: '@test/first-party',
+      packageVersion: '2.1.0',
+      directory: '/tmp/test',
+      hardeningFindings: makeHardeningFindings(),
+    };
+
+    const result = await publishScanResults(data, 'https://api.oa2a.org');
+    expect(result.success).toBe(true);
+    expect(result.isCommunity).toBe(false);
+
+    const fetchCalls = (fetch as any).mock.calls;
+    const body = JSON.parse(fetchCalls[1][1].body);
+
+    // Provenance fields present and well-formed.
+    expect(body.source).toBe('first_party_scanner');
+    expect(typeof body.nonce).toBe('string');
+    expect(body.nonce.length).toBeGreaterThan(0);
+    expect(String(body.signedAt).length).toBe(10); // Unix seconds, not ms
+    // Raw 32-byte Ed25519 public key (base64), NOT a PEM block.
+    expect(body.publicKey).not.toContain('BEGIN');
+    expect(Buffer.from(body.publicKey, 'base64').length).toBe(32);
+
+    // The signature verifies over the registry's STRONG canonical
+    // name|version|score|maxScore|source|nonce|signedAt — proving it would unlock
+    // privileged provenance at the server.
+    const nacl = require('tweetnacl');
+    const canonical = `${body.name}|${body.version}|${body.score}|${body.maxScore}|${body.source}|${body.nonce}|${body.signedAt}`;
+    const ok = nacl.sign.detached.verify(
+      Buffer.from(canonical, 'utf-8'),
+      Buffer.from(body.signature, 'base64'),
+      Buffer.from(body.publicKey, 'base64'),
+    );
+    expect(ok).toBe(true);
   });
 
   it('falls back to legacy endpoint on 404', async () => {

--- a/src/registry/publish.ts
+++ b/src/registry/publish.ts
@@ -18,6 +18,7 @@ import type { SoulScanResult } from '../soul';
 import type { BenchmarkResult } from '../benchmarks';
 import { RegistryClient, type UnifiedPublishPayload, type UnifiedFinding } from './client';
 import { reportFindings, reportRemediation } from './remediation';
+import { firstPartySignerFromEnv } from '@opena2a/registry-client';
 
 /**
  * Compute a deterministic tree hash of a directory's contents.
@@ -324,7 +325,18 @@ export async function publishScanResults(
   registryUrl: string,
 ): Promise<PublishResult> {
   const keypair = readAgentKeypair();
-  const isCommunity = !keypair;
+
+  // First-party scanner provenance: our official batch scanner signs the strong canonical
+  // with a DEDICATED Ed25519 key supplied via env (HMA_SCANNER_SIGNING_KEY, Secretless —
+  // never the per-user ~/.opena2a identity). This is the only path that unlocks
+  // source=first_party_scanner at the registry. End-user `--publish` runs (no env key)
+  // keep the existing claimed-agent / community behavior.
+  const firstPartySigner = firstPartySignerFromEnv({
+    keyEnv: 'HMA_SCANNER_SIGNING_KEY',
+    source: 'first_party_scanner',
+  });
+
+  const isCommunity = !keypair && !firstPartySigner;
 
   if (isCommunity) {
     console.log("No signing keys found at ~/.opena2a/keys/. Run 'opena2a claim <package>' to create keys for full-weight publishing. Submitting as community contribution (0.5x weight).");
@@ -350,8 +362,29 @@ export async function publishScanResults(
 
   const payload = buildPublishPayload(data, toolVersion);
 
-  // Sign and include identity in body (not headers)
-  if (keypair) {
+  // Sign and include identity in body (not headers).
+  if (firstPartySigner) {
+    // First-party scanner: sign the registry's STRONG canonical
+    // (name|version|score|maxScore|source|nonce|signedAt) with the raw scanner key.
+    // These override any claimed-agent PEM signature — the registry allowlist matches a
+    // raw 32-byte key over this canonical, not a full-JSON PEM signature.
+    const prov = firstPartySigner.sign({
+      name: payload.name,
+      version: payload.version,
+      score: payload.score,
+      maxScore: payload.maxScore,
+    });
+    payload.source = prov.source;
+    payload.nonce = prov.nonce;
+    payload.signedAt = prov.signedAt;
+    payload.signature = prov.signature;
+    payload.publicKey = prov.publicKey;
+    if (keypair?.agentId) {
+      payload.agentId = keypair.agentId;
+    }
+  } else if (keypair) {
+    // Legacy claimed-agent path: full-JSON PEM signature, surfaced as X-Agent-Signature
+    // on the legacy endpoint. Does not unlock privileged provenance (publishes as community).
     const payloadString = JSON.stringify(payload);
     const signature = signPayload(payloadString, keypair.privateKey);
     if (signature) {

--- a/src/registry/publish.ts
+++ b/src/registry/publish.ts
@@ -363,26 +363,35 @@ export async function publishScanResults(
   const payload = buildPublishPayload(data, toolVersion);
 
   // Sign and include identity in body (not headers).
+  let signedFirstParty = false;
   if (firstPartySigner) {
     // First-party scanner: sign the registry's STRONG canonical
     // (name|version|score|maxScore|source|nonce|signedAt) with the raw scanner key.
     // These override any claimed-agent PEM signature — the registry allowlist matches a
-    // raw 32-byte key over this canonical, not a full-JSON PEM signature.
-    const prov = firstPartySigner.sign({
-      name: payload.name,
-      version: payload.version,
-      score: payload.score,
-      maxScore: payload.maxScore,
-    });
-    payload.source = prov.source;
-    payload.nonce = prov.nonce;
-    payload.signedAt = prov.signedAt;
-    payload.signature = prov.signature;
-    payload.publicKey = prov.publicKey;
-    if (keypair?.agentId) {
-      payload.agentId = keypair.agentId;
+    // raw 32-byte key over this canonical, not a full-JSON PEM signature. Signing must
+    // never crash a publish: on any signer error, fall through to the claimed-agent /
+    // community path below (the registry records that as community — fail-closed).
+    try {
+      const prov = firstPartySigner.sign({
+        name: payload.name,
+        version: payload.version,
+        score: payload.score,
+        maxScore: payload.maxScore,
+      });
+      payload.source = prov.source;
+      payload.nonce = prov.nonce;
+      payload.signedAt = prov.signedAt;
+      payload.signature = prov.signature;
+      payload.publicKey = prov.publicKey;
+      if (keypair?.agentId) {
+        payload.agentId = keypair.agentId;
+      }
+      signedFirstParty = true;
+    } catch {
+      // Degrade to community (or claimed-agent below).
     }
-  } else if (keypair) {
+  }
+  if (!signedFirstParty && keypair) {
     // Legacy claimed-agent path: full-JSON PEM signature, surfaced as X-Agent-Signature
     // on the legacy endpoint. Does not unlock privileged provenance (publishes as community).
     const payloadString = JSON.stringify(payload);


### PR DESCRIPTION
Wires hackmyagent's \`--publish\` path to the shared \`@opena2a/registry-client\` \`FirstPartySigner\` (0.2.0). When \`HMA_SCANNER_SIGNING_KEY\` (a dedicated Ed25519 seed, env-only / Secretless) is set, the publish self-tags \`source=first_party_scanner\` and signs the registry STRONG canonical \`name|version|score|maxScore|source|nonce|signedAt\` with the raw key — the only shape the registry's first-party allowlist verifies.

## Why
\`community_scans.source\` (registry migration 248) separates organic community scans from our own first-party scanner, but a client-claimed \`source\` is attacker-controllable. The registry only honors a privileged \`source\` (\`first_party_scanner|ci|partner\`) when the publish proves first-party identity with an Ed25519 signature over the strong canonical, signed by an allowlisted key. Until clients send that proof, our own scanner's rows land as \`community\` (safe default — undercounts platform coverage, never inflates).

## What changed
- \`src/registry/publish.ts\`: build + send \`source\`/\`nonce\`/\`signedAt\`/\`signature\`/\`publicKey\` via \`firstPartySignerFromEnv({ keyEnv: 'HMA_SCANNER_SIGNING_KEY', source: 'first_party_scanner' })\`. Wrapped so signing **never crashes a publish** — any failure falls closed to \`community\`.
- \`src/registry/client.ts\`: forward the provenance fields in the unified publish body.
- Dedicated scanner key (NOT the per-user \`~/.opena2a\` PEM identity) so \`first_party_scanner\` means OUR scanner, not any claimed agent. Absent the env key, every publish stays \`community\` — end-user runs are never mis-tagged.
- \`package.json\` + \`package-lock.json\`: bump \`@opena2a/registry-client\` to 0.2.0 (published, SLSA v1); pulls \`tweetnacl\` transitively.

## Tests
- 23 publish tests pass, including a positive test that reconstructs the strong canonical from the on-wire body and verifies the emitted signature with \`tweetnacl\`, plus negative assertions that \`source\` is **undefined** on community and claimed-agent publishes (guards the never-mis-tag invariant).
- Full suite: 2277 pass.

## Rollout note
No user-visible effect until the prod registry has the scanner pubkey in \`FIRST_PARTY_SCANNER_PUBKEYS\` (set last, after staging verify). Until then, signed publishes are accepted and recorded as \`community\` (fail-closed).

Part of the first-party publish-signing rollout (companion: \`@opena2a/registry-client\` 0.2.0, opena2a #193).