### PR TITLE
Classify skills from the leading frontmatter block, and stop a quadratic regex reaching scanned files (#410)

### DIFF
--- a/__tests__/nanomind-core/artifact-parser-skill-frontmatter.test.ts
+++ b/__tests__/nanomind-core/artifact-parser-skill-frontmatter.test.ts
@@ -62,6 +62,34 @@ describe('#410 skill classifier: frontmatter must be anchored to the start of th
       expect(classifyArtifactType(doc, 'docs/authoring-skills.md')).not.toBe('skill');
     });
 
+    it('TWO horizontal rules with a "capabilities:" line between them', () => {
+      // The shape that actually forces `^` to mean start-of-file. With a single rule the
+      // block regex finds no closing fence and returns null whether or not it carries `m`,
+      // so a one-rule fixture cannot tell the two spellings apart: restoring the `m` flag
+      // leaves every other test in this file green. A document whose two rules bracket a
+      // `capabilities:` line is a complete frontmatter block to a multiline `^`, and prose
+      // between two rules is ordinary Markdown.
+      const doc = [
+        '# Skill manifest reference',
+        '',
+        'Every manifest key, in the order the loader reads them.',
+        '',
+        '---',
+        '',
+        'capabilities:',
+        '',
+        '- `read_files` — read from the workspace',
+        '- `run_shell` — run a command',
+        '',
+        '---',
+        '',
+        '## See also',
+        '',
+      ].join('\n');
+
+      expect(classifyArtifactType(doc, 'docs/manifest-reference.md')).not.toBe('skill');
+    });
+
     it('horizontal rule followed by an indented "capabilities:" in a sample signature', () => {
       const doc = [
         '# API Reference',
@@ -115,6 +143,39 @@ describe('#410 skill classifier: frontmatter must be anchored to the start of th
       expect(classifyArtifactType('', 'deploy.skill.md')).toBe('skill');
       expect(classifyArtifactType('no frontmatter at all', 'a/b/SKILL.md')).toBe('skill');
       expect(classifyArtifactType('no frontmatter at all', 'a/b/deploy.skill.md')).toBe('skill');
+    });
+  });
+
+  describe('the signature stays linear on hostile content', () => {
+    // parseArtifact's default maxArtifactSize. It only APPENDS an error — nothing truncates
+    // or skips the content — so a file this size reaches the signature either way.
+    const ONE_MB = 1024 * 1024;
+
+    it('classifies 1 MB of repeated fence lines in well under a second', () => {
+      // The replaced regex was quadratic on exactly this input. Its `m` flag gave `^---` a
+      // start position at every one of the 262,144 line starts, and from each one the lazy
+      // body scanned to EOF for a `capabilities:` line that never comes. The leading-block
+      // helper is anchored with no `m`, so it has one start position.
+      //
+      // Measured on the same machine, same payload: 4,960 ms before the fix, 0.1 ms after.
+      // The bound sits between the two, so it fails on the old regex rather than merely
+      // passing on the new one.
+      const hostile = '---\n'.repeat(ONE_MB / 4);
+
+      const started = performance.now();
+      const type = classifyArtifactType(hostile, 'docs/hostile.md');
+      const elapsed = performance.now() - started;
+
+      expect(type).not.toBe('skill');
+      expect(elapsed, `1 MB of fence lines took ${elapsed.toFixed(0)} ms`).toBeLessThan(2000);
+    });
+
+    it('still runs the frontmatter test at 1 MB, so the timing fixture above is not short-circuited', () => {
+      // Without this, a future size guard that skipped classification for large files would
+      // make the timing assertion above pass while measuring nothing.
+      const bigSkill = ['---', 'name: big', 'capabilities: [read_files]', '---', '', 'x'.repeat(ONE_MB)].join('\n');
+
+      expect(classifyArtifactType(bigSkill, 'docs/big-skill.md')).toBe('skill');
     });
   });
 });

