### PR TITLE
Clarify scan-soul control counts and polish governance CLI UX

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,20 @@ All notable changes to HackMyAgent are documented in this file.
 
 ## [Unreleased]
 
+### Changed
+
+- **`scan-soul` verdict now distinguishes applicable controls from the full catalog.** A fully-hardened SOUL.md scanned at BASIC tier reported `All 29 governance controls covered`, which read as a contradiction of the `72 controls` that `scan-soul --explain` and `harden-soul --dry-run` advertise. The verdict now reads `All 29 applicable controls covered (of 72 in catalog · BASIC tier)` when the evaluated set is a tier/profile subset of the catalog. Both numbers were always correct — 72 is the full governance catalog, 29 is the subset applicable to the detected tier and profile — but the wording now makes the relationship explicit (release-test follow-up).
+- **`scan-soul --explain` now explains the 11-19 domain numbering.** The behavioral domains are numbered 11-19 by design (OASB-2 numbers them to extend the OASB-1 technical domains 1-10; see 0.23.7). The explainer now states this so the gap at 1-10 doesn't read as missing domains.
+
+### Added
+
+- **`detect` now accepts `--contribute` / `--no-contribute`.** The global telemetry footer advertised `--no-contribute`, but `detect` rejected it with `unknown option` while `secure`/`scan-soul`/`attack` accepted it. `detect` now honors both flags (and, like its peers, never auto-contributes in CI unless `--contribute` is explicit).
+- **One-time install hint when a remediation cites the separate `opena2a` CLI.** Scans whose Next Steps cite `opena2a protect` / `opena2a mcp audit` now append `opena2a is a separate CLI — install with: npm i -g opena2a`, so a fresh user who only `npm install hackmyagent` does not hit a dead-end (CISO Rule 11).
+
+### Fixed
+
+- **`explain <SOUL-XX-NNN>` now describes the specific control.** `explain SOUL-IH-003` previously restated the id with a generic "behavioral governance finding" line; it now renders the control name, domain, and remediation from the governance catalog (e.g. "Role-play refusal — Injection Hardening domain …").
+
 ## [0.23.9] - 2026-06-07
 
 ### Added

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -46,6 +46,8 @@ import {
   type FailPolicy,
   // Soul scanner imports
   SoulScanner,
+  GOVERNANCE_CATALOG_SIZE,
+  CONTROL_DEFS,
   type SoulScanResult,
   type DomainResult,
   type SoulLevel,
@@ -6284,7 +6286,7 @@ program
   .description(`Scan behavioral governance coverage
 
 Analyzes SOUL.md (or equivalent governance file) for coverage
-across 9 behavioral governance domains with 72 security controls.
+across 9 behavioral governance domains with ${GOVERNANCE_CATALOG_SIZE} security controls.
 
 Searches for governance files in priority order:
   SOUL.md > system-prompt.md > SYSTEM_PROMPT.md > .cursorrules
@@ -6431,7 +6433,15 @@ Examples:
         soulVerdictText = `Profile marker invalid: '${result.markerInvalid.attemptedValue}' is not a recognized profile`;
       } else if (missing === 0) {
         soulVerdictColor = colors.green;
-        soulVerdictText = `All ${result.totalControls} governance controls covered`;
+        // `result.totalControls` is the count *applicable* to this agent's
+        // detected tier + profile — a subset of the GOVERNANCE_CATALOG_SIZE
+        // (72) catalog that `--explain` and `harden-soul --dry-run` report.
+        // When the scan evaluated fewer than the full catalog, say "applicable"
+        // and tie the number back to the catalog so 29-of-72 doesn't read as a
+        // contradiction of the 72-control model (release-test P2).
+        soulVerdictText = result.totalControls < GOVERNANCE_CATALOG_SIZE
+          ? `All ${result.totalControls} applicable controls covered (of ${GOVERNANCE_CATALOG_SIZE} in catalog · ${result.agentTier} tier)`
+          : `All ${result.totalControls} governance controls covered`;
       } else if (result.conformance === 'none') {
         soulVerdictColor = colors.brightRed;
         soulVerdictText = `${missing} control${missing > 1 ? 's' : ''} failing — no conformance`;
@@ -7441,6 +7451,15 @@ program
     const categoryLabel = prefixDescriptions[explainPrefix] || 'security check';
     const staticExplanation = staticExplanations[checkId];
 
+    // Per-control lookup for governance catalog IDs (SOUL-TH-001, SOUL-IH-003,
+    // …). Without this, `explain SOUL-IH-003` falls through to the generic
+    // "behavioral governance finding" line (release-test P3). The catalog
+    // carries the control name + remediation, so render those instead.
+    const soulControl = CONTROL_DEFS.find((c) => c.id === checkId);
+    const soulControlExplanation = soulControl
+      ? `${soulControl.name} — ${soulControl.domain} domain (scan-soul control ${soulControl.id}).${soulControl.remediation ? ` ${soulControl.remediation}` : ''} Run: hackmyagent harden-soul <dir> to add governance that satisfies this control.`
+      : undefined;
+
     // ── Header ──────────────────────────────────────────────────────
     console.log();
     console.log(`  ${colors.bold}${colors.white}${checkId}${RESET()}  ${colors.dim}${categoryLabel}${RESET()}`);
@@ -7448,6 +7467,12 @@ program
 
     if (staticExplanation) {
       console.log(`  ${staticExplanation}`);
+    } else if (soulControlExplanation) {
+      console.log(`  ${soulControlExplanation}`);
+      if (attackClass) {
+        console.log();
+        console.log(`  ${colors.dim}Attack class:${RESET()} ${attackClass}`);
+      }
     } else if (attackClass || categoryLabel !== 'security check') {
       console.log(`  ${prefixDescriptions[explainPrefix] ? prefixDescriptions[explainPrefix].charAt(0).toUpperCase() + prefixDescriptions[explainPrefix].slice(1) : 'Security check'} finding.`);
       if (attackClass) {
@@ -7723,12 +7748,18 @@ Examples:
   .option('--json', 'Output as JSON')
   .option('--verbose', 'Show full MCP server list and identity details')
   .option('--export-csv <file>', 'Export asset inventory as CSV (for ServiceNow, CMDB, etc.)')
+  .option('--contribute', 'Share anonymized scan findings with OpenA2A Registry (overrides config)')
+  .option('--no-contribute', 'Do not share findings for this scan (overrides config)')
   .action(async (directory: string | undefined, options: {
     json?: boolean;
     verbose?: boolean;
     exportCsv?: string;
+    contribute?: boolean;
   }) => {
     const targetDir = directory ?? process.cwd();
+    // In CI, never auto-contribute unless the user explicitly opts in (parity
+    // with secure/scan-soul). Outside CI the flag falls through to config.
+    if (globalCiMode && options.contribute === undefined) options.contribute = false;
     const { detect: runDetect } = await import('./scanner/detect.js');
     const exitCode = await runDetect({
       targetDir,
@@ -7740,8 +7771,9 @@ Examples:
 
     // Wire detect scans into the community contribution pipeline.
     // Detect findings are agent/MCP/governance posture — relevant data for the registry.
+    // Honors --contribute / --no-contribute (release-test P2); otherwise respects global config.
     await handleContribution(
-      undefined,      // no --contribute flag on detect; respects global config
+      options.contribute,
       targetDir,
       [],             // detect doesn't produce SecurityFinding[]; summary goes via contribute metadata
       0,
@@ -8682,14 +8714,21 @@ function printCheckNextSteps(
   console.log();
   console.log(`  ${colors.dim}──${RESET()} ${colors.bold}Next Steps${RESET()} ${colors.dim}${'─'.repeat(49)}${RESET()}`);
 
+  // Tracks whether any next-step cites the separate `opena2a` CLI so we can
+  // print a one-time install hint — a fresh user who only `npm i hackmyagent`
+  // does not have `opena2a` on PATH, otherwise the step reads as a dead-end
+  // (release-test P2 / CISO Rule 11).
+  let citedOpena2a = false;
   if (context?.hasGovernanceIssues && isLocal) {
     console.log(`  ${colors.cyan}Auto-fix governance:${RESET()}  ${CLI_PREFIX} harden-soul ${dirTarget}`);
   }
   if (context?.hasCredentialFindings) {
     console.log(`  ${colors.cyan}Protect credentials:${RESET()}  opena2a protect ${isLocal ? dirTarget : '.'}`);
+    citedOpena2a = true;
   }
   if (context?.hasMcpFindings) {
     console.log(`  ${colors.cyan}Audit MCP servers:${RESET()}    opena2a mcp audit  ${colors.dim}(run from project dir)${RESET()}`);
+    citedOpena2a = true;
   }
   if (context?.hasCodeVulns && isLocal) {
     console.log(`  ${colors.cyan}Auto-fix all issues:${RESET()}  ${CLI_PREFIX} secure --fix`);
@@ -8717,6 +8756,9 @@ function printCheckNextSteps(
     }
   }
   console.log(`  ${colors.cyan}All commands:${RESET()}         ${CLI_PREFIX} --help`);
+  if (citedOpena2a) {
+    console.log(`  ${colors.dim}opena2a is a separate CLI — install with: npm i -g opena2a${RESET()}`);
+  }
   console.log();
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -205,7 +205,7 @@ export { SkillCapabilityMonitor, createCapabilityMonitor, parseDeclaredCapabilit
 export type { DeclaredCapabilities, ObservedBehavior, CapabilityViolation } from './arp';
 
 // Soul module (Behavioral Governance Scanner)
-export { SoulScanner, CONTROL_DEFS, DOMAIN_ORDER, GOVERNANCE_FILES, PROFILE_DOMAINS } from './soul';
+export { SoulScanner, CONTROL_DEFS, DOMAIN_ORDER, GOVERNANCE_FILES, GOVERNANCE_CATALOG_SIZE, PROFILE_DOMAINS } from './soul';
 export type {
   AgentTier,
   AgentProfile,

--- a/src/soul/governance-model.test.ts
+++ b/src/soul/governance-model.test.ts
@@ -1,0 +1,28 @@
+import { describe, it, expect } from 'vitest';
+import { renderGovernanceModel, buildDomainSummaries } from './governance-model';
+import { GOVERNANCE_CATALOG_SIZE } from './scanner';
+
+describe('renderGovernanceModel', () => {
+  const output = renderGovernanceModel();
+
+  it('reports the full catalog total (9 domains, 72 controls)', () => {
+    const summaries = buildDomainSummaries();
+    expect(summaries).toHaveLength(9);
+    expect(GOVERNANCE_CATALOG_SIZE).toBe(72);
+    expect(output).toContain('scan-soul governance model: 9 domains, 72 controls');
+  });
+
+  it('numbers domains 11-19 per the OASB-2 spec, with context for the gap at 1-10 (P3)', () => {
+    const domainLines = output.split('\n').filter((l) => l.startsWith('Domain '));
+    expect(domainLines).toHaveLength(9);
+    // OASB-2 numbers the behavioral domains 11-19 (extending OASB-1's 1-10).
+    // This is the canonical spec numbering, not a leaked internal index — see
+    // CHANGELOG 0.23.7. The renderer must keep these ids, not renumber to 1-9.
+    domainLines.forEach((line, i) => {
+      expect(line.startsWith(`Domain ${11 + i} — `)).toBe(true);
+    });
+    // And it must explain the 11-19 numbering so the 1-10 gap doesn't read as
+    // missing domains.
+    expect(output).toContain('OASB-2 behavioral domains');
+  });
+});

--- a/src/soul/governance-model.ts
+++ b/src/soul/governance-model.ts
@@ -73,6 +73,13 @@ export function renderGovernanceModel(): string {
   lines.push('');
   lines.push('Domains are evaluated in the order shown. The agent profile (--profile)');
   lines.push('selects which domains apply; tiers narrow the controls within each domain.');
+  // The domain numbers are 11-19 by design: OASB-2 numbers the 9 behavioral
+  // governance domains 11-19 so they extend the OASB-1 technical security
+  // domains (1-10) into a unified 1-19 set. They are not a 1-9 index — see
+  // CHANGELOG 0.23.7. This note keeps a fresh reader from reading the gap at
+  // 1-10 as missing domains (release-test P3).
+  lines.push('Domains are numbered 11-19 (OASB-2 behavioral domains, extending the');
+  lines.push('OASB-1 technical domains 1-10) — this is the canonical spec numbering.');
   lines.push('');
 
   for (const d of domains) {

--- a/src/soul/index.ts
+++ b/src/soul/index.ts
@@ -2,7 +2,7 @@
  * Soul module - Behavioral Governance Scanner
  */
 
-export { SoulScanner, CONTROL_DEFS, DOMAIN_ORDER, GOVERNANCE_FILES, PROFILE_DOMAINS } from './scanner';
+export { SoulScanner, CONTROL_DEFS, DOMAIN_ORDER, GOVERNANCE_FILES, GOVERNANCE_CATALOG_SIZE, PROFILE_DOMAINS } from './scanner';
 export type {
   AgentTier,
   AgentProfile,

--- a/src/soul/scanner.ts
+++ b/src/soul/scanner.ts
@@ -434,6 +434,16 @@ const CONTROL_DEFS: ControlDef[] = [
     remediation: 'When instructions are ambiguous, default to the safer interpretation or ask for clarification. Disambiguate uncertain instructions.' },
 ];
 
+/**
+ * Total number of controls in the governance catalog across all 9 domains
+ * and all tiers. This is the "72" that `scan-soul --explain` and
+ * `harden-soul --dry-run` report. A specific scan only evaluates the subset
+ * of these that is *applicable* to the detected tier + profile (see
+ * `applicableControls`), so a scan verdict count (e.g. 29 at BASIC tier) is a
+ * subset of this catalog — not a contradiction of it.
+ */
+export const GOVERNANCE_CATALOG_SIZE = CONTROL_DEFS.length;
+
 // Unique domain names in order
 const DOMAIN_ORDER = [
   'Trust Hierarchy',


### PR DESCRIPTION
Release-test follow-ups for HMA 0.23.9 (P2/P3, pre-existing, UX-only — no change to scoring or detection). From `todo/2026-06-07-hma-0.23.9-release-test-followups.md`.

## The 29-vs-72 contradiction — reconciled (not a bug in either count)
Both numbers are correct and measure different things:
- **72** = the full governance catalog (`CONTROL_DEFS.length`, all 9 domains × all tiers) — what `--explain` and `harden-soul --dry-run` report.
- **29** = the controls *applicable* to the scanned agent at its detected tier + profile (`applicableControls()` filters by `tiers.includes(tier) && profileDomains.includes(domainId)`). `harden-soul` writes `<!-- soul:tier=BASIC -->`, so a freshly-hardened SOUL.md scans at BASIC → 29 applicable (6+6+4+4+7+2).

The fix is wording, not either count. The verdict now reads `All 29 applicable controls covered (of 72 in catalog · BASIC tier)`.

## Changes
- **scan-soul verdict** distinguishes the applicable subset from the catalog total (P2.3).
- **scan-soul --explain** keeps the canonical OASB-2 **11-19** domain numbering (0.23.7 aligned these to extend OASB-1's 1-10) and now adds a header line explaining it, so the gap at 1-10 doesn't read as missing domains. *(The release-test flagged this as "should be 1-9" — that was a mis-call; renumbering would have reintroduced the misalignment 0.23.7 fixed.)* (P3.2)
- **detect** now accepts `--contribute` / `--no-contribute` (was `unknown option`; the global footer advertised it) (P2.1).
- **Next Steps** appends a one-time `opena2a is a separate CLI — install with: npm i -g opena2a` hint when a step cites the separate CLI, clearing the fresh-user dead-end (P2.2).
- **explain <SOUL-XX-NNN>** renders the control name/domain/remediation from the catalog instead of a generic line (P3.1).
- Added `GOVERNANCE_CATALOG_SIZE` export; the scan-soul help "72 security controls" is now derived from it.

## Deferred (separate PR)
HMA P3.3 (`--version` telemetry banner on stdout) and P3.4 (`secure --fix` verdict for remote packages) live in shared `@opena2a/cli-ui` and need a coordinated publish + consumer pin bumps. Tracked in `todo/2026-06-07-cli-ui-shared-followups.md`.

## Testing
- Full suite: **2279 pass** (+ new `governance-model.test.ts` asserting the 11-19 numbering).
- New-user walkthrough of all changed commands; edge cases (unknown flags still rejected, legacy `SOUL-001` not shadowed by the catalog lookup).
- HMA self-scan 98/100 (1 LOW, pre-existing). Adversarial self-review: no CRITICAL/HIGH.