### PR TITLE
feat(nanomind): analyst coverage sweep — abstention-gated escalations in secure --nanomind

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ hackmyagent secure --ci                       # non-interactive, exit non-zero o
 hackmyagent secure --publish                  # push anonymised results to the OpenA2A Registry
 hackmyagent secure -b oasb-1                  # OASB-1 benchmark (L1, L2, L3)
 hackmyagent secure -b oasb-1 --fail-below 70  # CI gate
-hackmyagent secure --nanomind                 # per-finding AI threat narratives on HIGH or CRITICAL
+hackmyagent secure --nanomind                 # AI analyst: per-finding narratives + coverage escalations
 ```
 
 Output shows an Observations block (surfaces, checks, categories, verdict) and a per-finding list. Every HIGH or CRITICAL finding has a `file:line` location and a runnable `Fix:` command.
@@ -145,7 +145,7 @@ Runs automatically on every `secure` scan. On first use, HMA downloads a 5.5 MB 
 - 9 attack classes: `exfiltration`, `injection`, `privilege_escalation`, `persistence`, `credential_abuse`, `lateral_movement`, `social_engineering`, `policy_violation`, `benign`.
 - `--deep` adds the 20-probe behavioural simulation.
 - `--static-only` disables the semantic layer.
-- `--nanomind` opts into per-finding AI threat narratives. This is the specialist analyst, not the classifier, and runs only on HIGH or CRITICAL findings.
+- `--nanomind` opts into the generative analyst (specialist model, not the classifier). It produces per-finding threat narratives on HIGH or CRITICAL findings, and a coverage sweep over artifacts the deterministic checks did not flag — analyst verdicts there surface as advisory escalations for human review (never changing the score, findings, or exit code).
 
 ### `red-team` (adaptive attack engine)
 

--- a/__tests__/nanomind-core/analyst-coverage.test.ts
+++ b/__tests__/nanomind-core/analyst-coverage.test.ts
@@ -1,0 +1,165 @@
+import { describe, it, expect } from 'vitest';
+import {
+  routeAnalystVerdict,
+  combineVerdict,
+  namesAttackClass,
+  isKnownAttackClass,
+  NON_ATTACK_CLASSES,
+  HIGH_SEVERITIES,
+  KNOWN_ATTACK_CLASSES,
+  type AnalystVerdict,
+} from '../../src/nanomind-core/analyst-coverage';
+
+// ============================================================================
+// routeAnalystVerdict — posture-vs-attack + severity/agreement abstention
+// ============================================================================
+
+describe('routeAnalystVerdict', () => {
+  const v = (over: Partial<AnalystVerdict>): AnalystVerdict => ({
+    attackClass: 'none',
+    severity: null,
+    source: 'nlm',
+    ...over,
+  });
+
+  it('gate-suppressed verdict is benign by construction (no model judgement)', () => {
+    // Even if a stale attackClass/severity rides along, the gate path is benign.
+    expect(
+      routeAnalystVerdict(v({ source: 'input-classifier-gate', attackClass: 'privilege_escalation', severity: 'critical' })),
+    ).toBe('benign');
+  });
+
+  it('real attack class at HIGH/CRITICAL is an attack', () => {
+    expect(routeAnalystVerdict(v({ attackClass: 'privilege_escalation', severity: 'critical' }))).toBe('attack');
+    expect(routeAnalystVerdict(v({ attackClass: 'credential_exfiltration', severity: 'high' }))).toBe('attack');
+  });
+
+  it('none/benign attack class is benign', () => {
+    expect(routeAnalystVerdict(v({ attackClass: 'none', severity: 'none' }))).toBe('benign');
+    expect(routeAnalystVerdict(v({ attackClass: 'benign', severity: null }))).toBe('benign');
+    expect(routeAnalystVerdict(v({ attackClass: '', severity: null }))).toBe('benign');
+  });
+
+  it('real attack class at MEDIUM/LOW is the abstention band (escalate, not confident)', () => {
+    expect(routeAnalystVerdict(v({ attackClass: 'data_exfiltration', severity: 'medium' }))).toBe('abstain');
+    expect(routeAnalystVerdict(v({ attackClass: 'supply_chain', severity: 'low' }))).toBe('abstain');
+  });
+
+  it('real attack class with missing/unknown severity abstains (uncertain, not confident)', () => {
+    expect(routeAnalystVerdict(v({ attackClass: 'persistence', severity: null }))).toBe('abstain');
+    expect(routeAnalystVerdict(v({ attackClass: 'persistence', severity: 'weird' }))).toBe('abstain');
+  });
+
+  it('"suspicious" classification with no attack class abstains', () => {
+    expect(routeAnalystVerdict(v({ attackClass: 'none', classification: 'suspicious' }))).toBe('abstain');
+  });
+
+  it('does NOT threshold on confidence (clustered ~0.95, unreliable) — high confidence does not upgrade severity', () => {
+    // A mid-severity attack with very high confidence still abstains; confidence is ignored on purpose.
+    expect(routeAnalystVerdict(v({ attackClass: 'data_exfiltration', severity: 'medium', confidence: 0.99 }))).toBe('abstain');
+    // A high-severity attack with low confidence is still an attack (severity governs, not confidence).
+    expect(routeAnalystVerdict(v({ attackClass: 'data_exfiltration', severity: 'high', confidence: 0.4 }))).toBe('attack');
+  });
+
+  it('robustness guard: non-benign UNKNOWN class (prose/parser-noise) never auto-attacks, even at HIGH/CRITICAL', () => {
+    // Free-form prose the analyst sometimes emits as its class.
+    expect(routeAnalystVerdict(v({ attackClass: 'Privilege Escalation / Unauthorized Command Execution', severity: 'critical' }))).toBe('abstain');
+    // Parser noise / hedges.
+    expect(routeAnalystVerdict(v({ attackClass: 'confidence: 0.15', severity: 'high' }))).toBe('abstain');
+    expect(routeAnalystVerdict(v({ attackClass: '[No valid attack class applies]', severity: 'high' }))).toBe('abstain');
+    expect(routeAnalystVerdict(v({ attackClass: 'N/A', severity: 'critical' }))).toBe('abstain');
+  });
+
+  it('known canonical classes DO auto-attack at HIGH/CRITICAL', () => {
+    for (const cls of ['injection', 'exfiltration', 'lateral_movement', 'credential_abuse', 'heartbeat_rce']) {
+      expect(routeAnalystVerdict(v({ attackClass: cls, severity: 'high' }))).toBe('attack');
+    }
+  });
+
+  it('normalises case/whitespace on class and severity', () => {
+    expect(routeAnalystVerdict(v({ attackClass: '  Privilege_Escalation ', severity: ' CRITICAL ' }))).toBe('attack');
+    expect(routeAnalystVerdict(v({ attackClass: 'NONE', severity: 'None' }))).toBe('benign');
+  });
+});
+
+// ============================================================================
+// combineVerdict — three policies
+// ============================================================================
+
+describe('combineVerdict', () => {
+  describe('structural-only', () => {
+    it('passes the structural verdict through; never escalates', () => {
+      expect(combineVerdict(true, 'attack', 'structural-only')).toEqual({ attack: true, escalate: false });
+      expect(combineVerdict(false, 'attack', 'structural-only')).toEqual({ attack: false, escalate: false });
+    });
+  });
+
+  describe('union', () => {
+    it('auto-adds an analyst attack to a structural miss (recall ceiling)', () => {
+      expect(combineVerdict(false, 'attack', 'union')).toEqual({ attack: true, escalate: false });
+    });
+    it('keeps a structural attack regardless of analyst', () => {
+      expect(combineVerdict(true, 'benign', 'union')).toEqual({ attack: true, escalate: false });
+    });
+    it('escalates a mid-band abstention on an otherwise-clean artifact', () => {
+      expect(combineVerdict(false, 'abstain', 'union')).toEqual({ attack: false, escalate: true });
+    });
+    it('benign analyst on a clean artifact stays benign, no escalation', () => {
+      expect(combineVerdict(false, 'benign', 'union')).toEqual({ attack: false, escalate: false });
+    });
+  });
+
+  describe('abstention-gated (CDS-024 safe — analyst never raises the auto-verdict)', () => {
+    it('an analyst attack on a structural miss does NOT auto-flip; it escalates', () => {
+      expect(combineVerdict(false, 'attack', 'abstention-gated')).toEqual({ attack: false, escalate: true });
+    });
+    it('an analyst abstain on a structural miss escalates', () => {
+      expect(combineVerdict(false, 'abstain', 'abstention-gated')).toEqual({ attack: false, escalate: true });
+    });
+    it('structural attack stands; no redundant escalation', () => {
+      expect(combineVerdict(true, 'attack', 'abstention-gated')).toEqual({ attack: true, escalate: false });
+    });
+    it('both clean: benign, no escalation', () => {
+      expect(combineVerdict(false, 'benign', 'abstention-gated')).toEqual({ attack: false, escalate: false });
+    });
+  });
+
+  it('abstention-gated auto-verdict always equals structural-only auto-verdict (FPR is preserved)', () => {
+    for (const s of [true, false]) {
+      for (const a of ['attack', 'benign', 'abstain'] as const) {
+        expect(combineVerdict(s, a, 'abstention-gated').attack).toBe(
+          combineVerdict(s, a, 'structural-only').attack,
+        );
+      }
+    }
+  });
+});
+
+// ============================================================================
+// helpers / invariants
+// ============================================================================
+
+describe('helpers', () => {
+  it('namesAttackClass distinguishes real classes from none/benign', () => {
+    expect(namesAttackClass({ attackClass: 'tool_abuse', severity: 'high' })).toBe(true);
+    expect(namesAttackClass({ attackClass: 'none', severity: null })).toBe(false);
+    expect(namesAttackClass({ attackClass: 'benign', severity: null })).toBe(false);
+  });
+
+  it('isKnownAttackClass gates auto-attack to the canonical vocabulary only', () => {
+    expect(isKnownAttackClass({ attackClass: 'privilege_escalation', severity: null })).toBe(true);
+    expect(isKnownAttackClass({ attackClass: 'heartbeat_rce', severity: null })).toBe(true);
+    // Prose / unknown is "named" but not "known".
+    expect(namesAttackClass({ attackClass: 'Privilege Escalation / RCE', severity: null })).toBe(true);
+    expect(isKnownAttackClass({ attackClass: 'Privilege Escalation / RCE', severity: null })).toBe(false);
+    expect(KNOWN_ATTACK_CLASSES.has('privilege_escalation')).toBe(true);
+  });
+
+  it('exported sets carry the expected members', () => {
+    expect(NON_ATTACK_CLASSES.has('none')).toBe(true);
+    expect(NON_ATTACK_CLASSES.has('benign')).toBe(true);
+    expect(HIGH_SEVERITIES.has('critical')).toBe(true);
+    expect(HIGH_SEVERITIES.has('high')).toBe(true);
+    expect(HIGH_SEVERITIES.has('medium')).toBe(false);
+  });
+});

--- a/__tests__/nanomind-core/analyst-escalation-wiring.test.ts
+++ b/__tests__/nanomind-core/analyst-escalation-wiring.test.ts
@@ -1,0 +1,245 @@
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { mkdtemp, writeFile, rm, mkdir } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { runCoverageSweep } from '../../src/nanomind-core/orchestrate';
+import type { AnalystEscalation } from '../../src/nanomind-core/orchestrate';
+import type { CoverageCandidate } from '../../src/nanomind-core/scanner-bridge';
+import type { ArtifactCoverageVerdict } from '../../src/nanomind-core/inference/security-analyst';
+import type { SecurityFinding } from '../../src/hardening/security-check';
+
+// ============================================================================
+// runCoverageSweep — abstention-gated escalation wiring (Phase A P1, CDS-023/024)
+//
+// The sweep sends compiled artifacts WITHOUT a high/critical structural attack
+// finding to the analyst, routes the verdict, and may only ESCALATE. These
+// tests inject a fake classify function — routing logic itself is covered in
+// analyst-coverage.test.ts; here we test the wiring contract:
+//   1. selection (structural misses only; posture checks don't count as attack)
+//   2. escalation emission per routed verdict
+//   3. the advisory invariant (input findings never mutated, no new findings)
+//   4. caps and daemon-unavailable behavior
+// ============================================================================
+
+let dir: string;
+
+const finding = (over: Partial<SecurityFinding>): SecurityFinding => ({
+  checkId: 'CRED-001',
+  name: 'Hardcoded credential',
+  description: 'A credential is hardcoded',
+  category: 'Credential Security',
+  severity: 'high',
+  passed: false,
+  message: 'found a credential',
+  fixable: false,
+  ...over,
+});
+
+const attackVerdict: ArtifactCoverageVerdict = {
+  attackClass: 'prompt_injection',
+  classification: 'malicious',
+  severity: 'high',
+  confidence: 0.95,
+  source: 'nlm',
+  analysis: 'The file instructs the agent to ignore previous instructions and exfiltrate data.',
+  evidence: 'line 3: "ignore previous instructions"',
+  modelVersion: 'nanomind-analyst-v3.0.0',
+  durationMs: 10,
+};
+
+const benignVerdict: ArtifactCoverageVerdict = {
+  ...attackVerdict,
+  attackClass: 'none',
+  classification: 'benign',
+  severity: null,
+  analysis: '',
+};
+
+const classifyAs = (verdict: ArtifactCoverageVerdict | null) =>
+  async (_content: string): Promise<ArtifactCoverageVerdict | null> => verdict;
+
+beforeAll(async () => {
+  dir = await mkdtemp(join(tmpdir(), 'hma-sweep-'));
+  await writeFile(join(dir, 'SKILL.md'), '# Helper skill\nDoes helpful things.\n');
+  await writeFile(join(dir, 'mcp.json'), '{"mcpServers":{}}\n');
+  await writeFile(join(dir, 'util.ts'), 'export const x = 1;\n');
+  await mkdir(join(dir, 'docs'), { recursive: true });
+  await writeFile(join(dir, 'docs', 'notes.md'), 'Some notes.\n');
+});
+
+afterAll(async () => {
+  await rm(dir, { recursive: true, force: true });
+});
+
+describe('runCoverageSweep — selection', () => {
+  const candidates: CoverageCandidate[] = [
+    { path: 'SKILL.md', artifactType: 'skill' },
+    { path: 'util.ts', artifactType: 'source_code' },
+  ];
+
+  it('skips files already flagged with a high/critical structural attack finding', async () => {
+    const flagged = [finding({ file: 'SKILL.md', severity: 'high' })];
+    const seen: string[] = [];
+    const classify = async (content: string) => {
+      seen.push(content);
+      return benignVerdict;
+    };
+    const out = await runCoverageSweep(dir, candidates, flagged, classify, true);
+    // Only util.ts is eligible; SKILL.md is covered by the per-finding stage.
+    expect(out.stats.candidates).toBe(1);
+    expect(out.stats.swept).toBe(1);
+    expect(seen).toHaveLength(1);
+    expect(seen[0]).toContain('export const x');
+  });
+
+  it('posture/hardening checks do NOT count as structural attack (file stays eligible)', async () => {
+    // AST-PROMPT-001 at high severity flags a MISSING defense, not a present
+    // attack — same exclusion set as the published benchmark verdict mapping.
+    const postureOnly = [finding({ checkId: 'AST-PROMPT-001', file: 'SKILL.md', severity: 'high' })];
+    const out = await runCoverageSweep(dir, candidates, postureOnly, classifyAs(benignVerdict), true);
+    expect(out.stats.candidates).toBe(2);
+  });
+
+  it('medium/low findings do not exclude a file', async () => {
+    const lowSev = [finding({ file: 'SKILL.md', severity: 'medium' })];
+    const out = await runCoverageSweep(dir, candidates, lowSev, classifyAs(benignVerdict), true);
+    expect(out.stats.candidates).toBe(2);
+  });
+
+  it('passed and fixed findings do not exclude a file', async () => {
+    const inactive = [
+      finding({ file: 'SKILL.md', passed: true }),
+      finding({ file: 'util.ts', fixed: true } as Partial<SecurityFinding>),
+    ];
+    const out = await runCoverageSweep(dir, candidates, inactive, classifyAs(benignVerdict), true);
+    expect(out.stats.candidates).toBe(2);
+  });
+});
+
+describe('runCoverageSweep — escalation emission', () => {
+  const candidates: CoverageCandidate[] = [{ path: 'SKILL.md', artifactType: 'skill' }];
+
+  it('analyst attack verdict on a structural miss escalates (routed=attack)', async () => {
+    const out = await runCoverageSweep(dir, candidates, [], classifyAs(attackVerdict), true);
+    expect(out.escalations).toHaveLength(1);
+    const esc = out.escalations[0];
+    expect(esc.routed).toBe('attack');
+    expect(esc.file).toBe('SKILL.md');
+    expect(esc.policy).toBe('abstention-gated');
+  });
+
+  it('uncertain verdict (suspicious, no class) escalates as abstain', async () => {
+    const suspicious: ArtifactCoverageVerdict = {
+      ...benignVerdict,
+      classification: 'suspicious',
+    };
+    const out = await runCoverageSweep(dir, candidates, [], classifyAs(suspicious), true);
+    expect(out.escalations).toHaveLength(1);
+    expect(out.escalations[0].routed).toBe('abstain');
+  });
+
+  it('unknown non-benign attack class never escalates as attack (allow-list guard)', async () => {
+    const hallucinated: ArtifactCoverageVerdict = {
+      ...attackVerdict,
+      attackClass: 'Privilege Escalation / Unauthorized Command Execution',
+    };
+    const out = await runCoverageSweep(dir, candidates, [], classifyAs(hallucinated), true);
+    expect(out.escalations).toHaveLength(1);
+    expect(out.escalations[0].routed).toBe('abstain');
+  });
+
+  it('benign verdict produces no escalation', async () => {
+    const out = await runCoverageSweep(dir, candidates, [], classifyAs(benignVerdict), true);
+    expect(out.escalations).toHaveLength(0);
+  });
+
+  it('gate-suppressed verdict produces no escalation (benign by construction)', async () => {
+    const gated: ArtifactCoverageVerdict = {
+      ...attackVerdict,
+      source: 'input-classifier-gate',
+      attackClass: 'none',
+      confidence: null,
+    };
+    const out = await runCoverageSweep(dir, candidates, [], classifyAs(gated), true);
+    expect(out.escalations).toHaveLength(0);
+  });
+
+  it('escalation entries carry complete advisory fields', async () => {
+    const out = await runCoverageSweep(dir, candidates, [], classifyAs(attackVerdict), true);
+    const esc: AnalystEscalation = out.escalations[0];
+    expect(esc.file).toBeTruthy();
+    expect(esc.artifactType).toBe('skill');
+    expect(esc.attackClass).toBe('prompt_injection');
+    expect(esc.severity).toBe('high');
+    expect(esc.classification).toBe('malicious');
+    expect(esc.summary).toContain('exfiltrate');
+    expect(esc.modelVersion).toBe('nanomind-analyst-v3.0.0');
+  });
+});
+
+describe('runCoverageSweep — advisory invariant (CDS-024)', () => {
+  it('never mutates the findings array or its entries', async () => {
+    const findings = [finding({ file: 'util.ts', severity: 'low' })];
+    const snapshot = JSON.stringify(findings);
+    const candidates: CoverageCandidate[] = [
+      { path: 'SKILL.md', artifactType: 'skill' },
+      { path: 'util.ts', artifactType: 'source_code' },
+    ];
+    const out = await runCoverageSweep(dir, candidates, findings, classifyAs(attackVerdict), true);
+    expect(JSON.stringify(findings)).toBe(snapshot);
+    // Escalations live in their own channel — they are not SecurityFindings
+    // and carry no severity-bearing 'passed' field that scoring could read.
+    expect(out.escalations.length).toBeGreaterThan(0);
+    for (const esc of out.escalations) {
+      expect('passed' in esc).toBe(false);
+      expect('checkId' in esc).toBe(false);
+    }
+  });
+});
+
+describe('runCoverageSweep — caps and failure behavior', () => {
+  it('daemon unavailable (classify=null) yields zero escalations, no throw', async () => {
+    const candidates: CoverageCandidate[] = [{ path: 'SKILL.md', artifactType: 'skill' }];
+    const out = await runCoverageSweep(dir, candidates, [], classifyAs(null), true);
+    expect(out.escalations).toHaveLength(0);
+    expect(out.stats.swept).toBe(1);
+  });
+
+  it('vanished files are skipped without blocking the sweep', async () => {
+    const candidates: CoverageCandidate[] = [
+      { path: 'does-not-exist.md', artifactType: 'skill' },
+      { path: 'SKILL.md', artifactType: 'skill' },
+    ];
+    const out = await runCoverageSweep(dir, candidates, [], classifyAs(attackVerdict), true);
+    expect(out.escalations).toHaveLength(1);
+    expect(out.escalations[0].file).toBe('SKILL.md');
+  });
+
+  it('caps at 10 files per scan and reports the skip count (no silent caps)', async () => {
+    const many: CoverageCandidate[] = [];
+    for (let i = 0; i < 14; i++) {
+      // All point at real files so swept counts reflect the cap, not read failures.
+      many.push({ path: 'util.ts', artifactType: 'source_code' });
+    }
+    const out = await runCoverageSweep(dir, many, [], classifyAs(benignVerdict), true);
+    expect(out.stats.candidates).toBe(14);
+    expect(out.stats.swept).toBe(10);
+    expect(out.stats.skipped).toBe(4);
+  });
+
+  it('agent artifacts are swept before source code when the cap binds', async () => {
+    const candidates: CoverageCandidate[] = [];
+    for (let i = 0; i < 10; i++) candidates.push({ path: 'util.ts', artifactType: 'source_code' });
+    candidates.push({ path: 'SKILL.md', artifactType: 'skill' });
+    const seen: string[] = [];
+    const classify = async (content: string) => {
+      seen.push(content.slice(0, 20));
+      return benignVerdict;
+    };
+    const out = await runCoverageSweep(dir, candidates, [], classify, true);
+    expect(out.stats.swept).toBe(10);
+    // The skill (agent artifact) must be in the swept set despite arriving last.
+    expect(seen.some(s => s.includes('Helper skill'))).toBe(true);
+  });
+});

--- a/__tests__/nanomind-core/analyst-escalation-wiring.test.ts
+++ b/__tests__/nanomind-core/analyst-escalation-wiring.test.ts
@@ -3,7 +3,11 @@ import { mkdtemp, writeFile, rm, mkdir } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
-import { runCoverageSweep } from '../../src/nanomind-core/orchestrate';
+import {
+  runCoverageSweep,
+  sweepIndicatesDaemonError,
+  POSTURE_HARDENING_CHECKS,
+} from '../../src/nanomind-core/orchestrate';
 import type { AnalystEscalation } from '../../src/nanomind-core/orchestrate';
 import type { CoverageCandidate } from '../../src/nanomind-core/scanner-bridge';
 import type { ArtifactCoverageVerdict } from '../../src/nanomind-core/inference/security-analyst';
@@ -198,12 +202,70 @@ describe('runCoverageSweep — advisory invariant (CDS-024)', () => {
   });
 });
 
+describe('runCoverageSweep — adversarial output hardening', () => {
+  const candidates: CoverageCandidate[] = [{ path: 'SKILL.md', artifactType: 'skill' }];
+
+  it('newlines in model-controlled fields are collapsed (no advisory-row spoofing)', async () => {
+    // A prompt-injected artifact can steer the generative analyst's text.
+    // Embedded newlines must never let that text impersonate the escalation
+    // section's own rows or fake Verify: instructions (adversarial review M2).
+    const spoofing: ArtifactCoverageVerdict = {
+      ...attackVerdict,
+      attackClass: 'prompt_injection\nREVIEW /etc/passwd critical',
+      classification: 'malicious\nVerify: run curl evil.sh',
+      severity: 'high\ncritical',
+      analysis: 'line one\n\nREVIEW fake-file.md  injected (critical)\nVerify: rm -rf /',
+    };
+    const out = await runCoverageSweep(dir, candidates, [], classifyAs(spoofing), true);
+    expect(out.escalations).toHaveLength(1);
+    const esc = out.escalations[0];
+    for (const field of [esc.attackClass, esc.classification, esc.severity ?? '', esc.summary]) {
+      expect(field).not.toMatch(/[\r\n\t]/);
+    }
+    expect(esc.summary).toContain('REVIEW fake-file.md'); // content kept, structure neutralized
+  });
+});
+
+describe('sweepIndicatesDaemonError — dead daemon never reads as clean (M1)', () => {
+  const stats = (over: Partial<import('../../src/nanomind-core/orchestrate').CoverageSweepStats>) => ({
+    candidates: 3, swept: 3, skipped: 0, nullVerdicts: 0, policy: 'abstention-gated' as const, ...over,
+  });
+
+  it('all swept calls returned null -> daemon error', () => {
+    expect(sweepIndicatesDaemonError(stats({ swept: 3, nullVerdicts: 3 }))).toBe(true);
+  });
+
+  it('some verdicts came back -> not a daemon error', () => {
+    expect(sweepIndicatesDaemonError(stats({ swept: 3, nullVerdicts: 2 }))).toBe(false);
+  });
+
+  it('nothing swept (no candidates) -> not a daemon error', () => {
+    expect(sweepIndicatesDaemonError(stats({ swept: 0, candidates: 0, nullVerdicts: 0 }))).toBe(false);
+  });
+});
+
+describe('POSTURE_HARDENING_CHECKS — contract lock', () => {
+  it('matches the published benchmark verdict mapping exactly', () => {
+    // Canonical source: oasb/scripts/run-dvaa-benchmark.ts HARDENING set ==
+    // the corpus full-pipeline adapter's HARDENING_CHECK_IDS (29.1% baseline,
+    // CDS-026). If the canonical set changes, change BOTH and re-measure —
+    // silent drift would mis-select sweep candidates.
+    expect([...POSTURE_HARDENING_CHECKS].sort()).toEqual([
+      'AST-GOV-001', 'AST-GOV-002', 'AST-GOV-003', 'AST-GOV-004', 'AST-GOV-005',
+      'AST-PROMPT-001', 'AST-PROMPT-003', 'AST-PROMPT-004',
+      'AST-SCOPE-001',
+    ]);
+  });
+});
+
 describe('runCoverageSweep — caps and failure behavior', () => {
-  it('daemon unavailable (classify=null) yields zero escalations, no throw', async () => {
+  it('daemon unavailable (classify=null) yields zero escalations and counts nullVerdicts', async () => {
     const candidates: CoverageCandidate[] = [{ path: 'SKILL.md', artifactType: 'skill' }];
     const out = await runCoverageSweep(dir, candidates, [], classifyAs(null), true);
     expect(out.escalations).toHaveLength(0);
     expect(out.stats.swept).toBe(1);
+    expect(out.stats.nullVerdicts).toBe(1);
+    expect(sweepIndicatesDaemonError(out.stats)).toBe(true);
   });
 
   it('vanished files are skipped without blocking the sweep', async () => {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1556,8 +1556,12 @@ function displayUnifiedCheck(opts: UnifiedCheckDisplayOptions): void {
   const hiddenAbstains = allEscalations.length - escalations.length;
   if (allEscalations.length > 0) {
     divider('NanoMind Coverage Escalations');
-    console.log(`  ${colors.dim}Advisory — the AI analyst flagged ${allEscalations.length} file${allEscalations.length === 1 ? '' : 's'} the deterministic checks did not.${RESET()}`);
-    console.log(`  ${colors.dim}Score and exit code are unchanged. Review each file to confirm or dismiss.${RESET()}`);
+    const flaggedCount = allEscalations.filter(e => e.routed === 'attack').length;
+    const headline = flaggedCount > 0
+      ? `Advisory — the AI analyst flagged ${flaggedCount} file${flaggedCount === 1 ? '' : 's'} the deterministic checks did not.`
+      : `Advisory — the AI analyst was uncertain about ${allEscalations.length} file${allEscalations.length === 1 ? '' : 's'} the deterministic checks did not flag.`;
+    console.log(`  ${colors.dim}${headline}${RESET()}`);
+    console.log(`  ${colors.dim}Score and exit code are unchanged.${RESET()}`);
     console.log();
     // Model-derived fields are single-lined at the source (orchestrate.ts) AND
     // here: the analyst reads attacker-controlled artifacts, so an embedded

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -662,6 +662,23 @@ interface UnifiedCheckDisplayOptions {
     reason: 'clean-scan' | 'not-ready' | 'backend-unavailable' | 'daemon-error' | 'platform-not-supported';
     modelLabel: string;
   };
+  /**
+   * Analyst coverage escalations (--nanomind, abstention-gated policy).
+   * Advisory channel: rendered in their own section, never merged into
+   * findings, never counted toward score or exit code. Shape from
+   * orchestrate.ts AnalystEscalation.
+   */
+  analystEscalations?: Array<{
+    file: string;
+    artifactType: string;
+    routed: 'attack' | 'abstain';
+    attackClass: string;
+    severity: string | null;
+    classification: string;
+    summary: string;
+    modelVersion: string;
+    policy: 'abstention-gated';
+  }>;
   /** When set, this path is used in Next Steps hints instead of `name`. Use for local directory targets (e.g., `secure`). */
   nextStepsTarget?: string;
   /**
@@ -1517,6 +1534,41 @@ function displayUnifiedCheck(opts: UnifiedCheckDisplayOptions): void {
         ? `${Math.round(af.confidence * 100)}% (uncalibrated)`
         : confLabel;
       console.log(`  ${colors.dim}Confidence: ${display} | ${af.modelVersion} (${af.durationMs}ms)${RESET()}`);
+      console.log();
+    }
+  }
+
+  // ── NanoMind Coverage Escalations (advisory) ────────────────────────
+  // Files the deterministic scan did NOT flag but the analyst routed to
+  // attack/abstain under the abstention-gated policy. Advisory by design:
+  // the analyst's raw verdict is not auto-applied (it carries a measured
+  // ~22% false-positive rate on dual-use security code), so these never
+  // change the score or exit code — they queue files for human review.
+  const escalations = opts.analystEscalations ?? [];
+  if (escalations.length > 0) {
+    divider('NanoMind Coverage Escalations');
+    console.log(`  ${colors.dim}Advisory — the AI analyst flagged ${escalations.length} file${escalations.length === 1 ? '' : 's'} the deterministic checks did not.${RESET()}`);
+    console.log(`  ${colors.dim}Score and exit code are unchanged. Review each file to confirm or dismiss.${RESET()}`);
+    console.log();
+    for (const esc of escalations) {
+      const isAttack = esc.routed === 'attack';
+      const tag = isAttack ? `${colors.red}${colors.bold}REVIEW${RESET()}` : `${colors.yellow}${colors.bold}UNCERTAIN${RESET()}`;
+      const sev = esc.severity ? ` (${esc.severity})` : '';
+      const cls = esc.attackClass && esc.attackClass !== 'none'
+        ? `${esc.attackClass}${sev}`
+        : (esc.classification || 'unclassified');
+      console.log(`  ${tag}  ${colors.white}${esc.file}${RESET()}  ${colors.dim}${cls}${RESET()}`);
+      if (esc.summary) {
+        const summaryText = esc.summary.length > 220 && !verbose
+          ? `${esc.summary.slice(0, 217)}...`
+          : esc.summary;
+        console.log(`  ${colors.dim}${summaryText}${RESET()}`);
+        if (esc.summary.length > 220 && !verbose) {
+          console.log(`  ${colors.dim}(run with --verbose for the full analysis)${RESET()}`);
+        }
+      }
+      console.log(`  ${colors.cyan}Verify:${RESET()} review ${esc.file} for the behavior described above`);
+      console.log(`  ${colors.dim}${esc.modelVersion} | ${esc.routed === 'attack' ? 'named attack class at high severity' : 'uncertain verdict — needs a human call'}${RESET()}`);
       console.log();
     }
   }
@@ -3581,9 +3633,12 @@ Examples:
           }
         }
 
-        const jsonBase = nmResult.analystFindings?.length
-          ? { ...result, analystFindings: nmResult.analystFindings }
-          : result;
+        const jsonBase = {
+          ...result,
+          ...(nmResult.analystFindings?.length ? { analystFindings: nmResult.analystFindings } : {}),
+          ...(nmResult.analystEscalations?.length ? { analystEscalations: nmResult.analystEscalations } : {}),
+          ...(nmResult.coverageSweep ? { coverageSweep: nmResult.coverageSweep } : {}),
+        };
         const jsonOutput = publishStatus ? { ...jsonBase, publish: publishStatus } : jsonBase;
         if (options.output) {
           require('fs').writeFileSync(options.output, JSON.stringify(jsonOutput, null, 2) + '\n');
@@ -3712,6 +3767,9 @@ Examples:
           ? nmResult.analystFindings
           : undefined,
         analystZeroState: nmResult.analystZeroState,
+        analystEscalations: nmResult.analystEscalations?.length
+          ? nmResult.analystEscalations
+          : undefined,
         artifactSummaries: nmResult.artifactSummaries,
         nextStepsTarget: directory,
       });
@@ -8915,6 +8973,7 @@ async function checkGitHubRepo(
     // Run NanoMind semantic analysis and re-filter
     let analystFindings: any[] | undefined;
     let analystZeroState: { reason: 'clean-scan' | 'not-ready' | 'backend-unavailable' | 'daemon-error' | 'platform-not-supported'; modelLabel: string } | undefined;
+    let analystEscalations: any[] | undefined;
     let artifactSummaries: any[] | undefined;
     try {
       const { orchestrateNanoMind } = await import('./nanomind-core/orchestrate.js');
@@ -8927,6 +8986,7 @@ async function checkGitHubRepo(
       result.score = scanner.calculateScore(result.findings.filter((f: any) => !f.passed && !f.fixed)).score;
       analystFindings = nmResult.analystFindings;
       analystZeroState = nmResult.analystZeroState;
+      analystEscalations = nmResult.analystEscalations;
       artifactSummaries = nmResult.artifactSummaries;
     } catch {
       // NanoMind unavailable — surface this in the CLI output instead of going
@@ -8977,6 +9037,7 @@ async function checkGitHubRepo(
       usedAnalm: resolveNanomindFlag(options),
       analystFindings,
       analystZeroState,
+      analystEscalations,
       artifactSummaries,
     });
 
@@ -9217,6 +9278,7 @@ async function checkPyPiPackage(
     // Run NanoMind semantic analysis and re-filter
     let analystFindings: any[] | undefined;
     let analystZeroState: { reason: 'clean-scan' | 'not-ready' | 'backend-unavailable' | 'daemon-error' | 'platform-not-supported'; modelLabel: string } | undefined;
+    let analystEscalations: any[] | undefined;
     let artifactSummaries: any[] | undefined;
     try {
       const { orchestrateNanoMind } = await import('./nanomind-core/orchestrate.js');
@@ -9229,6 +9291,7 @@ async function checkPyPiPackage(
       result.score = scanner.calculateScore(result.findings.filter((f: any) => !f.passed && !f.fixed)).score;
       analystFindings = nmResult.analystFindings;
       analystZeroState = nmResult.analystZeroState;
+      analystEscalations = nmResult.analystEscalations;
       artifactSummaries = nmResult.artifactSummaries;
     } catch {
       // NanoMind unavailable -- use base scan results
@@ -9276,6 +9339,7 @@ async function checkPyPiPackage(
       usedAnalm: resolveNanomindFlag(options),
       analystFindings,
       analystZeroState,
+      analystEscalations,
       artifactSummaries,
     });
 
@@ -9413,6 +9477,7 @@ async function checkRawUrl(
 
     let analystFindings: any[] | undefined;
     let analystZeroState: { reason: 'clean-scan' | 'not-ready' | 'backend-unavailable' | 'daemon-error' | 'platform-not-supported'; modelLabel: string } | undefined;
+    let analystEscalations: any[] | undefined;
     let artifactSummaries: any[] | undefined;
     try {
       const { orchestrateNanoMind } = await import('./nanomind-core/orchestrate.js');
@@ -9425,6 +9490,7 @@ async function checkRawUrl(
       result.score = scanner.calculateScore(result.findings.filter((f: any) => !f.passed && !f.fixed)).score;
       analystFindings = nmResult.analystFindings;
       analystZeroState = nmResult.analystZeroState;
+      analystEscalations = nmResult.analystEscalations;
       artifactSummaries = nmResult.artifactSummaries;
     } catch {
       // NanoMind unavailable — surface this in the CLI output instead of going
@@ -9455,6 +9521,7 @@ async function checkRawUrl(
         findings: result.findings,
       };
       if (analystFindings?.length) jsonOut.analystFindings = analystFindings;
+      if (analystEscalations?.length) jsonOut.analystEscalations = analystEscalations;
       writeJsonStdout(jsonOut);
       return;
     }
@@ -9470,6 +9537,7 @@ async function checkRawUrl(
       usedAnalm: resolveNanomindFlag(options),
       analystFindings,
       analystZeroState,
+      analystEscalations,
       artifactSummaries,
     });
 
@@ -9582,6 +9650,7 @@ async function checkNpmPackage(
     // Run NanoMind semantic analysis and re-filter (matches secure command pipeline)
     let analystFindings: any[] | undefined;
     let analystZeroState: { reason: 'clean-scan' | 'not-ready' | 'backend-unavailable' | 'daemon-error' | 'platform-not-supported'; modelLabel: string } | undefined;
+    let analystEscalations: any[] | undefined;
     let artifactSummaries: any[] | undefined;
     try {
       const { orchestrateNanoMind } = await import('./nanomind-core/orchestrate.js');
@@ -9594,6 +9663,7 @@ async function checkNpmPackage(
       result.score = scanner.calculateScore(result.findings.filter((f: any) => !f.passed && !f.fixed)).score;
       analystFindings = nmResult.analystFindings;
       analystZeroState = nmResult.analystZeroState;
+      analystEscalations = nmResult.analystEscalations;
       artifactSummaries = nmResult.artifactSummaries;
     } catch {
       // NanoMind unavailable — surface this in the CLI output instead of going
@@ -9641,6 +9711,7 @@ async function checkNpmPackage(
       usedAnalm: resolveNanomindFlag(options),
       analystFindings,
       analystZeroState,
+      analystEscalations,
       artifactSummaries,
     });
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1550,20 +1550,27 @@ function displayUnifiedCheck(opts: UnifiedCheckDisplayOptions): void {
     console.log(`  ${colors.dim}Advisory — the AI analyst flagged ${escalations.length} file${escalations.length === 1 ? '' : 's'} the deterministic checks did not.${RESET()}`);
     console.log(`  ${colors.dim}Score and exit code are unchanged. Review each file to confirm or dismiss.${RESET()}`);
     console.log();
+    // Model-derived fields are single-lined at the source (orchestrate.ts) AND
+    // here: the analyst reads attacker-controlled artifacts, so an embedded
+    // newline must never let injected text impersonate this section's own rows.
+    const singleLine = (s: string | null | undefined) => String(s ?? '').replace(/\s+/g, ' ').trim();
     for (const esc of escalations) {
       const isAttack = esc.routed === 'attack';
       const tag = isAttack ? `${colors.red}${colors.bold}REVIEW${RESET()}` : `${colors.yellow}${colors.bold}UNCERTAIN${RESET()}`;
-      const sev = esc.severity ? ` (${esc.severity})` : '';
-      const cls = esc.attackClass && esc.attackClass !== 'none'
-        ? `${esc.attackClass}${sev}`
-        : (esc.classification || 'unclassified');
+      const sevText = singleLine(esc.severity);
+      const sev = sevText ? ` (${sevText})` : '';
+      const attackClass = singleLine(esc.attackClass);
+      const cls = attackClass && attackClass !== 'none'
+        ? `${attackClass}${sev}`
+        : (singleLine(esc.classification) || 'unclassified');
       console.log(`  ${tag}  ${colors.white}${esc.file}${RESET()}  ${colors.dim}${cls}${RESET()}`);
-      if (esc.summary) {
-        const summaryText = esc.summary.length > 220 && !verbose
-          ? `${esc.summary.slice(0, 217)}...`
-          : esc.summary;
+      const summary = singleLine(esc.summary);
+      if (summary) {
+        const summaryText = summary.length > 220 && !verbose
+          ? `${summary.slice(0, 217)}...`
+          : summary;
         console.log(`  ${colors.dim}${summaryText}${RESET()}`);
-        if (esc.summary.length > 220 && !verbose) {
+        if (summary.length > 220 && !verbose) {
           console.log(`  ${colors.dim}(run with --verbose for the full analysis)${RESET()}`);
         }
       }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1544,10 +1544,19 @@ function displayUnifiedCheck(opts: UnifiedCheckDisplayOptions): void {
   // the analyst's raw verdict is not auto-applied (it carries a measured
   // ~22% false-positive rate on dual-use security code), so these never
   // change the score or exit code — they queue files for human review.
-  const escalations = opts.analystEscalations ?? [];
-  if (escalations.length > 0) {
+  const allEscalations = opts.analystEscalations ?? [];
+  // Default render shows ATTACK-routed escalations (named canonical attack
+  // class at high severity — worth a row). Abstain-routed ones are usually
+  // model hedges or parser noise ("confidence: 0.15") on benign-but-security-
+  // shaped content (measured 2026-06-10 on the benign corpus fixtures); they
+  // collapse to a count line so clean repos don't drown in UNCERTAIN rows.
+  // --verbose and --json always carry every escalation, so the abstention
+  // channel stays fully visible to humans who ask and to automation.
+  const escalations = verbose ? allEscalations : allEscalations.filter(e => e.routed === 'attack');
+  const hiddenAbstains = allEscalations.length - escalations.length;
+  if (allEscalations.length > 0) {
     divider('NanoMind Coverage Escalations');
-    console.log(`  ${colors.dim}Advisory — the AI analyst flagged ${escalations.length} file${escalations.length === 1 ? '' : 's'} the deterministic checks did not.${RESET()}`);
+    console.log(`  ${colors.dim}Advisory — the AI analyst flagged ${allEscalations.length} file${allEscalations.length === 1 ? '' : 's'} the deterministic checks did not.${RESET()}`);
     console.log(`  ${colors.dim}Score and exit code are unchanged. Review each file to confirm or dismiss.${RESET()}`);
     console.log();
     // Model-derived fields are single-lined at the source (orchestrate.ts) AND
@@ -1576,6 +1585,11 @@ function displayUnifiedCheck(opts: UnifiedCheckDisplayOptions): void {
       }
       console.log(`  ${colors.cyan}Verify:${RESET()} review ${esc.file} for the behavior described above`);
       console.log(`  ${colors.dim}${esc.modelVersion} | ${esc.routed === 'attack' ? 'named attack class at high severity' : 'uncertain verdict — needs a human call'}${RESET()}`);
+      console.log();
+    }
+    if (hiddenAbstains > 0) {
+      console.log(`  ${colors.dim}${hiddenAbstains} uncertain analyst verdict${hiddenAbstains === 1 ? '' : 's'} (model hedged or gave no usable class) not shown.${RESET()}`);
+      console.log(`  ${colors.dim}Inspect with --verbose, or programmatically via --json analystEscalations.${RESET()}`);
       console.log();
     }
   }

--- a/src/nanomind-core/analyst-coverage.ts
+++ b/src/nanomind-core/analyst-coverage.ts
@@ -1,0 +1,187 @@
+/**
+ * Analyst coverage routing (NanoMind Phase A — P1, CDS-023).
+ *
+ * The v3.0.0 reasoning analyst (`sendClassify` -> gate -> Qwen3-1.7B NLM) can
+ * recover behavioral attacks the structural AST pipeline misses. But its raw
+ * verdict is NOT safe to auto-apply (CDS-024): on dual-use security code it
+ * carries ~22% false-positive rate and its confidences cluster near 0.95 (weak
+ * calibration, measured 2026-06-05). This module is the routing layer that lets
+ * the analyst INFORM and ESCALATE without auto-flipping the deterministic
+ * verdict, until a policy is chosen in P3.
+ *
+ * It is intentionally PURE and dependency-free: it post-processes one analyst
+ * verdict + the structural signal and returns a routed decision. The same
+ * function backs both the live daemon path (a `ClassifyOkResponse` is
+ * structurally an `AnalystVerdict`) and the offline benchmark JOIN that
+ * measures F1/FPR over captured verdicts.
+ *
+ * This module is measurement-path only in P1. It is deliberately NOT wired into
+ * `orchestrateNanoMind` / `scanner-bridge` — shipped `secure` behavior is
+ * unchanged. Wiring an auto-verdict into the product is gated behind P3
+ * (the per-sample structural+analyst policy comparison vs the published
+ * 82.9% F1 / 1.16% FPR).
+ */
+
+/** Routed analyst contribution to a per-artifact verdict. */
+export type RoutedAnalystVerdict =
+  | 'attack' // names a real attack class at HIGH/CRITICAL — high-confidence threat
+  | 'benign' // gate-suppressed, or none/benign — no threat
+  | 'abstain'; // uncertain (mid-severity attack class or "suspicious") — escalate, do not auto-verdict
+
+/** Policy for combining the structural verdict with the routed analyst verdict. */
+export type CombinePolicy =
+  | 'structural-only' // baseline: analyst ignored
+  | 'union' // analyst auto-adds attacks (max recall; pays the analyst's benign FPR)
+  | 'abstention-gated'; // structural auto-verdict stands; analyst only ESCALATES misses (CDS-024 safe)
+
+/**
+ * The subset of the daemon's classify response this layer reasons about.
+ * `ClassifyOkResponse` from nanomind-guard-client is assignable to this, as is a
+ * captured-verdict record from the offline measurement harness.
+ */
+export interface AnalystVerdict {
+  /** "none" | "benign" | <attack class>; constant "none" on the gate-bypass path. */
+  attackClass: string;
+  /** "benign" | "suspicious" | "malicious"; optional (not all captures carry it). */
+  classification?: string;
+  /** "critical" | "high" | "medium" | "low" | "none" | null. */
+  severity: string | null;
+  /** null on the gate-bypass path, a number on the NLM path. */
+  confidence?: number | null;
+  /** "input-classifier-gate" (suppressed) or "nlm" (model ran). */
+  source?: 'input-classifier-gate' | 'nlm' | string;
+}
+
+export interface CombinedVerdict {
+  /** Auto-applied verdict under the policy. `abstention-gated` never lets the analyst raise this. */
+  attack: boolean;
+  /**
+   * The analyst surfaced something for human review that the auto-verdict did
+   * not act on (a structural miss the analyst flagged, or an abstention). Drives
+   * the escalation queue; never silently changes the score.
+   */
+  escalate: boolean;
+}
+
+/** Attack-class strings that mean "no attack". */
+export const NON_ATTACK_CLASSES: ReadonlySet<string> = new Set(['none', 'benign', '']);
+/** Severities that make a named attack class a confident threat. */
+export const HIGH_SEVERITIES: ReadonlySet<string> = new Set(['critical', 'high']);
+/** Severities that put a named attack class in the abstention band. */
+export const MID_SEVERITIES: ReadonlySet<string> = new Set(['medium', 'low']);
+
+/**
+ * Canonical attack-class vocabulary: the TME 10-class taxonomy unioned with the
+ * snake_case classes the v3.0.0 analyst actually emits (observed across the
+ * DVAA + corpus captures). An auto-`attack` requires membership here.
+ *
+ * Robustness guard (P1 adversarial review M1): the analyst sometimes emits
+ * free-form prose as its class ("Privilege Escalation / Unauthorized Command
+ * Execution"), parser noise ("confidence: 0.15", "N/A"), or a hedge ("[No valid
+ * attack class applies]"). Treating any non-benign string as a named attack
+ * would let one hallucinated severity convert model word-salad into an
+ * auto-verdict. Unknown classes therefore route to `abstain` (escalate for human
+ * review) — the signal is preserved, but it never auto-flips the verdict.
+ */
+export const KNOWN_ATTACK_CLASSES: ReadonlySet<string> = new Set([
+  // TME 10-class taxonomy
+  'prompt_injection', 'data_exfiltration', 'tool_abuse', 'privilege_escalation',
+  'model_manipulation', 'social_engineering', 'supply_chain', 'denial_of_service',
+  'steganographic_attack',
+  // Analyst-emitted classes observed in captures
+  'injection', 'exfiltration', 'lateral_movement', 'persistence', 'credential_abuse',
+  'steganography', 'policy_violation', 'heartbeat_rce', 'credential_exfiltration',
+  'unicode_stego', 'parser_differential', 'prompt_injection_vulnerability', 'jailbreak',
+]);
+
+function norm(s: string | null | undefined): string {
+  return (s ?? '').trim().toLowerCase();
+}
+
+/** True iff the analyst named a real (non-benign) attack class — including prose. */
+export function namesAttackClass(v: AnalystVerdict): boolean {
+  return !NON_ATTACK_CLASSES.has(norm(v.attackClass));
+}
+
+/** True iff the class is a recognised canonical attack class (auto-`attack` gate). */
+export function isKnownAttackClass(v: AnalystVerdict): boolean {
+  return KNOWN_ATTACK_CLASSES.has(norm(v.attackClass));
+}
+
+/**
+ * Route one analyst verdict into attack / benign / abstain.
+ *
+ * Posture-vs-attack: an analyst output is an `attack` ONLY when it names a real
+ * attack class at HIGH/CRITICAL severity — matching the structural verdict's
+ * own "high/critical attack finding" bar so the two halves are comparable. A
+ * gate-suppressed verdict (`source: input-classifier-gate`, attackClass "none")
+ * is `benign` by construction.
+ *
+ * Calibrated abstention is severity/agreement-based, NOT confidence-based: the
+ * v3.0.0 analyst's confidences cluster near 0.95 regardless of correctness
+ * (selective-risk is non-monotonic — baseline 2026-06-05), so thresholding on
+ * `confidence` would be measurement theatre. Instead, a real attack class at
+ * MEDIUM/LOW severity, or a "suspicious" classification, is treated as `abstain`
+ * (uncertain — escalate for human review) rather than a confident verdict.
+ */
+export function routeAnalystVerdict(v: AnalystVerdict): RoutedAnalystVerdict {
+  // Gate-suppressed path is benign by construction (no model judgement made).
+  if (norm(v.source) === 'input-classifier-gate') return 'benign';
+
+  const classification = norm(v.classification);
+  if (!namesAttackClass(v)) {
+    // No attack class. "suspicious" with no class still warrants a look.
+    return classification === 'suspicious' ? 'abstain' : 'benign';
+  }
+
+  // Non-benign but unrecognised class (free-form prose / parser noise / hedge):
+  // never auto-`attack`; escalate for human review instead (robustness guard).
+  if (!isKnownAttackClass(v)) return 'abstain';
+
+  const sev = norm(v.severity);
+  if (HIGH_SEVERITIES.has(sev)) return 'attack';
+  if (MID_SEVERITIES.has(sev)) return 'abstain';
+
+  // Known attack class with no/unknown severity: uncertain, not confident.
+  return 'abstain';
+}
+
+/**
+ * Combine the structural verdict (HIGH/CRITICAL attack finding present, posture
+ * excluded) with the routed analyst verdict under a policy.
+ *
+ *  - `structural-only`  analyst ignored; the published baseline.
+ *  - `union`            analyst auto-adds attacks. Maximises recall but inherits
+ *                       the analyst's benign FPR — NOT auto-safe (CDS-024); for
+ *                       measuring the recall ceiling and the FPR cost only.
+ *  - `abstention-gated` the structural auto-verdict is never raised by the
+ *                       analyst; an analyst `attack`/`abstain` on a structural
+ *                       miss becomes an ESCALATION (human review). Auto-FPR
+ *                       therefore equals the structural FPR. This is the only
+ *                       policy that is safe to run in product before P3.
+ */
+export function combineVerdict(
+  structuralAttack: boolean,
+  analyst: RoutedAnalystVerdict,
+  policy: CombinePolicy,
+): CombinedVerdict {
+  switch (policy) {
+    case 'structural-only':
+      return { attack: structuralAttack, escalate: false };
+
+    case 'union':
+      return {
+        attack: structuralAttack || analyst === 'attack',
+        // Mid-band analyst signal on an otherwise-clean artifact still escalates.
+        escalate: !structuralAttack && analyst === 'abstain',
+      };
+
+    case 'abstention-gated':
+      return {
+        // Analyst NEVER raises the auto-verdict pre-P3.
+        attack: structuralAttack,
+        // It surfaces structural misses (attack or abstain) for human review.
+        escalate: !structuralAttack && (analyst === 'attack' || analyst === 'abstain'),
+      };
+  }
+}

--- a/src/nanomind-core/index.ts
+++ b/src/nanomind-core/index.ts
@@ -78,7 +78,10 @@ export type {
 
 // Analyst coverage routing (Phase A P1, CDS-023): posture-vs-attack + abstention
 // layer that lets the analyst inform/escalate without auto-flipping the verdict.
-// Measurement-path only in P1 — NOT wired into orchestrateNanoMind.
+// Wired into orchestrateNanoMind's coverage sweep under the abstention-gated
+// policy (the only product-safe policy per the P3 corpus join, 2026-06-06):
+// the analyst escalates structural misses for human review; raw analyst
+// auto-verdict remains NO-GO (CDS-024).
 export {
   routeAnalystVerdict,
   combineVerdict,
@@ -95,6 +98,19 @@ export type {
   AnalystVerdict,
   CombinedVerdict,
 } from './analyst-coverage.js';
+
+// Orchestration (scan-path entry: scanner-bridge + analyst stages + coverage sweep)
+export { orchestrateNanoMind, runCoverageSweep } from './orchestrate.js';
+export type {
+  OrchestrationOptions,
+  OrchestrationResult,
+  AnalystEscalation,
+  CoverageSweepStats,
+  CoverageSweepOutcome,
+} from './orchestrate.js';
+export type { CoverageCandidate, NanoMindScanResult } from './scanner-bridge.js';
+export { classifyArtifactForCoverage } from './inference/security-analyst.js';
+export type { ArtifactCoverageVerdict } from './inference/security-analyst.js';
 
 // Ingestion
 export { parseArtifact, classifyArtifactType, computeHash } from './ingestion/artifact-parser.js';

--- a/src/nanomind-core/index.ts
+++ b/src/nanomind-core/index.ts
@@ -76,6 +76,26 @@ export type {
   FalsePositiveAssessment,
 } from './inference/security-analyst.js';
 
+// Analyst coverage routing (Phase A P1, CDS-023): posture-vs-attack + abstention
+// layer that lets the analyst inform/escalate without auto-flipping the verdict.
+// Measurement-path only in P1 — NOT wired into orchestrateNanoMind.
+export {
+  routeAnalystVerdict,
+  combineVerdict,
+  namesAttackClass,
+  isKnownAttackClass,
+  NON_ATTACK_CLASSES,
+  HIGH_SEVERITIES,
+  MID_SEVERITIES,
+  KNOWN_ATTACK_CLASSES,
+} from './analyst-coverage.js';
+export type {
+  RoutedAnalystVerdict,
+  CombinePolicy,
+  AnalystVerdict,
+  CombinedVerdict,
+} from './analyst-coverage.js';
+
 // Ingestion
 export { parseArtifact, classifyArtifactType, computeHash } from './ingestion/artifact-parser.js';
 export { sanitizeForNanoMind, detectManipulation } from './ingestion/input-sanitizer.js';

--- a/src/nanomind-core/index.ts
+++ b/src/nanomind-core/index.ts
@@ -100,7 +100,12 @@ export type {
 } from './analyst-coverage.js';
 
 // Orchestration (scan-path entry: scanner-bridge + analyst stages + coverage sweep)
-export { orchestrateNanoMind, runCoverageSweep } from './orchestrate.js';
+export {
+  orchestrateNanoMind,
+  runCoverageSweep,
+  sweepIndicatesDaemonError,
+  POSTURE_HARDENING_CHECKS,
+} from './orchestrate.js';
 export type {
   OrchestrationOptions,
   OrchestrationResult,

--- a/src/nanomind-core/inference/security-analyst.ts
+++ b/src/nanomind-core/inference/security-analyst.ts
@@ -354,6 +354,59 @@ export async function runAnalystInference(
 }
 
 /**
+ * Raw (but boundary-sanitized) per-artifact classification for the coverage
+ * sweep (Phase A P1, CDS-023). Unlike runAnalystInference, this preserves the
+ * daemon's universal verdict fields verbatim so the routing layer
+ * (analyst-coverage.ts routeAnalystVerdict) can apply the posture-vs-attack +
+ * abstention mapping itself. The shape is assignable to AnalystVerdict.
+ */
+export interface ArtifactCoverageVerdict {
+  /** "none" | "benign" | <attack class>; "none" on the gate-bypass path. */
+  attackClass: string;
+  /** "benign" | "suspicious" | "malicious" | "" when absent. */
+  classification: string;
+  /** "critical" | "high" | "medium" | "low" | "none" | null. */
+  severity: string | null;
+  /** null on the gate-bypass path; the NLM's reported number otherwise. */
+  confidence: number | null;
+  source: 'input-classifier-gate' | 'nlm';
+  /** Sanitized analysis narrative (may be empty on the gate path). */
+  analysis: string;
+  /** Sanitized evidence section (may be empty). */
+  evidence: string;
+  modelVersion: string;
+  durationMs: number;
+}
+
+/**
+ * Classify one artifact's content through the daemon (gate + NLM) and return
+ * the universal verdict without task shaping. Returns null when the daemon is
+ * absent, unhealthy, or errors — callers treat null as "analyst unavailable",
+ * never as a benign verdict.
+ */
+export async function classifyArtifactForCoverage(
+  content: string,
+): Promise<ArtifactCoverageVerdict | null> {
+  const startMs = Date.now();
+  const response = await sendClassify(content.slice(0, MAX_INPUT_CHARS));
+  if (response === null || !isClassifyOk(response)) {
+    return null;
+  }
+  const severity = sanitizeAnalystString(response.severity).toLowerCase();
+  return {
+    attackClass: sanitizeAnalystString(response.predictedAttackClass),
+    classification: sanitizeAnalystString(response.classification).toLowerCase(),
+    severity: severity.length > 0 ? severity : null,
+    confidence: typeof response.confidence === 'number' ? response.confidence : null,
+    source: response.source === 'input-classifier-gate' ? 'input-classifier-gate' : 'nlm',
+    analysis: sanitizeAnalystString(response.analysis),
+    evidence: sanitizeAnalystString(response.evidence),
+    modelVersion: `nanomind-analyst-v${MODEL_VERSION}`,
+    durationMs: Date.now() - startMs,
+  };
+}
+
+/**
  * Adapt the daemon's universal classifier response to the task-specific
  * fields each renderer in cli.ts reads. The v3 NLM is a unified
  * security-artifact classifier and does not accept per-task system prompts;

--- a/src/nanomind-core/orchestrate.ts
+++ b/src/nanomind-core/orchestrate.ts
@@ -97,7 +97,23 @@ export interface CoverageSweepStats {
   swept: number;
   /** Candidates dropped by the per-scan cap or the time budget. */
   skipped: number;
+  /**
+   * Sweep calls that returned null (daemon absent/errored mid-sweep). Null is
+   * "analyst unavailable", never a benign verdict — when every swept call was
+   * null the scan must surface daemon-error, not a clean zero-state.
+   */
+  nullVerdicts: number;
   policy: 'abstention-gated';
+}
+
+/**
+ * True when the sweep ran but got NO verdict back for anything it swept — the
+ * daemon answered healthz at the gate check and then failed every classify
+ * (wedged, OOM mid-scan). Distinguishes "swept N, all benign" from "swept N,
+ * all unavailable" so a dead daemon is never rendered as a clean scan.
+ */
+export function sweepIndicatesDaemonError(stats: CoverageSweepStats): boolean {
+  return stats.swept > 0 && stats.nullVerdicts === stats.swept;
 }
 
 /**
@@ -259,9 +275,13 @@ export async function orchestrateNanoMind(
 
         if (significant.length === 0 && sweep.escalations.length === 0) {
           // No HIGH/CRITICAL findings and the coverage sweep raised nothing.
-          // The deterministic Observations block carries the verdict.
+          // Distinguish a genuinely clean sweep from a daemon that answered
+          // healthz and then failed every classify call — reporting the
+          // latter as clean-scan would gaslight the user into thinking
+          // analysis ran (same failure mode the per-finding stage guards
+          // against above).
           result.analystZeroState = {
-            reason: 'clean-scan',
+            reason: sweepIndicatesDaemonError(sweep.stats) ? 'daemon-error' : 'clean-scan',
             modelLabel: 'Qwen3 v3.0.0 inline',
           };
         }
@@ -392,7 +412,7 @@ async function runAnalystOnFindings(
  * (HARDENING_CHECK_IDS incl. the AST-SCOPE-001 wildcard; AST-SCOPE-003 stays
  * a verdict driver).
  */
-const POSTURE_HARDENING_CHECKS: ReadonlySet<string> = new Set([
+export const POSTURE_HARDENING_CHECKS: ReadonlySet<string> = new Set([
   'AST-PROMPT-001', 'AST-PROMPT-003', 'AST-PROMPT-004',
   'AST-GOV-001', 'AST-GOV-002', 'AST-GOV-003', 'AST-GOV-004', 'AST-GOV-005',
   'AST-SCOPE-001',
@@ -456,9 +476,18 @@ export async function runCoverageSweep(
 
   const escalations: AnalystEscalation[] = [];
   let swept = 0;
+  let nullVerdicts = 0;
   const deadlineAt = Date.now() + SWEEP_DEADLINE_MS;
   const { readFile } = await import('node:fs/promises');
   const { join } = await import('node:path');
+
+  // The analyst is a generative model reading attacker-controlled artifact
+  // content, so every model-derived string is rendered/serialized as a single
+  // line: embedded newlines could otherwise spoof extra advisory rows or fake
+  // Verify: instructions inside HMA's trusted output (adversarial review M2).
+  // Control/ANSI sequences are already stripped at the IPC boundary.
+  const oneLine = (s: string | null): string =>
+    (s ?? '').replace(/\s+/g, ' ').trim();
 
   for (const candidate of selected) {
     if (Date.now() >= deadlineAt) {
@@ -480,21 +509,26 @@ export async function runCoverageSweep(
 
     const verdict = await classify(content);
     swept++;
-    if (verdict === null) continue; // daemon unavailable/errored — not a benign verdict, but never fabricate
+    if (verdict === null) {
+      // Daemon unavailable/errored — not a benign verdict, never fabricate.
+      nullVerdicts++;
+      continue;
+    }
 
     const routed = routeAnalystVerdict(verdict);
     // structuralAttack=false by selection; under abstention-gated the analyst
     // can only escalate, so `attack` from combineVerdict is always false here.
     const combined = combineVerdict(false, routed, 'abstention-gated');
     if (combined.escalate && (routed === 'attack' || routed === 'abstain')) {
+      const severity = oneLine(verdict.severity);
       escalations.push({
         file: candidate.path,
         artifactType: candidate.artifactType,
         routed,
-        attackClass: verdict.attackClass,
-        severity: verdict.severity,
-        classification: verdict.classification,
-        summary: verdict.analysis.slice(0, 600),
+        attackClass: oneLine(verdict.attackClass),
+        severity: severity.length > 0 ? severity : null,
+        classification: oneLine(verdict.classification),
+        summary: oneLine(verdict.analysis).slice(0, 600),
         modelVersion: verdict.modelVersion,
         policy: 'abstention-gated',
       });
@@ -515,6 +549,7 @@ export async function runCoverageSweep(
       candidates: eligible.length,
       swept,
       skipped: Math.max(0, skipped),
+      nullVerdicts,
       policy: 'abstention-gated',
     },
   };

--- a/src/nanomind-core/orchestrate.ts
+++ b/src/nanomind-core/orchestrate.ts
@@ -15,8 +15,9 @@
  */
 
 import type { SecurityFinding, ProjectType } from '../hardening/security-check.js';
-import type { NanoMindScanResult, ArtifactSummary } from './scanner-bridge.js';
-import type { AnalystResponse } from './inference/security-analyst.js';
+import type { NanoMindScanResult, ArtifactSummary, CoverageCandidate } from './scanner-bridge.js';
+import type { AnalystResponse, ArtifactCoverageVerdict } from './inference/security-analyst.js';
+import { routeAnalystVerdict, combineVerdict } from './analyst-coverage.js';
 
 export type { ArtifactSummary } from './scanner-bridge.js';
 
@@ -54,6 +55,49 @@ export interface OrchestrationResult {
     reason: 'clean-scan' | 'not-ready' | 'backend-unavailable' | 'daemon-error' | 'platform-not-supported';
     modelLabel: string;
   };
+  /**
+   * Analyst coverage escalations (--nanomind, Phase A P1, CDS-023/024).
+   * Files the deterministic scan did NOT flag but the v3.0.0 analyst routed to
+   * `attack` or `abstain` under the abstention-gated policy. ADVISORY channel
+   * only: these never enter mergedFindings, never change severity, score, or
+   * exit code, and never suppress a static finding. Raw analyst auto-verdict
+   * is NO-GO (~22% FPR on dual-use security code, weak calibration); the
+   * analyst informs, abstention escalates — a human closes the loop.
+   */
+  analystEscalations?: AnalystEscalation[];
+  /** Coverage-sweep accounting so capped scans are never silently partial. */
+  coverageSweep?: CoverageSweepStats;
+}
+
+/** One advisory escalation from the analyst coverage sweep. */
+export interface AnalystEscalation {
+  /** Relative path of the escalated artifact (matches SecurityFinding.file). */
+  file: string;
+  /** Compiler-assigned artifact type (skill, mcp_config, soul, source_code, ...). */
+  artifactType: string;
+  /** 'attack' = named canonical class at HIGH/CRITICAL; 'abstain' = uncertain. */
+  routed: 'attack' | 'abstain';
+  /** Analyst-reported attack class (verbatim, sanitized). */
+  attackClass: string;
+  /** Analyst-reported severity, or null when it reported none. */
+  severity: string | null;
+  /** Analyst-reported classification (benign | suspicious | malicious | ""). */
+  classification: string;
+  /** Sanitized analysis narrative (truncated for transport). */
+  summary: string;
+  modelVersion: string;
+  /** The combine policy that produced this escalation. Always 'abstention-gated'. */
+  policy: 'abstention-gated';
+}
+
+export interface CoverageSweepStats {
+  /** Compiled artifacts with no high/critical structural attack finding. */
+  candidates: number;
+  /** How many the analyst actually classified this scan. */
+  swept: number;
+  /** Candidates dropped by the per-scan cap or the time budget. */
+  skipped: number;
+  policy: 'abstention-gated';
 }
 
 /**
@@ -129,7 +173,7 @@ export async function orchestrateNanoMind(
     };
 
     // --- Security Analyst (generative model, --analyze flag) ---
-    const { isAnalystReady, runAnalystInference } = await import('./inference/security-analyst.js');
+    const { isAnalystReady, runAnalystInference, classifyArtifactForCoverage } = await import('./inference/security-analyst.js');
 
     if (nanomind) {
       const ready = await isAnalystReady();
@@ -183,10 +227,39 @@ export async function orchestrateNanoMind(
               );
             }
           }
-        } else {
-          // No HIGH/CRITICAL findings — skip the analyst call. LOW/MEDIUM-only
-          // scans are effectively "clean" from an AI-threat perspective; the
-          // deterministic Observations block carries the verdict.
+        }
+
+        // --- Coverage sweep (Phase A P1, CDS-023): the per-finding stage above
+        // only reaches files the structural layer ALREADY flagged. Behavioral
+        // attacks the AST is blind to (intent-as-instruction-text: prompt
+        // injection, social engineering, code-level RCE in prose) produce zero
+        // structural findings and so never reached the analyst — measured as
+        // DVAA-full-repo 29.1% structural vs 82.6% with the analyst reading
+        // the same artifacts (2026-06-05/06 baseline). The sweep sends compiled
+        // artifacts WITHOUT a high/critical structural attack finding through
+        // the analyst and routes the verdict under the abstention-gated policy:
+        // the analyst can only ESCALATE for human review, never raise the
+        // auto-verdict (CDS-024 — raw auto-verdict is NO-GO).
+        const sweep = await runCoverageSweep(
+          targetDir,
+          nmResult.coverageCandidates,
+          nmResult.mergedFindings,
+          classifyArtifactForCoverage,
+          silent,
+        );
+        result.coverageSweep = sweep.stats;
+        if (sweep.escalations.length > 0) {
+          result.analystEscalations = sweep.escalations;
+          if (!silent) {
+            process.stderr.write(
+              `NanoMind: coverage sweep escalated ${sweep.escalations.length} artifact(s) for review\n`,
+            );
+          }
+        }
+
+        if (significant.length === 0 && sweep.escalations.length === 0) {
+          // No HIGH/CRITICAL findings and the coverage sweep raised nothing.
+          // The deterministic Observations block carries the verdict.
           result.analystZeroState = {
             reason: 'clean-scan',
             modelLabel: 'Qwen3 v3.0.0 inline',
@@ -304,4 +377,145 @@ async function runAnalystOnFindings(
   }
 
   return results;
+}
+
+// ============================================================================
+// Coverage sweep (Phase A P1 — CDS-023/024, abstention-gated)
+// ============================================================================
+
+/**
+ * Posture / hardening checks flag MISSING defenses or an over-permissive
+ * posture, not a present attack; they fire on benign and malicious alike. A
+ * file whose only high/critical findings are posture checks is still a
+ * structural MISS for attack purposes and stays eligible for the sweep. Same
+ * set as the published OASB corpus adapter / DVAA benchmark verdict mapping
+ * (HARDENING_CHECK_IDS incl. the AST-SCOPE-001 wildcard; AST-SCOPE-003 stays
+ * a verdict driver).
+ */
+const POSTURE_HARDENING_CHECKS: ReadonlySet<string> = new Set([
+  'AST-PROMPT-001', 'AST-PROMPT-003', 'AST-PROMPT-004',
+  'AST-GOV-001', 'AST-GOV-002', 'AST-GOV-003', 'AST-GOV-004', 'AST-GOV-005',
+  'AST-SCOPE-001',
+]);
+
+/** Per-scan cap on analyst coverage calls — mirrors the per-finding stage's
+ *  top-10 cap so a --nanomind scan stays bounded at ~20 inference calls. */
+const MAX_SWEEP_FILES = 10;
+
+/** Sweep-stage deadline, separate from the per-finding stage's 90s budget. */
+const SWEEP_DEADLINE_MS = 90_000;
+
+/** Agent artifact types get sweep priority: they are the primary behavioral
+ *  attack surface (instruction text the runtime will obey). */
+const AGENT_ARTIFACT_TYPES = new Set([
+  'skill', 'mcp_config', 'soul', 'system_prompt', 'agent_config', 'a2a_card',
+]);
+
+export interface CoverageSweepOutcome {
+  escalations: AnalystEscalation[];
+  stats: CoverageSweepStats;
+}
+
+/**
+ * Run the analyst over compiled artifacts the structural layer did NOT flag
+ * with a high/critical attack finding, and route each verdict under the
+ * abstention-gated policy. The analyst can only ESCALATE (advisory, human
+ * review); it never produces a finding, never changes severity/score/exit
+ * code, and never suppresses anything (CDS-024).
+ *
+ * The classify function is injected so tests can exercise routing without a
+ * daemon; production passes classifyArtifactForCoverage (gate + NLM over the
+ * NanoMind-Guard Unix socket).
+ */
+export async function runCoverageSweep(
+  targetDir: string,
+  candidates: CoverageCandidate[],
+  mergedFindings: SecurityFinding[],
+  classify: (content: string) => Promise<ArtifactCoverageVerdict | null>,
+  silent = false,
+): Promise<CoverageSweepOutcome> {
+  // Files already carrying a high/critical structural ATTACK finding are
+  // covered by the per-finding analyst stage; the sweep targets the misses.
+  const structurallyFlagged = new Set<string>();
+  for (const f of mergedFindings) {
+    if (f.passed || f.fixed || !f.file) continue;
+    if (f.severity !== 'critical' && f.severity !== 'high') continue;
+    if (POSTURE_HARDENING_CHECKS.has(f.checkId)) continue;
+    structurallyFlagged.add(f.file);
+  }
+
+  const eligible = candidates.filter(c => !structurallyFlagged.has(c.path));
+  // Agent artifacts first (primary behavioral surface), discovery order within
+  // each group (stable sort).
+  const ordered = [...eligible].sort((a, b) => {
+    const aAgent = AGENT_ARTIFACT_TYPES.has(a.artifactType) ? 0 : 1;
+    const bAgent = AGENT_ARTIFACT_TYPES.has(b.artifactType) ? 0 : 1;
+    return aAgent - bAgent;
+  });
+  const selected = ordered.slice(0, MAX_SWEEP_FILES);
+
+  const escalations: AnalystEscalation[] = [];
+  let swept = 0;
+  const deadlineAt = Date.now() + SWEEP_DEADLINE_MS;
+  const { readFile } = await import('node:fs/promises');
+  const { join } = await import('node:path');
+
+  for (const candidate of selected) {
+    if (Date.now() >= deadlineAt) {
+      if (!silent) {
+        process.stderr.write(
+          `NanoMind: coverage sweep budget exhausted after ${swept}/${selected.length} artifact(s). ` +
+          'Remaining artifacts not swept.\n',
+        );
+      }
+      break;
+    }
+
+    let content: string;
+    try {
+      content = await readFile(join(targetDir, candidate.path), 'utf-8');
+    } catch {
+      continue; // file vanished between scan and sweep — skip, never block
+    }
+
+    const verdict = await classify(content);
+    swept++;
+    if (verdict === null) continue; // daemon unavailable/errored — not a benign verdict, but never fabricate
+
+    const routed = routeAnalystVerdict(verdict);
+    // structuralAttack=false by selection; under abstention-gated the analyst
+    // can only escalate, so `attack` from combineVerdict is always false here.
+    const combined = combineVerdict(false, routed, 'abstention-gated');
+    if (combined.escalate && (routed === 'attack' || routed === 'abstain')) {
+      escalations.push({
+        file: candidate.path,
+        artifactType: candidate.artifactType,
+        routed,
+        attackClass: verdict.attackClass,
+        severity: verdict.severity,
+        classification: verdict.classification,
+        summary: verdict.analysis.slice(0, 600),
+        modelVersion: verdict.modelVersion,
+        policy: 'abstention-gated',
+      });
+    }
+  }
+
+  const skipped = eligible.length - swept;
+  if (!silent && eligible.length > selected.length) {
+    process.stderr.write(
+      `NanoMind: coverage sweep capped at ${MAX_SWEEP_FILES} of ${eligible.length} eligible artifact(s). ` +
+      'Re-run on a narrower path for full coverage.\n',
+    );
+  }
+
+  return {
+    escalations,
+    stats: {
+      candidates: eligible.length,
+      swept,
+      skipped: Math.max(0, skipped),
+      policy: 'abstention-gated',
+    },
+  };
 }

--- a/src/nanomind-core/scanner-bridge.ts
+++ b/src/nanomind-core/scanner-bridge.ts
@@ -82,6 +82,17 @@ export interface ArtifactSummary {
   weakConstraintCount: number;       // # of constraints with bypassRisk > 0.5
 }
 
+/** One compiled artifact eligible for the analyst coverage sweep (Phase A P1).
+ *  Collected for EVERY compiled file (agent artifacts, source code, docs) —
+ *  behavioral attacks hide in all three — so the sweep layer, not discovery,
+ *  decides what the analyst reads. */
+export interface CoverageCandidate {
+  /** Relative path from scan root (matches SecurityFinding.file). */
+  path: string;
+  /** Compiler-assigned artifact type (skill, mcp_config, soul, source_code, ...). */
+  artifactType: string;
+}
+
 export interface NanoMindScanResult {
   mergedFindings: SecurityFinding[];
   astFindings: ASTFinding[];
@@ -89,6 +100,8 @@ export interface NanoMindScanResult {
   compiledArtifacts: number;
   artifactSummaries: ArtifactSummary[];
   nanomindAvailable: boolean;
+  /** Every compiled artifact, for the --nanomind analyst coverage sweep. */
+  coverageCandidates: CoverageCandidate[];
 }
 
 /**
@@ -117,6 +130,7 @@ export async function runNanoMindScan(
       compiledArtifacts: 0,
       artifactSummaries: [],
       nanomindAvailable: false,
+      coverageCandidates: [],
     };
   }
 
@@ -152,6 +166,7 @@ export async function runNanoMindScan(
   // Step 4: Compile each file and run analyzers
   const allASTFindings: ASTFinding[] = [];
   const artifactSummaries: ArtifactSummary[] = [];
+  const coverageCandidates: CoverageCandidate[] = [];
   // Advisory per-artifact NanoMind intent, keyed by relative path. Populated
   // only when the non-generative classifier (not the heuristic fallback)
   // classified the artifact, so the signal honestly means "the model said X".
@@ -166,6 +181,7 @@ export async function runNanoMindScan(
 
       const result = await compiler.compile(content, relativePath);
       compiledCount++;
+      coverageCandidates.push({ path: relativePath, artifactType: result.ast.artifactType });
 
       if (result.nanomindUsed) {
         nanomindUsedAtLeastOnce = true;
@@ -258,6 +274,7 @@ export async function runNanoMindScan(
     compiledArtifacts: compiledCount,
     artifactSummaries,
     nanomindAvailable: nanomindUsedAtLeastOnce || useNanoMind,
+    coverageCandidates,
   };
 }
 


### PR DESCRIPTION
## What

Wires the v3.0.0 analyst into the behavioral scan path (NanoMind Phase A P1 product half, CDS-023). Under `--nanomind`, compiled artifacts with **no high/critical structural attack finding** (posture checks excluded — the 9-ID benchmark mapping, contract-locked by test) are classified by the NanoMind-Guard daemon and routed through the posture-vs-attack + abstention layer (`analyst-coverage.ts`) under the **abstention-gated** policy: the analyst can only ESCALATE for human review.

Escalations are an advisory channel (`analystEscalations` + `coverageSweep` in `secure --json`): they never enter findings, never change severity, score, or exit code, and never suppress a static finding. **Raw analyst auto-verdict remains NO-GO** (CDS-024: ~22% FP on dual-use security code, weak calibration).

## Why

The structural AST layer is blind to intent-as-instruction-text. Measured: DVAA-full-repo 29.1% structural (AST-only, published) vs 82.6% for the unchanged analyst on the same artifacts — the gap was wiring, not the model. Example caught live by this PR: a knowledge-base doc with `<!-- SYSTEM: Ignore all previous instructions -->` that scores 98/100 structurally now surfaces as a REVIEW escalation (injection/critical).

## Measured with the wiring live (shipping CLI, daemon at gate threshold 0.90)

- DVAA n=86, 0 errors: product structural auto **47.7%** (full static+AST surface — NOT comparable to the AST-only 29.1%); escalation-assisted **94.2%** attack-routed (default render) / **96.5%** incl. abstains; 42/45 product misses escalated.
- 3 silent misses all had `coverageSweep.candidates=0` (.html/.txt-only scenarios outside the compiler discovery surface — follow-up, not slipped into this PR).
- Benign hard-negatives (corpus fixtures + secretless dev tree): 3 attack-routed REVIEW FPs + 11 abstains; abstains collapse to a count line by default (measured hedge/parser-noise dominance), full detail in `--verbose`/`--json`. Ordinary-benign volume estimate stays the frozen n=600 capture (0.7% auto + 1.8% escalation).
- Full report: `nanomind-training/reports/nanomind-phase-a-p1-product-wiring.md`; ledger entry 2026-06-10 in `CDS_LEDGER.md`.

## Safety / bounds

- 10 artifacts/scan (agent artifacts first), 90s sweep budget, capped scans logged.
- Unknown/hallucinated attack classes can never route `attack` (allow-list, CDS-028).
- All model-derived strings control-stripped at the IPC boundary and single-lined before render (an artifact-induced model response cannot spoof advisory rows).
- A daemon that answers healthz then nulls every sweep call surfaces as `daemon-error`, never as a clean scan.
- Independent diff-only adversarial review ran; its M1/M2/LOW-3 findings are fixed in `ff79c6b`.

## Tests

20 wiring tests + 23 routing-module tests; full suite **2400 pass**; benign-FPR oracle gate (P0-1) untouched.

## Known scope boundaries

- `check <npm|pypi|github> --json` does not yet carry escalations (needs an `@opena2a/check-core` bump); text render works on all surfaces.
- Sweep discovery surface = compiler discovery surface (no .html/.txt) — separate measured change.