### PR TITLE
fix(semantic): consolidate duplicate weak-constraint check AST-GOVERN-001

### DIFF
--- a/__tests__/nanomind-core/capability-analyzer.test.ts
+++ b/__tests__/nanomind-core/capability-analyzer.test.ts
@@ -1,9 +1,11 @@
 import { describe, it, expect } from 'vitest';
 import { SemanticCompiler } from '../../src/nanomind-core/compiler/semantic-compiler';
 import { analyzeCapabilities } from '../../src/nanomind-core/analyzers/capability-analyzer';
+import { analyzeGovernance } from '../../src/nanomind-core/analyzers/governance-analyzer';
 
 describe('Capability Analyzer (AST-based)', () => {
   const compiler = new SemanticCompiler({ useNanoMind: false });
+  const verifier = (ast: any) => compiler.verifyAST(ast);
 
   describe('Benign skill', () => {
     const skill = `---
@@ -80,12 +82,25 @@ It is recommended to check permissions when appropriate.
       expect(unconstrained.length).toBeGreaterThan(0);
     });
 
-    it('detects weak constraint language', async () => {
+    it('does not emit AST-GOVERN-001 (delegated to governance-analyzer AST-GOV-002)', async () => {
+      // Capability-analyzer used to emit AST-GOVERN-001 for weak constraint language,
+      // duplicating governance-analyzer's AST-GOV-002. AST-GOV-002 iterates the effective
+      // constraint set (declared ∪ project-level) -- a superset of the declaredConstraints
+      // this analyzer saw -- with line numbers and enforceability tiers. The emitter was
+      // consolidated into governance-analyzer; capability-analyzer must no longer emit it.
       const { ast } = await compiler.compile(skill, 'admin.skill.md');
       const findings = analyzeCapabilities(ast);
       const weak = findings.filter(f => f.checkId === 'AST-GOVERN-001');
-      expect(weak.length).toBeGreaterThan(0);
-      expect(weak[0].guidance?.toLowerCase()).toContain('advisory');
+      expect(weak).toHaveLength(0);
+    });
+
+    it('weak constraint language is still caught by governance-analyzer (AST-GOV-002)', async () => {
+      // Coverage-preservation guard for the AST-GOVERN-001 consolidation: the same advisory
+      // fixture must still produce a weak-constraint finding via the canonical emitter.
+      const { ast } = await compiler.compile(skill, 'admin.skill.md');
+      const findings = analyzeGovernance(ast, verifier, undefined, undefined, skill);
+      const gov002 = findings.filter(f => f.checkId === 'AST-GOV-002');
+      expect(gov002.length).toBeGreaterThan(0);
     });
   });
 

--- a/__tests__/skills/create-skill-output-clean.test.ts
+++ b/__tests__/skills/create-skill-output-clean.test.ts
@@ -107,7 +107,8 @@ describe('create-skill output passes its own secure scan (P1-4 / P1-2 regression
       'AST-GOV-001',
       'AST-GOV-002',
       'AST-PROMPT-004',
-      'AST-GOVERN-001',
+      // AST-GOVERN-001 removed: consolidated into governance-analyzer AST-GOV-002.
+      // Non-emission is guarded directly in capability-analyzer.test.ts.
       'LIFECYCLE-001',
     ];
     const allCheckIds = result.findings.map(f => f.checkId);

--- a/src/nanomind-core/analyzers/capability-analyzer.ts
+++ b/src/nanomind-core/analyzers/capability-analyzer.ts
@@ -106,16 +106,13 @@ export function analyzeCapabilities(ast: SecurityAST, projectType?: ProjectType,
   // Check 7: Memory/persistence attack patterns
   findings.push(...checkPersistencePatterns(ast));
 
-  // Check 8: Constraint weakness analysis
-  // Skip for SDK/library -- no constraints expected
-  if (!isLibOrSDK) {
-    findings.push(...checkConstraintWeaknesses(ast));
-
-    // Zero-constraint emission intentionally delegated to governance-analyzer
-    // (AST-GOV-003). That analyzer already covers both declared and inferred
-    // capabilities; emitting AST-GOVERN-002 here produced a duplicate Governance
-    // finding on every artifact with zero constraints. One canonical emitter.
-  }
+  // Check 8: Constraint weakness analysis is delegated to governance-analyzer.
+  // Both AST-GOVERN-001 (weak constraint language) and AST-GOVERN-002 (zero-constraint
+  // emission) used to fire here, duplicating governance-analyzer's AST-GOV-002 and
+  // AST-GOV-003 on every governed artifact. governance-analyzer is the canonical emitter:
+  // it evaluates the *effective* constraint set (declared ∪ project-level SOUL.md), with
+  // line numbers, enforceability tiers, and the SDK/library noise gate -- a strict superset
+  // of what this analyzer saw. capability-analyzer no longer emits either.
 
   // Check 9: NanoMind manipulation detected
   findings.push(...checkManipulationAttempts(ast));
@@ -351,32 +348,6 @@ function checkPersistencePatterns(ast: SecurityAST): ASTFinding[] {
       attackClass: 'PERSISTENCE',
       confidence: 0.7,
     });
-  }
-
-  return findings;
-}
-
-function checkConstraintWeaknesses(ast: SecurityAST): ASTFinding[] {
-  const findings: ASTFinding[] = [];
-
-  for (const constraint of ast.declaredConstraints) {
-    if (constraint.bypassRisk > 0.5) {
-      findings.push({
-        checkId: `AST-GOVERN-001`,
-        name: 'Weak Governance Constraint',
-        description: `Constraint "${constraint.text.slice(0, 80)}..." has high bypass risk (${(constraint.bypassRisk * 100).toFixed(0)}%).`,
-        category: 'Governance',
-        severity: constraint.bypassRisk > 0.7 ? 'high' : 'medium',
-        passed: false,
-        message: `Weak constraint: ${constraint.weakness ?? 'enforcement gap'}`,
-        fixable: false,
-        file: ast.artifactPath,
-        fix: `Strengthen this constraint. Replace advisory language ("should", "recommended") with mandatory language ("must never", "forbidden", "shall not").`,
-        guidance: constraint.weakness,
-        attackClass: 'SOUL-BYPASS',
-        confidence: constraint.bypassRisk,
-      });
-    }
   }
 
   return findings;


### PR DESCRIPTION
## Summary
`capability-analyzer` emits **AST-GOVERN-001** ("Weak Governance Constraint") which duplicates `governance-analyzer`'s **AST-GOV-002** ("Weak Constraint Enforceability"). This removes the redundant emitter and its function, and documents the delegation.

A Governance-category check living inside the *capability* analyzer was the smell that surfaced this.

## Why AST-GOV-002 subsumes AST-GOVERN-001
| | AST-GOVERN-001 (removed) | AST-GOV-002 (canonical) |
|---|---|---|
| Location | capability-analyzer.ts:359 | governance-analyzer.ts:284 |
| Iterates | `ast.declaredConstraints` | `effectiveConstraints = declared ∪ projectConstraints` (**superset**, governance-analyzer.ts:149) |
| Fires when | `bypassRisk > 0.5` | `enforceability < 0.6` |
| Output | no line number | line number + decoration tier + mandatory-language fix |
| SDK/library gate | yes | yes |

- `Constraint.enforceability` and `.bypassRisk` are inverse (types.ts:94-97); `scanner-bridge.ts:82` canonically defines "weak" as `bypassRisk > 0.5`, and GOV-002's `enforceability < 0.6` threshold subsumes it.
- Both checks are already SDK/library-gated, so this is a **pure dedup, not an FP/coverage-direction change**.
- **Precedent:** `AST-GOVERN-002` was already consolidated out of capability-analyzer for the identical reason (it duplicated AST-GOV-003). This finishes that cleanup.

## Coverage preserved — proven, not assumed
Added a test that the **same advisory-language fixture** still produces AST-GOV-002 via `analyzeGovernance`. Both the non-emission guard and the coverage guard are in `capability-analyzer.test.ts`.

## Side effect
Net emitted unique check IDs: **30 → 29**, which makes the README's documented "29 semantic checks" *exactly* accurate (it was previously 29 only after discounting this duplicate).

## Tests
454 `nanomind-core` + `skills` tests pass; `tsc --noEmit` clean.

## ⚠️ Reviewer: please confirm before merge
The subsumption argument rests on **`bypassRisk` and `enforceability` being strict inverses** (so `bypassRisk > 0.5` ⊂ `enforceability < 0.6`). The fields are *modeled* as inverse and the empirical coverage test passes on the advisory fixture, but the numeric extractor that assigns these values lives in the semantic compiler and wasn't fully traced. If a constraint can have `bypassRisk > 0.5` **and** `enforceability >= 0.6` simultaneously, there's a narrow theoretical gap. Worth a glance before merging.

**Do not auto-merge** — opened for next-session review per request.