### PR TITLE
chore: point published contact email to info@opena2a.org

### DIFF
--- a/README.md
+++ b/README.md
@@ -377,7 +377,7 @@ git clone https://github.com/opena2a-org/hackmyagent.git
 cd hackmyagent && npm install && npm run build && npm test
 ```
 
-Security issues: `security@opena2a.org` (coordinated disclosure, response within 24 hours).
+Security issues: `info@opena2a.org` (coordinated disclosure, response within 24 hours).
 
 ## Links
 


### PR DESCRIPTION
Points published contact/security emails to `info@opena2a.org`, the real monitored business inbox.

The previously listed addresses (`security@`, `research@`, `support@`, etc.) are not provisioned and receive no mail.

Part of an org-wide contact-email sweep. Only the email strings changed; no logic.