### PR TITLE
fix(cli): single source of truth for check/category counts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to HackMyAgent are documented in this file.
 
+## [0.25.1] - 2026-07-22
+
+### Fixed
+
+- **One source of truth for the check/category counts.** The `secure` scan Observations block hardcoded `209 static checks / 44 categories`, `--help` and `check-metadata` derived `323 / 74` from the taxonomy, and the docs said `187 / 39` — the same tool contradicted itself, and a user running the CLI could see it. All surfaces (scan display, `--help`, command descriptions, `check-metadata`, the MCP tool description, README and docs) now read the real counts from `getCheckCounts()` in `src/hardening/taxonomy.ts`: 323 checks / 74 categories total, of which 310 static / 69 categories plus the NanoMind semantic layer. `check-metadata --json` now also reports `staticChecks`, `semanticChecks`, `categories`, and `staticCategories`. A regression test (`__tests__/hardening/check-count-consistency.test.ts`) fails on any drift and on re-introducing a hardcoded static-count literal.
+
 ## [0.25.0] - 2026-07-07
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ npx hackmyagent secure
 
   ── Observations ────────────────────────────────────────────
   Surfaces    library · 47 files
-  Checks      209 static · 12 semantic (NanoMind AST) · 0 skipped
+  Checks      310 static · 12 semantic (NanoMind AST) · 0 skipped
   Categories  credentials (3 critical) · MCP (2 high) · 18 others clear
   Verdict     Not safe to ship. Fix 3 critical issues before using this in production.
 
@@ -45,7 +45,7 @@ No config files. No flags required. Exit code 1 if any critical or high finding 
 
 ## What it finds
 
-- **209 static checks across 44 categories.** Credentials, MCP configs, OpenClaw and NemoClaw, Unicode steganography, CVEs, governance, supply chain, memory and RAG poisoning, agent identity, sandbox escape.
+- **310 static checks across 69 categories** (323 checks across 74 categories including the NanoMind semantic layer). Credentials, MCP configs, OpenClaw and NemoClaw, Unicode steganography, CVEs, governance, supply chain, memory and RAG poisoning, agent identity, sandbox escape. Run `hackmyagent check-metadata` for the live list.
 - **29 NanoMind semantic checks.** Every artifact (skill, MCP config, SOUL.md, system prompt) compiles into an Abstract Security Tree. The seven AST analyzers run against the tree: `capability`, `credential`, `governance`, `scope`, `prompt`, `code`, `stego`. Pattern matching misses undeclared capabilities, constraint weakness, scope mismatches, and scanner-evasion attempts. AST queries catch them. (This 29 is the fixed catalog of semantic checks. The `Checks` line in scan output — e.g. `12 semantic (NanoMind AST)` above — reports the number of artifacts compiled in that particular run, not this catalog size.)
 - **164 adversarial payloads across 16 categories.** Prompt injection, jailbreak, data exfiltration, capability abuse, context manipulation, MCP and A2A exploitation, memory weaponisation, context window, supply chain, tool shadow, parser differential, persistent agent, fake tool, context lifecycle, policy enforcement integrity.
 - **20-probe behavioural simulation** under `--deep`. Observes what a skill actually does, not only what it declares.
@@ -96,7 +96,7 @@ npm view hackmyagent dist.attestations --json
 
 | Surface | Command | What gets scanned |
 |---|---|---|
-| Your own project | `hackmyagent secure` | 209 static checks + NanoMind on current directory |
+| Your own project | `hackmyagent secure` | 310 static checks + NanoMind on current directory |
 | A local directory | `hackmyagent check ./my-agent/` | tree + auto-detected artifacts |
 | An npm package | `hackmyagent check express` | downloads tarball, scans before you install |
 | A PyPI package | `hackmyagent check pip:requests` | downloads sdist, scans before you install |