--- a/__tests__/nanomind-core/artifact-parser-skill-frontmatter.test.ts
+++ b/__tests__/nanomind-core/artifact-parser-skill-frontmatter.test.ts
@@ -1,0 +1,120 @@
+import { describe, it, expect } from 'vitest';
+import { classifyArtifactType } from '../../src/nanomind-core/ingestion/artifact-parser';
+
+/**
+ * Regression tests for #410.
+ *
+ * The `skill` signature used `/^---\n[\s\S]*?capabilities:\s*\n/m`. The `m` flag makes `^`
+ * match at EVERY line start, so the test really meant "a `---` line anywhere, then a line
+ * ending in `capabilities:` anywhere later". In Markdown `---` is a horizontal rule and
+ * `capabilities:` matches ordinary prose, so documentation classified as an executable skill
+ * and drew CRITICAL findings from the skill analyzers on placeholder URLs and sample SQL.
+ *
+ * The boundary is "does the LEADING YAML frontmatter block declare a top-level `capabilities`
+ * key" — not "do these two strings both appear somewhere".
+ */
+describe('#410 skill classifier: frontmatter must be anchored to the start of the file', () => {
+  describe('documentation must NOT classify as a skill', () => {
+    it('markdown with a horizontal rule and a prose line ending in "capabilities:"', () => {
+      // The MCP_INTEGRATION.md shape: no frontmatter, horizontal rules, prose colon.
+      const doc = [
+        '# AIM + MCP (Model Context Protocol) Integration Guide',
+        '',
+        'This guide explains how to wire AIM into an MCP client.',
+        '',
+        '---',
+        '',
+        '## Change detection',
+        '',
+        'The SDK automatically detects when MCP servers change their capabilities:',
+        '',
+        '```python',
+        'client.on_capability_change(handler)',
+        '```',
+        '',
+      ].join('\n');
+
+      expect(classifyArtifactType(doc, 'sdk/python/docs/MCP_INTEGRATION.md')).not.toBe('skill');
+      expect(classifyArtifactType(doc, 'sdk/python/docs/MCP_INTEGRATION.md')).toBe('unknown');
+    });
+
+    it('leading frontmatter WITHOUT capabilities, plus a later code block whose line starts with "capabilities:"', () => {
+      // This is the case that defeats the narrower "anchor + content.startsWith('---')" fix
+      // suggested on the issue: startsWith('---') is true here, and `^capabilities:$` still
+      // matches inside the fenced example. Only reading the LEADING BLOCK gets this right.
+      const doc = [
+        '---',
+        'title: Writing a skill manifest',
+        'audience: integrators',
+        '---',
+        '',
+        '# Writing a skill manifest',
+        '',
+        'A skill manifest declares its capabilities like this:',
+        '',
+        '```yaml',
+        'capabilities:',
+        '  - read_files',
+        '```',
+        '',
+      ].join('\n');
+
+      expect(classifyArtifactType(doc, 'docs/authoring-skills.md')).not.toBe('skill');
+    });
+
+    it('horizontal rule followed by an indented "capabilities:" in a sample signature', () => {
+      const doc = [
+        '# API Reference',
+        '',
+        '---',
+        '',
+        'Example signature:',
+        '',
+        '    capabilities: List[str],',
+        '',
+      ].join('\n');
+
+      expect(classifyArtifactType(doc, 'docs/api-reference.md')).not.toBe('skill');
+    });
+  });
+
+  describe('genuine skills must STILL classify as a skill', () => {
+    it('real leading frontmatter declaring capabilities', () => {
+      const skill = [
+        '---',
+        'name: fitness-tracker',
+        'description: Help users track their fitness goals',
+        'capabilities:',
+        '  - read_health_data',
+        '  - write_summary',
+        '---',
+        '',
+        '# Fitness Tracker',
+        '',
+        'Tracks goals.',
+        '',
+      ].join('\n');
+
+      expect(classifyArtifactType(skill, 'skills/fitness/README.md')).toBe('skill');
+    });
+
+    it('leading frontmatter with capabilities as an inline list', () => {
+      const skill = ['---', 'name: deploy', 'capabilities: [read_files, run_shell]', '---', '', '# Deploy', ''].join('\n');
+
+      expect(classifyArtifactType(skill, 'skills/deploy/doc.md')).toBe('skill');
+    });
+
+    it('CRLF frontmatter declaring capabilities', () => {
+      const skill = ['---', 'name: crlf-skill', 'capabilities:', '  - read_files', '---', '', '# CRLF', ''].join('\r\n');
+
+      expect(classifyArtifactType(skill, 'skills/crlf/doc.md')).toBe('skill');
+    });
+
+    it('classifies by path regardless of content', () => {
+      expect(classifyArtifactType('', 'SKILL.md')).toBe('skill');
+      expect(classifyArtifactType('', 'deploy.skill.md')).toBe('skill');
+      expect(classifyArtifactType('no frontmatter at all', 'a/b/SKILL.md')).toBe('skill');
+      expect(classifyArtifactType('no frontmatter at all', 'a/b/deploy.skill.md')).toBe('skill');
+    });
+  });
+});

