### PR TITLE
chore(cli-ui): adopt 0.5.2 — stream-split --version + remote-aware verdict

### DIFF
--- a/__tests__/cli/version-stream-split.test.ts
+++ b/__tests__/cli/version-stream-split.test.ts
@@ -1,0 +1,77 @@
+/**
+ * cli-ui 0.5.2 — `--version` stream split.
+ *
+ * The version output is rendered via `versionLineParts` and a manual
+ * `option:version` handler (not Commander's `.version()`, which writes
+ * everything to stdout). The bare `hackmyagent x.y.z` must land on stdout as
+ * a single parseable line; the telemetry disclosure must land on stderr.
+ *
+ * A script doing `hackmyagent --version` (capturing stdout) must get exactly
+ * one clean line, with the privacy disclosure still surfaced via stderr.
+ */
+import { describe, it, expect } from 'vitest';
+import { spawnSync } from 'node:child_process';
+import { existsSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+const CLI_PATH = resolve(__dirname, '../../dist/cli.js');
+const STRIP_ANSI = /\x1b\[[0-9;]*m/g;
+
+function runVersion(flag: string): { stdout: string; stderr: string; status: number } {
+  const res = spawnSync(process.execPath, [CLI_PATH, flag], {
+    encoding: 'utf8',
+    timeout: 20000,
+    env: { ...process.env, NODE_OPTIONS: '', NO_COLOR: '1', OPENA2A_TELEMETRY: 'on' },
+  });
+  return {
+    stdout: (res.stdout ?? '').replace(STRIP_ANSI, ''),
+    stderr: (res.stderr ?? '').replace(STRIP_ANSI, ''),
+    status: res.status ?? 1,
+  };
+}
+
+describe('--version stream split (cli-ui 0.5.2)', () => {
+  it('dist/cli.js exists', () => {
+    expect(existsSync(CLI_PATH)).toBe(true);
+  });
+
+  it('stdout is a single clean `hackmyagent x.y.z` line, telemetry goes to stderr', () => {
+    if (!existsSync(CLI_PATH)) return;
+    const { stdout, stderr, status } = runVersion('--version');
+    expect(status).toBe(0);
+
+    const stdoutLines = stdout.trim().split('\n').filter((l) => l.length > 0);
+    expect(stdoutLines).toHaveLength(1);
+    expect(stdoutLines[0]).toMatch(/^hackmyagent \d+\.\d+\.\d+/);
+    // The telemetry disclosure must NOT pollute the parseable stream.
+    expect(stdout).not.toMatch(/Telemetry:/);
+
+    // Disclosure still surfaces — on stderr.
+    expect(stderr).toMatch(/Telemetry: on/);
+  });
+
+  it('-v behaves identically to --version (stdout, stderr disclosure, exit 0)', () => {
+    if (!existsSync(CLI_PATH)) return;
+    const long = runVersion('--version');
+    const short = runVersion('-v');
+    expect(short.status).toBe(0);
+    expect(short.stdout.trim()).toBe(long.stdout.trim());
+    // The disclosure must also surface on stderr via the short flag.
+    expect(short.stderr).toMatch(/Telemetry: on/);
+  });
+
+  it('OPENA2A_TELEMETRY=off: stdout stays the single version line, no telemetry leak', () => {
+    if (!existsSync(CLI_PATH)) return;
+    const res = spawnSync(process.execPath, [CLI_PATH, '--version'], {
+      encoding: 'utf8',
+      timeout: 20000,
+      env: { ...process.env, NODE_OPTIONS: '', NO_COLOR: '1', OPENA2A_TELEMETRY: 'off' },
+    });
+    const stdout = (res.stdout ?? '').replace(STRIP_ANSI, '');
+    expect(res.status).toBe(0);
+    const lines = stdout.trim().split('\n').filter((l) => l.length > 0);
+    expect(lines).toHaveLength(1);
+    expect(lines[0]).toMatch(/^hackmyagent \d+\.\d+\.\d+/);
+    expect(stdout).not.toMatch(/Telemetry:/);
+  });
+});

--- a/docs/testing/release-smoke.md
+++ b/docs/testing/release-smoke.md
@@ -38,9 +38,15 @@ Fail the release if:
 ## 1. Help and version (1 min)
 
 ```bash
-node dist/cli.js --help     # prints command list; no stack traces
-node dist/cli.js -v         # prints: hackmyagent 0.x.x
+node dist/cli.js --help              # prints command list; no stack traces
+node dist/cli.js -v                   # prints: hackmyagent 0.x.x + telemetry line
+node dist/cli.js -v 2>/dev/null       # stdout ONLY: single clean line `hackmyagent 0.x.x`
+node dist/cli.js -v 2>&1 1>/dev/null  # stderr ONLY: `Telemetry: on (opt-out: ...)`
 ```
+
+As of cli-ui 0.5.2 the version output is stream-split: the bare `tool x.y.z`
+goes to **stdout** (a single parseable line) and the telemetry disclosure goes
+to **stderr**. A script doing `hackmyagent --version` must get exactly one line.
 
 The `--help` output must list: `check`, `secure`, `scan-soul`, `harden-soul`,
 `red-team`, `wild`, `detect`, `explain`, `check-metadata`, `analm`, `eval`,
@@ -162,7 +168,7 @@ unset OPENA2A_TELEMETRY
 
 | # | Command | Expected |
 |---|---|---|
-| 5.1 | `node dist/cli.js -v` | Version line + `Telemetry: on (opt-out: ...)` |
+| 5.1 | `node dist/cli.js -v` | Version line on **stdout** (`hackmyagent 0.x.x`, single line) + `Telemetry: on (opt-out: ...)` on **stderr**. `-v 2>/dev/null` shows only the version; `-v 2>&1 1>/dev/null` shows only the telemetry line. |
 | 5.2 | `node dist/cli.js telemetry status` | Prints `state: on`, install_id, config path, toggle hint |
 | 5.3 | `node dist/cli.js telemetry off` | Prints `Telemetry disabled for hackmyagent.` |
 | 5.4 | `node dist/cli.js telemetry on` | Re-enables persistently |

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "@noble/post-quantum": "^0.2.1",
         "@opena2a/aim-core": "^0.1.2",
         "@opena2a/check-core": "0.2.0",
-        "@opena2a/cli-ui": "0.5.1",
+        "@opena2a/cli-ui": "0.5.2",
         "@opena2a/contribute": "^0.1.0",
         "@opena2a/credential-patterns": "0.1.1",
         "@opena2a/registry-client": "0.2.0",
@@ -661,9 +661,9 @@
       }
     },
     "node_modules/@opena2a/cli-ui": {
-      "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/@opena2a/cli-ui/-/cli-ui-0.5.1.tgz",
-      "integrity": "sha512-QfiZUEQS8HIHQKthZrXSGyO4OP3t2/AhR1/YDvglkbDstg6lG2GL5/O2UjH+8PlIBRhBzSvMpJt0OuCoVVuHoQ==",
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/@opena2a/cli-ui/-/cli-ui-0.5.2.tgz",
+      "integrity": "sha512-KtJzCDHWbrGzSi+1viurDaa19yfJjitL4i5LEpkj4pIEfwBwyM21SQbM8DWkeOBastc2BzQmVolPVOi1MyK75A==",
       "license": "Apache-2.0",
       "dependencies": {
         "chalk": "^5.3.0"

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "@noble/post-quantum": "^0.2.1",
     "@opena2a/aim-core": "^0.1.2",
     "@opena2a/check-core": "0.2.0",
-    "@opena2a/cli-ui": "0.5.1",
+    "@opena2a/cli-ui": "0.5.2",
     "@opena2a/contribute": "^0.1.0",
     "@opena2a/credential-patterns": "0.1.1",
     "@opena2a/registry-client": "0.2.0",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -686,6 +686,14 @@ interface UnifiedCheckDisplayOptions {
     /** Target string emitted in the follow-up line (path or name as typed). */
     fullAuditTarget: string;
   };
+  /**
+   * True when the scanned artifact is a downloaded third-party package
+   * (`check pip:`, `check npm:`, a GitHub repo, a raw URL) rather than the
+   * user's own working tree. Threaded into the cli-ui SurfaceSummary so the
+   * verdict guidance is review / choose-a-vetted-version instead of
+   * `secure --fix` on code the user does not own. Defaults to local (false).
+   */
+  remote?: boolean;
 }
 
 function stripAnsi(s: string): string {
@@ -1096,7 +1104,7 @@ function displayUnifiedCheck(opts: UnifiedCheckDisplayOptions): void {
     const categorySummaries = buildCategorySummaries(failed);
     const verdictLine = buildVerdict(
       { critical, high, medium, low },
-      { kind, filesScanned },
+      { kind, filesScanned, remote: opts.remote === true },
       failed.map(f => ({
         severity: f.severity as 'critical' | 'high' | 'medium' | 'low',
         name: f.name,
@@ -1107,7 +1115,7 @@ function displayUnifiedCheck(opts: UnifiedCheckDisplayOptions): void {
     );
 
     const { lines, artifactLines } = renderObservationsBlock({
-      surfaces: { kind, filesScanned, artifactsCompiled: semanticCount },
+      surfaces: { kind, filesScanned, artifactsCompiled: semanticCount, remote: opts.remote === true },
       checks: { staticCount, semanticCount },
       categories: categorySummaries,
       verdict: verdictLine,
@@ -8956,6 +8964,7 @@ async function checkGitHubRepo(
     displayUnifiedCheck({
       name: displayName,
       sourceLabel: 'GitHub',
+      remote: true,
       projectType: result.projectType,
       localScan: { score: result.score, maxScore: result.maxScore, findings: result.findings },
       registry: registryData,
@@ -9253,6 +9262,7 @@ async function checkPyPiPackage(
     displayUnifiedCheck({
       name,
       sourceLabel: 'PyPI',
+      remote: true,
       projectType: result.projectType,
       version: meta.info.version,
       localScan: { score: result.score, maxScore: result.maxScore, findings: result.findings },
@@ -9448,6 +9458,7 @@ async function checkRawUrl(
     displayUnifiedCheck({
       name: displayName,
       sourceLabel: 'URL',
+      remote: true,
       projectType: result.projectType,
       localScan: { score: result.score, maxScore: result.maxScore, findings: result.findings },
       verbose: !!options.verbose,
@@ -9618,6 +9629,7 @@ async function checkNpmPackage(
     displayUnifiedCheck({
       name,
       projectType: result.projectType,
+      remote: true,
       localScan: { score: result.score, maxScore: result.maxScore, findings: result.findings },
       registry: registryData,
       verbose: !!options.verbose,
@@ -9809,14 +9821,20 @@ async function checkNpmPackage(
   // the integrity check) so INTEGRITY_FAIL can fire. CommonJS / ESM bridge:
   // dynamic import inside async main, type-only `TelemetryAction` import
   // with resolution-mode: 'import'.
-  const { versionLine, runTelemetryCommand } = await import('@opena2a/cli-ui');
+  const { versionLineParts, runTelemetryCommand } = await import('@opena2a/cli-ui');
 
-  // Set the --version line now that we have live telemetry status.
-  program.version(
-    versionLine({ tool: 'hackmyagent', version: VERSION, telemetry: tele.status() }),
-    '-v, --version',
-    'Output the version number',
-  );
+  // Set the --version line now that we have live telemetry status. Use a
+  // manual `option:version` handler (not Commander's `.version()`, which
+  // writes everything to stdout) so the bare version goes to stdout and the
+  // telemetry disclosure goes to stderr — `hackmyagent --version` stays a
+  // clean, single, parseable line while the privacy disclosure still prints.
+  const vparts = versionLineParts({ tool: 'hackmyagent', version: VERSION, telemetry: tele.status() });
+  program.option('-v, --version', 'Output the version number');
+  program.on('option:version', () => {
+    process.stdout.write(vparts.stdout + '\n');
+    if (vparts.stderr) process.stderr.write(vparts.stderr + '\n');
+    process.exit(0);
+  });
 
   // Telemetry tracking — records command start time, fires on postAction.
   // The 'telemetry' subcommand itself is excluded to avoid self-referential


### PR DESCRIPTION
Adopts the published \`@opena2a/cli-ui@0.5.2\` (SLSA provenance) into hackmyagent. Part of the cli-ui 0.5.2 consumer-adoption sweep (todo/2026-06-08-cli-ui-0.5.2-consumer-adoption.md).

## Changes
- **Pin bump:** \`@opena2a/cli-ui\` 0.5.1 → 0.5.2 (lockfile synced via \`npm install\`).
- **Stream-split \`--version\`:** replaced Commander's \`.version()\` (which writes everything to stdout) with \`versionLineParts\` + a manual \`option:version\` handler. \`hackmyagent --version\` now prints the bare \`hackmyagent x.y.z\` as a single line on **stdout**; the telemetry disclosure prints to **stderr**. Scripts capturing stdout get one clean, parseable line while the privacy disclosure still surfaces.
- **Remote-aware verdict:** threaded a new \`remote\` flag through \`displayUnifiedCheck\` into the cli-ui \`buildVerdict\` surface + \`renderObservationsBlock\` surfaces. Downloaded-package check paths (PyPI, npm, GitHub repo, raw URL) now set \`remote: true\`, so the verdict guidance is **review / choose a vetted version** instead of \`secure --fix\` on code the user does not own. Local \`secure\` / \`check .\` keep \`remote: false\`.

## Verification
- \`hackmyagent --version 2>/dev/null\` → single line \`hackmyagent 0.23.9\`; \`--version 2>&1 1>/dev/null\` → telemetry line only.
- \`check pip:requests\` verdict → "…review them before depending on it" (no \`secure --fix\`); local \`secure .\` retains \`secure --fix\` guidance.
- New test: \`__tests__/cli/version-stream-split.test.ts\` (4 cases: stdout single line, telemetry on stderr, -v parity + exit/stderr, telemetry-off no leak).
- Full suite green (2282 pass / 18 skip). release-smoke §1 + §5.1 updated for the stdout/stderr split.

## Not in this PR
No republish — rides hackmyagent's next release per the publish budget.