### PR TITLE
Adopt @opena2a/check-core 0.3.0: carry coverageSweep through check --json

### DIFF
--- a/__tests__/nanomind-core/check-output-escalation-wiring.test.ts
+++ b/__tests__/nanomind-core/check-output-escalation-wiring.test.ts
@@ -1,0 +1,87 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+import { buildCheckOutput } from '@opena2a/check-core';
+
+/**
+ * check --json must carry the --nanomind advisory channel end-to-end.
+ *
+ * HMA computed analystEscalations/coverageSweep in every check path and then
+ * dropped them at buildCheckOutput (check-core 0.2.0 had no carrier fields).
+ * check-core 0.3.0 added the optional fields; this suite pins the wiring so
+ * a future edit to a check path cannot silently drop the channel again.
+ */
+
+describe('check --json escalation wiring (check-core 0.3.0 adoption)', () => {
+  it('every buildCheckOutput scan block in cli.ts passes analystEscalations + coverageSweep', () => {
+    // Static wiring guard (deterministic, no network, no spawn): find each
+    // buildCheckOutput call site and assert its scan{} block carries both
+    // advisory fields. Same pattern as the concept-explainer reference test.
+    const cli = readFileSync(join(__dirname, '..', '..', 'src', 'cli.ts'), 'utf8');
+    const sites = [...cli.matchAll(/buildCheckOutput\(\{[\s\S]*?\n {6}\}\)\)/g)];
+    expect(sites.length).toBeGreaterThanOrEqual(3); // github, pypi, npm paths
+    for (const site of sites) {
+      const block = site[0];
+      expect(block, `buildCheckOutput site missing analystEscalations:\n${block}`).toContain(
+        'analystEscalations',
+      );
+      expect(block, `buildCheckOutput site missing coverageSweep:\n${block}`).toContain(
+        'coverageSweep',
+      );
+    }
+  });
+
+  it('pinned check-core emits the advisory fields after analystFindings, before narrative', () => {
+    const out = buildCheckOutput({
+      name: 'fixture-pkg',
+      type: 'npm-package',
+      scan: {
+        projectType: 'library',
+        score: 90,
+        maxScore: 100,
+        findings: [],
+        analystFindings: [{ checkId: 'AST-X' }],
+        analystEscalations: [{ file: 'docs/setup.html', routed: 'attack' }],
+        coverageSweep: { candidates: 3, swept: 2, skipped: 1, nullVerdicts: 0, policy: 'abstention-gated' },
+      },
+      narrative: { summary: 'x' },
+    });
+    const keys = Object.keys(out);
+    const idx = (k: string) => keys.indexOf(k);
+    expect(out.analystEscalations).toEqual([{ file: 'docs/setup.html', routed: 'attack' }]);
+    expect(out.coverageSweep).toEqual({
+      candidates: 3, swept: 2, skipped: 1, nullVerdicts: 0, policy: 'abstention-gated',
+    });
+    expect(idx('analystFindings')).toBeLessThan(idx('analystEscalations'));
+    expect(idx('analystEscalations')).toBeLessThan(idx('coverageSweep'));
+    expect(idx('narrative')).toBe(keys.length - 1);
+  });
+
+  it('without --nanomind inputs the keys stay absent (parity contract)', () => {
+    const out = buildCheckOutput({
+      name: 'fixture-pkg',
+      type: 'npm-package',
+      scan: { projectType: 'library', score: 90, maxScore: 100, findings: [] },
+    });
+    expect('analystEscalations' in out).toBe(false);
+    expect('coverageSweep' in out).toBe(false);
+  });
+
+  it('empty escalations are omitted but sweep accounting still emits', () => {
+    const out = buildCheckOutput({
+      name: 'fixture-pkg',
+      type: 'npm-package',
+      scan: {
+        projectType: 'library',
+        score: 90,
+        maxScore: 100,
+        findings: [],
+        analystEscalations: [],
+        coverageSweep: { candidates: 0, swept: 0, skipped: 0, nullVerdicts: 0, policy: 'abstention-gated' },
+      },
+    });
+    expect('analystEscalations' in out).toBe(false);
+    expect(out.coverageSweep).toBeDefined();
+  });
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@noble/ed25519": "^2.3.0",
         "@noble/post-quantum": "^0.2.1",
         "@opena2a/aim-core": "^0.1.2",
-        "@opena2a/check-core": "0.2.0",
+        "@opena2a/check-core": "0.3.0",
         "@opena2a/cli-ui": "0.5.2",
         "@opena2a/contribute": "^0.1.0",
         "@opena2a/credential-patterns": "0.1.1",
@@ -640,9 +640,9 @@
       }
     },
     "node_modules/@opena2a/check-core": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/@opena2a/check-core/-/check-core-0.2.0.tgz",