--- a/__tests__/hardening/check-count-consistency.test.ts
+++ b/__tests__/hardening/check-count-consistency.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'fs';
+import { join } from 'path';
+import { getCheckCounts, getTaxonomyMap } from '../../src/hardening/taxonomy';
+
+/**
+ * Guards the single source of truth for HMA's check/category counts.
+ *
+ * Regression context: `secure` scan output hardcoded `HMA_STATIC_CHECK_COUNT = 209`
+ * (and README/docs said 209/44 and 187/39) while `--help` and `check-metadata`
+ * derived 323/74 from the taxonomy — a self-contradiction a user running the CLI
+ * could see. getCheckCounts() is now the one source every surface reads.
+ *
+ * The source-scan test below FAILS on the pre-fix code (which contained the
+ * hardcoded literal), which is what gives this suite teeth.
+ */
+describe('check-count single source of truth', () => {
+  const counts = getCheckCounts();
+
+  it('total equals the taxonomy map size', () => {
+    expect(counts.total).toBe(Object.keys(getTaxonomyMap()).length);
+  });
+
+  it('static + semantic partition the total exactly', () => {
+    expect(counts.static + counts.semantic).toBe(counts.total);
+  });
+
+  it('static categories are a subset of total categories', () => {
+    expect(counts.staticCategories).toBeLessThanOrEqual(counts.totalCategories);
+    expect(counts.staticCategories).toBeGreaterThan(0);
+  });
+
+  // Golden values. Update these together with README.md and docs/SECURITY_CHECKS.md
+  // whenever the taxonomy changes — this test fails on drift by design, forcing
+  // the public-facing numbers to be updated in the same change.
+  it('matches the published golden counts (update docs when this changes)', () => {
+    expect(counts.total).toBe(323);
+    expect(counts.static).toBe(310);
+    expect(counts.semantic).toBe(13);
+    expect(counts.totalCategories).toBe(74);
+    expect(counts.staticCategories).toBe(69);
+  });
+
+  it('the scan display no longer hardcodes a static-check count (teeth)', () => {
+    const cliSource = readFileSync(join(__dirname, '../../src/cli.ts'), 'utf8');
+    // The pre-fix bug: `const HMA_STATIC_CHECK_COUNT = 209;`. Any hardcoded
+    // static-count literal reintroduces the drift this suite exists to prevent.
+    expect(cliSource).not.toMatch(/HMA_STATIC_CHECK_COUNT\s*=\s*\d+/);
+    // And the display must derive from the single source.
+    expect(cliSource).toMatch(/getCheckCounts\(\)\.static/);
+  });
+});

--- a/docs/SECURITY_CHECKS.md
+++ b/docs/SECURITY_CHECKS.md
@@ -1,6 +1,6 @@
 # Security Checks Reference
 
-HackMyAgent performs 187 security checks across 39 categories. This document provides detailed information about each check, including severity, description, and remediation guidance.
+HackMyAgent performs 323 security checks across 74 categories (310 static checks plus the NanoMind semantic layer). This document describes representative checks by category; run `hackmyagent check-metadata --json` for the complete, authoritative list.
 
 ## Severity Levels
 

--- a/docs/USE-CASES.md
+++ b/docs/USE-CASES.md
@@ -4,7 +4,7 @@ Guided walkthroughs for common security workflows.
 
 | Use Case | Time | Description |
 |----------|------|-------------|
-| [Scan My Agent](use-cases/scan-my-agent.md) | 5 min | Run all 187 security checks and auto-fix findings |
+| [Scan My Agent](use-cases/scan-my-agent.md) | 5 min | Run all 310 security checks and auto-fix findings |
 | [Red-Team MCP Servers](use-cases/red-team-mcp.md) | 10 min | Test MCP servers with 75 adversarial payloads |
 | [Secure OpenClaw](use-cases/openclaw-security.md) | 10 min | Run 34 OpenClaw-specific checks and detect known CVEs |
 | [CI/CD Pipeline](use-cases/ci-pipeline.md) | 5 min | Add HMA to GitHub Actions with JSON/SARIF output |

