### PR TITLE
fix(scanner): GIT-003 .env severity is content-aware, not presence-based (#242)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ All notable changes to HackMyAgent are documented in this file.
 
 ### Fixed
 
+- **`GIT-003` (`.env Not Ignored`) severity is now content-aware instead of presence-based (#242).** An un-gitignored `.env` was hard-coded `CRITICAL` regardless of contents, so a config-only file (`PORT=3000`, `LOG_LEVEL=info`) was rated CRITICAL with the guidance "contains API keys and secrets" — internally inconsistent with HMA's own credential scanner, which finds zero secrets in it, and a downstream score/verdict incoherence for `opena2a review` (#221). GIT-003 now reads the `.env` body: a file holding a real secret stays `CRITICAL` (and floors the opena2a composite, keeping "Not safe to ship" coherent); a secret-less `.env` is `HIGH` preventive hygiene with conditional guidance that no longer claims keys are present. Secret detection is two-tier — recognized vendor key formats, JWTs, and `user:pass@host` URLs are flagged regardless of the variable name (no key-rename evasion), while a bare opaque value is only treated as a secret under a credential-shaped key (so build hashes and `${VAR}`-interpolated DSNs don't false-CRITICAL). This is calibration by content, not detection narrowing: a single real secret still fires CRITICAL.
 - **`explain <SOUL-XX-NNN>` now describes the specific control.** `explain SOUL-IH-003` previously restated the id with a generic "behavioral governance finding" line; it now renders the control name, domain, and remediation from the governance catalog (e.g. "Role-play refusal — Injection Hardening domain …").
 
 ## [0.23.9] - 2026-06-07

--- a/__tests__/hardening/scanner.test.ts
+++ b/__tests__/hardening/scanner.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { HardeningScanner, ScanOptions } from '../../src/hardening/scanner';
+import { HardeningScanner, ScanOptions, envBodyContainsSecrets } from '../../src/hardening/scanner';
 import type { SecurityFinding, ScanResult, ProjectType } from '../../src/hardening/security-check';
 import * as fs from 'fs/promises';
 import * as path from 'path';
@@ -401,9 +401,12 @@ describe('Git security checks', () => {
     expect(finding).toBeUndefined();
   });
 
-  it('detects .env file when .gitignore missing .env pattern', async () => {
+  it('GIT-003 is CRITICAL when un-ignored .env holds a real vendor secret (#242)', async () => {
     await fs.writeFile(path.join(tempDir, '.gitignore'), 'node_modules/\n');
-    await fs.writeFile(path.join(tempDir, '.env'), 'SECRET=value\n');
+    await fs.writeFile(
+      path.join(tempDir, '.env'),
+      'PORT=3000\nANTHROPIC_API_KEY=sk-ant-api03-AbCdEf0123456789AbCdEf0123456789\n'
+    );
 
     const result = await scanner.scan({ targetDir: tempDir });
     const finding = result.findings.find((f) => f.checkId === 'GIT-003');
@@ -411,6 +414,149 @@ describe('Git security checks', () => {
     expect(finding).toBeDefined();
     expect(finding?.file).toBe('.env');
     expect(finding?.severity).toBe('critical');
+    expect(finding?.guidance).toMatch(/API keys or secrets/);
+  });
+
+  it('GIT-003 is CRITICAL when un-ignored .env holds a generic secret-shaped value (#242)', async () => {
+    await fs.writeFile(path.join(tempDir, '.gitignore'), 'node_modules/\n');
+    await fs.writeFile(
+      path.join(tempDir, '.env'),
+      'DB_PASSWORD=hunter2-prod-supersecret\n'
+    );
+
+    const result = await scanner.scan({ targetDir: tempDir });
+    const finding = result.findings.find((f) => f.checkId === 'GIT-003');
+
+    expect(finding).toBeDefined();
+    expect(finding?.severity).toBe('critical');
+  });
+
+  it('GIT-003 is HIGH (not CRITICAL) when un-ignored .env has no secrets (#242)', async () => {
+    await fs.writeFile(path.join(tempDir, '.gitignore'), 'node_modules/\n');
+    await fs.writeFile(path.join(tempDir, '.env'), 'PORT=3000\nLOG_LEVEL=info\n');
+
+    const result = await scanner.scan({ targetDir: tempDir });
+    const finding = result.findings.find((f) => f.checkId === 'GIT-003');
+
+    expect(finding).toBeDefined();
+    expect(finding?.file).toBe('.env');
+    expect(finding?.severity).toBe('high');
+    // Must not falsely claim the file contains API keys.
+    expect(finding?.guidance).not.toMatch(/contains API keys/);
+    expect(finding?.guidance).toMatch(/No secrets detected/);
+  });
+
+  it('GIT-003 treats a placeholder-only .env as secret-less → HIGH (#242)', async () => {
+    await fs.writeFile(path.join(tempDir, '.gitignore'), 'node_modules/\n');
+    await fs.writeFile(
+      path.join(tempDir, '.env'),
+      'API_KEY=your-api-key-here\nDATABASE_URL=postgres://localhost:5432/app\n'
+    );
+
+    const result = await scanner.scan({ targetDir: tempDir });
+    const finding = result.findings.find((f) => f.checkId === 'GIT-003');
+
+    expect(finding).toBeDefined();
+    expect(finding?.severity).toBe('high');
+  });
+
+  it('GIT-003 does not fire when .env is gitignored (#242)', async () => {
+    await fs.writeFile(path.join(tempDir, '.gitignore'), '.env\nnode_modules/\n');
+    await fs.writeFile(
+      path.join(tempDir, '.env'),
+      'ANTHROPIC_API_KEY=sk-ant-api03-AbCdEf0123456789AbCdEf0123456789\n'
+    );
+
+    const result = await scanner.scan({ targetDir: tempDir });
+    const finding = result.findings.find((f) => f.checkId === 'GIT-003');
+
+    expect(finding).toBeUndefined();
+  });
+
+  it('GIT-003 does not fire when no .env is present (#242)', async () => {
+    await fs.writeFile(path.join(tempDir, '.gitignore'), 'node_modules/\n');
+
+    const result = await scanner.scan({ targetDir: tempDir });
+    const finding = result.findings.find((f) => f.checkId === 'GIT-003');
+
+    expect(finding).toBeUndefined();
+  });
+});
+
+describe('envBodyContainsSecrets (GIT-003 content calibration, #242)', () => {
+  it('returns false for config-only .env', () => {
+    expect(envBodyContainsSecrets('PORT=3000\nLOG_LEVEL=info\nNODE_ENV=production\n')).toBe(false);
+  });
+
+  it('returns false for an empty / comment-only .env', () => {
+    expect(envBodyContainsSecrets('')).toBe(false);
+    expect(envBodyContainsSecrets('# config\n# DATABASE_URL=...\n')).toBe(false);
+  });
+
+  it('returns false for secret-shaped keys holding booleans/numbers', () => {
+    expect(envBodyContainsSecrets('SECRET_SCANNING_ENABLED=true\nTOKEN_TTL=3600\n')).toBe(false);
+  });
+
+  it('returns false for placeholder values', () => {
+    expect(envBodyContainsSecrets('API_KEY=your-api-key-here\nAUTH_TOKEN=<replace-me>\n')).toBe(false);
+    expect(envBodyContainsSecrets('OPENAI_API_KEY=changeme\n')).toBe(false);
+  });
+
+  it('returns false for a DB URL without embedded credentials', () => {
+    expect(envBodyContainsSecrets('DATABASE_URL=postgres://localhost:5432/app\n')).toBe(false);
+  });
+
+  it('returns true for real vendor keys', () => {
+    expect(envBodyContainsSecrets('ANTHROPIC_API_KEY=sk-ant-api03-AbCdEf0123456789AbCdEf0123456789\n')).toBe(true);
+    expect(envBodyContainsSecrets('AWS_ACCESS_KEY_ID=AKIAIOSFODNN7EXAMPLE\n')).toBe(true);
+  });
+
+  it('returns true for generic secret-shaped key with a substantial value', () => {
+    expect(envBodyContainsSecrets('DB_PASSWORD=hunter2-prod-supersecret\n')).toBe(true);
+    expect(envBodyContainsSecrets('CLIENT_SECRET=a1b2c3d4e5f6g7h8\n')).toBe(true);
+  });
+
+  it('returns true for a DB URL carrying user:password', () => {
+    expect(envBodyContainsSecrets('DATABASE_URL=postgres://admin:s3cr3tpass@db.internal/app\n')).toBe(true);
+  });
+
+  it('ignores leading export and surrounding quotes', () => {
+    expect(envBodyContainsSecrets('export DB_PASSWORD="hunter2-prod-supersecret"\n')).toBe(true);
+    expect(envBodyContainsSecrets('export PORT=3000\n')).toBe(false);
+  });
+
+  // --- #242 adversarial-review F1/F2: strong signals must NOT be gated by key name ---
+  it('catches a real secret stashed under an innocuous key name (no key-gate evasion)', () => {
+    expect(envBodyContainsSecrets('SESSION=eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxMjM0NTYifQ.abcDEF123456\n')).toBe(true); // JWT
+    expect(envBodyContainsSecrets('PAYMENT=sk_test_abcdef1234567890abcdef\n')).toBe(true); // Stripe test key
+    expect(envBodyContainsSecrets('WIDGET=gho_abcdefghijklmnopqrstuvwxyz0123456789\n')).toBe(true); // GitHub OAuth
+  });
+
+  it('catches user:password embedded in a URL under any key', () => {
+    expect(envBodyContainsSecrets('MY_DB=postgres://admin:supersecret@db.example.com:5432/app\n')).toBe(true);
+    expect(envBodyContainsSecrets('CACHE=redis://default:s3cretpassword@redis.host:6379\n')).toBe(true);
+  });
+
+  it('does NOT false-CRITICAL on benign opaque config under non-credential keys', () => {
+    // Build hashes / cache busters are opaque 8+ char values but not secrets.
+    expect(envBodyContainsSecrets('BUILD_HASH=a1b2c3d4e5f6g7h8\nCACHE_BUST=20260618abcdef\nCOMMIT_SHA=deadbeefcafebabe\n')).toBe(false);
+  });
+
+  // --- #242 second-pass review F1: templated / placeholder DSNs must NOT be CRITICAL ---
+  it('does NOT flag an interpolated or placeholder DSN as a secret', () => {
+    expect(envBodyContainsSecrets('DATABASE_URL=postgres://${DB_USER}:${DB_PASS}@db\n')).toBe(false);
+    expect(envBodyContainsSecrets('DATABASE_URL=postgres://user:password@localhost:5432/mydb\n')).toBe(false);
+    expect(envBodyContainsSecrets('MONGO=mongodb://YOUR_USER:YOUR_PASS@broker\n')).toBe(false);
+    expect(envBodyContainsSecrets('DB=mysql://<user>:<pass>@host\n')).toBe(false);
+  });
+
+  it('still flags a DSN with a real literal password even when the user is generic', () => {
+    expect(envBodyContainsSecrets('DATABASE_URL=postgres://user:Tr0ub4dor3xKw9@host\n')).toBe(true);
+    expect(envBodyContainsSecrets('DATABASE_URL=postgres://admin:supersecret@db.example.com:5432/app\n')).toBe(true);
+  });
+
+  it('does NOT false-match a benign identifier that merely starts with a vendor prefix', () => {
+    expect(envBodyContainsSecrets('WIDGET_ID=AIzakaya_restaurant_booking_id_001\n')).toBe(false);
   });
 });
 

--- a/src/hardening/scanner.ts
+++ b/src/hardening/scanner.ts
@@ -619,6 +619,114 @@ export function hasSkillMaliceSignals(content: string): boolean {
 
 
 /**
+ * Heuristic: does a `.env` file body actually contain secret-like values?
+ *
+ * GIT-003 severity is calibrated by content, not presence (#242). A real
+ * exposed secret floors the downstream opena2a composite (CRITICAL); a
+ * secret-less `.env` (e.g. `PORT=3000` / `LOG_LEVEL=info`) is only preventive
+ * hygiene (HIGH). This is calibration-by-content, NOT detection narrowing — a
+ * single real secret still returns true.
+ *
+ * Calibrated to err toward CRITICAL: a false downgrade (missing a real secret)
+ * is worse than a false upgrade, so the value bar is deliberately low for
+ * credential-shaped keys. Only values that are clearly non-secret (booleans,
+ * numbers, short config strings, template placeholders) are treated as benign.
+ */
+export function envBodyContainsSecrets(content: string): boolean {
+  // 1. Any known vendor credential pattern anywhere in the body → real secret.
+  //    CREDENTIAL_PATTERNS are non-global, so `.test` carries no lastIndex state.
+  for (const { pattern } of CREDENTIAL_PATTERNS) {
+    if (pattern.test(content)) return true;
+  }
+
+  // 2. Per-line KEY=VALUE inspection. Two-tier on purpose (#242 adversarial
+  //    review): a "strong" value signal is unambiguous and runs regardless of
+  //    the key name (so a secret stashed under an innocuous key — `SESSION=eyJ…`,
+  //    `X=sk_test_…`, a `user:pass@host` URL — can't evade CRITICAL). A "weak"
+  //    opaque-value signal is gated by a credential-shaped key, because an
+  //    opaque 8+ char value alone is ambiguous (build hash, cache-buster, DSN
+  //    without creds) and counting it everywhere would re-introduce the very
+  //    over-rating this issue fixes.
+  const lines = content.split(/\r?\n/);
+  for (const raw of lines) {
+    const line = raw.trim();
+    if (!line || line.startsWith('#')) continue;
+    const eq = line.indexOf('=');
+    if (eq <= 0) continue;
+
+    const key = line.slice(0, eq).trim().replace(/^export\s+/i, '');
+    let value = line.slice(eq + 1).trim();
+    // Strip an inline trailing comment only when the value is unquoted.
+    if (!/^["']/.test(value)) value = value.replace(/\s+#.*$/, '').trim();
+    // Strip surrounding quotes.
+    value = value.replace(/^(["'])(.*)\1$/, '$2').trim();
+    if (!value) continue; // empty value = nothing exposed
+
+    // --- Strong, key-independent signals (high precision) ---
+    // Recognized vendor key formats and JWTs are unambiguous secrets. Lengths
+    // are kept no looser than CREDENTIAL_PATTERNS so a benign identifier that
+    // merely starts with `AIza`/`sk-` can't false-match (#242 review F3).
+    if (
+      /(?:^|[^a-zA-Z0-9])(?:sk-ant-api\d|sk-proj-[a-zA-Z0-9]{16,}|sk-[a-zA-Z0-9]{40,}|sk_live_[a-zA-Z0-9]{16,}|sk_test_[a-zA-Z0-9]{16,}|ghp_[a-zA-Z0-9]{20,}|gh[osru]_[a-zA-Z0-9]{20,}|github_pat_[a-zA-Z0-9_]{20,}|xox[abprs]-[0-9a-zA-Z-]{10,}|AKIA[0-9A-Z]{16}|AIza[0-9A-Za-z_-]{35}|SG\.[a-zA-Z0-9_-]{16,})/.test(
+        value,
+      ) ||
+      /^eyJ[a-zA-Z0-9_-]{8,}\.[a-zA-Z0-9_-]{8,}\.[a-zA-Z0-9_-]+$/.test(value) // JWT (header.payload.signature)
+    ) {
+      return true;
+    }
+
+    // URL carrying embedded credentials (`scheme://user:pass@host`) — but only
+    // when the password is a real literal, not an interpolated `${VAR}` /
+    // doc-grade placeholder. A templated DSN provably holds no secret, and
+    // flagging it CRITICAL would re-introduce the #242 over-rating (review F1).
+    const urlCred = /:\/\/([^/\s:@]+):([^/\s:@]+)@/.exec(value);
+    if (urlCred) {
+      const userinfo = urlCred[1] + urlCred[2];
+      const passLower = urlCred[2].toLowerCase();
+      const interpolated = /[${}<>]/.test(userinfo) || /%[a-zA-Z_]+%/.test(userinfo);
+      const passIsPlaceholder =
+        /(?:^|[-_])your[-_]/.test(passLower) ||
+        /^(?:pass|passwd|password|secret|changeme|change_me|placeholder|example|dummy|todo|tbd)$/.test(passLower);
+      if (!interpolated && !passIsPlaceholder) return true;
+    }
+
+    // --- Weak opaque-value signal, gated by a credential-shaped key ---
+    const keyMatchesCredentialShape =
+      /(?:_KEY$|_KEY_|_TOKEN|_SECRET|_PASSWORD|_PASSWD|^PASSWORD$|^PASSWD$|^SECRET$|^TOKEN$|^API_?KEY$|PRIVATE_KEY|CLIENT_SECRET|ACCESS_KEY|AUTH_TOKEN|_CREDENTIALS?$)/i.test(
+        key,
+      );
+    if (!keyMatchesCredentialShape) continue;
+
+    // Reject obvious placeholders / template markers (these are .env.example-grade).
+    const lower = value.toLowerCase();
+    const isPlaceholder =
+      /^\$\{/.test(value) || // ${VAR} interpolation reference
+      /^<.*>$/.test(value) || // <your-key>
+      /\.\.\./.test(value) ||
+      /^x{3,}$/i.test(value) ||
+      /(?:^|[-_])your[-_]/.test(lower) ||
+      /\b(?:changeme|change_me|placeholder|example|dummy|replace[-_ ]?me|todo|tbd|none|null|undefined)\b/.test(
+        lower,
+      );
+    if (isPlaceholder) continue;
+
+    // Reject clearly non-secret value shapes: booleans, env names, log levels,
+    // numbers, and credential-less URLs (a URL *with* creds was already caught).
+    if (/^(?:true|false|yes|no|on|off|debug|info|warn|error|trace|development|production|staging|test)$/i.test(value)) {
+      continue;
+    }
+    if (/^-?\d+(?:\.\d+)?$/.test(value)) continue; // pure number
+    if (/^[a-z][a-z0-9+.-]*:\/\//i.test(value)) continue; // bare scheme://host with no creds
+
+    // A substantial opaque value under a credential-shaped key → real secret.
+    if (/^[A-Za-z0-9+/=_.\-$]{8,}$/.test(value)) return true;
+  }
+
+  return false;
+}
+
+
+/**
  * Check if a variation selector at position i in rawBuffer is a legitimate
  * emoji presentation selector (U+FE0F following an emoji base character).
  *
@@ -1958,19 +2066,35 @@ dist/
 
     // Only report if .env is at risk
     if (envAtRisk) {
+      // GIT-003 severity is calibrated by content, not mere presence (#242).
+      // An un-ignored `.env` that actually holds a secret is real exposure
+      // (CRITICAL — floors the downstream opena2a composite); a secret-less
+      // `.env` (config-only, e.g. PORT=3000) is preventive hygiene (HIGH).
+      // The guidance is conditional too — we don't claim "contains API keys"
+      // when the file demonstrably does not.
+      let envContent = '';
+      try {
+        envContent = await fs.readFile(path.join(targetDir, '.env'), 'utf-8');
+      } catch {}
+      const hasSecrets = envBodyContainsSecrets(envContent);
+
       findings.push({
         checkId: 'GIT-003',
         name: '.env Not Ignored',
-        description: '.env exists but not in .gitignore - secrets may be committed',
+        description: hasSecrets
+          ? '.env contains secret-like values but is not in .gitignore - credentials may be committed'
+          : '.env exists but not in .gitignore - secrets added later may be committed',
         category: 'git',
-        severity: 'critical',
+        severity: hasSecrets ? 'critical' : 'high',
         passed: git003Fixed,
         message: 'Add .env to .gitignore',
         file: '.env',
         fixable: true,
         fixed: git003Fixed,
         fix: `${this.cliName} secure --fix`,
-        guidance: '.env files contain API keys and secrets. Without .gitignore protection, a single git add . can expose all credentials in your repository history.',
+        guidance: hasSecrets
+          ? '.env contains API keys or secrets. Without .gitignore protection, a single git add . can expose all credentials in your repository history.'
+          : 'No secrets detected in this .env yet, but .env files are where credentials accumulate. Add .env to .gitignore now so a future key is never committed by accident.',
       });
     }
 


### PR DESCRIPTION
Fixes #242.

## Problem
`GIT-003 .env Not Ignored` fired **CRITICAL on the mere presence** of an un-gitignored `.env`, regardless of contents. A config-only `.env` (`PORT=3000`, `LOG_LEVEL=info`) was rated CRITICAL with guidance claiming it "contains API keys and secrets" — internally inconsistent with HMA's own credential scanner (which finds zero secrets in it), and a downstream score/verdict incoherence for `opena2a review` (#221): the barely-weighted CRITICAL prints "Not safe to ship" beside a green high composite.

## Fix — calibration by content, not detection narrowing
GIT-003 now reads the `.env` body via a new `envBodyContainsSecrets` helper:
- **real secret present → CRITICAL** (unchanged; floors the opena2a composite so "Not safe to ship" stays coherent with a low score)
- **no secret-like value → HIGH** preventive hygiene, with conditional guidance that no longer claims keys are present (renders coherently as "Good overall (N/100). harden …" with #221)

A single real secret still fires CRITICAL — this only down-grades the genuinely secret-less case to the preventive tier it actually is.

### Two-tier secret detection (hardened across two adversarial review passes)
- **Strong, key-independent signals** — recognized vendor key formats, JWTs (`header.payload.signature`), and `user:pass@host` URLs are flagged regardless of the variable name. (Closes a key-rename evasion: `SESSION=eyJ…` / `PAYMENT=sk_test_…` can't hide a usable secret under an innocuous key.)
- **Weak opaque-value signal** — a bare opaque value is only treated as a secret under a credential-shaped key, so benign config (build hashes, cache-busters) doesn't false-CRITICAL.
- **Placeholder/interpolation guards** — `${VAR}`-interpolated and doc-placeholder DSNs (`postgres://${DB_USER}:${DB_PASS}@db`, `postgres://user:password@host`) are **not** flagged, so we don't re-introduce the very over-rating this fixes.

## Tests
- Positive: vendor key, generic secret-shaped value, secret-under-innocuous-key, `user:pass@host` URL → CRITICAL.
- Negative: config-only, placeholder, `${VAR}`-templated DSN → HIGH.
- `.env` gitignored → no finding; no `.env` → no finding.
- Direct unit coverage of `envBodyContainsSecrets` (both tiers + bypass/FP cases).
- Cross-analyzer consistency verified end-to-end: secret-less `.env` → GIT-003 HIGH + **0** CRED findings (agree); real-secret `.env` → GIT-003 CRITICAL + CRED-001 CRITICAL (agree).
- Full suite green (2440 passed); benign-FPR oracle suite green; HMA self-scan 98/100.

## Downstream (post-publish)
The live `opena2a review` / `ai-trust` corpus-parity verification (secret-less `.env` → "Good overall" at composite ≥ 80) lands once HMA publishes and `opena2a-cli` bumps its HMA pin — those tools consume the published HMA, so it's a release-time check, not a code change here.

## Note (pre-existing, out of scope)
Corpus release-smoke fixture `soul/benign/hardened-soul` scores 98 vs a stale `[90,96]` manifest range — confirmed failing on baseline without this change (no `.env` in that fixture, so unrelated to GIT-003). Flagging for a separate corpus-manifest recalibration.