-      "integrity": "sha512-d+ZKrJ9H8d5F3bPTMbk3j0Bl8ELMH+84unI/4UUOQ6MqBNChgziUcsX5SPhO1id1UUHZmKk2RKtSdHJj167MAQ==",
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@opena2a/check-core/-/check-core-0.3.0.tgz",
+      "integrity": "sha512-ai4ypCiAiD6McgZLURc1TsDwjzKhQBqB5KVQJcm7HBdqCNgZKMVmvV8dr2o0KWchSiwXBf0CAjkiWAE0QeXvkg==",
       "license": "Apache-2.0",
       "dependencies": {
         "@opena2a/registry-client": "0.1.0"

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "@noble/ed25519": "^2.3.0",
     "@noble/post-quantum": "^0.2.1",
     "@opena2a/aim-core": "^0.1.2",
-    "@opena2a/check-core": "0.2.0",
+    "@opena2a/check-core": "0.3.0",
     "@opena2a/cli-ui": "0.5.2",
     "@opena2a/contribute": "^0.1.0",
     "@opena2a/credential-patterns": "0.1.1",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -8999,6 +8999,7 @@ async function checkGitHubRepo(
     let analystFindings: any[] | undefined;
     let analystZeroState: { reason: 'clean-scan' | 'not-ready' | 'backend-unavailable' | 'daemon-error' | 'platform-not-supported'; modelLabel: string } | undefined;
     let analystEscalations: any[] | undefined;
+    let coverageSweep: Record<string, unknown> | undefined;
     let artifactSummaries: any[] | undefined;
     try {
       const { orchestrateNanoMind } = await import('./nanomind-core/orchestrate.js');
@@ -9012,6 +9013,7 @@ async function checkGitHubRepo(
       analystFindings = nmResult.analystFindings;
       analystZeroState = nmResult.analystZeroState;
       analystEscalations = nmResult.analystEscalations;
+      coverageSweep = nmResult.coverageSweep as Record<string, unknown> | undefined;
       artifactSummaries = nmResult.artifactSummaries;
     } catch {
       // NanoMind unavailable — surface this in the CLI output instead of going
@@ -9044,6 +9046,8 @@ async function checkGitHubRepo(
           maxScore: result.maxScore,
           findings: result.findings,
           analystFindings,
+          analystEscalations,
+          coverageSweep,
         },
         registry: registryData,
       }));
@@ -9304,6 +9308,7 @@ async function checkPyPiPackage(
     let analystFindings: any[] | undefined;
     let analystZeroState: { reason: 'clean-scan' | 'not-ready' | 'backend-unavailable' | 'daemon-error' | 'platform-not-supported'; modelLabel: string } | undefined;
     let analystEscalations: any[] | undefined;
+    let coverageSweep: Record<string, unknown> | undefined;
     let artifactSummaries: any[] | undefined;
     try {
       const { orchestrateNanoMind } = await import('./nanomind-core/orchestrate.js');
@@ -9317,6 +9322,7 @@ async function checkPyPiPackage(
       analystFindings = nmResult.analystFindings;
       analystZeroState = nmResult.analystZeroState;
       analystEscalations = nmResult.analystEscalations;
+      coverageSweep = nmResult.coverageSweep as Record<string, unknown> | undefined;
       artifactSummaries = nmResult.artifactSummaries;
     } catch {
       // NanoMind unavailable -- use base scan results
@@ -9345,6 +9351,8 @@ async function checkPyPiPackage(
           maxScore: result.maxScore,
           findings: result.findings,
           analystFindings,
+          analystEscalations,
+          coverageSweep,
           version: meta.info.version,
         },
         registry: registryData,
@@ -9503,6 +9511,7 @@ async function checkRawUrl(
     let analystFindings: any[] | undefined;
     let analystZeroState: { reason: 'clean-scan' | 'not-ready' | 'backend-unavailable' | 'daemon-error' | 'platform-not-supported'; modelLabel: string } | undefined;
     let analystEscalations: any[] | undefined;
+    let coverageSweep: Record<string, unknown> | undefined;
     let artifactSummaries: any[] | undefined;
     try {
       const { orchestrateNanoMind } = await import('./nanomind-core/orchestrate.js');
@@ -9516,6 +9525,7 @@ async function checkRawUrl(
       analystFindings = nmResult.analystFindings;
       analystZeroState = nmResult.analystZeroState;
       analystEscalations = nmResult.analystEscalations;
+      coverageSweep = nmResult.coverageSweep as Record<string, unknown> | undefined;
       artifactSummaries = nmResult.artifactSummaries;
     } catch {
       // NanoMind unavailable — surface this in the CLI output instead of going
@@ -9547,6 +9557,7 @@ async function checkRawUrl(
       };
       if (analystFindings?.length) jsonOut.analystFindings = analystFindings;
       if (analystEscalations?.length) jsonOut.analystEscalations = analystEscalations;
+      if (coverageSweep !== undefined) jsonOut.coverageSweep = coverageSweep;
       writeJsonStdout(jsonOut);
       return;
     }
@@ -9676,6 +9687,7 @@ async function checkNpmPackage(
     let analystFindings: any[] | undefined;
     let analystZeroState: { reason: 'clean-scan' | 'not-ready' | 'backend-unavailable' | 'daemon-error' | 'platform-not-supported'; modelLabel: string } | undefined;
     let analystEscalations: any[] | undefined;
+    let coverageSweep: Record<string, unknown> | undefined;
     let artifactSummaries: any[] | undefined;
     try {
       const { orchestrateNanoMind } = await import('./nanomind-core/orchestrate.js');
@@ -9689,6 +9701,7 @@ async function checkNpmPackage(
       analystFindings = nmResult.analystFindings;
       analystZeroState = nmResult.analystZeroState;
       analystEscalations = nmResult.analystEscalations;
+      coverageSweep = nmResult.coverageSweep as Record<string, unknown> | undefined;
       artifactSummaries = nmResult.artifactSummaries;
     } catch {
       // NanoMind unavailable — surface this in the CLI output instead of going
@@ -9719,6 +9732,8 @@ async function checkNpmPackage(
           maxScore: result.maxScore,
           findings: result.findings,
           analystFindings,
+          analystEscalations,
+          coverageSweep,
         },
         registry: registryData,
       }));


### PR DESCRIPTION
## Summary
Pins `@opena2a/check-core` to **0.3.0** (exact) and wires the `--nanomind` advisory channel through all four `check --json` paths (github, npm, pypi, raw-url). Previously each path computed `analystEscalations`/`coverageSweep` and then dropped `coverageSweep` at `buildCheckOutput` (0.2.0 had no carrier field; `analystEscalations` was only hand-threaded into the raw-url path).

Depends on `@opena2a/check-core@0.3.0` (published this session, SLSA v1 provenance).

## Changes
- `package.json`: `"@opena2a/check-core": "0.3.0"` (exact pin, per the supply-chain tightness rule).
- `src/cli.ts`: each check path now passes `analystEscalations` + `coverageSweep` into `buildCheckOutput`'s `scan{}` (raw-url path threads `coverageSweep` into its hand-rolled JSON).
- New `__tests__/nanomind-core/check-output-escalation-wiring.test.ts`: a static wiring guard asserting every `buildCheckOutput` site carries both fields, plus emission-order + parity-contract coverage against the pinned check-core.

## Testing
- Full suite 2410 passed (18 skipped, 10 todo).
- 4 adoption wiring tests green.
- HMA self-scan 100/100.
- Parity unaffected (fixtures never pass `--nanomind`).

Phase 4.5 adversarial review skipped: no detection logic, scoring, or severity changed — output-field plumbing + a dependency pin bump.