### PR TITLE
Stop `secure` reporting a category clear while hiding its own finding (#421)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,83 @@
 
 All notable changes to HackMyAgent are documented in this file.
 
+## [Unreleased]
+
+### Security
+
+- **`secure` reported `logging` as clear while holding a HIGH finding it had already
+  made.** `LOG-002` read `server.js`, matched `console.log(password` in it, and pushed a
+  failed HIGH. The run then printed:
+
+  ```
+  Security    98/100
+  Checks      … 61 of 61 check groups ran … 2 files read by static checks
+  Categories  git hygiene (1 low) · 16 others clear
+  ```
+
+  Two separate filters dropped it, and fixing either alone left it invisible. The check
+  never recorded WHICH file it matched, and findings without a file path are filtered out
+  as generic advice — so the detection reached neither the output nor the score on any
+  project type. Separately, the whole `LOG-` group was scoped to webapp/api/mcp projects,
+  which removed it from `allFindings` on a library as well.
+
+  `LOG-002` now carries the file and line it matched, and is scoped to every project type:
+  code that logs a password is wrong in a library exactly as much as in an API. The same
+  fixture now reports `Sensitive Data in Logs in server.js:1` and scores 69, identically
+  whether it is detected as a library or an API.
+
+  Bringing the check back into the score made its pattern load-bearing for the first time,
+  so it was tightened at the same time. It no longer fires on an identifier that merely
+  starts with the keyword (`console.log(tokenCount)`), nor on the pattern inside a comment
+  or a string — a comment recording that the bug was removed used to be enough to fail a
+  project. The reported line is counted on the original text rather than a lowercased copy,
+  which is not length-preserving and let a file shift the line number in its own finding.
+
+  **That boundary also narrows detection, in a direction worth knowing.** The check matches
+  the four spellings it always did and now requires the identifier to end there, so
+  `console.log(secretKey)` and `console.log(passwords)` are NOT flagged, and neither are
+  `console.error(password)`, `console.log( password )`, or a match on a line long enough to
+  hit the string-literal walker's iteration cap. None of these reached the output before
+  either — the finding was being dropped for every input — so nothing regresses against
+  0.26.0, but the check is a narrow literal matcher and should not be read as coverage of
+  logged credentials in general. Tracked with the wider class in #426.
+
+  **Expect scores to move on upgrade.** A project containing a logged credential will score
+  LOWER than it did on 0.26.0. The finding was always there; it was never shown.
+
+- **The run now says how many checks failed without being shown.** This is the reason the
+  finding above was invisible rather than merely wrong: a scan that silences a failed check
+  and then prints `61 of 61 check groups ran` and a list of clear categories is
+  indistinguishable from a scan that found nothing.
+
+  On a clean three-file library (`package.json`, `.gitignore`, `index.js`):
+
+  ```
+  Coverage    17 of 25 categories examined · 8 unexamined (read no file) · 45 checks reported an absent mitigation (not shown)
+  ```
+
+  Most silenced checks report the ABSENCE of a mitigation rather than a discovery — "no
+  rate limiting detected" on a library with no HTTP server. That library carries 45 of
+  them, two nominally critical. They are counted, never named per category: they found
+  nothing, so they do not make a `clear` claim false, and listing them by category would be
+  a wall of categories the reader cannot act on.
+
+  A check that MATCHED something and was dropped anyway — because the check does not apply
+  to the detected project type — is different, and that category is now named on an
+  `Unresolved` line instead of being counted as clear. This is not hypothetical: an
+  ordinary library carrying an `mcp.json` that binds a server to `0.0.0.0` scores 98/100
+  with a CRITICAL `NET-001` matched and discarded, because `NET-` is scoped to
+  webapp/api. The finding is still not shown — that is a separate problem, tracked in
+  #426 — but the category no longer claims to be clear:
+
+  ```
+  Unresolved  network
+  Categories  git hygiene (1 low) · 17 others clear
+  ```
+
+  `secure --json` gains `coverage.suppressedFailures` (each silenced detection's identity,
+  never a path or a message) and `coverage.unevidencedFailures` (the count above).
+
 ## [0.26.1] - 2026-08-07
 
 ### Security

--- a/__tests__/hardening/check-project-types-order.test.ts
+++ b/__tests__/hardening/check-project-types-order.test.ts
@@ -1,0 +1,113 @@
+// `CHECK_PROJECT_TYPES` is resolved by FIRST match in declaration order, so a
+// full check ID only overrides the group it belongs to while it is declared
+// ABOVE that group. Nothing in the language enforces that: reordering the map,
+// or a merge that reflows it, silently sends the specific key back to its
+// group and removes a check from project types it was applying to.
+//
+// #421 rides on exactly this — `LOG-002` sits above `LOG-` so it applies
+// everywhere while its advice-style siblings stay server-scoped. The
+// alternative (resolve the longest key, no ordering dependency) was tried and
+// reverted: two entries in the map are narrower than their group and had never
+// taken effect, so activating them SUBTRACTED project types from unrelated
+// checks — `SANDBOX-005` stopped applying to `webapp` and `api`.
+//
+// This asserts the ordering directly, and reports what a reorder would cost.
+
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { findingAppliesTo } from '../../src/hardening/scanner';
+import type { SecurityFinding, ProjectType } from '../../src/hardening/security-check';
+
+const SOURCE = readFileSync(
+  join(__dirname, '..', '..', 'src', 'hardening', 'scanner.ts'),
+  'utf-8',
+);
+
+/** Declaration order of the map's keys, as written. */
+function declaredKeys(): { key: string; types: string[] }[] {
+  const start = SOURCE.indexOf('const CHECK_PROJECT_TYPES');
+  expect(start, 'CHECK_PROJECT_TYPES not found — did it move or get renamed?')
+    .toBeGreaterThan(-1);
+  const block = SOURCE.slice(start, SOURCE.indexOf('\n};', start));
+  const entries = [...block.matchAll(/^\s*'([A-Za-z0-9_-]+)':\s*\[([^\]]*)\]/gm)].map(m => ({
+    key: m[1],
+    types: m[2].replace(/[^a-z,]/g, '').split(',').filter(Boolean),
+  }));
+  // The parser is a regex over source. If the map grows a spelling it cannot
+  // see (a double-quoted key, a multi-line array) that entry vanishes and every
+  // assertion below passes vacuously for it. Pin the count so that fails loudly
+  // rather than silently reducing coverage.
+  expect(entries.length, 'parsed far fewer entries than the map holds — the parser missed a spelling')
+    .toBeGreaterThanOrEqual(50);
+  return entries;
+}
+
+function finding(checkId: string): SecurityFinding {
+  return {
+    checkId,
+    name: 'synthetic',
+    description: 'synthetic',
+    category: 'synthetic',
+    severity: 'high',
+    passed: false,
+    message: 'synthetic',
+    fixable: false,
+  };
+}
+
+const PROJECT_TYPES: ProjectType[] = [
+  'cli', 'library', 'sdk', 'webapp', 'api', 'mcp', 'openclaw',
+];
+
+describe('CHECK_PROJECT_TYPES declaration order', () => {
+  it('declares every full-ID override above the group it overrides', () => {
+    const entries = declaredKeys();
+    const misordered: string[] = [];
+    entries.forEach((specific, si) => {
+      entries.forEach((group, gi) => {
+        if (specific.key === group.key) return;
+        if (!specific.key.startsWith(group.key)) return;
+        // `specific` is only reachable while it precedes `group`.
+        if (gi < si) {
+          misordered.push(
+            `'${specific.key}' is declared AFTER its group '${group.key}', so it is unreachable ` +
+            `and '${specific.key}' silently resolves to [${group.types.join(', ')}]`,
+          );
+        }
+      });
+    });
+    // Entries that ARE unreachable today are listed explicitly rather than
+    // asserted away, so adding a third one is a visible change.
+    const KNOWN_UNREACHABLE = [
+      "'SKILL-MEM-' is declared AFTER its group 'SKILL-'",
+      "'SANDBOX-005' is declared AFTER its group 'SANDBOX-'",
+    ];
+    const unexpected = misordered.filter(
+      m => !KNOWN_UNREACHABLE.some(k => m.startsWith(k)),
+    );
+    expect(unexpected, unexpected.join('\n')).toEqual([]);
+  });
+
+  // The consequence, asserted on behaviour rather than on the source text, so
+  // the two cannot disagree.
+  it('resolves LOG-002 ahead of the LOG- group', () => {
+    for (const t of PROJECT_TYPES) {
+      expect(findingAppliesTo(finding('LOG-002'), t), `LOG-002 must apply to ${t}`).toBe(true);
+    }
+    // Its siblings stay where they were, which is what proves the override is
+    // the specific entry and not a widening of the group.
+    expect(findingAppliesTo(finding('LOG-001'), 'library')).toBe(false);
+    expect(findingAppliesTo(finding('LOG-003'), 'library')).toBe(false);
+  });
+
+  // A reorder that buries LOG-002 under LOG- is the regression this file
+  // exists for; this states the cost in the failure message.
+  it('keeps the two known-unreachable entries behaving as their group', () => {
+    // If either of these ever becomes reachable, its own narrower list applies
+    // and the check STOPS applying to project types it currently covers.
+    expect(findingAppliesTo(finding('SANDBOX-005'), 'webapp')).toBe(true);
+    expect(findingAppliesTo(finding('SANDBOX-005'), 'api')).toBe(true);
+    expect(findingAppliesTo(finding('SKILL-MEM-001'), 'library')).toBe(true);
+  });
+});

