### PR TITLE
docs(detect): clarify machine-wide discovery always runs (release-test P3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to HackMyAgent are documented in this file.
 
 ## [Unreleased]
 
+### Changed
+
+- **`detect` help now states that machine-wide discovery always runs.** A fresh user passing `detect /path/to/project` could expect directory-scoped results, but `detect` always audits the whole machine (running assistants, MCP servers, machine-level configs) and uses the directory only for the project-local scan. The command description, examples, and the directory-argument help now say so explicitly (release-test P3).
+
 ## [0.23.11] - 2026-06-18
 
 ### Changed

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -7841,13 +7841,17 @@ Scans your machine and the current project directory for:
 
 Reports a governance score and actionable findings for CISOs and security engineers.
 
+The machine-wide discovery (running assistants, MCP servers, machine-level
+configs) ALWAYS runs; the directory argument only sets which project tree is
+scanned for project-local configs and governance files.
+
 Examples:
-  $ ${CLI_PREFIX} detect                  Audit current directory
-  $ ${CLI_PREFIX} detect /path/to/project Audit a specific project
+  $ ${CLI_PREFIX} detect                  Machine-wide audit + current project dir
+  $ ${CLI_PREFIX} detect /path/to/project Machine-wide audit + a specific project dir
   $ ${CLI_PREFIX} detect --json           Machine-readable output
   $ ${CLI_PREFIX} detect --verbose        Show full MCP server list
   $ ${CLI_PREFIX} detect --export-csv inventory.csv  Asset inventory for CMDB`)
-  .argument('[directory]', 'Project directory to audit (defaults to current directory)')
+  .argument('[directory]', 'Project tree for the project-local scan (defaults to current directory; machine-wide discovery always runs)')
   .option('--json', 'Output as JSON')
   .option('--verbose', 'Show full MCP server list and identity details')
   .option('--export-csv <file>', 'Export asset inventory as CSV (for ServiceNow, CMDB, etc.)')


### PR DESCRIPTION
A fresh-user release-test observation (P3): passing `hackmyagent detect /path/to/project` still reports AI agents found across the whole machine, which a newcomer supplying a path may not expect.

`detect` is by-design a shadow-AI **machine audit** — the directory argument only narrows the project-local portion of the scan. This PR makes that explicit in the command description, the examples, and the directory-argument help. Help-text only; no behavior change.

```
$ hackmyagent detect                  Machine-wide audit + current project dir
$ hackmyagent detect /path/to/project Machine-wide audit + a specific project dir
  directory   Project tree for the project-local scan (defaults to current
              directory; machine-wide discovery always runs)
```

Full suite green (2451 passed); no help snapshot affected.

(The companion P3 — `--json` deprecated on `secure` — needs no change: `secure`'s examples already use `--format`/`-f`, `--json` is a graceful deprecated alias with a pointer, and its continued use on other commands is a deliberate migration-in-progress, not a broken example.)