### PR TITLE
feat(arp): G6 — wire opt-out to registry right-to-delete purge

### DIFF
--- a/src/arp/cli/index.ts
+++ b/src/arp/cli/index.ts
@@ -21,7 +21,10 @@ import {
   disclosureText,
   loadSensorId,
   currentOrgPseudonym,
+  purgeRemoteSignatures,
+  manualPurgeCurl,
 } from '../telemetry/signature';
+import type { SignatureTelemetryConfig } from '../types';
 
 const args = process.argv.slice(2);
 const command = args[0];
@@ -274,10 +277,27 @@ async function telemetryCommand(): Promise<void> {
       console.log('\n' + disclosureText(tcfg) + '\n');
       break;
     case 'opt-out': {
+      // Write the local marker FIRST — it is what actually stops transmission. The
+      // remote purge below is best-effort cleanup of already-sent data and must
+      // never block or undo the opt-out (fail OPEN).
       const p = writeOptOutMarker();
       console.log('\n  OpenA2A telemetry DISABLED (both signature and GTIN channels).');
       console.log(`  Marker: ${p}`);
+
+      if (args.includes('--no-purge')) {
+        console.log('  Skipped deleting already-sent signatures (--no-purge).');
+        console.log('  Delete them later with: arp telemetry purge');
+      } else {
+        await runRemotePurge(tcfg);
+      }
       console.log('  Re-enable with: arp telemetry opt-in\n');
+      break;
+    }
+    case 'purge': {
+      // Standalone right-to-delete: request the registry delete already-sent
+      // signatures without changing the opt-out state.
+      await runRemotePurge(tcfg);
+      console.log('');
       break;
     }
     case 'opt-in': {
@@ -302,8 +322,10 @@ async function telemetryCommand(): Promise<void> {
     status        Show telemetry state, sensor identity, and send counts
     log [N]       Show the last N audited payloads sent (default 20)
     disclosure    Print the full install-time disclosure
-    opt-out       Disable ALL OpenA2A telemetry on this machine
+    opt-out       Disable ALL OpenA2A telemetry (also deletes already-sent
+                  signatures from the registry; use --no-purge to skip that)
     opt-in        Remove the local opt-out marker
+    purge         Ask the registry to delete already-sent signatures (right-to-delete)
 
   Structural signatures are DEFAULT-ON. Only the SHAPE of an anomalous
   behavior is shared, never payloads. Every byte sent is recorded locally
@@ -315,6 +337,26 @@ async function telemetryCommand(): Promise<void> {
       console.error('  Run: arp telemetry --help');
       process.exit(1);
   }
+}
+
+// runRemotePurge requests the registry delete this sensor's already-sent
+// signatures (G6 right-to-delete). Fails OPEN: any network/registry failure is
+// reported with a manual retry command but never throws — the caller's opt-out
+// (or standalone purge intent) completes regardless.
+async function runRemotePurge(tcfg?: SignatureTelemetryConfig): Promise<void> {
+  console.log('  Requesting deletion of already-sent signatures from the registry...');
+  const result = await purgeRemoteSignatures(tcfg);
+  if (result.ok) {
+    const n = typeof result.deleted === 'number' ? result.deleted : 'unknown';
+    console.log(`  Registry purge complete (deleted: ${n}).`);
+    return;
+  }
+  // Fail open: the local opt-out still stands; tell the user how to retry the purge.
+  console.log(`  Could not reach the registry to delete sent signatures (${result.error ?? 'unknown error'}).`);
+  console.log('  Your opt-out still took effect locally; no new data will be sent.');
+  console.log('  Retry the deletion later with: arp telemetry purge');
+  console.log('  Or run it directly:');
+  console.log(`    ${manualPurgeCurl(result)}`);
 }
 
 async function telemetryLog(): Promise<void> {

--- a/src/arp/telemetry/signature/index.ts
+++ b/src/arp/telemetry/signature/index.ts
@@ -79,3 +79,13 @@ export {
   markDisclosureShown,
   maybeShowDisclosure,
 } from './disclosure';
+
+export {
+  PURGE_SCHEMA_VERSION,
+  SIGNATURE_PURGE_PATH,
+  buildPurgeCanonical,
+  buildPurgeProof,
+  purgeRemoteSignatures,
+  manualPurgeCurl,
+} from './purge';
+export type { PurgeProofBody, PurgeResult } from './purge';

--- a/src/arp/telemetry/signature/purge.test.ts
+++ b/src/arp/telemetry/signature/purge.test.ts
@@ -1,0 +1,140 @@
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { mkdtempSync, rmSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import * as ed25519 from '@noble/ed25519';
+import {
+  PURGE_SCHEMA_VERSION,
+  SIGNATURE_PURGE_PATH,
+  buildPurgeCanonical,
+  buildPurgeProof,
+  purgeRemoteSignatures,
+  manualPurgeCurl,
+} from './purge';
+
+const RE_NONCE = /^[A-Za-z0-9_-]{8,128}$/;
+const RE_UUID = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/;
+
+let home: string;
+beforeAll(() => {
+  home = mkdtempSync(join(tmpdir(), 'arp-purge-'));
+  process.env.OPENA2A_HOME = home;
+});
+afterAll(() => {
+  delete process.env.OPENA2A_HOME;
+  rmSync(home, { recursive: true, force: true });
+});
+
+describe('buildPurgeCanonical — byte-parity with the Go server PurgeCanonical()', () => {
+  it('joins fields in the exact registry order with the purge schema prefix', () => {
+    const c = buildPurgeCanonical({ sensorId: 'sid', nonce: 'n12345678', signedAt: 1234567890 });
+    expect(c).toBe('telemetry-purge-v1|sid|n12345678|1234567890');
+  });
+
+  it('uses a schema prefix distinct from the ingest schema (no cross-replay)', () => {
+    const c = buildPurgeCanonical({ sensorId: 'sid', nonce: 'n12345678', signedAt: 1 });
+    expect(c.startsWith(PURGE_SCHEMA_VERSION + '|')).toBe(true);
+    expect(c.startsWith('telemetry-sig-v1|')).toBe(false);
+  });
+});
+
+describe('buildPurgeProof', () => {
+  it('produces a canonical-UUID sensorId, a url-safe nonce, and a verifying signature', async () => {
+    const now = new Date('2026-06-25T12:00:00Z');
+    const { url, body } = await buildPurgeProof({ now });
+
+    expect(body.sensorId).toMatch(RE_UUID); // canonical lowercase-hyphenated
+    expect(body.nonce).toMatch(RE_NONCE);
+    expect(body.signedAt).toBe(Math.floor(now.getTime() / 1000));
+    expect(url).toBe(`${SIGNATURE_PURGE_PATH}/${body.sensorId}`);
+
+    // The signature must verify against the supplied public key over the canonical.
+    const canonical = buildPurgeCanonical({
+      sensorId: body.sensorId,
+      nonce: body.nonce,
+      signedAt: body.signedAt,
+    });
+    const ok = await ed25519.verifyAsync(
+      Buffer.from(body.signature, 'hex'),
+      new TextEncoder().encode(canonical),
+      Buffer.from(body.publicKey, 'hex'),
+    );
+    expect(ok).toBe(true);
+  });
+
+  it('uses a fresh nonce on each call (anti-replay)', async () => {
+    const a = await buildPurgeProof();
+    const b = await buildPurgeProof();
+    expect(a.body.nonce).not.toBe(b.body.nonce);
+  });
+});
+
+describe('purgeRemoteSignatures', () => {
+  it('returns ok + deleted count and issues a DELETE with the signed body on 200', async () => {
+    let captured: { url: string; init: RequestInit } | undefined;
+    const fakeFetch = (async (url: string, init: RequestInit) => {
+      captured = { url, init };
+      return {
+        ok: true,
+        status: 200,
+        json: async () => ({ deleted: 3 }),
+      } as unknown as Response;
+    }) as unknown as typeof fetch;
+
+    const res = await purgeRemoteSignatures({ registryUrl: 'https://r.test' }, { fetchImpl: fakeFetch });
+    expect(res.ok).toBe(true);
+    expect(res.deleted).toBe(3);
+    expect(res.status).toBe(200);
+    expect(captured?.init.method).toBe('DELETE');
+    expect(captured?.url).toBe(`https://r.test${res.url.replace('https://r.test', '')}`);
+    expect(captured?.url.startsWith('https://r.test/api/v1/telemetry/signature/sensor/')).toBe(true);
+    // The body is the signed proof.
+    const sent = JSON.parse((captured?.init.body as string) ?? '{}');
+    expect(sent.signature).toBeTruthy();
+    expect(sent.publicKey).toBeTruthy();
+    expect(sent.sensorId).toMatch(RE_UUID);
+  });
+
+  it('returns ok=false with the status on a non-200 (does not throw)', async () => {
+    const fakeFetch = (async () =>
+      ({ ok: false, status: 401, json: async () => ({}) }) as unknown as Response) as unknown as typeof fetch;
+    const res = await purgeRemoteSignatures({ registryUrl: 'https://r.test' }, { fetchImpl: fakeFetch });
+    expect(res.ok).toBe(false);
+    expect(res.status).toBe(401);
+  });
+
+  it('fails OPEN on a network error — resolves with ok=false, never throws', async () => {
+    const fakeFetch = (async () => {
+      throw new Error('ECONNREFUSED');
+    }) as unknown as typeof fetch;
+    const res = await purgeRemoteSignatures({ registryUrl: 'https://r.test' }, { fetchImpl: fakeFetch });
+    expect(res.ok).toBe(false);
+    expect(res.error).toContain('ECONNREFUSED');
+    expect(res.url.startsWith('https://r.test/')).toBe(true);
+  });
+
+  it('strips a trailing slash from the registry base URL', async () => {
+    let capturedUrl = '';
+    const fakeFetch = (async (url: string) => {
+      capturedUrl = url;
+      return { ok: true, status: 200, json: async () => ({ deleted: 0 }) } as unknown as Response;
+    }) as unknown as typeof fetch;
+    await purgeRemoteSignatures({ registryUrl: 'https://r.test/' }, { fetchImpl: fakeFetch });
+    expect(capturedUrl.startsWith('https://r.test/api/v1/')).toBe(true);
+    expect(capturedUrl).not.toContain('//api'); // no double slash from the trailing one
+  });
+});
+
+describe('manualPurgeCurl', () => {
+  it('renders a runnable DELETE curl with the signed body', async () => {
+    const res = await purgeRemoteSignatures({ registryUrl: 'https://r.test' }, {
+      fetchImpl: (async () => {
+        throw new Error('offline');
+      }) as unknown as typeof fetch,
+    });
+    const curl = manualPurgeCurl(res);
+    expect(curl).toContain("curl -X DELETE 'https://r.test/api/v1/telemetry/signature/sensor/");
+    expect(curl).toContain("-H 'Content-Type: application/json'");
+    expect(curl).toContain(res.body.signature);
+  });
+});

--- a/src/arp/telemetry/signature/purge.ts
+++ b/src/arp/telemetry/signature/purge.ts
@@ -1,0 +1,146 @@
+/**
+ * Right-to-delete / opt-out purge (G6 producer half).
+ *
+ * When a customer opts out, they can ALSO ask the registry to delete every
+ * signature this sensor has already reported. The purge keys on the local
+ * sensor_id. For a registered (verified) sensor the registry REQUIRES proof of
+ * key ownership, so we sign a purge canonical with the sensor's Ed25519 key and
+ * send the public key; for an unverified sensor the registry treats the random
+ * sensor_id as the capability and the proof is simply accepted.
+ *
+ * Fails OPEN: a purge network/registry failure NEVER blocks the local opt-out.
+ * The opt-out MARKER (written separately, before this runs) is what actually
+ * stops transmission; this remote purge is best-effort cleanup of already-sent
+ * data. The caller prints a manual retry command when the purge could not reach
+ * the registry, so a customer is never silently left with un-purged history.
+ *
+ * The canonical MUST byte-match the server's Go PurgeCanonical()
+ * (opena2a-registry/internal/domain/telemetry_signature.go):
+ *
+ *   telemetry-purge-v1|<sensorId>|<nonce>|<signedAt>
+ *
+ * The server normalizes the path sensor_id to its canonical UUID string and
+ * reconstructs the canonical from that, so we sign/send the canonical form too
+ * (a locally-generated sensor_id already is one; an operator-pinned
+ * OPENA2A_SENSOR_ID must be the canonical lowercase-hyphenated service-account id).
+ */
+
+import { loadSensorPrivateKey, loadSensorId, publicKeyHex, signCanonicalHex } from './sensor-identity';
+import { generateNonce } from './wire';
+import { resolveRegistryUrl, type SignatureTelemetryConfig } from './config';
+
+/** The purge canonical schema prefix (distinct from the ingest schema). */
+export const PURGE_SCHEMA_VERSION = 'telemetry-purge-v1';
+
+/** Path template for the purge endpoint; :sensor_id is filled in per request. */
+export const SIGNATURE_PURGE_PATH = '/api/v1/telemetry/signature/sensor';
+
+const PURGE_TIMEOUT_MS = 10_000;
+
+/** Build the deterministic purge canonical that is signed and server-verified. */
+export function buildPurgeCanonical(r: { sensorId: string; nonce: string; signedAt: number }): string {
+  return [PURGE_SCHEMA_VERSION, r.sensorId, r.nonce, String(r.signedAt)].join('|');
+}
+
+/** The signed proof body POSTed in the DELETE request. */
+export interface PurgeProofBody {
+  sensorId: string;
+  signature: string;
+  publicKey: string;
+  signedAt: number; // unix SECONDS
+  nonce: string;
+}
+
+export interface PurgeResult {
+  /** True only when the registry confirmed the delete (HTTP 200). */
+  ok: boolean;
+  /** Rows the registry reported deleted (present on success). */
+  deleted?: number;
+  /** HTTP status when a response was received. */
+  status?: number;
+  /** Human-readable failure reason when ok is false. */
+  error?: string;
+  /** The exact URL targeted (so the caller can print a manual retry). */
+  url: string;
+  /** The signed proof body (so the caller can print a manual curl on failure). */
+  body: PurgeProofBody;
+}
+
+/** Normalize a UUID to the canonical form the server signs (lowercase). */
+function canonicalSensorId(id: string): string {
+  return id.trim().toLowerCase();
+}
+
+/**
+ * Build the signed purge proof for this sensor. Pure except for the persisted
+ * sensor key and the supplied clock (defaulted to now). Exposed for testing.
+ */
+export async function buildPurgeProof(opts: { now?: Date } = {}): Promise<{ url: string; body: PurgeProofBody }> {
+  const now = opts.now ?? new Date();
+  const signedAt = Math.floor(now.getTime() / 1000);
+  const nonce = generateNonce();
+  const sensorId = canonicalSensorId(loadSensorId());
+
+  const priv = loadSensorPrivateKey();
+  const publicKey = await publicKeyHex(priv);
+  const canonical = buildPurgeCanonical({ sensorId, nonce, signedAt });
+  const signature = await signCanonicalHex(priv, canonical);
+
+  const body: PurgeProofBody = { sensorId, signature, publicKey, signedAt, nonce };
+  const url = `${SIGNATURE_PURGE_PATH}/${encodeURIComponent(sensorId)}`;
+  return { url, body };
+}
+
+/**
+ * Request the registry purge every signature reported by this sensor. ALWAYS
+ * resolves (never throws) — a network error, timeout, or non-200 is returned in
+ * the result so the caller can fail OPEN and continue the local opt-out.
+ *
+ * `fetchImpl` is injectable for testing; it defaults to the global fetch.
+ */
+export async function purgeRemoteSignatures(
+  config?: SignatureTelemetryConfig,
+  opts: { now?: Date; fetchImpl?: typeof fetch } = {},
+): Promise<PurgeResult> {
+  const doFetch = opts.fetchImpl ?? fetch;
+  const base = resolveRegistryUrl(config).replace(/\/+$/, '');
+  const { url: path, body } = await buildPurgeProof({ now: opts.now });
+  const url = `${base}${path}`;
+
+  try {
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), PURGE_TIMEOUT_MS);
+    let res: Response;
+    try {
+      res = await doFetch(url, {
+        method: 'DELETE',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(body),
+        signal: controller.signal,
+      });
+    } finally {
+      clearTimeout(timer);
+    }
+
+    if (!res.ok) {
+      return { ok: false, status: res.status, error: `HTTP ${res.status}`, url, body };
+    }
+    let deleted: number | undefined;
+    try {
+      const json = (await res.json()) as { deleted?: number };
+      if (typeof json?.deleted === 'number') deleted = json.deleted;
+    } catch {
+      // A 200 with an unparseable body still counts as success; deleted unknown.
+    }
+    return { ok: true, status: res.status, deleted, url, body };
+  } catch (err) {
+    const error = err instanceof Error ? err.message : String(err);
+    return { ok: false, error, url, body };
+  }
+}
+
+/** A copy-pasteable curl the user can run to retry a failed purge by hand. */
+export function manualPurgeCurl(result: PurgeResult): string {
+  const json = JSON.stringify(result.body);
+  return `curl -X DELETE '${result.url}' -H 'Content-Type: application/json' -d '${json}'`;
+}


### PR DESCRIPTION
## G6 — right-to-delete / opt-out purge (producer half)

When a customer opts out, they can now also delete every signature this sensor has already reported from the registry. Pairs with the registry endpoint `DELETE /api/v1/telemetry/signature/sensor/:sensor_id`.

### Commands
- `arp telemetry opt-out` — disables telemetry **and** requests deletion of already-sent signatures by default. Use `--no-purge` to skip the deletion (just stop future sends).
- `arp telemetry purge` — standalone right-to-delete; requests deletion without changing opt-out state.

### How the purge authorizes
Keys on the local `sensor_id`. For a registered (verified) sensor the registry requires proof of key ownership, so the request carries an Ed25519 signature over the purge canonical `telemetry-purge-v1|<sensorId>|<nonce>|<signedAt>` plus the public key; for an unverified sensor the random `sensor_id` is itself the capability. The canonical's schema prefix is distinct from the ingest schema, so a captured ingest signature cannot be replayed as a purge.

### Fails OPEN
The opt-out marker is written **first** and is what actually stops transmission. A purge network/registry failure never blocks or undoes the opt-out — on failure the CLI prints a runnable `curl` so the deletion can be retried by hand. No secret material is transmitted (only the public key and the signature).

### Changes
- `purge.ts`: `buildPurgeCanonical` / `buildPurgeProof` / `purgeRemoteSignatures` (injectable fetch, always resolves) / `manualPurgeCurl`.
- `cli`: `opt-out --no-purge`, new `purge` subcommand, updated help text.
- 9 unit tests: canonical byte-parity with the server, signature verifies against the public key, success / non-200 / network-error fail-open, trailing-slash base URL, manual-curl rendering.

Full suite green (2515 passed); type-check clean. New-user walkthrough exercised status / opt-out / opt-in / purge / error path (correct exit codes, fail-open verified).