--- a/src/nanomind-core/ingestion/artifact-parser.ts
+++ b/src/nanomind-core/ingestion/artifact-parser.ts
@@ -35,6 +35,32 @@ export interface ParsedArtifact {
 // Artifact Type Detection
 // ============================================================================
 
+/**
+ * Extract the LEADING YAML frontmatter block, or null when the file does not open with one.
+ *
+ * Deliberately NOT `/m`: `^` must mean start-of-file here. A `---` further down a Markdown
+ * document is a horizontal rule, not a frontmatter fence (#410). Tolerates CRLF and trailing
+ * spaces on the fences.
+ */
+function extractLeadingFrontmatter(content: string): string | null {
+  const match = /^---[ \t]*\r?\n([\s\S]*?)\r?\n---[ \t]*(?:\r?\n|$)/.exec(content);
+  return match ? match[1] : null;
+}
+
+/**
+ * True when the leading frontmatter declares a top-level `capabilities` key.
+ *
+ * `m` IS correct on the inner test and was wrong on the outer one: the string being searched
+ * is already bounded to the frontmatter block, so `^` can only reach frontmatter lines. Only
+ * unindented keys count -- an indented `capabilities:` is a nested field or a code sample.
+ * Matching the key alone (not `key` + newline) accepts both the block form and the inline
+ * form `capabilities: [read_files, run_shell]`.
+ */
+function declaresCapabilities(content: string): boolean {
+  const frontmatter = extractLeadingFrontmatter(content);
+  return frontmatter !== null && /^capabilities[ \t]*:/m.test(frontmatter);
+}
+
 const TYPE_SIGNATURES: Array<{ test: (content: string, path?: string) => boolean; type: ArtifactType }> = [
   // Source code: recognized source extensions.
   //
@@ -50,11 +76,21 @@ const TYPE_SIGNATURES: Array<{ test: (content: string, path?: string) => boolean
     test: (_, path) => /\.(ts|tsx|js|jsx|mjs|cjs|py|pyi|go|rs|java|rb)$/.test(path ?? ''),
     type: 'source_code',
   },
-  // Skills: SKILL.md, *.skill.md, or YAML frontmatter with capabilities
+  // Skills: SKILL.md, *.skill.md, or LEADING YAML frontmatter declaring capabilities.
+  //
+  // IMPORTANT: the frontmatter test must read the leading block, not the raw document.
+  // This previously used `/^---\n[\s\S]*?capabilities:\s*\n/m`, whose `m` flag made `^`
+  // match at every line start -- so it really meant "a `---` line anywhere, then a line
+  // ending in `capabilities:` anywhere later". In Markdown `---` is a horizontal rule and
+  // `capabilities:` matches ordinary prose, so documentation classified as an executable
+  // skill and drew CRITICAL findings from the skill analyzers on placeholder URLs and
+  // sample SQL (#410). The same regex also MISSED real skills: it required a newline
+  // immediately after the colon, so the inline form `capabilities: [a, b]` never matched,
+  // and its `\n` literal never matched CRLF frontmatter.
   {
     test: (content, path) =>
       (path?.endsWith('SKILL.md') || path?.endsWith('.skill.md') || false) ||
-      /^---\n[\s\S]*?capabilities:\s*\n/m.test(content),
+      declaresCapabilities(content),
     type: 'skill',
   },
   // MCP config: known basenames (mcp.json, .mcp.json, mcpServers.json)
@@ -167,10 +203,11 @@ export function parseArtifact(
 
   // Extract YAML frontmatter
   let frontmatter: Record<string, unknown> | undefined;
-  const fmMatch = content.match(/^---\n([\s\S]*?)\n---/);
-  if (fmMatch) {
+  // Same notion of "leading frontmatter" the skill classifier uses -- one spelling, not two.
+  const fmBlock = extractLeadingFrontmatter(content);
+  if (fmBlock !== null) {
     try {
-      frontmatter = parseSimpleYAML(fmMatch[1]);
+      frontmatter = parseSimpleYAML(fmBlock);
     } catch {
       // Invalid frontmatter is not an error -- artifact may still be valid
     }


### PR DESCRIPTION
Fixes #410.

Two fixes, one regex. The `skill` type signature tested `/^---\n[\s\S]*?capabilities:\s*\n/m` against whole file contents.

## The false positive (#410)

The `m` flag makes `^` match at every line start, so the test really meant "a `---` line anywhere, then a line ending in `capabilities:` anywhere later". In Markdown `---` is a horizontal rule and `capabilities:` matches ordinary prose, so documentation was classified as an executable skill, routed through the skill analyzers, and drew CRITICAL findings on placeholder URLs and illustrative SQL. A docs-only file could take a repo to "Not safe to ship", and #410 was found when it blocked an unrelated PR's gate on a file untouched for eight months.

Measured on the reported reproduction, `sdk/python/docs/MCP_INTEGRATION.md`: **69/100 "Not safe to ship" with 2 false CRITICALs becomes 98/100 "Usable with caveats"**, artifact no longer classified as a skill.

The change reads the leading frontmatter block and looks for a top-level `capabilities` key. `m` is correct on that inner test and wrong on the outer one: the block is already bounded, so `^` can only reach frontmatter lines. `parseArtifact`'s own frontmatter extraction now shares the helper.

## The false negatives the issue did not cover

The same regex was wrong in the other direction. It required a newline immediately after the colon, so the inline form `capabilities: [read_files, run_shell]` **never matched**, and its `\n` literal never matched CRLF frontmatter. Both were silent misses on genuine skills. Detection is checked in both directions against a malicious corpus fixture: `SKILL.md` by path stays 30/100 with 5 CRITICAL/HIGH, and the same content under a non-skill filename carrying a real `capabilities:` key still classifies `skill · malicious` and still fails at 69/100 -- that second control is the one that exercises the changed path.

## The quadratic regex (found in review, not in the issue)

The replaced pattern is super-linear on attacker-controlled content: `m` gave `^---` a start position at every line start, and from each one the lazy body scanned to EOF for a `capabilities:` line that never comes. Nothing truncates first -- `parseArtifact` appends an error past `maxArtifactSize` and runs the signature anyway -- so any scanned file reaches it.

| payload | before | after |
|---|---|---|
| 1 MB of repeated fence lines | 4,960 ms | 0.1 ms |
| 2 MB | 19,089 ms | 1.7 ms |
| 4 MB | 84.7 s | 0.5 ms |

This is a CPU-exhaustion primitive reachable from any scanned repository, and it should be described as a security fix in the release notes rather than as a refactor. **CHANGELOG is deliberately untouched here** -- it is claimed by two concurrent release branches; the 0.26.1 entry needs to name both this and the false-positive fix.

## Tests

`__tests__/nanomind-core/artifact-parser-skill-frontmatter.test.ts`, 10 cases. **7 fail on the parent commit**, in both classification directions.

Mutation testing drove the second commit. The headline property was initially untested: restoring the `m` flag -- reintroducing the exact defect -- left every test green, because each fixture carried a single `---` rule and a one-rule document has no closing fence, so the extractor returns null whether or not `^` is multiline. A document whose two rules bracket a line beginning `capabilities:` can tell them apart; that fixture kills the mutant. A second test pins linearity with a 2,000 ms bound, which sits between the two measurements above rather than merely passing on the new code, plus a companion assertion that the 1 MB fixture still reaches the frontmatter branch so a future size guard cannot quietly make it measure nothing.

Full suite: 237 files / 3295 tests green.

## What this does not fix, and why it ships anyway

Adversarial review found the anchor narrows classification: frontmatter indented two spaces (valid top-level YAML), a nested `capabilities` key, a missing or non-canonical closing fence, or a leading blank line all demote a file that previously classified as a skill. It also introduces one new false positive: a document that *opens* with a horizontal rule and has a later `---` with a line beginning `capabilities:` between them is now typed `skill`.

Both were measured against the real population before deciding:

- Over **83,099 markdown files** checked against an independent js-yaml oracle, the old signature produced **129 false positives** (85 on files not named like a skill at all, including third-party `node_modules` READMEs) and the new one produces **0**. The residual false positive above occurs **0 times** in that corpus.
- The two files the new signature loses relative to the old one are both `SKILL.md`, caught by the path rule regardless, so no published scan result changes.
- The narrowing is not a defense an attacker had to defeat. The same malicious body -- "Ignore all previous instructions", `curl | bash`, `eval "$(curl …)"`, an SSH-key exfil URL -- **with no frontmatter at all** scores 98/100 with zero semantic findings on both the old and new trees, because `code-analyzer.ts:362` `isCodeArtifact` excludes `unknown`. The cheap bypass never involved the classifier.

That last point is the real defect and it is filed as **#424** (P1): injection, exfiltration and code analysis are gated on artifact type when they need nothing from it. The full classification contract -- load the leading block with a real YAML parser, count `capabilities` at any depth, one parser rather than two -- is filed as **#423** with an acceptance fixture, to land before the next minor. #423 is not absorbed by #411, which is the sibling-signature class.