### PR TITLE
Release 0.25.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,11 @@
 
 All notable changes to HackMyAgent are documented in this file.
 
-## [Unreleased]
+## [0.25.0] - 2026-07-07
+
+### Changed
+
+- **Pinned `@opena2a/aim-sdk` to 1.0.2.** The bump moves the SDK's `@opena2a/atx-verify` dependency from 0.2.0 to 0.3.0, closing the transitive `declaredPurpose` forgery gap that 0.24.0 shipped: under atx-verify 0.2.0 a legitimately-signed v1.1 credential whose `declaredPurpose` was tampered after signing still verified. Narrow exposure (only `src/arp` consumes the SDK), but a security tool should not pin a verifier with a known signature-coverage gap.
 
 ### Fixed
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,19 +1,19 @@
 {
   "name": "hackmyagent",
-  "version": "0.24.0",
+  "version": "0.25.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "hackmyagent",
-      "version": "0.24.0",
+      "version": "0.25.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.12.1",
         "@noble/ed25519": "^2.3.0",
         "@noble/post-quantum": "^0.2.1",
         "@opena2a/aim-core": "^0.1.2",
-        "@opena2a/aim-sdk": "1.0.1",
+        "@opena2a/aim-sdk": "1.0.2",
         "@opena2a/check-core": "0.3.0",
         "@opena2a/cli-ui": "0.5.2",
         "@opena2a/contribute": "^0.1.0",
@@ -641,14 +641,14 @@
       }
     },
     "node_modules/@opena2a/aim-sdk": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@opena2a/aim-sdk/-/aim-sdk-1.0.1.tgz",
-      "integrity": "sha512-KdwPxF7//ZLv+Thxt/SGJfSNUIaA9mfGLqqSY13xhb1f/r403vgHrnsm8CZHIJ637xqqhPv8ILqkdOinEXcfmw==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@opena2a/aim-sdk/-/aim-sdk-1.0.2.tgz",
+      "integrity": "sha512-COAqsyscdMdygQYQYZrQm4zfeN/PxIIHdkq9XrgqceH6JfY2qrUpbA0F1nfjUCEUGpjSODdPcOnDPlXgSNMLqg==",
       "license": "Apache-2.0",
       "dependencies": {
         "@noble/ed25519": "^2.1.0",
         "@noble/post-quantum": "^0.2.1",
-        "@opena2a/atx-verify": "0.2.0",
+        "@opena2a/atx-verify": "0.3.0",
         "fastify-plugin": "^6.0.0",
         "js-yaml": "^4.1.1"
       },
@@ -669,9 +669,9 @@
       }
     },
     "node_modules/@opena2a/atx-verify": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/@opena2a/atx-verify/-/atx-verify-0.2.0.tgz",
-      "integrity": "sha512-tq1mZTgDLhEm0Gyhh0jqtcon1iBQbwYNxGPly3uT/SQoRVHXMRNCx8b9zmBFKgSwe8Q7NBrLjOHySGuKCX/ucg==",
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@opena2a/atx-verify/-/atx-verify-0.3.0.tgz",
+      "integrity": "sha512-2kRybBSfQv128jhcmfgZSpG0y9uK989pdgL86dCIiqEnj5/YXLpoYjrF0ijHgtpfJdhPekwaprnUbDXi1htqhw==",
       "license": "Apache-2.0",
       "dependencies": {
         "canonicalize": "2.1.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hackmyagent",
-  "version": "0.24.0",
+  "version": "0.25.0",
   "description": "Find it. Break it. Fix it. The hacker's toolkit for AI agents.",
   "bin": {
     "hackmyagent": "dist/cli.js"
@@ -40,7 +40,7 @@
     "@noble/ed25519": "^2.3.0",
     "@noble/post-quantum": "^0.2.1",
     "@opena2a/aim-core": "^0.1.2",
-    "@opena2a/aim-sdk": "1.0.1",
+    "@opena2a/aim-sdk": "1.0.2",
     "@opena2a/check-core": "0.3.0",
     "@opena2a/cli-ui": "0.5.2",
     "@opena2a/contribute": "^0.1.0",


### PR DESCRIPTION
Releases everything merged to main since 0.24.0 plus the aim-sdk security pin bump.

## Changes in this PR
- `@opena2a/aim-sdk` 1.0.1 -> 1.0.2 EXACT (moves transitive `@opena2a/atx-verify` 0.2.0 -> 0.3.0, closing the post-signing `declaredPurpose` tamper gap that 0.24.0 shipped in its arp re-export path)
- Version 0.24.0 -> 0.25.0 (MINOR: new finding classes — 6 governance violations; severity-model changes — GIT existence-aware LOW<->HIGH, CRED-002 incomplete-scan HIGH; new scanned surfaces — secrets.json, recursive key walk)
- CHANGELOG [Unreleased] stamped as [0.25.0]

## Ships (already merged on main, withheld from 0.24.0 users)
- CRED-002/PERM-001 findings now reach output/score/exit code (#250)
- GIT-001/002/003 existence-aware severity backed by git check-ignore (#250)
- CRED-002 recursive scan + no false clean bill; CRED-001 scans secrets.json/credentials.json (#250)
- scan-soul direction-aware matching + 6 first-class governance-violation classes (#251)
- Security-taxonomy documents no longer false-positive AST-CRED-002/003 (#256)
- Hermetic corpus release-smoke harness (#250)

## Release verification (this session)
- 2202 unit tests green (158 files); corpus hermetic 12/12; OASB arp drift-guard 182 green on the new pin (CJS 86/ESM 89 export keys unchanged)
- Zero-context fresh-user walkthrough: 22/22 commands functional; every finding classified — zero regressions vs 0.24.0; pre-existing items tracked in #252/#253/#259/#260/#261/#262
- Cross-analyzer direction agreement proven on corpus soul fixtures (scan-soul 19/7/4 with violations 0/0/9; check clean/flag; secure 98/76 with exit 0/1)
- Headline user-visible fix verified: un-ignored private key now produces CRITICAL Private Key Files (file-attributed), score impact, exit 1 — invisible on published 0.24.0
- Self-scan 96/100 exit 0; prod npm audit 0; aim-sdk 1.0.2 SLSA v1 provenance verified