--- a/__tests__/hardening/log-finding-loss.test.ts
+++ b/__tests__/hardening/log-finding-loss.test.ts
@@ -1,0 +1,452 @@
+// Regression gate for #421 — a HIGH check ran, matched, and reached neither
+// `findings` nor `allFindings`.
+//
+// `checkLoggingSecurity` read `server.js`, matched `console.log(password`, and
+// pushed LOG-002 with `passed: false`. The run then printed 98/100, `logging`
+// inside "16 others clear", and `61 of 61 check groups ran`. LOG-003 — pushed
+// LATER IN THE SAME METHOD — survived, so it was never "the check did not run"
+// and never "passed findings are filtered".
+//
+// Two independent causes, and fixing either alone leaves the finding invisible:
+//
+//   1. LOG-002 emitted no `file`. `filteredFindings` drops every pathless
+//      finding ("concrete findings, not generic advice"), so the detection was
+//      cut from the user-facing array AND from the score on EVERY project type
+//      — including `webapp`/`api`, where scoping already allowed it.
+//   2. `CHECK_PROJECT_TYPES` scoped the whole `LOG-` group to webapp/api/mcp,
+//      so on a `library` it was cut from `allFindings` as well.
+//
+// Layer 1 (contract) pins the scoping decision and runs everywhere. Layer 2
+// (spawned CLI) proves the finding actually reaches the output and the score,
+// which the contract layer would still pass if the emission bug came back.
+
+import { describe, it, expect, beforeAll } from 'vitest';
+import { spawnSync } from 'node:child_process';
+import { existsSync, mkdtempSync, mkdirSync, writeFileSync, readFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { findingAppliesTo } from '../../src/hardening/scanner';
+import type { SecurityFinding, ProjectType } from '../../src/hardening/security-check';
+import { OBSERVATION_LABEL_WIDTH, OBSERVATION_LABELS } from '../../src/ui/quick-scan-labels';
+import { classifyCategory } from '@opena2a/cli-ui';
+import { assertDistFreshIfPresent } from '../helpers/dist-freshness';
+
+function failing(checkId: string): SecurityFinding {
+  return {
+    checkId,
+    name: `${checkId} synthetic`,
+    description: 'synthetic',
+    category: 'logging',
+    severity: 'high',
+    passed: false,
+    message: 'synthetic',
+    fixable: false,
+  };
+}
+
+describe('#421 layer 1 — LOG-002 scoping contract', () => {
+  // The bug's second cause. `library` is the project type the reported
+  // reproduction detects as; `cli` is an unrelated non-server type, included so
+  // a pass cannot come from `library` being special-cased.
+  it.each(['library', 'cli', 'webapp', 'api', 'mcp'] as const)(
+    'LOG-002 applies to a %s project — logging a password is wrong in any shape of code',
+    (projectType) => {
+      expect(findingAppliesTo(failing('LOG-002'), projectType)).toBe(true);
+    },
+  );
+
+  // This is also the order-independence proof for the lookup change. In
+  // CHECK_PROJECT_TYPES the group key `LOG-` is declared BEFORE the full ID
+  // `LOG-002`, so a first-match loop — what this used to be — resolves LOG-002
+  // to the group and returns false here. Only longest-key-wins passes.
+  it('resolves the full ID over the group it sits in, despite the group being declared first', () => {
+    expect(findingAppliesTo(failing('LOG-002'), 'library')).toBe(true);
+    expect(findingAppliesTo(failing('LOG-001'), 'library')).toBe(false);
+  });
+
+  // Scope of the siblings is UNCHANGED by this work. LOG-001 and LOG-004 are
+  // advice (no winston; no audit logging). LOG-003 is NOT advice — it stats
+  // log files and fails on a world-readable one — but it emits no `file`, so
+  // it is dropped exactly like LOG-002 was. That is the same defect in a
+  // sibling and it is tracked separately; this test pins today's scope, it
+  // does not endorse LOG-003's classification.
+  it.each(['LOG-001', 'LOG-003', 'LOG-004'])(
+    'leaves the sibling %s at the scope it already had',
+    (checkId) => {
+      expect(findingAppliesTo(failing(checkId), 'library')).toBe(false);
+      expect(findingAppliesTo(failing(checkId), 'api')).toBe(true);
+    },
+  );
+
+  it('keeps the unrelated groups the map already scoped', () => {
+    // Guards against a longest-match rewrite quietly widening everything.
+    expect(findingAppliesTo(failing('MCP-010'), 'library')).toBe(false);
+    expect(findingAppliesTo(failing('INJ-003'), 'library')).toBe(false);
+    expect(findingAppliesTo(failing('CRED-001'), 'library')).toBe(true);
+  });
+
+  // The two entries that must NOT move.
+  //
+  // `findingAppliesTo` resolves the first matching key in declaration order.
+  // Switching it to longest-key-wins — which is what the map's "prefix OR full
+  // ID" wording implies, and which would remove the ordering dependency — was
+  // tried and reverted, because two entries in the map are NARROWER than the
+  // group they sit in and had never taken effect. Making them live subtracted
+  // project types: `SANDBOX-005`, a HIGH file-and-line detection for a
+  // messaging API pre-allowed in a sandbox policy, silently stopped applying
+  // to `webapp` and `api`. Widening them instead put a HIGH false positive on
+  // every clean library. Both directions are detection changes for checks that
+  // have nothing to do with #421.
+  it.each(['webapp', 'api', 'mcp'] as const)(
+    'leaves SANDBOX-005 applying to a %s project, as it always has',
+    (projectType) => {
+      expect(findingAppliesTo(failing('SANDBOX-005'), projectType)).toBe(true);
+    },
+  );
+
+  it('leaves SKILL-MEM-001 applying everywhere, as it always has', () => {
+    expect(findingAppliesTo(failing('SKILL-MEM-001'), 'library')).toBe(true);
+    expect(findingAppliesTo(failing('SKILL-MEM-001'), 'webapp')).toBe(true);
+  });
+
+  it('holds the new observation label under the column width', () => {
+    // A label of exactly OBSERVATION_LABEL_WIDTH runs into its own value after
+    // padEnd — that shipped twice before. "Inconclusive" is exactly 12.
+    expect(OBSERVATION_LABELS.unresolved.length).toBeLessThan(OBSERVATION_LABEL_WIDTH);
+  });
+});
+
+const REPO_ROOT = join(__dirname, '..', '..');
+const CLI = join(REPO_ROOT, 'dist', 'cli.js');
+
+interface ScanJson {
+  projectType: string;
+  score: number;
+  findings: Array<Record<string, unknown>>;
+  allFindings: Array<Record<string, unknown>>;
+  coverage?: {
+    suppressedFailures?: Array<Record<string, unknown>>;
+  };
+}
+
+/**
+ * Builds the exact fixture from the issue and scans it under an isolated HOME,
+ * so a stray `~/.openclaw` skill in the developer's own tree cannot appear in
+ * the results. `deps` flips the detected project type without changing a byte
+ * of the scanned code — which is the point: the same code must produce the
+ * same logging finding either way.
+ */
+function scanFixture(home: string, deps: Record<string, string> | undefined): ScanJson | null {
+  const dir = mkdtempSync(join(tmpdir(), 'hma-421-'));
+  writeFileSync(
+    join(dir, 'package.json'),
+    JSON.stringify({ name: 'x', version: '1.0.0', ...(deps ? { dependencies: deps } : {}) }),
+  );
+  writeFileSync(join(dir, 'server.js'), 'console.log(password);\n');
+  const run = spawnSync(process.execPath, [CLI, 'secure', '--json'], {
+    cwd: dir,
+    encoding: 'utf-8',
+    env: { ...process.env, HOME: home },
+    timeout: 180_000,
+  });
+  const start = run.stdout?.indexOf('{') ?? -1;
+  if (start === -1) return null;
+  try {
+    return JSON.parse(run.stdout.slice(start)) as ScanJson;
+  } catch {
+    return null;
+  }
+}
+
+function renderFixture(home: string): string {
+  const dir = mkdtempSync(join(tmpdir(), 'hma-421-txt-'));
+  writeFileSync(join(dir, 'package.json'), JSON.stringify({ name: 'x', version: '1.0.0' }));
+  writeFileSync(join(dir, 'server.js'), 'console.log(password);\n');
+  const run = spawnSync(process.execPath, [CLI, 'secure'], {
+    cwd: dir,
+    encoding: 'utf-8',
+    env: { ...process.env, HOME: home },
+    timeout: 180_000,
+  });
+  return run.stdout ?? '';
+}
+
+const canSpawn = existsSync(CLI);
+const describeSpawn = canSpawn ? describe : describe.skip;
+
+describeSpawn('#421 layer 2 — the finding reaches the output and the score', () => {
+  // #285 — without this the suite would happily measure a binary older than
+  // src/ and report a pass.
+  beforeAll(assertDistFreshIfPresent);
+
+  // One HOME for the whole suite so the classifier model is fetched at most
+  // once rather than per scan.
+  const HOME_DIR = mkdtempSync(join(tmpdir(), 'hma-421-home-'));
+  mkdirSync(HOME_DIR, { recursive: true });
+
+  let asLibrary: ScanJson | null;
+  let asServer: ScanJson | null;
+
+  beforeAll(() => {
+    asLibrary = scanFixture(HOME_DIR, undefined);
+    asServer = scanFixture(HOME_DIR, { express: '^4.18.0' });
+  });
+
+  it('detects the two fixtures as different project types', () => {
+    expect(asLibrary?.projectType).toBe('library');
+    // express makes it server-shaped; the exact label is the scanner's call.
+    expect(asServer?.projectType).not.toBe('library');
+  });
+
+  // THE BUG. Pre-fix this array held only the LOW missing-.gitignore finding.
+  it.each([['library'], ['server']])(
+    'surfaces LOG-002 in user-facing findings on the %s fixture',
+    (which) => {
+      const scan = which === 'library' ? asLibrary : asServer;
+      const log002 = (scan?.findings ?? []).find(f => f.checkId === 'LOG-002');
+      expect(log002, 'LOG-002 must reach result.findings').toBeDefined();
+      expect(log002?.passed).toBe(false);
+      expect(log002?.severity).toBe('high');
+    },
+  );
+
+  // The emission bug itself: the check knew which file matched and dropped it.
+  // Without a path the finding is filtered out again no matter how it is scoped.
+  it('attributes the file and line the pattern actually matched', () => {
+    const log002 = (asLibrary?.findings ?? []).find(f => f.checkId === 'LOG-002');
+    expect(log002?.file).toBe('server.js');
+    expect(log002?.line).toBe(1);
+  });
+
+  // The single-line fixture above cannot tell a real line count from a
+  // hardcoded 1, and the count is computed by scanning rather than splitting
+  // (the content is untrusted and split allocates per line), so it gets a
+  // fixture where the answer is not 1.
+  it('counts the line rather than assuming the first one', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'hma-421-multiline-'));
+    writeFileSync(join(dir, 'package.json'), JSON.stringify({ name: 'ml', version: '1.0.0' }));
+    writeFileSync(join(dir, 'app.js'), '// line1\n// line2\n// line3\nconsole.log(password);\n');
+    const run = spawnSync(process.execPath, [CLI, 'secure', '--json'], {
+      cwd: dir, encoding: 'utf-8', env: { ...process.env, HOME: HOME_DIR }, timeout: 180_000,
+    });
+    const scan = JSON.parse(run.stdout.slice(run.stdout.indexOf('{'))) as ScanJson;
+    const log002 = (scan.findings ?? []).find(f => f.checkId === 'LOG-002');
+    expect(log002?.file).toBe('app.js');
+    expect(log002?.line).toBe(4);
+  });
+
+  // NOTE this passes on the evidence fix ALONE — `dropPathlessNoiseFloor`
+  // short-circuits on `f.file` before it ever consults project-type scope, so
+  // reverting the scoping change leaves this green. Kept as a plain
+  // end-to-end assertion; the scoping change is guarded by the contract layer
+  // above, not by this.
+  it('carries LOG-002 into allFindings on a library', () => {
+    const ids = (asLibrary?.allFindings ?? []).map(f => f.checkId);
+    expect(ids).toContain('LOG-002');
+  });
+
+  // Resurrecting a dead check means its pattern is now load-bearing for the
+  // score. A raw case-insensitive substring test fires on all of these, and
+  // each takes a clean project to 69 and "Not safe as-is".
+  it.each([
+    ['an identifier that merely starts with the keyword', 'console.log(tokenCount, n);\n'],
+    ['a comment recording the bug was removed', '// console.log(password) -- removed for security\n'],
+    ['a help string quoting the bad pattern', 'const HELP = "Never write console.log(password) here";\n'],
+    ['an identifier that starts with "secret"', 'console.log(secretlessEnabled);\n'],
+  ])('does not fire on %s', (_label, body) => {
+    const dir = mkdtempSync(join(tmpdir(), 'hma-421-fp-'));
+    writeFileSync(join(dir, 'package.json'), JSON.stringify({ name: 'fp', version: '1.0.0' }));
+    writeFileSync(join(dir, 'index.js'), body);
+    const run = spawnSync(process.execPath, [CLI, 'secure', '--json'], {
+      cwd: dir, encoding: 'utf-8', env: { ...process.env, HOME: HOME_DIR }, timeout: 180_000,
+    });
+    const scan = JSON.parse(run.stdout.slice(run.stdout.indexOf('{'))) as ScanJson;
+    expect((scan.findings ?? []).find(f => f.checkId === 'LOG-002')).toBeUndefined();
+  });
+
+  // The line is computed on the ORIGINAL text. Searching a `toLowerCase()`
+  // copy and reporting an offset from it misattributes the finding, because
+  // `toLowerCase` is not length-preserving: U+0130 becomes two code units. The
+  // finding fired while its own `Verify:` command pointed at an innocent line,
+  // which is a dead end inside the thing meant to unblock the reader.
+  it('reports a line the scanned file cannot shift', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'hma-421-unicode-'));
+    writeFileSync(join(dir, 'package.json'), JSON.stringify({ name: 'u', version: '1.0.0' }));
+    const body = `${'İ'.repeat(30)}\nconsole.log(password);\naaa\nbbb\nccc\nddd\n`;
+    writeFileSync(join(dir, 'index.js'), body);
+    const run = spawnSync(process.execPath, [CLI, 'secure', '--json'], {
+      cwd: dir, encoding: 'utf-8', env: { ...process.env, HOME: HOME_DIR }, timeout: 180_000,
+    });
+    const scan = JSON.parse(run.stdout.slice(run.stdout.indexOf('{'))) as ScanJson;
+    const log002 = (scan.findings ?? []).find(f => f.checkId === 'LOG-002');
+    expect(log002?.line).toBe(2);
+    // The citation has to survive being followed.
+    expect(body.split('\n')[(log002!.line as number) - 1]).toContain('console.log(password)');
+  });
+
+  // Because the finding now carries a path, `.hmaignore` can reach it. #280
+  // says a multi-file finding survives while ANY covered path is un-ignored —
+  // which only works if every matching file is recorded, not just the cited
+  // one. Stopping at the first match would let one ignored file delete the
+  // evidence for every other.
+  it('survives .hmaignore on one matching file and re-points onto another', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'hma-421-ignore-'));
+    writeFileSync(join(dir, 'package.json'), JSON.stringify({ name: 'i', version: '1.0.0' }));
+    writeFileSync(join(dir, 'a.js'), 'console.log(password);\n');
+    writeFileSync(join(dir, 'z.js'), 'console.log(password);\n');
+    writeFileSync(join(dir, '.hmaignore'), 'a.js\n');
+    const run = spawnSync(process.execPath, [CLI, 'secure', '--json'], {
+      cwd: dir, encoding: 'utf-8', env: { ...process.env, HOME: HOME_DIR }, timeout: 180_000,
+    });
+    const scan = JSON.parse(run.stdout.slice(run.stdout.indexOf('{'))) as ScanJson;
+    const log002 = (scan.findings ?? []).find(f => f.checkId === 'LOG-002');
+    expect(log002, 'ignoring a.js must not hide the match in z.js').toBeDefined();
+    expect(log002?.file).toBe('z.js');
+  });
+
+  // The score is the part a pre-push gate reads. A HIGH that does not move the
+  // number is a HIGH nobody acts on.
+  it('scores the HIGH, and scores it identically whatever the project type', () => {
+    expect(asLibrary!.score).toBeLessThan(98);
+    expect(asLibrary!.score).toBe(asServer!.score);
+  });
+
+  // Negative control: evidence is recorded only when there IS evidence, so the
+  // fix cannot be "always attach a filename".
+  it('leaves a passing LOG-002 pathless rather than inventing evidence', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'hma-421-benign-'));
+    writeFileSync(join(dir, 'package.json'), JSON.stringify({ name: 'b', version: '1.0.0' }));
+    writeFileSync(join(dir, 'index.js'), 'console.log("started");\n');
+    const run = spawnSync(process.execPath, [CLI, 'secure', '--json'], {
+      cwd: dir, encoding: 'utf-8', env: { ...process.env, HOME: HOME_DIR }, timeout: 180_000,
+    });
+    const scan = JSON.parse(run.stdout.slice(run.stdout.indexOf('{'))) as ScanJson;
+    const log002 = (scan.allFindings ?? []).find(f => f.checkId === 'LOG-002');
+    expect(log002?.passed).toBe(true);
+    expect(log002?.file).toBeUndefined();
+  });
+});
+
+describeSpawn('#421 layer 2 — the run discloses what it silenced', () => {
+  beforeAll(assertDistFreshIfPresent);
+  const HOME_DIR = mkdtempSync(join(tmpdir(), 'hma-421-home2-'));
+
+  /**
+   * A plain library that happens to carry an `mcp.json`. `detectProjectType`
+   * keys on openclaw markers and package.json, NOT on the presence of an MCP
+   * config, so this stays `library` while `NET-001` (CRITICAL, "Server Bound
+   * to All Interfaces") matches inside `mcp.json` and is then dropped because
+   * `NET-` is scoped to webapp/api. A hidden CRITICAL is exactly what the
+   * backstop is for, and this is an ordinary repo shape.
+   */
+  function hiddenDetectionFixture(): ScanJson {
+    const dir = mkdtempSync(join(tmpdir(), 'hma-421-hidden-'));
+    writeFileSync(join(dir, 'package.json'), JSON.stringify({ name: 'plainlib', version: '1.0.0' }));
+    writeFileSync(join(dir, '.gitignore'), 'node_modules/\n.env\n');
+    writeFileSync(join(dir, 'index.js'), 'module.exports = {};\n');
+    writeFileSync(
+      join(dir, 'mcp.json'),
+      JSON.stringify({ servers: { s: { args: ['server.js', '--host', '0.0.0.0'] } } }),
+    );
+    const run = spawnSync(process.execPath, [CLI, 'secure', '--json'], {
+      cwd: dir, encoding: 'utf-8', env: { ...process.env, HOME: HOME_DIR }, timeout: 180_000,
+    });
+    return JSON.parse(run.stdout.slice(run.stdout.indexOf('{'))) as ScanJson;
+  }
+
+  function hiddenDetectionRender(): string {
+    const dir = mkdtempSync(join(tmpdir(), 'hma-421-hidden-txt-'));
+    writeFileSync(join(dir, 'package.json'), JSON.stringify({ name: 'plainlib', version: '1.0.0' }));
+    writeFileSync(join(dir, '.gitignore'), 'node_modules/\n.env\n');
+    writeFileSync(join(dir, 'index.js'), 'module.exports = {};\n');
+    writeFileSync(
+      join(dir, 'mcp.json'),
+      JSON.stringify({ servers: { s: { args: ['server.js', '--host', '0.0.0.0'] } } }),
+    );
+    const run = spawnSync(process.execPath, [CLI, 'secure'], {
+      cwd: dir, encoding: 'utf-8', env: { ...process.env, HOME: HOME_DIR }, timeout: 180_000,
+    });
+    return run.stdout ?? '';
+  }
+
+  // THE WIRING GUARD. Without a fixture that reaches it, the whole
+  // clear-withdrawal could be deleted from cli.ts and the suite stayed green.
+  it('records a detection that scoping hid, as identity only — never paths or messages', () => {
+    const scan = hiddenDetectionFixture();
+    expect(scan.projectType).toBe('library');
+    const suppressed = scan.coverage?.suppressedFailures ?? [];
+    expect(
+      suppressed.map(s => s.checkId),
+      'NET-001 matched inside mcp.json and was scoped out — it must be recorded',
+    ).toContain('NET-001');
+    for (const s of suppressed) {
+      expect(Object.keys(s).sort()).toEqual(['category', 'checkId', 'name', 'severity']);
+      expect(s).not.toHaveProperty('file');
+      expect(s).not.toHaveProperty('message');
+    }
+  });
+
+  it('names the category of a hidden detection instead of calling it clear', () => {
+    const out = hiddenDetectionRender();
+    const unresolved = new RegExp(
+      `^\\s*${OBSERVATION_LABELS.unresolved}\\s{2,}(.+)$`, 'm',
+    ).exec(out);
+    expect(unresolved, `no Unresolved line in:\n${out}`).not.toBeNull();
+    // NET-* renders under the label `network`.
+    expect(unresolved![1]).toContain('network');
+  });
+
+  // The volume of failed-but-unshown checks is what made a silenced finding
+  // indistinguishable from a clean result. It is disclosed as a count.
+  it('counts the checks that failed with nothing to point at', () => {
+    const scan = scanFixture(HOME_DIR, undefined);
+    expect(scan?.coverage?.unevidencedFailures).toBeGreaterThan(0);
+  });
+
+  it('states that count on the Coverage line', () => {
+    const out = renderFixture(HOME_DIR);
+    const coverage = /^\s*Coverage\s{2,}(.+)$/m.exec(out);
+    expect(coverage, `no Coverage line in:\n${out}`).not.toBeNull();
+    expect(coverage![1]).toMatch(/\d+ checks reported an absent mitigation \(not shown\)/);
+  });
+
+  // Absent mitigations must NOT withdraw `clear` — nothing was found, and
+  // naming ~45 categories a clean library cannot act on is the false-reassurance
+  // problem inverted into a wall of FUD.
+  it('still reports categories clear when only absent mitigations were silenced', () => {
+    const out = renderFixture(HOME_DIR);
+    const categories = /^\s*Categories\s{2,}(.+)$/m.exec(out);
+    expect(categories![1]).toMatch(/\d+ others clear/);
+  });
+
+  it('does not fold the logging detection into the clear tail', () => {
+    const out = renderFixture(HOME_DIR);
+    const categories = /^\s*Categories\s{2,}(.+)$/m.exec(out);
+    // LOG-* renders under the label `audit`, not `logging`.
+    expect(categories![1]).toContain('audit');
+  });
+
+  // Every examined category lands in exactly one state, so the tally accounts
+  // for itself and a withdrawn `clear` cannot become a silent gap.
+  it('accounts for every examined category exactly once', () => {
+    const out = renderFixture(HOME_DIR);
+    const examined = /(\d+) of \d+ categories examined/.exec(out);
+    const categoriesLine = /^\s*Categories\s{2,}(.+)$/m.exec(out);
+    const segments = categoriesLine![1].split('·').map(s => s.trim()).filter(Boolean);
+    const clearMatch = /^(\d+) others clear$/.exec(segments[segments.length - 1] ?? '');
+    const clearCount = clearMatch ? Number(clearMatch[1]) : 0;
+    const reportedCount = clearMatch ? segments.length - 1 : segments.length;
+
+    const unresolvedLine = new RegExp(
+      `^\\s*${OBSERVATION_LABELS.unresolved}\\s{2,}(.+)$`, 'm',
+    ).exec(out);
+    let unresolvedCount = 0;
+    if (unresolvedLine) {
+      const more = / \+ (\d+) more/.exec(unresolvedLine[1]);
+      const named = unresolvedLine[1]
+        .replace(/ \+ \d+ more.*$/, '').split(',').filter(s => s.trim()).length;
+      unresolvedCount = named + (more ? Number(more[1]) : 0);
+    }
+    expect(reportedCount + clearCount + unresolvedCount).toBe(Number(examined![1]));
+  });
+});

