### PR TITLE
feat(arp): activate proxy classification annotator via Guard public-key config

### DIFF
--- a/__tests__/arp/proxy/guard-pubkey-annotator.test.ts
+++ b/__tests__/arp/proxy/guard-pubkey-annotator.test.ts
@@ -1,0 +1,309 @@
+/**
+ * Integration coverage for the Guard public-key config surface that activates
+ * the ARP proxy's classification annotator.
+ *
+ * These exercise the production wiring end to end: ARPProxy.start() loads a
+ * signed capability manifest, resolves the configured Guard public key, builds
+ * a NanoMindGuardClassificationProvider + ClassificationAnnotator, and the
+ * existing detection wiring enqueues every event for annotation. The daemon
+ * client (`sendClassify`) is mocked so we control the signed result without a
+ * live Guard socket.
+ *
+ *   1. Valid key + signed result    → event.data.classification populated.
+ *   2. No key configured            → annotator not built, classification null.
+ *   3. Malformed key                → log-once + disabled, startup survives.
+ *   4. Daemon down (null response)  → classification stays null.
+ *   5. Enforce-default-off invariant: a class that WOULD be denied under
+ *      enforcement is annotated (label written) but never denied, because the
+ *      manifest does not set comply.enforce.
+ *
+ * Signing reuses the deterministic Ed25519 (0x03) + ML-DSA-44 (0x04) lane the
+ * other ARP intelligence tests use, so a verified result round-trips through
+ * the real verify-classification path (no crypto is stubbed).
+ */
+
+import { describe, it, expect, beforeAll, afterEach, vi } from 'vitest';
+import * as crypto from 'crypto';
+import * as path from 'path';
+import * as ed25519 from '@noble/ed25519';
+import { ml_dsa44 } from '@noble/post-quantum/ml-dsa';
+
+// Mock the daemon client the provider wraps. The real socket is never touched.
+vi.mock('../../../src/nanomind-core/inference/nanomind-guard-client', () => ({
+  sendClassify: vi.fn(),
+}));
+
+import { sendClassify } from '../../../src/nanomind-core/inference/nanomind-guard-client';
+import type { ClassifyResponse } from '../../../src/nanomind-core/inference/nanomind-guard-client';
+import { ARPProxy, type ARPProxyDeps } from '../../../src/arp/proxy/server';
+import { EventEngine } from '../../../src/arp/engine/event-engine';
+import { IntelligenceCoordinator } from '../../../src/arp/intelligence/coordinator';
+import {
+  GUARD_SIGNATURE_ALGORITHM,
+  canonicalizeGuardResultPayload,
+} from '../../../src/arp/intelligence/verify-classification';
+import type { ARPConfig, ARPEvent, ProxyConfig } from '../../../src/arp/types';
+import type {
+  EncodedHybridPublicKey,
+  EncodedHybridSignature,
+} from '../../../src/arp/crypto/types';
+
+const HAPPY_MANIFEST = path.join(
+  __dirname,
+  '..',
+  '..',
+  '..',
+  'test',
+  'fixtures',
+  'capability-manifests',
+  'happy.yaml',
+);
+
+const ED_PRIV = new Uint8Array(32).fill(0x03);
+const MLDSA_SEED = new Uint8Array(32).fill(0x04);
+
+const mockedSendClassify = vi.mocked(sendClassify);
+
+let guardPublicKeyJson: string;
+let mldsaSecret: Uint8Array;
+
+function toBase64(bytes: Uint8Array): string {
+  return Buffer.from(bytes).toString('base64');
+}
+
+function sha256hex(s: string): string {
+  return crypto.createHash('sha256').update(s).digest('hex');
+}
+
+/**
+ * Produce a signed daemon ok-bag bound to `text`. The contentHash is the
+ * SHA-256 of the exact text the provider will hand the daemon, so the
+ * annotator's content-hash binding check passes. Signs over the canonical
+ * payload (sans signature) with the deterministic Guard keys.
+ */
+async function signedBagForText(
+  text: string,
+  classification: string,
+): Promise<ClassifyResponse> {
+  const payload = {
+    classification,
+    confidence: 0.9,
+    modelVersion: 'nanomind-guard-test',
+    contentHash: sha256hex(text),
+    timestamp: Date.now(),
+  };
+  const canonical = canonicalizeGuardResultPayload({ ...payload });
+  const edSig = await ed25519.signAsync(canonical, ED_PRIV);
+  const mldsaSig = ml_dsa44.sign(mldsaSecret, canonical);
+  const signature: EncodedHybridSignature = {
+    alg: GUARD_SIGNATURE_ALGORITHM as EncodedHybridSignature['alg'],
+    ed25519Sig: toBase64(edSig),
+    mldsaSig: toBase64(mldsaSig),
+    ts: payload.timestamp,
+  };
+  return { ok: true, ...payload, signature } as unknown as ClassifyResponse;
+}
+
+function baseConfig(): ARPConfig {
+  // intelligence.enabled false keeps L2 inert; we exercise only the annotator
+  // build path and the comply gate. The proxy builds the annotator from the
+  // key regardless of this flag (the CLI is what gates on `enabled`).
+  return { agentName: 'guard-pubkey-test-agent', intelligence: { enabled: false } };
+}
+
+function proxyConfig(withManifest: boolean): ProxyConfig {
+  return {
+    port: 0,
+    upstreams: [],
+    ...(withManifest ? { manifestPath: HAPPY_MANIFEST } : {}),
+  };
+}
+
+interface Harness {
+  proxy: ARPProxy;
+  engine: EventEngine;
+  teed: ARPEvent[];
+  /** Resolves the next time an event is teed (annotation has completed). */
+  nextTee(): Promise<void>;
+}
+
+function buildHarness(deps: Partial<ARPProxyDeps>, withManifest = true): Harness {
+  const engine = new EventEngine(baseConfig());
+  const teed: ARPEvent[] = [];
+  let resolveTee: (() => void) | null = null;
+  const proxy = new ARPProxy(proxyConfig(withManifest), {
+    engine,
+    onInScopeEvent: (e) => {
+      teed.push(e);
+      resolveTee?.();
+      resolveTee = null;
+    },
+    ...deps,
+  });
+  return {
+    proxy,
+    engine,
+    teed,
+    nextTee: () => new Promise<void>((r) => (resolveTee = r)),
+  };
+}
+
+async function emitOne(engine: EventEngine, description = 'agent did a thing'): Promise<ARPEvent> {
+  return engine.emit({
+    source: 'prompt',
+    category: 'normal',
+    severity: 'info',
+    description,
+    data: {},
+  });
+}
+
+beforeAll(async () => {
+  const edPub = await ed25519.getPublicKeyAsync(ED_PRIV);
+  const mldsaKeys = ml_dsa44.keygen(MLDSA_SEED);
+  mldsaSecret = mldsaKeys.secretKey;
+  const guardPublicKey: EncodedHybridPublicKey = {
+    algorithm: GUARD_SIGNATURE_ALGORITHM,
+    ed25519PublicKey: toBase64(edPub),
+    mldsaPublicKey: toBase64(mldsaKeys.publicKey),
+    mldsaVariant: 'ML-DSA-44',
+  };
+  guardPublicKeyJson = JSON.stringify(guardPublicKey);
+});
+
+afterEach(() => {
+  mockedSendClassify.mockReset();
+});
+
+describe('ARP proxy Guard public-key annotator', () => {
+  it('populates event.data.classification with a valid key and signed result', async () => {
+    mockedSendClassify.mockImplementation(
+      async (text: string) => signedBagForText(text, 'code-generation'),
+    );
+
+    const h = buildHarness({ guardPublicKey: guardPublicKeyJson });
+    await h.proxy.start();
+    try {
+      const tee = h.nextTee();
+      const event = await emitOne(h.engine);
+      await tee;
+
+      expect(event.data.classification).toBe('code-generation');
+      expect(h.teed[0].data.classification).toBe('code-generation');
+    } finally {
+      await h.proxy.stop();
+    }
+  });
+
+  it('does not build the annotator when no key is configured (classification stays null)', async () => {
+    mockedSendClassify.mockImplementation(
+      async (text: string) => signedBagForText(text, 'code-generation'),
+    );
+
+    const h = buildHarness({ /* no guardPublicKey */ });
+    await h.proxy.start();
+    try {
+      const tee = h.nextTee();
+      const event = await emitOne(h.engine);
+      await tee;
+
+      // No annotator was built, so the daemon was never consulted.
+      expect(mockedSendClassify).not.toHaveBeenCalled();
+      expect(event.data.classification).toBeUndefined();
+    } finally {
+      await h.proxy.stop();
+    }
+  });
+
+  it('disables annotation and logs once on a malformed key without crashing startup', async () => {
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    mockedSendClassify.mockImplementation(
+      async (text: string) => signedBagForText(text, 'code-generation'),
+    );
+
+    const h = buildHarness({ guardPublicKey: '}{ not json at all' });
+    try {
+      // start() must resolve — a bad key must never be a startup-time DoS.
+      await expect(h.proxy.start()).resolves.toBeUndefined();
+
+      const tee = h.nextTee();
+      const event = await emitOne(h.engine);
+      await tee;
+
+      expect(event.data.classification).toBeUndefined();
+      expect(mockedSendClassify).not.toHaveBeenCalled();
+      expect(errorSpy).toHaveBeenCalledTimes(1);
+      expect(errorSpy.mock.calls[0][0]).toContain('guard public key is malformed');
+    } finally {
+      await h.proxy.stop();
+      errorSpy.mockRestore();
+    }
+  });
+
+  it('leaves classification null when the daemon is down (null response)', async () => {
+    mockedSendClassify.mockResolvedValue(null);
+
+    const h = buildHarness({ guardPublicKey: guardPublicKeyJson });
+    await h.proxy.start();
+    try {
+      const tee = h.nextTee();
+      const event = await emitOne(h.engine);
+      await tee;
+
+      // The annotator WAS built (the daemon was consulted) but the outage
+      // degrades to no label rather than planting an unverified one.
+      expect(mockedSendClassify).toHaveBeenCalledTimes(1);
+      expect(event.data.classification).toBeUndefined();
+    } finally {
+      await h.proxy.stop();
+    }
+  });
+
+  it('annotates a would-be-denied class but does NOT deny it (enforce default off)', async () => {
+    // 'network-egress' clears the tier matrix at the manifest's `execute` tier
+    // but is NOT on happy.yaml's permitted list — so under comply.enforce=true
+    // it would be an `unknown` violation and denied. happy.yaml omits enforce,
+    // so the live annotator writes the label for DETECTION and the comply gate
+    // takes no action. Proves a populated classification cannot, by itself,
+    // become a hot-path deny.
+    mockedSendClassify.mockImplementation(
+      async (text: string) => signedBagForText(text, 'network-egress'),
+    );
+
+    const engine = new EventEngine(baseConfig());
+    const coordinator = new IntelligenceCoordinator(baseConfig(), '.', null);
+    const teed: ARPEvent[] = [];
+    let resolveTee: (() => void) | null = null;
+    const proxy = new ARPProxy(proxyConfig(true), {
+      engine,
+      coordinator,
+      guardPublicKey: guardPublicKeyJson,
+      onInScopeEvent: (e) => {
+        teed.push(e);
+        resolveTee?.();
+        resolveTee = null;
+      },
+    });
+
+    await proxy.start();
+    try {
+      // The proxy handed the verified manifest to the coordinator.
+      expect(coordinator.getCapabilityManifest()?.agentId).toBe('fixture-agent');
+      expect(coordinator.getCapabilityManifest()?.comply.enforce).toBeUndefined();
+
+      const tee = new Promise<void>((r) => (resolveTee = r));
+      const event = await emitOne(engine);
+      await tee;
+
+      // Label written (detection) ...
+      expect(event.data.classification).toBe('network-egress');
+      // ... but the comply gate never fired: no deny, no decision record.
+      expect(event.classifiedBy).not.toBe('L0-comply');
+      expect(event.data.comply).toBeUndefined();
+      expect(event.category).toBe('normal');
+      expect(event.severity).toBe('info');
+    } finally {
+      await proxy.stop();
+    }
+  });
+});

