### PR TITLE
chore(release): hackmyagent 0.24.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,13 +2,19 @@
 
 All notable changes to HackMyAgent are documented in this file.
 
-## [Unreleased]
+## [0.24.0] - 2026-07-06
 
 ### Changed
 
 - **The ARP runtime engine now lives in `@opena2a/aim-sdk`; `hackmyagent/arp` is a thin re-export.** The runtime-protection module (event engine, monitors and interceptors, behavioral twin, intelligence coordinator, enforcement, signature telemetry) moved to the AIM agent-side TypeScript SDK as its `@opena2a/aim-sdk/arp` module; hackmyagent keeps the scan-time surface (static scanner, hardening rules, artifact parsing, NanoMind artifact classification) and re-exports the SDK module so every existing `hackmyagent/arp` consumer — including the published `arp-guard` package and the `arp` CLI — keeps working unchanged. The OASB behavioral suite now exercises the SDK module through the re-export, keeping a behavioral drift guard on the dependency.
 
+- **Pinned `@opena2a/aim-sdk` to 1.0.1.** The `arp` re-export now ships the SDK's 1.0.1 fixes: typed `ConfigurationError` for credential-file errors, `EventEngine.emit` input validation, CJS error-class `constructor.name`, and the `./package.json` export.
+
 - **`detect` help now states that machine-wide discovery always runs.** A fresh user passing `detect /path/to/project` could expect directory-scoped results, but `detect` always audits the whole machine (running assistants, MCP servers, machine-level configs) and uses the directory only for the project-local scan. The command description, examples, and the directory-argument help now say so explicitly (release-test P3).
+
+### Security
+
+- **Bumped `hono` and `js-yaml` to clear known advisories in the production dependency tree.** hono (path-traversal on Windows via encoded backslash, CORS wildcard-with-credentials reflection, body-limit bypass, and the Set-Cookie/header-merge adapter bugs — GHSA cluster) and js-yaml (quadratic-complexity DoS in merge-key handling, GHSA-h67p-54hq-rp68), both via an in-range `npm audit fix`. Production `npm audit` is now clean.
 
 ## [0.23.11] - 2026-06-18
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,19 +1,19 @@
 {
   "name": "hackmyagent",
-  "version": "0.23.11",
+  "version": "0.24.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "hackmyagent",
-      "version": "0.23.11",
+      "version": "0.24.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.12.1",
         "@noble/ed25519": "^2.3.0",
         "@noble/post-quantum": "^0.2.1",
         "@opena2a/aim-core": "^0.1.2",
-        "@opena2a/aim-sdk": "1.0.0",
+        "@opena2a/aim-sdk": "1.0.1",
         "@opena2a/check-core": "0.3.0",
         "@opena2a/cli-ui": "0.5.2",
         "@opena2a/contribute": "^0.1.0",
@@ -641,9 +641,9 @@
       }
     },
     "node_modules/@opena2a/aim-sdk": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@opena2a/aim-sdk/-/aim-sdk-1.0.0.tgz",
-      "integrity": "sha512-GU1uEK7W76lq9gL1Y4nFQZ76L/6K6IdBMZRhX/f6oOoXE+IPauTvG63TdDMOoN0XgOgGBbHALC1URJv4oyQ+Fw==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@opena2a/aim-sdk/-/aim-sdk-1.0.1.tgz",
+      "integrity": "sha512-KdwPxF7//ZLv+Thxt/SGJfSNUIaA9mfGLqqSY13xhb1f/r403vgHrnsm8CZHIJ637xqqhPv8ILqkdOinEXcfmw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@noble/ed25519": "^2.1.0",
@@ -2097,9 +2097,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.12.21",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.21.tgz",
-      "integrity": "sha512-uV63apnb0kyPtAUwoWgaGh9HyIFcv8lgmzPZSiTBQAFOFGIzka5EZ1dZocmGnn0XdX0+XTqJ6Tqv7selMuGLRQ==",
+      "version": "4.12.27",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.27.tgz",
+      "integrity": "sha512-1yrb/+w6HWQJrUCLkJ2IF5jNIPvvFkblV5RNOYl6bV+OA6p9GLcMpHFFGTosSvHvcAUibuUukRqhlYI4z32C7Q==",
       "license": "MIT",
       "engines": {
         "node": ">=16.9.0"
@@ -2187,9 +2187,19 @@
       }
     },
     "node_modules/js-yaml": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
-      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
+      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hackmyagent",
-  "version": "0.23.11",
+  "version": "0.24.0",
   "description": "Find it. Break it. Fix it. The hacker's toolkit for AI agents.",
   "bin": {
     "hackmyagent": "dist/cli.js"
@@ -40,7 +40,7 @@
     "@noble/ed25519": "^2.3.0",
     "@noble/post-quantum": "^0.2.1",
     "@opena2a/aim-core": "^0.1.2",
-    "@opena2a/aim-sdk": "1.0.0",
+    "@opena2a/aim-sdk": "1.0.1",
     "@opena2a/check-core": "0.3.0",
     "@opena2a/cli-ui": "0.5.2",
     "@opena2a/contribute": "^0.1.0",


### PR DESCRIPTION
Release commit for 0.24.0 (already published to the npm registry via tag v0.24.0, OIDC trusted publishing, SLSA v1 attested).

- version 0.23.11 → 0.24.0
- @opena2a/aim-sdk exact pin 1.0.0 → 1.0.1
- hono + js-yaml in-range security bumps (prod audit clean)
- CHANGELOG [0.24.0] section

Diff is 3 files (package.json, package-lock.json, CHANGELOG.md); no source changes — #245–#249 are already on main. Merge with a merge commit so the v0.24.0 tag remains an ancestor of main.

Known pre-existing scanner follow-ups from release testing: #250, #251, #252, #253.