### PR TITLE
Add `arp telemetry register` sensor enrollment

### DIFF
--- a/src/arp/cli/index.ts
+++ b/src/arp/cli/index.ts
@@ -23,6 +23,9 @@ import {
   currentOrgPseudonym,
   purgeRemoteSignatures,
   manualPurgeCurl,
+  enrollSensor,
+  manualEnrollCurl,
+  readEnrollmentRecord,
 } from '../telemetry/signature';
 import type { SignatureTelemetryConfig } from '../types';
 
@@ -273,6 +276,9 @@ async function telemetryCommand(): Promise<void> {
     case 'status':
       await telemetryStatus(tcfg);
       break;
+    case 'register':
+      await telemetryRegister(tcfg);
+      break;
     case 'disclosure':
       console.log('\n' + disclosureText(tcfg) + '\n');
       break;
@@ -320,6 +326,7 @@ async function telemetryCommand(): Promise<void> {
   arp telemetry <subcommand>
 
     status        Show telemetry state, sensor identity, and send counts
+    register      Enroll this sensor with the registry (pending admin approval)
     log [N]       Show the last N audited payloads sent (default 20)
     disclosure    Print the full install-time disclosure
     opt-out       Disable ALL OpenA2A telemetry (also deletes already-sent
@@ -359,6 +366,41 @@ async function runRemotePurge(tcfg?: SignatureTelemetryConfig): Promise<void> {
   console.log(`    ${manualPurgeCurl(result)}`);
 }
 
+// telemetryRegister enrolls this sensor with the registry (the producer half of the
+// verified-sensor flow). Enrollment creates a PENDING enrollment that an admin must
+// approve before reports count as verified; until then reports still send at the
+// unverified weight. Fails OPEN: a network/registry failure is reported with a manual
+// retry command but never throws.
+async function telemetryRegister(tcfg?: SignatureTelemetryConfig): Promise<void> {
+  console.log('\n  Enrolling this sensor with the OpenA2A registry...');
+  if (isOptedOut(tcfg)) {
+    console.log('  NOTE: telemetry is currently opted out, so no reports will be sent');
+    console.log('  even after approval. Re-enable with: arp telemetry opt-in');
+  }
+
+  const result = await enrollSensor(tcfg);
+  if (result.ok) {
+    const state = result.state ?? 'pending';
+    console.log(`  Enrollment ${state === 'verified' ? 'VERIFIED' : 'PENDING'}.`);
+    if (result.sensorId) console.log(`  Sensor id: ${result.sensorId}`);
+    if (state === 'verified') {
+      console.log('  This sensor is approved; its reports are weighted as verified.');
+    } else {
+      console.log('  Next step: an OpenA2A admin must approve this enrollment.');
+      console.log('  Until then, reports still send at the unverified weight.');
+    }
+    console.log('  Check state anytime with: arp telemetry status\n');
+    return;
+  }
+
+  // Fail open: enrollment is best-effort; tell the user how to retry by hand.
+  console.log(`  Could not reach the registry to enroll (${result.error ?? 'unknown error'}).`);
+  console.log('  No verified status was granted; reports (if enabled) still send unverified.');
+  console.log('  Retry later with: arp telemetry register');
+  console.log('  Or run it directly:');
+  console.log(`    ${manualEnrollCurl(result)}\n`);
+}
+
 async function telemetryLog(): Promise<void> {
   const n = parseInt(args[2], 10) || 20;
   const records = await readAuditRecords(n);
@@ -396,6 +438,13 @@ async function telemetryStatus(tcfg?: import('../types').SignatureTelemetryConfi
     console.log(`  Org pseudonym:${' '}${currentOrgPseudonym()} (rotates monthly)`);
   } catch {
     // identity files may not exist until first send; do not fail status
+  }
+  const enrollment = readEnrollmentRecord();
+  if (enrollment) {
+    const label = enrollment.state === 'verified' ? 'verified' : 'pending admin approval';
+    console.log(`  Enrollment:   ${label}`);
+  } else {
+    console.log('  Enrollment:   not enrolled (run: arp telemetry register)');
   }
   console.log(`  Audit log:    ${auditLogPath()}`);
   console.log('  Sent:         ' + (counts['sent'] ?? 0));

--- a/src/arp/telemetry/signature/enroll.test.ts
+++ b/src/arp/telemetry/signature/enroll.test.ts
@@ -1,0 +1,177 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, rmSync, readFileSync, existsSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import * as ed25519 from '@noble/ed25519';
+import {
+  ENROLL_SCHEMA_VERSION,
+  SENSOR_ENROLL_PATH,
+  buildEnrollCanonical,
+  buildEnrollProof,
+  enrollSensor,
+  manualEnrollCurl,
+  readEnrollmentRecord,
+} from './enroll';
+import { loadSensorId } from './sensor-identity';
+
+const RE_NONCE = /^[A-Za-z0-9_-]{8,128}$/;
+const SENSOR_ID_FILE = 'telemetry-sensor-id';
+
+let home: string;
+beforeEach(() => {
+  home = mkdtempSync(join(tmpdir(), 'arp-enroll-'));
+  process.env.OPENA2A_HOME = home;
+  delete process.env.OPENA2A_SENSOR_ID;
+});
+afterEach(() => {
+  delete process.env.OPENA2A_HOME;
+  delete process.env.OPENA2A_SENSOR_ID;
+  rmSync(home, { recursive: true, force: true });
+});
+
+describe('buildEnrollCanonical — byte-parity with the Go server EnrollCanonical()', () => {
+  it('joins fields in the exact registry order with the enroll schema prefix', () => {
+    const c = buildEnrollCanonical({ publicKey: 'pk', nonce: 'n12345678', signedAt: 1234567890 });
+    expect(c).toBe('telemetry-enroll-v1|pk|n12345678|1234567890');
+  });
+
+  it('uses a schema prefix distinct from the ingest and purge schemas (no cross-replay)', () => {
+    const c = buildEnrollCanonical({ publicKey: 'pk', nonce: 'n12345678', signedAt: 1 });
+    expect(c.startsWith(ENROLL_SCHEMA_VERSION + '|')).toBe(true);
+    expect(c.startsWith('telemetry-sig-v1|')).toBe(false);
+    expect(c.startsWith('telemetry-purge-v1|')).toBe(false);
+  });
+});
+
+describe('buildEnrollProof', () => {
+  it('binds the public key verbatim and produces a verifying signature', async () => {
+    const now = new Date('2026-06-26T12:00:00Z');
+    const { url, body } = await buildEnrollProof({ now });
+
+    expect(url).toBe(SENSOR_ENROLL_PATH);
+    expect(body.publicKey).toMatch(/^[0-9a-f]{64}$/); // lowercase hex
+    expect(body.nonce).toMatch(RE_NONCE);
+    expect(body.signedAt).toBe(Math.floor(now.getTime() / 1000));
+
+    const canonical = buildEnrollCanonical({
+      publicKey: body.publicKey,
+      nonce: body.nonce,
+      signedAt: body.signedAt,
+    });
+    const ok = await ed25519.verifyAsync(
+      Buffer.from(body.signature, 'hex'),
+      new TextEncoder().encode(canonical),
+      Buffer.from(body.publicKey, 'hex'),
+    );
+    expect(ok).toBe(true);
+  });
+
+  it('uses a fresh nonce on each call', async () => {
+    const a = await buildEnrollProof();
+    const b = await buildEnrollProof();
+    expect(a.body.nonce).not.toBe(b.body.nonce);
+  });
+});
+
+describe('enrollSensor', () => {
+  it('POSTs the signed body and returns pending state on 201', async () => {
+    let captured: { url: string; init: RequestInit } | undefined;
+    const fakeFetch = (async (url: string, init: RequestInit) => {
+      captured = { url, init };
+      return {
+        ok: true,
+        status: 201,
+        json: async () => ({ sensorId: '11111111-1111-1111-1111-111111111111', state: 'pending', message: 'pending admin approval' }),
+      } as unknown as Response;
+    }) as unknown as typeof fetch;
+
+    const res = await enrollSensor({ registryUrl: 'https://r.test' }, { fetchImpl: fakeFetch });
+    expect(res.ok).toBe(true);
+    expect(res.state).toBe('pending');
+    expect(res.sensorId).toBe('11111111-1111-1111-1111-111111111111');
+    expect(captured?.init.method).toBe('POST');
+    expect(captured?.url).toBe('https://r.test/api/v1/telemetry/sensors/enroll');
+    const sent = JSON.parse((captured?.init.body as string) ?? '{}');
+    expect(sent.signature).toBeTruthy();
+    expect(sent.publicKey).toMatch(/^[0-9a-f]{64}$/);
+    expect(sent.sensorId).toBeUndefined(); // enroll does not send a sensorId
+  });
+
+  it('adopts the registry-assigned sensorId locally and records enrollment state', async () => {
+    const assigned = '22222222-2222-2222-2222-222222222222';
+    const fakeFetch = (async () =>
+      ({ ok: true, status: 201, json: async () => ({ sensorId: assigned, state: 'pending' }) }) as unknown as Response) as unknown as typeof fetch;
+
+    await enrollSensor({ registryUrl: 'https://r.test' }, { fetchImpl: fakeFetch });
+
+    // The local sensor id now equals the registry-assigned id (so future reports verify).
+    expect(loadSensorId()).toBe(assigned);
+    expect(readFileSync(join(home, SENSOR_ID_FILE), 'utf8').trim()).toBe(assigned);
+
+    const rec = readEnrollmentRecord();
+    expect(rec?.sensorId).toBe(assigned);
+    expect(rec?.state).toBe('pending');
+  });
+
+  it('reports verified state on idempotent re-enroll of an approved key', async () => {
+    const assigned = '33333333-3333-3333-3333-333333333333';
+    const fakeFetch = (async () =>
+      ({ ok: true, status: 201, json: async () => ({ sensorId: assigned, state: 'verified' }) }) as unknown as Response) as unknown as typeof fetch;
+    const res = await enrollSensor({ registryUrl: 'https://r.test' }, { fetchImpl: fakeFetch });
+    expect(res.state).toBe('verified');
+    expect(readEnrollmentRecord()?.state).toBe('verified');
+  });
+
+  it('returns ok=false with the status + server error on a non-2xx (does not throw)', async () => {
+    const fakeFetch = (async () =>
+      ({ ok: false, status: 401, json: async () => ({ error: 'unauthorized' }) }) as unknown as Response) as unknown as typeof fetch;
+    const res = await enrollSensor({ registryUrl: 'https://r.test' }, { fetchImpl: fakeFetch });
+    expect(res.ok).toBe(false);
+    expect(res.status).toBe(401);
+    expect(res.error).toContain('unauthorized');
+    // A failed enroll must NOT write a local enrollment record or adopt an id.
+    expect(readEnrollmentRecord()).toBeNull();
+    expect(existsSync(join(home, SENSOR_ID_FILE))).toBe(false);
+  });
+
+  it('fails OPEN on a network error — resolves with ok=false, never throws', async () => {
+    const fakeFetch = (async () => {
+      throw new Error('ECONNREFUSED');
+    }) as unknown as typeof fetch;
+    const res = await enrollSensor({ registryUrl: 'https://r.test' }, { fetchImpl: fakeFetch });
+    expect(res.ok).toBe(false);
+    expect(res.error).toContain('ECONNREFUSED');
+    expect(res.url).toBe('https://r.test/api/v1/telemetry/sensors/enroll');
+  });
+
+  it('strips a trailing slash from the registry base URL', async () => {
+    let capturedUrl = '';
+    const fakeFetch = (async (url: string) => {
+      capturedUrl = url;
+      return { ok: true, status: 201, json: async () => ({ sensorId: 'x', state: 'pending' }) } as unknown as Response;
+    }) as unknown as typeof fetch;
+    await enrollSensor({ registryUrl: 'https://r.test/' }, { fetchImpl: fakeFetch });
+    expect(capturedUrl).toBe('https://r.test/api/v1/telemetry/sensors/enroll');
+    expect(capturedUrl).not.toContain('//api');
+  });
+});
+
+describe('manualEnrollCurl', () => {
+  it('renders a runnable POST curl with the signed body', async () => {
+    const res = await enrollSensor({ registryUrl: 'https://r.test' }, {
+      fetchImpl: (async () => {
+        throw new Error('offline');
+      }) as unknown as typeof fetch,
+    });
+    const curl = manualEnrollCurl(res);
+    expect(curl).toContain("curl -X POST 'https://r.test/api/v1/telemetry/sensors/enroll'");
+    expect(curl).toContain("-H 'Content-Type: application/json'");
+    expect(curl).toContain(res.body.signature);
+  });
+});
+
+describe('readEnrollmentRecord', () => {
+  it('returns null when no enrollment has happened', () => {
+    expect(readEnrollmentRecord()).toBeNull();
+  });
+});

--- a/src/arp/telemetry/signature/enroll.ts
+++ b/src/arp/telemetry/signature/enroll.ts
@@ -1,0 +1,210 @@
+/**
+ * Self-serve sensor enrollment (the producer half of `arp telemetry register`).
+ *
+ * A sensor already holds an Ed25519 keypair (sensor-identity.ts). Enrollment
+ * registers that key with the registry, which creates a PENDING (unverified)
+ * enrollment that an admin must approve before the sensor's reports count as
+ * verified. Enrollment proves key ownership by signing an enroll canonical with the
+ * sensor key, so an attacker cannot pre-register a key it cannot sign for.
+ *
+ * On success the registry returns the service-account id it assigned. Future reports
+ * MUST carry that id as their sensorId (the registry binds the registered key to that
+ * id and only marks a report verified when its sensorId matches), so we ADOPT it
+ * locally via persistSensorId.
+ *
+ * Fails OPEN: a network/registry failure NEVER throws. The caller prints a manual
+ * retry command so a sensor is never silently left un-enrolled.
+ *
+ * The canonical MUST byte-match the server's Go EnrollCanonical()
+ * (opena2a-registry/internal/domain/telemetry_signature.go):
+ *
+ *   telemetry-enroll-v1|<publicKey>|<nonce>|<signedAt>
+ *
+ * publicKey and signature are transmitted as lowercase hex; the registry's
+ * normalizeToBase64 hex-decodes them before ed25519.Verify, and binds the publicKey
+ * verbatim into the canonical it reconstructs, so the hex form round-trips.
+ */
+
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'fs';
+import {
+  loadSensorPrivateKey,
+  publicKeyHex,
+  signCanonicalHex,
+  persistSensorId,
+} from './sensor-identity';
+import { generateNonce } from './wire';
+import { resolveRegistryUrl, type SignatureTelemetryConfig } from './config';
+import { opena2aHome, homePath, SENSOR_ENROLLMENT_FILE } from './paths';
+
+/** The enroll canonical schema prefix (distinct from the ingest/purge schemas). */
+export const ENROLL_SCHEMA_VERSION = 'telemetry-enroll-v1';
+
+/** The self-serve enrollment endpoint on the registry. */
+export const SENSOR_ENROLL_PATH = '/api/v1/telemetry/sensors/enroll';
+
+const ENROLL_TIMEOUT_MS = 10_000;
+
+/** The two enrollment states the registry reports. */
+export type EnrollmentState = 'pending' | 'verified';
+
+/** Build the deterministic enroll canonical that is signed and server-verified. */
+export function buildEnrollCanonical(r: { publicKey: string; nonce: string; signedAt: number }): string {
+  return [ENROLL_SCHEMA_VERSION, r.publicKey, r.nonce, String(r.signedAt)].join('|');
+}
+
+/** The signed enrollment body POSTed to the enroll endpoint. */
+export interface EnrollRequestBody {
+  publicKey: string;
+  nonce: string;
+  signedAt: number; // unix SECONDS
+  signature: string;
+}
+
+export interface EnrollResult {
+  /** True only when the registry accepted the enrollment (HTTP 2xx). */
+  ok: boolean;
+  /** Enrollment state the registry reported (present on success). */
+  state?: EnrollmentState;
+  /** The registry-assigned service-account id for this sensor (present on success). */
+  sensorId?: string;
+  /** Human-facing next-step guidance from the registry (present on success). */
+  message?: string;
+  /** HTTP status when a response was received. */
+  status?: number;
+  /** Human-readable failure reason when ok is false. */
+  error?: string;
+  /** The exact URL targeted (so the caller can print a manual retry). */
+  url: string;
+  /** The signed body (so the caller can print a manual curl on failure). */
+  body: EnrollRequestBody;
+}
+
+/** Locally persisted enrollment record. */
+export interface EnrollmentRecord {
+  sensorId: string;
+  state: EnrollmentState;
+  updatedAt: string;
+}
+
+/**
+ * Build the signed enrollment body for this sensor. Pure except for the persisted
+ * sensor key and the supplied clock (defaulted to now). Exposed for testing.
+ */
+export async function buildEnrollProof(opts: { now?: Date } = {}): Promise<{ url: string; body: EnrollRequestBody }> {
+  const now = opts.now ?? new Date();
+  const signedAt = Math.floor(now.getTime() / 1000);
+  const nonce = generateNonce();
+
+  const priv = loadSensorPrivateKey();
+  const publicKey = await publicKeyHex(priv);
+  const canonical = buildEnrollCanonical({ publicKey, nonce, signedAt });
+  const signature = await signCanonicalHex(priv, canonical);
+
+  const body: EnrollRequestBody = { publicKey, nonce, signedAt, signature };
+  return { url: SENSOR_ENROLL_PATH, body };
+}
+
+/** Persist the enrollment record locally (best effort; never throws). */
+export function writeEnrollmentRecord(rec: EnrollmentRecord): void {
+  try {
+    const home = opena2aHome();
+    if (!existsSync(home)) mkdirSync(home, { recursive: true });
+    writeFileSync(homePath(SENSOR_ENROLLMENT_FILE), JSON.stringify(rec) + '\n', { mode: 0o600 });
+  } catch {
+    // best effort — a failed local record never blocks the (successful) enrollment
+  }
+}
+
+/** Read the locally persisted enrollment record, or null if none / unreadable. */
+export function readEnrollmentRecord(): EnrollmentRecord | null {
+  const p = homePath(SENSOR_ENROLLMENT_FILE);
+  if (!existsSync(p)) return null;
+  try {
+    const parsed = JSON.parse(readFileSync(p, 'utf8')) as Partial<EnrollmentRecord>;
+    if (parsed && typeof parsed.sensorId === 'string' && (parsed.state === 'pending' || parsed.state === 'verified')) {
+      return { sensorId: parsed.sensorId, state: parsed.state, updatedAt: parsed.updatedAt ?? '' };
+    }
+  } catch {
+    // unreadable / malformed — treat as no record
+  }
+  return null;
+}
+
+/**
+ * Enroll this sensor with the registry. ALWAYS resolves (never throws) — a network
+ * error, timeout, or non-2xx is returned in the result so the caller can fail OPEN.
+ *
+ * On a successful enrollment the registry-assigned sensorId is adopted locally (so
+ * future reports carry it) and the enrollment record is persisted.
+ *
+ * `fetchImpl` is injectable for testing; it defaults to the global fetch.
+ */
+export async function enrollSensor(
+  config?: SignatureTelemetryConfig,
+  opts: { now?: Date; fetchImpl?: typeof fetch } = {},
+): Promise<EnrollResult> {
+  const doFetch = opts.fetchImpl ?? fetch;
+  const base = resolveRegistryUrl(config).replace(/\/+$/, '');
+  const { url: path, body } = await buildEnrollProof({ now: opts.now });
+  const url = `${base}${path}`;
+
+  try {
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), ENROLL_TIMEOUT_MS);
+    let res: Response;
+    try {
+      res = await doFetch(url, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(body),
+        signal: controller.signal,
+      });
+    } finally {
+      clearTimeout(timer);
+    }
+
+    if (!res.ok) {
+      let error = `HTTP ${res.status}`;
+      try {
+        const json = (await res.json()) as { error?: string };
+        if (json?.error) error = `HTTP ${res.status}: ${json.error}`;
+      } catch {
+        // non-JSON error body; keep the bare status
+      }
+      return { ok: false, status: res.status, error, url, body };
+    }
+
+    let state: EnrollmentState | undefined;
+    let sensorId: string | undefined;
+    let message: string | undefined;
+    try {
+      const json = (await res.json()) as { sensorId?: string; state?: string; message?: string };
+      if (json?.state === 'pending' || json?.state === 'verified') state = json.state;
+      if (typeof json?.sensorId === 'string') sensorId = json.sensorId;
+      if (typeof json?.message === 'string') message = json.message;
+    } catch {
+      // A 2xx with an unparseable body still counts as success; details unknown.
+    }
+
+    // Adopt the registry-assigned id locally so future reports verify, and record state.
+    if (sensorId) {
+      persistSensorId(sensorId);
+      writeEnrollmentRecord({
+        sensorId,
+        state: state ?? 'pending',
+        updatedAt: (opts.now ?? new Date()).toISOString(),
+      });
+    }
+
+    return { ok: true, status: res.status, state, sensorId, message, url, body };
+  } catch (err) {
+    const error = err instanceof Error ? err.message : String(err);
+    return { ok: false, error, url, body };
+  }
+}
+
+/** A copy-pasteable curl the user can run to retry a failed enrollment by hand. */
+export function manualEnrollCurl(result: EnrollResult): string {
+  const json = JSON.stringify(result.body);
+  return `curl -X POST '${result.url}' -H 'Content-Type: application/json' -d '${json}'`;
+}

--- a/src/arp/telemetry/signature/index.ts
+++ b/src/arp/telemetry/signature/index.ts
@@ -89,3 +89,15 @@ export {
   manualPurgeCurl,
 } from './purge';
 export type { PurgeProofBody, PurgeResult } from './purge';
+
+export {
+  ENROLL_SCHEMA_VERSION,
+  SENSOR_ENROLL_PATH,
+  buildEnrollCanonical,
+  buildEnrollProof,
+  enrollSensor,
+  manualEnrollCurl,
+  readEnrollmentRecord,
+  writeEnrollmentRecord,
+} from './enroll';
+export type { EnrollRequestBody, EnrollResult, EnrollmentRecord, EnrollmentState } from './enroll';

--- a/src/arp/telemetry/signature/paths.ts
+++ b/src/arp/telemetry/signature/paths.ts
@@ -28,6 +28,8 @@ export const AUDIT_LOG_FILE = 'telemetry-audit.log';
 export const DISCLOSURE_MARKER_FILE = 'telemetry-disclosure-shown';
 /** Opt-out marker file (presence = opted out, in addition to env/config). */
 export const OPTOUT_MARKER_FILE = 'telemetry-optout';
+/** Local record of the sensor's enrollment state (JSON: sensorId, state, updatedAt). */
+export const SENSOR_ENROLLMENT_FILE = 'telemetry-enrollment';
 
 export function homePath(file: string): string {
   return join(opena2aHome(), file);

--- a/src/arp/telemetry/signature/sensor-identity.ts
+++ b/src/arp/telemetry/signature/sensor-identity.ts
@@ -54,6 +54,21 @@ export function loadSensorId(): string {
   return id;
 }
 
+/**
+ * Persist the sensor id locally (the canonical SENSOR_ID_FILE). Used after a
+ * successful enrollment to ADOPT the registry-assigned service-account id as this
+ * sensor's id, so future reports carry the id the registry binds to the registered
+ * key — the exact-match resolveIdentity requires for verified status. Note an
+ * OPENA2A_SENSOR_ID env override still takes precedence in loadSensorId, so an
+ * operator pin is never silently overwritten in effect.
+ */
+export function persistSensorId(id: string): void {
+  const trimmed = id.trim();
+  if (!trimmed) return;
+  ensureHome();
+  writeFileSync(homePath(SENSOR_ID_FILE), trimmed, { mode: 0o600 });
+}
+
 /** Lowercase-hex Ed25519 public key (64 hex chars) for the given private key. */
 export async function publicKeyHex(priv: Uint8Array): Promise<string> {
   const pub = await ed25519.getPublicKeyAsync(priv);


### PR DESCRIPTION
## Summary

Adds the producer half of self-serve sensor enrollment. A sensor already holds an Ed25519 keypair; `arp telemetry register` enrolls that key with the registry, which creates a pending enrollment an admin must approve before the sensor's reports count as verified. Until approval, reports still send at the unverified weight.

## What's new
- **`src/arp/telemetry/signature/enroll.ts`** — builds the enroll proof (signs `telemetry-enroll-v1|publicKey|nonce|signedAt`, byte-matching the server canonical), POSTs to `/api/v1/telemetry/sensors/enroll`, and adopts the registry-assigned service-account id locally so future reports carry the id the registry binds to the registered key (the exact match required for verified status). Fails open: a network/registry failure prints a manual retry curl and never throws.
- **`arp telemetry register`** subcommand + help text. Persists an enrollment record under `~/.opena2a` and surfaces it in `arp telemetry status` (pending / verified / not enrolled).

## Design
- Mirrors the existing `purge.ts` producer pattern (signed canonical, injectable fetch, fail-open, manual-curl fallback).
- The enroll canonical uses a distinct schema prefix (`telemetry-enroll-v1`) so an enroll proof can never be replayed as an ingest or purge authorization.
- Only the public key and signature leave the device — the private key never does. The adopted sensor id is the registry's service-account id (an `OPENA2A_SENSOR_ID` env pin still takes precedence).

## Tests
12 unit tests: canonical byte-parity with the server, proof verifies against the public key, registry-assigned id adoption, pending/verified state, non-2xx + network-failure fail-open, trailing-slash normalization. Full producer suite green (2527 passed). New-user walkthrough: `register` happy path (pending + id adoption), fail-open (manual curl, no throw), `status` (not enrolled / pending), unknown-subcommand error path.

## Pairs with
The registry endpoint (`POST /api/v1/telemetry/sensors/enroll` + admin approval) in the registry backend.