--- a/src/arp/cli/index.ts
+++ b/src/arp/cli/index.ts
@@ -182,12 +182,24 @@ async function startProxy(): Promise<void> {
     config.agentName ?? 'arp-proxy',
   );
 
+  // Resolve the Guard public key for classification annotation. Gated on the
+  // intelligence layer being enabled (default on); the loader already merged
+  // config + ARP_GUARD_PUBLIC_KEY. When present AND a manifest is configured,
+  // the proxy builds the annotator at start() so events carry a cleared
+  // classification for DETECTION (the sequence corpus). Absent key → no
+  // annotator, classification stays null.
+  const guardPublicKey =
+    config.intelligence?.enabled === false
+      ? undefined
+      : config.intelligence?.guardPublicKey;
+
   const proxy = new ARPProxy(config.proxy, {
     engine,
     promptInterceptor,
     mcpInterceptor,
     a2aInterceptor,
     coordinator,
+    guardPublicKey,
     onInScopeEvent: (event) => sequenceLog.append(event),
   });
 

--- a/src/arp/config/loader.ts
+++ b/src/arp/config/loader.ts
@@ -7,6 +7,12 @@ import type { ARPConfig } from '../types';
  * Falls back to sensible defaults if no config found.
  */
 export function loadConfig(configPath?: string): ARPConfig {
+  const config = loadConfigFromDisk(configPath);
+  resolveGuardPublicKey(config);
+  return config;
+}
+
+function loadConfigFromDisk(configPath?: string): ARPConfig {
   if (configPath) {
     return parseConfigFile(configPath);
   }
@@ -25,6 +31,27 @@ export function loadConfig(configPath?: string): ARPConfig {
   }
 
   return defaultConfig();
+}
+
+/**
+ * Resolve the NanoMind-Guard public key for classification annotation, in
+ * precedence order: an explicit config value wins, then the
+ * `ARP_GUARD_PUBLIC_KEY` environment variable, otherwise `undefined`.
+ *
+ * Applied to the final merged config (regardless of source) because
+ * `parseConfigFile` shallow-merges the `intelligence` block — a file that
+ * declares `intelligence` would otherwise wipe the env fallback. There is no
+ * fabricated default: an absent key leaves `guardPublicKey` undefined and the
+ * proxy simply does not build the annotator (classification stays null).
+ */
+function resolveGuardPublicKey(config: ARPConfig): void {
+  if (!config.intelligence) {
+    config.intelligence = {};
+  }
+  config.intelligence.guardPublicKey =
+    config.intelligence.guardPublicKey ??
+    process.env.ARP_GUARD_PUBLIC_KEY ??
+    undefined;
 }
 
 function parseConfigFile(filePath: string): ARPConfig {

--- a/src/arp/proxy/server.ts
+++ b/src/arp/proxy/server.ts
@@ -11,7 +11,11 @@ import type { PromptInterceptor } from '../interceptors/prompt';
 import type { MCPProtocolInterceptor } from '../interceptors/mcp-protocol';
 import type { A2AProtocolInterceptor } from '../interceptors/a2a-protocol';
 import type { IntelligenceCoordinator } from '../intelligence/coordinator';
-import type { ClassificationAnnotator } from '../intelligence/classification-annotator';
+import {
+  ClassificationAnnotator,
+  NanoMindGuardClassificationProvider,
+} from '../intelligence/classification-annotator';
+import type { EncodedHybridPublicKey } from '../crypto/types';
 import {
   CapabilityManifestError,
   loadCapabilityManifest,
@@ -56,6 +60,22 @@ export interface ARPProxyDeps {
    */
   annotator?: ClassificationAnnotator;
   /**
+   * Optional JSON-encoded NanoMind-Guard hybrid public key
+   * (`EncodedHybridPublicKey`; optionally base64-wrapped). When set AND a
+   * capability manifest is loaded AND no `annotator` was already injected,
+   * `start()` constructs a `NanoMindGuardClassificationProvider` +
+   * `ClassificationAnnotator` keyed on this key and the verified manifest, and
+   * wires it as the `annotator` above.
+   *
+   * Fail-closed for the LABEL, safe for AVAILABILITY: a malformed key logs once
+   * and leaves the annotator unset (classification stays null) rather than
+   * crashing startup. The annotator only ever feeds DETECTION; a populated
+   * classification never enables a deny (that stays gated on signed
+   * `comply.enforce === true`). When an `annotator` is supplied directly (tests,
+   * or a future AIM-SDK provider), this field is ignored.
+   */
+  guardPublicKey?: string;
+  /**
    * Optional sink invoked once per event AFTER annotation completes (or
    * immediately when no annotator is wired). This is the sequence-projector
    * tee: the CLI points it at the append-only sequence log; a test points it
@@ -80,6 +100,43 @@ export interface ARPProxyDeps {
 const MANIFEST_DENY_CLIENT_REASON =
   'Request blocked by ARP: agent registration denied';
 
+/**
+ * Decode a configured Guard public key into an `EncodedHybridPublicKey`.
+ *
+ * The key is the JSON-encoded `EncodedHybridPublicKey` (an object whose key
+ * bytes are themselves base64 strings). For env-var ergonomics a base64 wrapper
+ * around that JSON is also accepted: JSON is tried first, then base64→JSON.
+ *
+ * Any parse failure — or a value that is not a JSON object — yields `null`, and
+ * the caller disables annotation. This only guards the *parse*: the byte-level
+ * key decode and the Ed25519+ML-DSA-44 algorithm checks happen later in
+ * `verifyClassification`, which is total and returns a typed `{valid:false}`
+ * rather than throwing. So a structurally-parseable but cryptographically wrong
+ * key still fails closed (every verification rejects, classification stays
+ * null) — it is never fail-open.
+ */
+function decodeGuardPublicKey(raw: string): EncodedHybridPublicKey | null {
+  const asObject = (s: string): EncodedHybridPublicKey | null => {
+    try {
+      const parsed: unknown = JSON.parse(s);
+      if (parsed !== null && typeof parsed === 'object' && !Array.isArray(parsed)) {
+        return parsed as EncodedHybridPublicKey;
+      }
+    } catch {
+      // not JSON
+    }
+    return null;
+  };
+
+  const direct = asObject(raw);
+  if (direct !== null) return direct;
+
+  // Fall back to base64-wrapped JSON. Buffer.from is permissive (never throws),
+  // so a non-base64 input simply produces bytes that fail the JSON parse below.
+  const unwrapped = Buffer.from(raw, 'base64').toString('utf-8');
+  return asObject(unwrapped);
+}
+
 export class ARPProxy {
   private readonly config: ProxyConfig;
   private readonly deps: ARPProxyDeps;
@@ -100,6 +157,11 @@ export class ARPProxy {
    * per CR-001.
    */
   private manifestRejected = false;
+  /**
+   * Set to true once a malformed Guard public key has been logged, so the
+   * single-shot warning in `maybeBuildAnnotator` is not repeated on retries.
+   */
+  private annotatorBuildFailed = false;
 
   constructor(config: ProxyConfig, deps: ARPProxyDeps) {
     this.config = config;
@@ -134,8 +196,11 @@ export class ARPProxy {
 
     // Wire the detection-mode coordinator once the manifest state is settled.
     // Skipped when the manifest was rejected (the proxy is deny-all and no
-    // detection should run against a rejected agent).
+    // detection should run against a rejected agent). The annotator is built
+    // FIRST (it needs the verified manifest), then the coordinator wiring picks
+    // it up via deps.
     if (!this.manifestRejected) {
+      this.maybeBuildAnnotator();
       this.wireDetectionCoordinator();
     }
 
@@ -198,6 +263,58 @@ export class ARPProxy {
     console.error(
       `[arp/proxy] capability manifest rejected ${JSON.stringify(entry)}`,
     );
+  }
+
+  /**
+   * Construct the classification annotator from a configured Guard public key,
+   * IF detection annotation is both wanted and possible:
+   *   - a Guard key was resolved (`deps.guardPublicKey`, from config/env),
+   *   - a verified capability manifest is loaded (the verify options need
+   *     `manifest.tier` to key the rejection matrix),
+   *   - no `annotator` was already injected (tests / a future AIM-SDK provider
+   *     supply their own; never clobber it).
+   *
+   * Fail-closed for the LABEL and safe for AVAILABILITY: a malformed key logs
+   * once and leaves the annotator unset (classification stays null); it never
+   * throws out of startup. The byte-level decode and algorithm/tier checks all
+   * happen later inside `verifyClassification`, which is total (never throws) —
+   * so a parseable-but-wrong key degrades to "every verify returns invalid →
+   * classification stays null", still fail-closed and never fail-open.
+   *
+   * The annotator only feeds DETECTION. A populated classification never
+   * enables enforcement: that remains gated on the signed manifest setting
+   * `comply.enforce === true` (see `coordinator.ts` and
+   * `wireDetectionCoordinator`). Building the annotator here therefore cannot,
+   * by itself, turn classification into a hot-path deny control.
+   */
+  private maybeBuildAnnotator(): void {
+    // An explicitly supplied annotator wins; do not override it.
+    if (this.deps.annotator) return;
+
+    const keyStr = this.deps.guardPublicKey;
+    // No key, or no manifest to clear classifications against → no annotation.
+    if (!keyStr || !this.manifest) return;
+
+    const guardPublicKey = decodeGuardPublicKey(keyStr);
+    if (guardPublicKey === null) {
+      if (!this.annotatorBuildFailed) {
+        this.annotatorBuildFailed = true;
+        // Log once. Disabling annotation (vs. crashing) keeps a bad
+        // ARP_GUARD_PUBLIC_KEY from being a startup-time DoS. No key material
+        // is logged.
+        // eslint-disable-next-line no-console
+        console.error(
+          '[arp/proxy] guard public key is malformed; classification annotation disabled',
+        );
+      }
+      return;
+    }
+
+    const provider = new NanoMindGuardClassificationProvider();
+    this.deps.annotator = new ClassificationAnnotator(provider, {
+      guardPublicKey,
+      manifest: this.manifest,
+    });
   }
 
   /**

--- a/src/arp/types.ts
+++ b/src/arp/types.ts
@@ -131,6 +131,21 @@ export interface AlertCondition {
 export interface IntelligenceConfig {
   /** Enable LLM-assisted analysis (default: true) */
   enabled?: boolean;
+  /**
+   * Trusted NanoMind-Guard hybrid public key (Ed25519+ML-DSA-44), JSON-encoded
+   * (an `EncodedHybridPublicKey`; optionally base64-wrapped for env-var
+   * ergonomics). When set, the CLI proxy constructs the classification
+   * annotator at start() and verifies every Guard result against this key
+   * before writing `event.data.classification` for DETECTION.
+   *
+   * Resolution order (see `config/loader.ts`):
+   * `intelligence.guardPublicKey ?? process.env.ARP_GUARD_PUBLIC_KEY ?? undefined`.
+   * There is no fabricated default — an absent key means the annotator is not
+   * built and classification stays null. A populated classification only ever
+   * feeds detection; it never enables a deny (that stays gated on signed
+   * `comply.enforce === true`).
+   */
+  guardPublicKey?: string;
   /** LLM adapter to use */
   adapter?: LLMAdapterType;
   /** Custom adapter config (API key, model, etc.) */


### PR DESCRIPTION
## Summary

Activates the ARP CLI proxy's classification annotator — the single missing seam that left `event.data.classification = null` in the projector corpus. The annotator, provider, and verifier already existed and were fully tested; the only gap was config → construction.

This unblocks the data flywheel: real classifications accrue into the ordered in-scope sequence corpus, validating the v0 consistency evaluator's structured tells and enabling Source A accrual.

## Changes

- **`IntelligenceConfig.guardPublicKey`** — JSON-encoded `EncodedHybridPublicKey` (optionally base64-wrapped). Resolved `config ?? ARP_GUARD_PUBLIC_KEY ?? undefined`, no fabricated default.
- **`ARPProxy.start()`** builds `NanoMindGuardClassificationProvider` + `ClassificationAnnotator` when a key resolves **and** a verified manifest is loaded **and** no annotator was injected. A malformed key logs once and disables annotation rather than crashing startup.
- **CLI** threads the resolved key, gated on `intelligence.enabled`.
- A populated classification only ever feeds **detection**; enforcement stays gated on signed `comply.enforce === true`.

## Design decisions

- **[CHIEF-CA]** Field on `IntelligenceConfig` (shared across surfaces), not `ProxyConfig` (transport-scoped). Construction in `start()` because the annotator's verify options need the manifest, which loads there.
- **[CHIEF-CSR]** Fail-closed-to-null, never fail-open: any decode/parse/verify failure leaves the label unwritten and never throws out of startup; the byte-level decode + algorithm checks happen in the total `verifyClassification`.

## Tests

New `__tests__/arp/proxy/guard-pubkey-annotator.test.ts` (5 cases): valid key + signed result populates the label; no key → annotator not built; malformed key → log-once + disabled, startup survives; daemon down → label null; **enforce-default-off invariant with a live annotator** (a would-be-denied class is annotated but never denied).

Full suite: 2337 passed, 24 skipped. Build (tsc) clean.

## Not in scope

No CLI UX change (no `--guard-public-key` flag) — internal plumbing only. No version bump / publish.