--- a/__tests__/ui/unresolved-categories.test.ts
+++ b/__tests__/ui/unresolved-categories.test.ts
@@ -1,0 +1,137 @@
+// #421 — the backstop that stops a category reporting `clear` while holding a
+// detection nobody was shown.
+//
+// Tested here rather than end-to-end on purpose. Firing it needs a project that
+// BOTH trips one of the 23 narrow-scoped checks that emit a file AND is not
+// detected as the project type that check belongs to — and those two conditions
+// pull against each other (a tree with an MCP config tends to be detected as
+// `mcp`). No natural fixture was found, and a guard that cannot be
+// distinguished from its absence is not a guard, so the logic was split out of
+// `cli.ts` and is exercised directly.
+
+import { describe, it, expect } from 'vitest';
+import {
+  suppressedCategoryLabels,
+  unresolvedCategoryNames,
+  type SuppressedFailureIdentity,
+} from '../../src/ui/unresolved-categories';
+
+function silenced(
+  checkId: string,
+  category: string,
+  name = `${checkId} finding`,
+): SuppressedFailureIdentity {
+  return { checkId, name, category, severity: 'high' };
+}
+
+describe('suppressedCategoryLabels', () => {
+  it('is empty when nothing was silenced', () => {
+    expect(suppressedCategoryLabels([]).size).toBe(0);
+  });
+
+  // THE POINT OF THE FUNCTION. The scanner records a finding's own `category`,
+  // but the renderer buckets by check-ID prefix into a DIFFERENT vocabulary.
+  // Keying the backstop off the raw field matches only the handful of names
+  // that coincide, and every other category goes on claiming `clear` while
+  // hiding a detection — the original bug, one layer along.
+  it.each([
+    // Every expected label here is the classifier's MEASURED answer, not a
+    // reading of the prefix table: `SEC-001` lands in `credentials` (a keyword
+    // rule fires before the `SEC` prefix rule) and `GATEWAY-001` in `network`.
+    // Both were guessed wrong first and corrected against the real output.
+    ['LOG-002', 'logging', 'audit'],
+    ['SESSION-003', 'session-security', 'session'],
+    ['SEC-001', 'secrets', 'credentials'],
+    ['INJ-003', 'input-validation', 'injection'],
+    ['GATEWAY-001', 'gateway', 'network'],
+  ])('buckets %s (category %s) under the renderer label %s', (checkId, category, label) => {
+    const labels = suppressedCategoryLabels([silenced(checkId, category)]);
+    expect([...labels]).toEqual([label]);
+    expect(labels.has(label)).toBe(true);
+  });
+
+  it('maps a check whose raw category is not a renderer label at all', () => {
+    // `session-security` is not in ALL_CATEGORY_LABELS; a raw-keyed lookup can
+    // never match it, so this is the case that silently did nothing.
+    const labels = suppressedCategoryLabels([silenced('SESSION-001', 'session-security')]);
+    expect(labels.has('session-security')).toBe(false);
+    expect(labels.has('session')).toBe(true);
+  });
+
+  it('collapses several silenced checks in one category to a single label', () => {
+    const labels = suppressedCategoryLabels([
+      silenced('LOG-002', 'logging'),
+      silenced('AUDIT-004', 'audit'),
+    ]);
+    expect([...labels]).toEqual(['audit']);
+  });
+});
+
+describe('unresolvedCategoryNames', () => {
+  const summaries = [
+    { name: 'audit', clear: true },
+    { name: 'credentials', clear: true },
+    { name: 'git hygiene', clear: false },
+    { name: 'network', clear: true },
+  ];
+  const examinedAlways = () => true;
+
+  it('withdraws clear from an examined category holding a silenced detection', () => {
+    const names = unresolvedCategoryNames(
+      summaries,
+      examinedAlways,
+      suppressedCategoryLabels([silenced('LOG-002', 'logging')]),
+    );
+    expect(names).toEqual(['audit']);
+  });
+
+  it('leaves a category alone when nothing in it was silenced', () => {
+    expect(unresolvedCategoryNames(summaries, examinedAlways, new Set())).toEqual([]);
+  });
+
+  // A category already showing a finding needs no correction — it is not
+  // claiming to be clear, so withdrawing anything would double-report it.
+  it('never names a category that is already reporting a finding', () => {
+    const names = unresolvedCategoryNames(
+      summaries,
+      examinedAlways,
+      new Set(['git hygiene']),
+    );
+    expect(names).toEqual([]);
+  });
+
+  // An unexamined category is already disclosed on the `Unexamined` line.
+  it('never names a category the run did not examine', () => {
+    const names = unresolvedCategoryNames(
+      summaries,
+      name => name !== 'audit',
+      suppressedCategoryLabels([silenced('LOG-002', 'logging')]),
+    );
+    expect(names).toEqual([]);
+  });
+
+  // Without a coverage ledger the caller passes an always-false predicate,
+  // because the disclosure line cannot render. Withdrawing `clear` there would
+  // trade a false claim for an unexplained gap, which is the failure this
+  // whole change exists to prevent.
+  it('withdraws nothing when the run has no coverage ledger', () => {
+    const names = unresolvedCategoryNames(
+      summaries,
+      () => false,
+      suppressedCategoryLabels([silenced('LOG-002', 'logging')]),
+    );
+    expect(names).toEqual([]);
+  });
+
+  it('names every qualifying category, in summary order', () => {
+    const names = unresolvedCategoryNames(
+      summaries,
+      examinedAlways,
+      suppressedCategoryLabels([
+        silenced('LOG-002', 'logging'),
+        silenced('NET-001', 'network'),
+      ]),
+    );
+    expect(names).toEqual(['audit', 'network']);
+  });
+});

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -54,6 +54,7 @@ import {
   type SoulLevel,
 } from './index';
 import { resolveAndLogMcpShorthand } from './resolve-mcp';
