### PR TITLE
docs: cross-link aicomply in Links section

### DIFF
--- a/README.md
+++ b/README.md
@@ -384,6 +384,7 @@ Security issues: `security@opena2a.org` (coordinated disclosure, response within
 - [Website](https://hackmyagent.com)
 - [Security Checks Reference](docs/SECURITY_CHECKS.md)
 - [OpenA2A CLI](https://github.com/opena2a-org/opena2a)
+- [aicomply](https://github.com/opena2a-org/aicomply) — inline PII, credential, and regulated-data classification for agent I/O at runtime (HMA scans the code; aicomply guards the live stream)
 - [Demos](https://opena2a.org/demos)
 - [Documentation](https://opena2a.org/docs)
 - [Research](https://research.opena2a.org)


### PR DESCRIPTION
Adds a one-line cross-link to [aicomply](https://github.com/opena2a-org/aicomply) in the README `## Links` section.

aicomply is the inline PII / credential / regulated-data classifier for agent I/O (now shipped on npm `@opena2a/aicomply`, PyPI `aicomply`, and as `opena2a comply`). Framing: HMA scans the code statically; aicomply guards the live I/O stream at runtime — complementary surfaces.

Docs-only, progressive-disclosure (bottom-of-README Links). No code, no version bump.

Part of the aicomply visibility work (org plan `todo/2026-06-18-aicomply-adoption-and-pypi-port.md`, Step 2 cross-links).