--- a/docs/use-cases/ci-pipeline.md
+++ b/docs/use-cases/ci-pipeline.md
@@ -57,7 +57,7 @@ The `--format json` output structure:
   "timestamp": "2026-03-15T10:30:00Z",
   "directory": "/home/runner/work/my-agent/my-agent",
   "summary": {
-    "total": 187,
+    "total": 310,
     "critical": 1,
     "high": 2,
     "medium": 3,

--- a/docs/use-cases/openclaw-security.md
+++ b/docs/use-cases/openclaw-security.md
@@ -17,7 +17,7 @@ From your OpenClaw project directory:
 npx hackmyagent secure
 ```
 
-HMA auto-detects OpenClaw by looking for `gateway.yaml`, `skills/`, and OpenClaw configuration files. All 34 OpenClaw checks run automatically alongside the standard 187 checks.
+HMA auto-detects OpenClaw by looking for `gateway.yaml`, `skills/`, and OpenClaw configuration files. All 34 OpenClaw checks run automatically alongside the standard 310 static checks.
 
 **Expected output (OpenClaw-specific findings):**
 
@@ -25,7 +25,7 @@ HMA auto-detects OpenClaw by looking for `gateway.yaml`, `skills/`, and OpenClaw
 HackMyAgent v0.10.1 -- Security Scanner
 
 Scanning: /home/user/openclaw-project
-Checks:  187 across 39 categories (34 OpenClaw-specific)
+Checks:  310 across 69 categories (34 OpenClaw-specific)
 
   CRITICAL  CVE-001   CVE-2026-25253 -- OpenClaw WebSocket RCE
             Found: openclaw v0.3.2 in package-lock.json (affected: < 0.3.5)

--- a/docs/use-cases/scan-my-agent.md
+++ b/docs/use-cases/scan-my-agent.md
@@ -11,7 +11,7 @@
 npx hackmyagent secure
 ```
 
-This runs all 187 checks against your current directory. No config files or setup needed.
+This runs all 310 static checks against your current directory. No config files or setup needed.
 
 **Expected output:**
 
@@ -19,7 +19,7 @@ This runs all 187 checks against your current directory. No config files or setu
 HackMyAgent v0.10.1 -- Security Scanner
 
 Scanning: /home/user/my-agent
-Checks:  187 across 39 categories
+Checks:  310 across 69 categories
 Time:    2.4s
 
   CRITICAL  CRED-001  Hardcoded API key in .env
@@ -74,7 +74,7 @@ npx hackmyagent secure --fix --dry-run
 HackMyAgent v0.10.1 -- Security Scanner (dry run)
 
 Scanning: /home/user/my-agent
-Checks:  187 across 39 categories
+Checks:  310 across 69 categories
 
   CRITICAL  CRED-001  Hardcoded API key in .env
             Would fix: Replace sk-proj-abc... with ${OPENAI_API_KEY}
@@ -103,7 +103,7 @@ npx hackmyagent secure --fix
 HackMyAgent v0.10.1 -- Security Scanner
 
 Scanning: /home/user/my-agent
-Checks:  187 across 39 categories
+Checks:  310 across 69 categories
 
   FIXED     CRED-001  Replaced hardcoded key with ${OPENAI_API_KEY} in .env
             Backup: .hackmyagent-backup/.env.1710504000
@@ -141,7 +141,7 @@ A clean scan exits with code `0` and shows no critical or high findings.
 
 ## Tips
 
-- Use `--verbose` to see all 187 checks, including ones that passed.
+- Use `--verbose` to see all 310 static checks, including ones that passed.
 - Use `--ignore CRED-001,LOG-001` to skip specific checks (e.g., known false positives).
 - Use `--json` to get machine-readable output for scripting.
 - Add `--ci` for non-interactive mode (no color, no prompts).
@@ -150,4 +150,4 @@ A clean scan exits with code `0` and shows no critical or high findings.
 
 - [Red-team your MCP servers](red-team-mcp.md) with adversarial payloads
 - [Add HMA to your CI/CD pipeline](ci-pipeline.md)
-- See the full [Security Checks Reference](../SECURITY_CHECKS.md) for all 187 checks
+- See the full [Security Checks Reference](../SECURITY_CHECKS.md) for all 310 static checks

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hackmyagent",
-  "version": "0.25.0",
+  "version": "0.25.1",
   "description": "Find it. Break it. Fix it. The hacker's toolkit for AI agents.",
   "bin": {
     "hackmyagent": "dist/cli.js"

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -79,7 +79,7 @@ const TELEMETRY_TOOL = 'hackmyagent';
 const NON_TRACKED_TELEMETRY_COMMANDS = new Set<string>(['telemetry', 'help']);
 // Per-invocation start times keyed by subcommand name (preAction → postAction).
 const telemetryStartedAt = new Map<string, number>();
-import { getTaxonomyMap } from './hardening/taxonomy';
+import { getTaxonomyMap, getCheckCounts } from './hardening/taxonomy';
 import { compareFindingsByTier } from './ui/finding-tier';
 import {
   scoreLineLabel,
@@ -94,19 +94,15 @@ import { trustAapGate } from './aap';
 const program = new Command();
 program.showHelpAfterError('(run with --help for usage)');
 
-// Total security check count + distinct category count, derived from the
-// taxonomy map (the same source check-metadata reads). Previously CHECK_COUNT
-// was hardcoded (209) and the category count was hardcoded in help text as
-// "60 categories" — both drifted. Deriving from the taxonomy keeps --help,
-// command descriptions, and check-metadata consistent without manual bumps.
-const CHECK_IDS = Object.keys(getTaxonomyMap());
-const CHECK_COUNT = CHECK_IDS.length;
-const CATEGORY_COUNT = new Set(
-  CHECK_IDS.map(id => {
-    const parts = id.split('-');
-    return (parts.length > 1 ? parts.slice(0, -1).join('-') : parts[0]).toLowerCase();
-  }),
-).size;
+// Total security check + category counts, derived from the taxonomy map via
+// getCheckCounts() — the single source of truth shared by --help, command
+// descriptions, the scan Observations block, and check-metadata. Previously
+// CHECK_COUNT was hardcoded and the scan display carried a separate hardcoded
+// "209 static" that contradicted --help; deriving both from one place keeps
+// every surface consistent without manual bumps.
+const CHECK_COUNTS = getCheckCounts();
+const CHECK_COUNT = CHECK_COUNTS.total;
+const CATEGORY_COUNT = CHECK_COUNTS.totalCategories;
 
 // How long registry-cached scan data is considered fresh before `check` re-scans.
 const STALE_SCAN_DAYS = 3;
@@ -1097,11 +1093,10 @@ function displayUnifiedCheck(opts: UnifiedCheckDisplayOptions): void {
   // briefs/cli-observation-verdict-ux.md [CPO-019]; intended home is
   // `@opena2a/cli-ui` per [CA-030] — inlined here pending step-0d.
   if (localScan || nanomindScan) {
-    // HMA advertises 209 static checks across 44 categories. Display
-    // the advertised count (not the findings count); a count of 0
-    // would be misleading.
-    const HMA_STATIC_CHECK_COUNT = 209;
-    const staticCount = HMA_STATIC_CHECK_COUNT;
+    // Static rule-check suite size, derived from the taxonomy (single source
+    // of truth, same as --help and check-metadata). This is the advertised
+    // suite size, not the findings count; a count of 0 would be misleading.
+    const staticCount = getCheckCounts().static;
     const semanticCount = nanomindScan?.compiledArtifacts ?? 0;
     const filesScanned = localScan?.filesScanned;
     // HMA-2: prefer registry.packageType (authoritative) over the local
@@ -7524,7 +7519,18 @@ program
       }
     }
 
-    writeJsonStdout({ totalChecks: Object.keys(metadata).length, checks: metadata });
+    // Summary counts come from the single source of truth (getCheckCounts,
+    // derived from the taxonomy) so this JSON, --help, and the scan display
+    // never disagree. `checks` still lists every metadata entry.
+    const counts = getCheckCounts();
+    writeJsonStdout({
+      totalChecks: counts.total,
+      staticChecks: counts.static,
+      semanticChecks: counts.semantic,
+      categories: counts.totalCategories,
+      staticCategories: counts.staticCategories,
+      checks: metadata,
+    });
   });
 
 // Show help and exit 0 when no arguments provided

--- a/src/hardening/taxonomy.ts
+++ b/src/hardening/taxonomy.ts
@@ -525,6 +525,58 @@ export function getTaxonomyMap(): Record<string, string> {
 }
 
 /**
+ * Check-ID prefixes for the NanoMind semantic (AST) layer. Everything else in
+ * the taxonomy is a static rule check.
+ */
+const SEMANTIC_CHECK_PREFIXES = ['SEM-', 'AST-'] as const;
+
+function isSemanticCheckId(checkId: string): boolean {
+  return SEMANTIC_CHECK_PREFIXES.some(p => checkId.startsWith(p));
+}
+
+/** Category slug for a check ID: everything before the trailing "-NNN" index. */
+function categoryOf(checkId: string): string {
+  const parts = checkId.split('-');
+  return (parts.length > 1 ? parts.slice(0, -1).join('-') : parts[0]).toLowerCase();
+}
+
+export interface CheckCounts {
+  /** Total distinct checks (static + semantic). */
+  total: number;
+  /** Static rule checks (non SEM-/AST-). */
+  static: number;
+  /** NanoMind semantic (AST) checks present in the taxonomy. */
+  semantic: number;
+  /** Distinct categories across all checks. */
+  totalCategories: number;
+  /** Distinct categories across static checks only. */
+  staticCategories: number;
+}
+
+/**
+ * The single source of truth for every user-facing check/category count.
+ * Derived from TAXONOMY_MAP so `--help`, command descriptions, the scan
+ * Observations block, `check-metadata`, README and docs cannot drift apart.
+ * Before this existed the scan display hardcoded "209 static / 44 categories"
+ * while --help derived 323/74 from the same map — a self-contradiction a user
+ * running the CLI could see. Keep the golden values in
+ * `__tests__/hardening/check-count-consistency.test.ts` updated when the
+ * taxonomy changes; that test fails on drift by design.
+ */
+export function getCheckCounts(): CheckCounts {
+  const ids = Object.keys(TAXONOMY_MAP);
+  const staticIds = ids.filter(id => !isSemanticCheckId(id));
+  const semanticIds = ids.filter(isSemanticCheckId);
+  return {
+    total: ids.length,
+    static: staticIds.length,
+    semantic: semanticIds.length,
+    totalCategories: new Set(ids.map(categoryOf)).size,
+    staticCategories: new Set(staticIds.map(categoryOf)).size,
+  };
+}
+
+/**
  * Enrich an array of SecurityFindings with their attack class mappings.
  * Modifies findings in place. Findings that already carry an `attackClass`
  * (set inline at the emission site, e.g. `AST-CRED-001` →

--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -31,12 +31,15 @@ import {
   toSecurityFindings,
   buildDeepScanResult,
 } from './semantic';
+import { getCheckCounts } from './hardening/taxonomy';
+
+const MCP_CHECK_COUNTS = getCheckCounts();
 
 const TOOL_DEFINITIONS = [
   {
     name: 'hackmyagent_scan',
     description:
-      'Scan the current project for AI agent security issues. Runs 187 security checks across 39 categories: credentials, MCP configs, permissions, git security, dependencies, and more. Returns actionable findings with severity and fix recommendations.',
+      `Scan the current project for AI agent security issues. Runs ${MCP_CHECK_COUNTS.total} security checks across ${MCP_CHECK_COUNTS.totalCategories} categories: credentials, MCP configs, permissions, git security, dependencies, and more. Returns actionable findings with severity and fix recommendations.`,
     inputSchema: {
       type: 'object' as const,
       properties: {


### PR DESCRIPTION
## The bug

HackMyAgent reported three different check counts for the same tool:

- `secure` scan Observations block: **209 static checks / 44 categories** (hardcoded `HMA_STATIC_CHECK_COUNT = 209`)
- `--help` + `check-metadata`: **323 checks / 74 categories** (derived from the taxonomy)
- `docs/SECURITY_CHECKS.md` and use-case docs: **187 / 39**

A user running `hackmyagent secure` then `hackmyagent --help` sees the tool contradict itself. For a security scanner, that undermines credibility. The "209" was also simply wrong — the real static count is 310.

## The fix

One source of truth. Added `getCheckCounts()` to `src/hardening/taxonomy.ts`, derived from `TAXONOMY_MAP`:

| | value |
|---|---|
| total checks | 323 |
| static (non SEM-/AST-) | 310 |
| semantic (in taxonomy) | 13 |
| total categories | 74 |
| static categories | 69 |

Every surface now reads it: the scan Observations block (`getCheckCounts().static` → 310), `--help`/command descriptions (`CHECK_COUNT` → 323), the MCP tool description, and `check-metadata --json` (which now also emits `staticChecks`/`semanticChecks`/`categories`/`staticCategories`). README, `SECURITY_CHECKS.md`, and the use-case docs updated to match.

Verified live after the fix — all three surfaces agree:
- `--help`: `323 checks`
- scan: `Checks  310 static · N semantic (NanoMind AST)`
- `check-metadata --json`: `totalChecks 323, staticChecks 310` (310 + 13 = 323)

## Regression test (with teeth)

`__tests__/hardening/check-count-consistency.test.ts` asserts the partition invariants, golden values, and — the part that catches this exact bug — that `src/cli.ts` no longer contains a hardcoded static-count literal and derives from `getCheckCounts()`. It fails on the pre-fix code.

## Scope

Count-reporting consistency only. No detection rule, severity, or scoring logic changed (Phase 4.5 skip condition). Full suite green: **2208 passed, 0 failures** across 160 files. Version bumped 0.25.0 → 0.25.1; CHANGELOG stamped.

## Follow-up (separate, not in this PR)

opena2a.org carries the same stale "209" across ~14 pages (the `/vs` comparison pages, `/hackmyagent`, homepage, contributions), including a "402 = 209 static + 29 semantic + 164 adversarial" total that needs recomputing against the corrected numbers. That's a separate `opena2a-website` PR (its own style-spec + website-release-test gate + Vercel deploy).