+import { suppressedCategoryLabels, unresolvedCategoryNames } from './ui/unresolved-categories';
 import { WildScanner, type WildScanReport } from './wild';
 import { buildCheckOutput, buildNotFoundOutput, mapScanStatusForMeter, translateDownloadError } from '@opena2a/check-core';
 import {
@@ -1504,13 +1505,61 @@ function displayUnifiedCheck(opts: UnifiedCheckDisplayOptions): void {
     const coverageByCategory = new Map(
       (coverageCategories ?? []).map(c => [c.category, c]),
     );
+    // #421 — being EXAMINED is necessary for a `clear` claim but not
+    // sufficient. A check can match something in the tree and still be dropped
+    // before it reaches `findings`, because its prefix is out of scope for the
+    // detected project type. The category then prints as clear, which is the
+    // same lie the coverage work above set out to remove: `LOG-002` matched
+    // `console.log(password` in a scanned file and `logging` was reported clear
+    // at 98/100.
+    //
+    // Scoped to detections that carried EVIDENCE. The scanner also drops failed
+    // checks that had nothing to point at — an absent mitigation rather than a
+    // discovery, ~45 of them on a clean three-file library — and those do not
+    // make `clear` false, because nothing was found. Withdrawing `clear` for
+    // them would replace a false reassurance with a wall of categories the user
+    // cannot act on. They are counted in `coverage.unevidencedFailures`.
+    //
+    // Such a category is dropped from the clear bucket rather than promoted to
+    // a finding: the scanner decided not to show that finding, and second-
+    // guessing it here would print a result with no detail behind it. Silence
+    // is the honest position — the same treatment `not-examined` already gets.
+    //
+    // Classified with `buildCategorySummaries` — the SAME function the real
+    // findings go through above — so the two sets are bucketed by one
+    // classifier and cannot drift into different category vocabularies. A map
+    // keyed by the finding's own `category` would have been a silent no-op:
+    // `LOG-*` findings carry `category: 'logging'` and render under `audit`.
+    const suppressedLabels = suppressedCategoryLabels(
+      localScan?.coverage?.suppressedFailures ?? [],
+    );
+    const holdsSuppressedFailure = (category: string): boolean =>
+      suppressedLabels.has(category);
+    // `suppressedFailures` rides on `coverage`, so without coverage the set is
+    // empty and the clear bucket is unchanged — the `Unresolved` line below
+    // also only renders under `coverageCategories`, and the two must agree or
+    // a category would be withdrawn with nothing naming it.
     const categorySummaries = quickScanDisclosure
       ? allCategorySummaries.filter(c => !c.clear)
       : coverageCategories
         ? allCategorySummaries.filter(
-            c => !c.clear || coverageByCategory.get(c.name)?.state === 'examined',
+            c => !c.clear || (
+              coverageByCategory.get(c.name)?.state === 'examined' &&
+              !holdsSuppressedFailure(c.name)
+            ),
           )
         : allCategorySummaries;
+    // The categories the rule above just took OUT of the clear bucket. Named on
+    // their own line so the tally stays accountable: dropping them silently
+    // would trade a false `clear` for an unexplained gap, which is the same
+    // kind of unreadable output in a quieter register.
+    const unresolvedCategories = unresolvedCategoryNames(
+      allCategorySummaries,
+      // No coverage ledger means the disclosure line below cannot render, so
+      // nothing may be withdrawn either.
+      name => Boolean(coverageCategories) && coverageByCategory.get(name)?.state === 'examined',
+      suppressedLabels,
+    );
     const verdictLine = buildVerdict(
       { critical, high, medium, low },
       { kind, filesScanned, remote: opts.remote === true },
@@ -1632,7 +1681,8 @@ function displayUnifiedCheck(opts: UnifiedCheckDisplayOptions): void {
     if (
       coverageCategories &&
       totalFindings === 0 &&
-      (explicitlySkipped.length > 0 || partiallyExamined.length > 0)
+      (explicitlySkipped.length > 0 || partiallyExamined.length > 0 ||
+        unresolvedCategories.length > 0)
     ) {
       const gaps: string[] = [];
       if (partiallyExamined.length > 0) {
@@ -1640,6 +1690,15 @@ function displayUnifiedCheck(opts: UnifiedCheckDisplayOptions): void {
       }
       if (explicitlySkipped.length > 0) {
         gaps.push(`${explicitlySkipped.length} were skipped by this scan depth`);
+      }
+      // #421 — a category whose check matched and was then scoped out is the
+      // sharpest version of this: "looks safe to use" printed directly above an
+      // `Unresolved` line naming a category where something DID match is the
+      // contradiction this whole change exists to remove.
+      if (unresolvedCategories.length > 0) {
+        gaps.push(
+          `${unresolvedCategories.length} had a check match that does not apply to a ${kind} project`,
+        );
       }
       verdictDisplay.value =
         `No issues in what was examined — but ${gaps.join(' and ')}. ` +
@@ -1688,6 +1747,17 @@ function displayUnifiedCheck(opts: UnifiedCheckDisplayOptions): void {
       const tally = [`${examinedCount} of ${coverageCategories.length} categories examined`];
       if (partiallyExamined.length > 0) tally.push(`${partiallyExamined.length} partial (file cap)`);
       if (notExamined.length > 0) tally.push(`${notExamined.length} unexamined (read no file)`);
+      // #421 — checks that did not pass and had nothing to point at, so they
+      // were not shown. Reported as a COUNT and never per category: they are
+      // absent mitigations ("no rate limiting detected" on a library with no
+      // HTTP server), not discoveries, so naming categories would read as an
+      // accusation the reader cannot act on. A clean three-file library
+      // carries ~45. Disclosing the volume is what stops `clear` being read as
+      // "every check passed", which is the claim it was never making.
+      const unevidenced = localScan?.coverage?.unevidencedFailures ?? 0;
+      if (unevidenced > 0) {
+        tally.push(`${unevidenced} checks reported an absent mitigation (not shown)`);
+      }
       // Yellow only for a measured shortfall: a cap that fired or a skip.
       const covTone = partiallyExamined.length > 0 || explicitlySkipped.length > 0
         ? colors.yellow : colors.dim;
@@ -1710,11 +1780,37 @@ function displayUnifiedCheck(opts: UnifiedCheckDisplayOptions): void {
         );
       }
       // One reason per category under verbose — the lines above name WHAT was
-      // not covered, this says WHY, so neither is a dead end.
+      // not covered, this says WHY, so neither is a dead end. These lines are
+      // indented rather than labelled, so they attach visually to whatever
+      // precedes them: they must stay directly under `Unexamined`, the line
+      // they explain, and BEFORE any further labelled line.
       if (verbose) {
         for (const c of [...notExamined, ...partiallyExamined]) {
           const tag = c.state === 'truncated' ? `${c.category} (partial)` : c.category;
           console.log(`  ${' '.repeat(LABEL_WIDTH)}${colors.dim}${tag} — ${c.reason ?? 'not examined'}${RESET()}`);
+        }
+      }
+      // #421 — the third state, between `clear` and a finding: a check in this
+      // category MATCHED something in the target, and its finding was dropped
+      // because the check is out of scope for this project type. One line, one
+      // claim, same shape as `Unexamined` above. Naming them is what keeps the
+      // withdrawn `clear` from reading as a silent omission.
+      if (unresolvedCategories.length > 0) {
+        const shown = verbose ? unresolvedCategories : unresolvedCategories.slice(0, 8);
+        const hidden = unresolvedCategories.length - shown.length;
+        const more = hidden > 0 ? ` + ${hidden} more (--verbose)` : '';
+        console.log(
+          `  ${colors.dim}${OBSERVATION_LABELS.unresolved.padEnd(LABEL_WIDTH, ' ')}${RESET()}` +
+          `${colors.dim}${shown.join(', ')}${more}${RESET()}`,
+        );
+        // Every named category carries a reason, so the line is not a dead end.
+        if (verbose) {
+          for (const name of unresolvedCategories) {
+            console.log(
+              `  ${' '.repeat(LABEL_WIDTH)}${colors.dim}${name} — a check here matched, ` +
+              `but does not apply to a ${kind} project, so its finding was not reported${RESET()}`,
+            );
+          }
         }
       }
     }

--- a/src/hardening/scanner.ts
+++ b/src/hardening/scanner.ts
@@ -259,7 +259,18 @@ const CHECK_PROJECT_TYPES: Record<string, ProjectType[]> = {
   'INJ-': ['webapp', 'api'], // SQL injection, input validation
   'ENCRYPT-': ['webapp', 'api'], // Encryption, password hashing
 
-  // Logging/audit - servers and MCP
+  // Logging/audit - servers and MCP.
+  //
+  // ORDER IS LOAD-BEARING. `findingAppliesTo` takes the FIRST key that matches,
+  // so `LOG-002` must stay ABOVE `LOG-` or it silently falls back to the group
+  // and stops applying outside webapp/api/mcp. Held by
+  // `check-project-types-order.test.ts`.
+  //
+  // The LOG- group is advice ("consider structured logging"), which is why it
+  // is scoped to server-shaped projects. LOG-002 is NOT advice: it matches
+  // sensitive data in a log call in code that was read. Code that logs a
+  // password is wrong in a library exactly as much as in an API (#421).
+  'LOG-002': ['all'],
   'LOG-': ['webapp', 'api', 'mcp'],
   'AUDIT-': ['webapp', 'api'],
 
@@ -284,7 +295,7 @@ const CHECK_PROJECT_TYPES: Record<string, ProjectType[]> = {
   // Agent DNA integrity checks
   'DNA-': ['all'],
   // Skill memory manipulation checks
-  'SKILL-MEM-': ['openclaw', 'mcp'],
+  'SKILL-MEM-': ['openclaw', 'mcp'], // dead entry: the SKILL- group is declared first and wins
   // NemoClaw/sandbox static analysis checks
   'NEMO-': ['all'],
 
@@ -303,7 +314,7 @@ const CHECK_PROJECT_TYPES: Record<string, ProjectType[]> = {
   'TMPPATH-': ['all'], // Hardcoded /tmp path attacks
   'DOCKERINJ-': ['all'], // Docker exec with variable injection
   'ENVLEAK-': ['all'], // Environment variable leakage to child processes
-  'SANDBOX-005': ['openclaw', 'mcp'], // Messaging API pre-allowed in sandbox
+  'SANDBOX-005': ['openclaw', 'mcp'], // Messaging API pre-allowed in sandbox (dead entry: the SANDBOX- group is declared first and wins)
   'WEBEXPOSE-': ['all'], // Sensitive files in web-served directories
   'AGENT-CRED-': ['all'], // Missing credential protection in system prompts
   'SOUL-OVERRIDE-': ['all'], // Skill content overriding SOUL.md
@@ -981,6 +992,20 @@ export function scoreExcludingOwnArchive(
  * NanoMind merge.
  */
 export function findingAppliesTo(finding: SecurityFinding, projectType: ProjectType): boolean {
+  // FIRST match in declaration order. A full check ID overrides the group it
+  // sits in by being DECLARED BEFORE it — `check-project-types-order.test.ts`
+  // holds that ordering, because nothing else does.
+  //
+  // Resolving the LONGEST key instead would remove the order dependency and is
+  // what the map's "prefix OR full ID" wording implies. It was tried and
+  // reverted: two entries in the map are narrower than the group they sit in
+  // and had never taken effect, so making them live SUBTRACTED project types.
+  // `SANDBOX-005` — a HIGH file-and-line detection for a messaging API
+  // pre-allowed in a sandbox policy — silently stopped applying to `webapp`
+  // and `api`. Widening those entries instead put a HIGH false positive on
+  // every clean library. Changing this resolution order is a detection change
+  // for the whole map and needs its own corpus; it is not a side effect of
+  // fixing one check.
   for (const [prefix, types] of Object.entries(CHECK_PROJECT_TYPES)) {
     if (finding.checkId.startsWith(prefix)) {
       if (types.includes('all')) return true;
@@ -2719,6 +2744,54 @@ export class HardeningScanner {
       return true;
     });
 
+    // #421 — which FAILED findings did the scanner silence on its own?
+    //
+    // Derived as a separate pass over the same inputs rather than folded into
+    // the filter above, so the filter's behaviour is unchanged by inspection.
+    // A finding counts here only if it failed, did not survive, and was not
+    // suppressed at the USER's request — `--ignore` and `.hmaignore` are
+    // disclosed through `ignored`, and re-reporting them would punish the user
+    // for a choice they made.
+    //
+    // What remains splits in two, and the split matters more than the total:
+    //
+    //  - WITH a file: the check matched something in the tree and the finding
+    //    was dropped anyway, because its prefix is out of scope for the
+    //    detected project type. That is a real detection, hidden. It is the
+    //    only kind that may withdraw a category's `clear`.
+    //  - WITHOUT a file: the check reported the ABSENCE of a mitigation and
+    //    has nothing to point at — "no rate limiting detected" on a library
+    //    with no HTTP server. A clean three-file library carries ~45 of these,
+    //    2 of them nominally critical. Nothing was found, so `clear` is not
+    //    made false by them, and surfacing them by category would be a wall of
+    //    FUD with no path forward. Counted, not named.
+    const survived = new Set<SecurityFinding>(filteredFindings);
+    const suppressedFailures: Array<{
+      checkId: string;
+      name: string;
+      category: string;
+      severity: string;
+    }> = [];
+    let unevidencedFailures = 0;
+    for (const f of findings) {
+      if (f.passed && !f.fixed) continue;
+      if (survived.has(f)) continue;
+      if (ignoredChecks.has(f.checkId.toUpperCase())) continue;
+      if (this.isCheckIdSuppressed(f.checkId, suppressedCheckPatterns)) continue;
+      if (!this.retainAfterPathSuppression(f, allIgnoredPaths)) continue;
+      if (!f.file) {
+        unevidencedFailures++;
+        continue;
+      }
+      // Identity only. No `file`, no `message` — see the field's contract.
+      suppressedFailures.push({
+        checkId: f.checkId,
+        name: f.name,
+        category: f.category,
+        severity: f.severity,
+      });
+    }
+
     // Deliberately carries no counts. This line used to read "Fix
     // verification: 1/2 fixes confirmed" four lines above the CLI's
     // "Attempted 1 fix, none confirmed" — two denominators for one run,
@@ -2833,6 +2906,8 @@ export class HardeningScanner {
         // Counts, never paths — a single-file scan normalises its target into
         // a generated temp directory, and emitting read paths leaked that name.
         filesReadByCategory: this.coverage.categoryFileCounts(),
+        suppressedFailures,
+        unevidencedFailures,
       },
     };
   }
@@ -3072,21 +3147,15 @@ export class HardeningScanner {
   }
 
   /**
-   * Check if a finding applies to the given project type
+   * Check if a finding applies to the given project type.
+   *
+   * Delegates to the exported `findingAppliesTo` so the scanner's own filter
+   * and the CLI's post-NanoMind-merge filter cannot drift apart. They were two
+   * separate copies of the same loop; the copies agreed by luck, and only one
+   * of them would have been fixed (#421).
    */
   findingAppliesTo(finding: SecurityFinding, projectType: ProjectType): boolean {
-    // Find the matching rule based on check ID prefix
-    for (const [prefix, types] of Object.entries(CHECK_PROJECT_TYPES)) {
-      if (finding.checkId.startsWith(prefix)) {
-        // Check if 'all' is in the types array
-        if (types.includes('all')) {
-          return true;
-        }
-        return types.includes(projectType);
-      }
-    }
-    // Default: applies to all if no rule found
-    return true;
+    return findingAppliesTo(finding, projectType);
   }
 
   private async checkCredentialExposure(
@@ -5711,25 +5780,76 @@ dist/
     });
 
     // LOG-002: Check for sensitive data in log patterns
-    let sensitiveInLogs = false;
-    const logPatterns = ['console.log(password', 'console.log(apiKey', 'console.log(secret', 'console.log(token'];
+    //
+    // #421 — this check MATCHES on file content, so it is evidence-based, not
+    // advice. It must carry the path it matched: `filteredFindings` drops every
+    // finding without a `file` ("concrete findings, not generic advice"), so a
+    // pathless LOG-002 was scored and displayed as though it had never fired.
+    // Recording the path is what makes the detection reach the output at all.
+    // Matches the same four spellings the literal list did
+    // (`console.log(password|apiKey|secret|token`), case-insensitively, with
+    // two corrections:
+    //
+    //  - Applied to the ORIGINAL text. The previous form searched a
+    //    `toLowerCase()` copy and reported an offset from it. `toLowerCase` is
+    //    not length-preserving (U+0130 lowercases to two code units), so a
+    //    file could shift its own reported line number — the finding fired
+    //    while its `Verify:` command pointed at an innocent line.
+    //  - A trailing identifier boundary. Without it `console.log(token` also
+    //    matched `console.log(tokenCount)`, which is ordinary code. That never
+    //    surfaced only because the finding was being dropped; resurrecting it
+    //    without the boundary would ship the false positive.
+    //
+    // Literal prefix, a four-way literal alternation and a lookahead: no
+    // nested quantifier, so it stays linear on untrusted input.
+    const sensitiveLogCall = /console\.log\((?:password|apikey|secret|token)(?![A-Za-z0-9_$])/i;
+
+    const sensitiveLogFiles: string[] = [];
+    let sensitiveLogFile: string | undefined;
+    let sensitiveLogLine: number | undefined;
 
     try {
       const files = await fs.readdir(targetDir);
       for (const file of files) {
+        // Extension list deliberately UNCHANGED here — widening it is #414,
+        // which is blocked on this fix precisely because a widened read
+        // produced no observable change while the finding was being dropped.
         if (file.endsWith('.ts') || file.endsWith('.js')) {
           try {
             const content = await fs.readFile(path.join(targetDir, file), 'utf-8');
-            for (const pattern of logPatterns) {
-              if (content.toLowerCase().includes(pattern.toLowerCase())) {
-                sensitiveInLogs = true;
+            // Walked line by line rather than split into an array: the content
+            // is an untrusted file and `split('\n')` holds one string per line
+            // live. This also yields the line number and the within-line offset
+            // directly, which is what the string/comment test needs.
+            let lineStart = 0;
+            let lineNo = 1;
+            while (lineStart <= content.length) {
+              let nl = content.indexOf('\n', lineStart);
+              if (nl === -1) nl = content.length;
+              const lineText = content.slice(lineStart, nl);
+              const m = sensitiveLogCall.exec(lineText);
+              // A match inside a string literal or a comment is text, not a
+              // log call — `// console.log(password) - removed` and a help
+              // string quoting the bad pattern are both documentation. Reuses
+              // the helper NEMO-009 already applies for exactly this.
+              if (m && !isMatchInsideStringLiteral(lineText, m.index)) {
+                sensitiveLogFiles.push(file);
+                if (sensitiveLogFile === undefined) {
+                  sensitiveLogFile = file;
+                  sensitiveLogLine = lineNo;
+                }
                 break;
               }
+              if (nl === content.length) break;
+              lineStart = nl + 1;
+              lineNo++;
             }
           } catch {}
         }
       }
     } catch {}
+
+    const sensitiveInLogs = sensitiveLogFile !== undefined;
 
     findings.push({
       checkId: 'LOG-002',
@@ -5741,6 +5861,20 @@ dist/
       message: sensitiveInLogs
         ? 'Code may be logging sensitive data - review console.log statements'
         : 'No obvious sensitive data logging patterns found',
+      // Only set when the check actually matched. A passed LOG-002 stays
+      // pathless: it has no evidence to point at.
+      file: sensitiveLogFile,
+      // Cited ONLY when a single file matched. `.hmaignore` can re-point a
+      // multi-file finding onto a surviving path (#280, `retainAfterPathSuppression`)
+      // and that re-point moves `file` without moving `line` — so a line from
+      // the ignored file would be printed against the surviving one, and
+      // `Verify: sed -n '5p' z.js` would print nothing. No line is better than
+      // a line that sends the reader somewhere the match is not.
+      line: sensitiveLogFiles.length === 1 ? sensitiveLogLine : undefined,
+      // EVERY matching file, not just the cited one. `.hmaignore` suppression
+      // keys on all covered paths (#280), so listing one path here would let a
+      // single ignored file delete a finding that also covers un-ignored ones.
+      ...(sensitiveLogFiles.length > 0 ? { details: { files: sensitiveLogFiles } } : {}),
       fixable: false,
       guidance: 'Passwords, API keys, and tokens logged to console or files persist in log aggregators and crash reports, where they can be harvested by anyone with log access.',
     });

--- a/src/hardening/security-check.ts
+++ b/src/hardening/security-check.ts
@@ -224,6 +224,55 @@ export interface ScanResult {
     truncations: CoverageTruncationRecord[];
     /** Distinct files read per category. Counts only — never filenames. */
     filesReadByCategory?: Record<string, number>;
+    /**
+     * FAILED checks that MATCHED something in the tree and were dropped from
+     * `findings` anyway, because the check's prefix is out of scope for the
+     * detected project type.
+     *
+     * Evidence-bearing only: every entry corresponds to a finding that carried
+     * a file. Failed checks with nothing to point at — "no rate limiting
+     * detected" on a library with no HTTP server — are counted in
+     * `unevidencedFailures` instead, because they report an absence rather
+     * than a discovery and do not make a `clear` claim false.
+     *
+     * Exists so the renderer cannot report a category `clear` while that
+     * category holds a real detection nobody was shown (#421). `clear` is a
+     * claim of "examined and found nothing"; a hidden match makes it false.
+     * This is the same contract as the coverage object itself, one layer
+     * deeper: that stopped an UNEXAMINED category printing clear, this stops
+     * an examined-but-silenced one.
+     *
+     * Carries the check's own identity ONLY — no file paths and no messages,
+     * so it keeps the "never emit read paths" discipline of the fields above.
+     * These are the identity fields the renderer's category classifier reads
+     * (it also reads `passed`, which the consumer supplies as `false`), which
+     * is the point: the consumer classifies these through the SAME function it
+     * classifies real findings with, so the two cannot drift into different
+     * category vocabularies. (`LOG-*` findings carry `category: 'logging'` but
+     * render under the label `audit` — a set keyed by the raw category would
+     * silently never match.)
+     *
+     * Findings the USER suppressed (`--ignore`, `.hmaignore`) are deliberately
+     * absent: that suppression was requested, and is already disclosed
+     * through `ignored`.
+     */
+    suppressedFailures?: Array<{
+      checkId: string;
+      name: string;
+      category: string;
+      severity: string;
+    }>;
+    /**
+     * Count of failed checks that produced no evidence — an absent mitigation
+     * rather than a discovery — and were therefore not shown.
+     *
+     * A count and not a list on purpose. These are dominated by checks that
+     * cannot pass on a project shape that does not need them (`SQL Injection
+     * Protection` on a library with no database), so naming them per category
+     * would read as an accusation with no path forward. The number exists so
+     * the volume is visible and can be attacked at the check level later.
+     */
+    unevidencedFailures?: number;
   };
 }
 

--- a/src/ui/quick-scan-labels.ts
+++ b/src/ui/quick-scan-labels.ts
@@ -146,4 +146,9 @@ export const OBSERVATION_LABEL_WIDTH = 12;
 export const OBSERVATION_LABELS = {
   unexamined: 'Unexamined',
   coverage: 'Coverage',
+  // #421 — categories that ran a check which did not pass, where the result
+  // was not shown because it carried no evidence to point at. Neither `clear`
+  // nor a finding. Without a name for that third state, withdrawing the
+  // `clear` claim would just leave an unexplained gap in the tally.
+  unresolved: 'Unresolved',
 } as const;

--- a/src/ui/unresolved-categories.ts
+++ b/src/ui/unresolved-categories.ts
@@ -1,0 +1,86 @@
+/**
+ * #421 — which categories may NOT be reported `clear`, because a check in them
+ * matched something in the target and its finding was dropped before it
+ * reached the user.
+ *
+ * Split out of `cli.ts` so it is unit-testable without spawning a scan. The
+ * scoping that makes a finding disappear (`findingAppliesTo` against the
+ * detected project type) fires on 23 narrow-scoped checks that emit a file,
+ * but reproducing one end-to-end needs a project that both trips such a check
+ * AND is not detected as the type that check belongs to — the two conditions
+ * pull against each other, and no natural fixture was found. A guard nobody can
+ * distinguish from its absence is not a guard, so the logic lives here and is
+ * exercised directly.
+ */
+
+import { buildCategorySummaries } from '@opena2a/cli-ui';
+
+/**
+ * The identity of a check whose failed finding the scanner silenced. Mirrors
+ * `ScanResult['coverage']['suppressedFailures']` — no paths, no messages.
+ */
+export interface SuppressedFailureIdentity {
+  checkId: string;
+  name: string;
+  category: string;
+  severity: string;
+}
+
+/**
+ * Category LABELS (the renderer's vocabulary, not the finding's `category`
+ * field) that hold at least one silenced detection.
+ *
+ * Bucketed with `buildCategorySummaries`, the same function the real findings
+ * go through, because the two vocabularies differ: `LOG-*` findings carry
+ * `category: 'logging'` and render under the label `audit`, `SESSION-*` carry
+ * `session-security` and render under `session`. Keying off the raw field
+ * silently matches only the handful of names that coincide.
+ */
+export function suppressedCategoryLabels(
+  suppressed: readonly SuppressedFailureIdentity[],
+): Set<string> {
+  if (suppressed.length === 0) return new Set();
+  return new Set(
+    buildCategorySummaries(
+      suppressed.map(s => ({
+        checkId: s.checkId,
+        name: s.name,
+        category: s.category,
+        severity: s.severity as 'critical' | 'high' | 'medium' | 'low',
+        passed: false,
+      })),
+    )
+      .filter(c => !c.clear)
+      .map(c => c.name),
+  );
+}
+
+/** A category summary as the renderer models it. */
+export interface CategoryClearState {
+  name: string;
+  clear: boolean;
+}
+
+/**
+ * Names of the categories to take OUT of the clear bucket.
+ *
+ * A category qualifies only when all three hold: it currently reads `clear`
+ * (a category already showing a finding needs no correction), the run actually
+ * EXAMINED it (an unexamined category is already disclosed as such and must
+ * not be double-reported), and it holds a silenced detection.
+ *
+ * `examined` is passed as a predicate rather than a map so the caller keeps
+ * ownership of what "examined" means; when coverage is absent the caller
+ * supplies a predicate that is always false, which yields an empty result —
+ * withdrawing `clear` while the disclosure line cannot render would be the
+ * silent omission this whole change exists to prevent.
+ */
+export function unresolvedCategoryNames(
+  summaries: readonly CategoryClearState[],
+  isExamined: (name: string) => boolean,
+  suppressedLabels: ReadonlySet<string>,
+): string[] {
+  return summaries
+    .filter(c => c.clear && suppressedLabels.has(c.name) && isExamined(c.name))
+    .map(c => c.name);
+}


### PR DESCRIPTION
Closes #421.

## The bug

`LOG-002` read `server.js`, matched `console.log(password` in it, and pushed a failed HIGH. The run printed 98/100, `logging` inside `16 others clear`, and `61 of 61 check groups ran`. `LOG-003`, pushed later in the same method, survived — so the check ran, and passed findings were not being filtered.

The check never recorded WHICH file it matched, and `filteredFindings` drops every pathless finding as generic advice. The detection reached neither the output nor the score **on any project type** — including webapp/api/mcp, where scoping already allowed it. Separately the `LOG-` group was scoped to webapp/api/mcp, which removed it from `allFindings` on a library too. The two causes are independent: the same bytes as an `api` project restore the finding to `allFindings` while `findings` stays empty and the score stays 98.

## What changed

`LOG-002` records the file and line it matched, and every file it matched, so `.hmaignore` on one cannot delete the evidence in another (#280). The line is cited only when a single file matched — a re-pointed finding moves `file` without moving `line`, and a citation the reader cannot follow is worse than none. `LOG-002` is declared above the `LOG-` group so it applies everywhere; a new test holds that ordering, because nothing else did.

Resurrecting a dead check makes its pattern load-bearing for the first time, so it is tightened here: no longer fires on `console.log(tokenCount)`, nor inside a comment or string (a comment recording that the bug was removed was enough to fail a project). The line is counted on the original text — the search ran on a `toLowerCase()` copy, which is not length-preserving, so a file could shift the line number in its own finding.

A run that silences a failed check and then lists clear categories is indistinguishable from a run that found nothing. The Coverage line now states how many checks failed unshown:

```
Coverage    17 of 25 categories examined · 8 unexamined (read no file) · 45 checks reported an absent mitigation (not shown)
```

Those are counted, never named per category — they overwhelmingly report an ABSENT mitigation and a clean three-file library carries 45. A check that MATCHED and was then dropped by project-type scoping is different, and its category is named on an `Unresolved` line instead of counted as clear. Not hypothetical: an ordinary library carrying an `mcp.json` bound to `0.0.0.0` has a CRITICAL `NET-001` matched and discarded at 98/100.

## What is deliberately NOT in this PR

`findingAppliesTo`s resolution order. Making full IDs win by length — which the maps own wording implies — activates two entries that had never taken effect and are **narrower** than their group, silently removing `SANDBOX-005` (a HIGH exfiltration detection) from webapp and api and taking a vulnerable API project from 69 to a perfect 100. Widening them instead put a HIGH false positive on every clean library. Thats a detection change for the whole map and needs its own corpus. Both entries are left dead and documented as dead.

## Score movement

**Expected and intended.** A project with a logged credential scores lower than on 0.26.0. The finding was always there; it was never shown.

## Verification

- Effective scope recomputed across 215 check IDs x 7 project types: unchanged except `LOG-002`.
- 53 tests across 3 files. **11 red on the parent commit**, including `expected git hygiene (1 low) · 16 others clear to contain audit`.
- 13 mutants killed, including deleting the backstop wiring and leaking a path into the identity-only ledger.
- Full suite 244 files / 3401 tests green · `tsc --noEmit` clean · `release-smoke:corpus` 12 passed / 0 failed.
- Two adversarial review rounds. The first found a CRITICAL in my own change (the scope narrowing above); the second found defects inside the first rounds fixes, so it was cut back to the minimum rather than fixed a third time.

## Follow-ups filed

- #426 — detections that emit no file are dropped the same way. `LOG-003` confirmed, ~23 candidates including CRITICALs.
- #427 — the CLIs five post-merge re-filters drop findings without recording them.

Touches no dependency file.