### PR TITLE
fix(arp): case-fold egress host before hashing

### DIFF
--- a/__tests__/arp/intelligence/sequence-log-writer.test.ts
+++ b/__tests__/arp/intelligence/sequence-log-writer.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import * as os from 'os';
 import * as path from 'path';
 import * as fs from 'fs';
+import { createHash } from 'crypto';
 import {
   SequenceLogWriter,
   arpEventToLoggedAction,
@@ -50,6 +51,30 @@ describe('arpEventToLoggedAction', () => {
     // host is hashed (64 hex), not stored in the clear
     expect(rec.egressTargetHash).toMatch(/^[0-9a-f]{64}$/);
     expect(JSON.stringify(rec)).not.toContain('evil.example.com');
+  });
+
+  it('case-folds the egress host so host-case variants hash identically', () => {
+    // DNS hosts are case-insensitive and never carry surrounding whitespace;
+    // an attacker must not be able to evade egress-target grounding by varying
+    // case. EVIL.COM, evil.com, and "  evil.com  " must all hash to the same
+    // egressTargetHash.
+    const mk = (host: string) =>
+      arpEventToLoggedAction(
+        event({ data: { source: 'network', host, responseSize: 1, capability: 'data:export' } }),
+        ctx(),
+      ).egressTargetHash;
+
+    const lower = mk('evil.com');
+    expect(mk('EVIL.COM')).toBe(lower);
+    expect(mk('Evil.Com')).toBe(lower);
+    expect(mk('  evil.com  ')).toBe(lower);
+
+    // Contract lock (cross-repo): the hash is sha256 of the NORMALIZED host
+    // (trim + lowercase). The consumer's hash_host in nanomind-training
+    // (evaluation/consistency-v0/contract.py) MUST stay byte-identical to this
+    // or the structured egress tell mis-grounds.
+    const expected = createHash('sha256').update('evil.com').digest('hex');
+    expect(lower).toBe(expected);
   });
 
   it('carries a cleared classification through when present on the event', () => {

--- a/src/arp/intelligence/sequence-log-writer.ts
+++ b/src/arp/intelligence/sequence-log-writer.ts
@@ -57,13 +57,29 @@ function deriveL0Decision(event: ARPEvent): 'allow' | 'block' | 'alert' {
   return 'allow';
 }
 
+/**
+ * Case-fold an egress host to its canonical identity before hashing. DNS host
+ * names are case-insensitive and surrounding whitespace is never part of a
+ * host, so `EVIL.COM`, `evil.com`, and `  evil.com  ` are the same target.
+ * Folding here (and identically in the consumer's `hash_host`) is what stops an
+ * attacker from evading egress-target grounding by varying host case. ASCII
+ * trim + lowercase only; IDNA/punycode normalization is intentionally out of
+ * scope for this bare-host token channel.
+ */
+function normalizeEgressHost(host: string): string {
+  return host.trim().toLowerCase();
+}
+
 /** Hash an egress host (host only — never a path or query) for the egress tell. */
 function deriveEgressTargetHash(event: ARPEvent): string | null {
   if (deriveEventType(event) !== 'EXTERNAL_CALL') return null;
   for (const key of HOST_KEYS) {
     const v = event.data?.[key];
     if (typeof v === 'string' && v.length > 0) {
-      return crypto.createHash('sha256').update(v).digest('hex');
+      return crypto
+        .createHash('sha256')
+        .update(normalizeEgressHost(v))
+        .digest('hex');
     }
   }
   return null;


### PR DESCRIPTION
## Summary

`deriveEgressTargetHash` (the ARP sequence projector's egress channel) hashed the **raw** host string, so `EVIL.COM`, `evil.com`, and `  evil.com  ` produced three distinct `egressTargetHash` values. DNS host names are case-insensitive and never carry surrounding whitespace, so an attacker could evade egress-target grounding in the consistency egress tell by varying host case.

Normalize the host with ASCII `trim + lowercase` before sha256.

## Cross-repo coordination

This is one half of a coordinated two-repo change. The consumer `hash_host` in **nanomind-training** `evaluation/consistency-v0/contract.py` normalizes identically in the same commit window, so the structured egress tell stays correctly grounded. A contract-lock test on **both** sides guards the byte-identity:
- here: `sequence-log-writer.test.ts` → "case-folds the egress host …" asserts `sha256(host.trim().toLowerCase())`
- there: `test_hash_host_matches_producer_normalized_sha256` + `test_hash_host_case_and_whitespace_fold`

The consistency-v0 held-out reproduction is unchanged (macro-F1 0.7466) — its adapter sets `egressTargetHash=None`, so `hash_host` is not on that path.

## Scope

IDNA/punycode normalization is intentionally out of scope for this bare-host token channel (flagged for later if hosts ever carry unicode).

## Decision

[CHIEF-CA] (cross-repo data contract) + [CHIEF-CSR] (evasion): normalize both sides together; the contract-lock test is the guard. Rejected: stay-raw (keeps the evasion), normalize-one-side (breaks grounding), full-URL/IDNA normalization (over-engineered for a host-only token).

## Tests

ARP suite green (377 passed). Build (tsc) clean.