### PR TITLE
Raise the js-yaml floor to the patched 4.3.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,7 @@
         "@opena2a/telemetry": "0.3.0",
         "ai-trust": "^0.2.6",
         "commander": "^12.0.0",
-        "js-yaml": "^4.1.1",
+        "js-yaml": "^4.3.1",
         "onnxruntime-node": "^1.27.0"
       },
       "bin": {
@@ -2166,9 +2166,9 @@
       }
     },
     "node_modules/js-yaml": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
-      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
       "funding": [
         {
           "type": "github",

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "@opena2a/telemetry": "0.3.0",
     "ai-trust": "^0.2.6",
     "commander": "^12.0.0",
-    "js-yaml": "^4.1.1",
+    "js-yaml": "^4.3.1",
     "onnxruntime-node": "^1.27.0"
   },
   "devDependencies": {


### PR DESCRIPTION
GHSA-5p4m-2wfm-xmqj — quadratic CPU consumption in `!!omap` resolution, severity high, affecting `js-yaml` 4.0.0 through 4.3.0. The lockfile sat on 4.3.0.

**Not introduced by any open PR.** The `Dependency audit` gate was green on `main` at 2026-08-06T12:38Z and red from 2026-08-07T01:08Z, on a lockfile nothing had touched in between — the advisory was published in that window. It is currently red on `main` and on every open pull request, including #420.

The floor moves to `^4.3.1`, not a caret at the version installed today. That is the mistake the 0.26.0 override work was cleaning up: a caret range's lower bound is where the lockfile settles, so `^<today's version>` freezes the tree on exactly the version the next advisory gets published against. `^4.3.1` cannot resolve back into the affected range.

`js-yaml` is a direct dependency and is also deduped under `@opena2a/aim-core`, `@opena2a/aim-sdk` and the `hackmyagent` copy inside `ai-trust`, so one bump covers all four.

## Evidence

```
before: npm audit --package-lock-only --audit-level=high  ->  1 high (js-yaml 4.3.0)
after:  npm audit --package-lock-only --audit-level=high  ->  found 0 vulnerabilities
resolved: node_modules/js-yaml 4.3.1
```

Suite unchanged: 236 files / 3285 tests, 0 failures. Diff is `package.json` + `package-lock.json`, 5 insertions / 5 deletions.