### PR TITLE
Disclose the rest of the verdict-without-measurement class in the 0.26.1 notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,71 @@ All notable changes to HackMyAgent are documented in this file.
   a tree. Tracked in [#414](https://github.com/opena2a-org/hackmyagent/issues/414); #412
   fixed the compile-set gate only.
 
+- **The defect class this release is mostly about is not closed.** #373 fixed `check
+  --json`, `secure-openclaw` and `secure-nemoclaw`. The same shape — *a verdict, or an
+  exit code, that does not depend on whether anything was actually measured* — is still
+  live in the commands below. Every one was measured on this build **and reproduces
+  identically on 0.26.0**, so none is new here; they are listed because staying silent
+  about the rest of a class while announcing three fixes to it would misrepresent what
+  upgrading gets you. All are scheduled to **0.27.0**.
+
+  | command | measured | tracked |
+  |---|---|---|
+  | `attack <unreachable-host>` | `Risk Score: 0/100 (SECURE)` at **exit 0**, all 111 attacks inconclusive, every `evidence` field `Error: fetch failed` | [#406](https://github.com/opena2a-org/hackmyagent/issues/406) |
+  | `attack --local` | `2/100 (LOW)` for a jailbreak prompt, a hardened prompt **and an empty string** — the score moves with `--intensity`, not with the target | [#430](https://github.com/opena2a-org/hackmyagent/issues/430) |
+  | `check <path-that-does-not-exist>` | `MEDIUM RISK` at **exit 0**, `--json` asserting `"revocation":{"revoked":false}` about an artifact that is not there | [#417](https://github.com/opena2a-org/hackmyagent/issues/417) |
+  | `secure <dir> -b oasb-2` | **exit 0** at `Conformance: NONE`, while the same directory exits 1 without `-b` and with `-b oasb-1`. `secure --help` promises exit 1 "or non-compliant in benchmark mode" | [#371](https://github.com/opena2a-org/hackmyagent/issues/371) |
+  | `check <remote target> --json` | the four network paths still carry no `coverage` object, so #388's disclosure is local-only | [#416](https://github.com/opena2a-org/hackmyagent/issues/416) |
+
+  Reproductions are in each issue. If you gate CI on any of these, gate on the text
+  channel or on `--fail-below` until 0.27.0 lands.
+
+- **Two auto-fix paths write sensitive bytes onto a git-tracked path.** Both reproduce
+  identically on 0.26.0. Scheduled to **0.27.0**.
+
+  - `secure --fix` moves the original file into `.hackmyagent-backup/`, and the
+    `.gitignore` it generates in the same run does not exclude that directory — so the
+    remediation for "credential in config" leaves the credential where `git add .` will
+    stage it. ([#389](https://github.com/opena2a-org/hackmyagent/issues/389))
+  - `fix-all` writes `.opena2a/credvault/store.key` beside the `secrets.enc` it decrypts,
+    with no `.gitignore` written at all, so the ciphertext and its key stage together. It
+    also creates no backup, so `rollback` cannot undo it despite the quick-start
+    advertising "auto-fix with rollback".
+    ([#431](https://github.com/opena2a-org/hackmyagent/issues/431))
+
+  Until 0.27.0: add `.hackmyagent-backup/` and `.opena2a/` to `.gitignore` yourself before
+  running either command in a repository, and prefer `--dry-run` first.
+
+- **Installing this package still reports 4 high advisories, and our own audit gate cannot
+  see them.** Measured on a fresh `npm init -y` tree, and identical on 0.26.0:
+
+  ```
+  $ npm install hackmyagent@0.26.1 && npm audit --audit-level=high
+  4 high severity vulnerabilities
+
+  hackmyagent -> ai-trust -> hackmyagent@0.17.11 -> onnxruntime-node -> adm-zip
+  ```
+
+  `ai-trust` pulls a nine-month-old copy of this package, which carries the vulnerable
+  `adm-zip` (crafted ZIP triggers a 4GB allocation). The `Dependency audit` workflow this
+  project added in 0.26.0 reports **0** — correctly, because it audits *this repo's*
+  lockfile, where `overrides` pins `adm-zip`. **`overrides` are not published**, so the
+  tree we audit is not the tree you install. Being explicit about it here rather than
+  letting the green badge stand for something it does not cover.
+  ([#432](https://github.com/opena2a-org/hackmyagent/issues/432))
+
+- **The exit-code contract differs per command and is not stated anywhere.** `secure`
+  exits 1 on a HIGH finding; `detect` prints `1 high-severity issue found` —
+  `HIGH  2 AI agents running without governance`, governance `12/100` — and exits **0**.
+  Reproduces on 0.26.0. ([#390](https://github.com/opena2a-org/hackmyagent/issues/390))
+
+  On `scan-soul` specifically, the measurement is narrower than #390's title suggests, so
+  to be exact: `scan-soul --ci` **does** exit 1 on a low-scoring governance file (measured
+  `4/100` -> exit 1). The case that exits 0 is a directory with **no `SOUL.md` at all**,
+  which scores `0/100` and passes `--ci` — the 0 there means nothing was evaluated, not
+  that something was evaluated and scored zero. That is the same
+  verdict-without-measurement shape as the table above.
+
 ### Fixed
 
 The three findings disclosed as known issues in 0.26.0 are closed here. Each turned out


### PR DESCRIPTION
CHANGELOG only. No `src/`, no version change. Blocks the `v0.26.1` tag until merged.

## Why

The 0.26.1 release-test walkthrough found **six P1s**. Every one was measured against
published `0.26.0` and **reproduces identically there**, so none is a regression and none
is a reason to hold the release — on each of these axes 0.26.0 is the same, and holding
would leave users with the same defects *and* none of the four fixes.

But the release's `Known issues` block named only #414, and four of the six are the exact
defect class 0.26.1 announces three fixes to: **a verdict, or an exit code, that does not
depend on whether anything was measured.** Announcing three fixes to a class while staying
silent about the rest of it misrepresents what upgrading gets you.

## What was measured

| finding | measured on 0.26.1 | on 0.26.0 | issue |
|---|---|---|---|
| `attack <unreachable>` | `0/100 (SECURE)` exit 0 | identical | #406 |
| `attack --local` | `2/100 (LOW)` for jailbreak, hardened **and empty** prompt | identical | **#430 (new)** |
| `check <missing path>` | `MEDIUM RISK` exit 0 | identical | #417 |
| `secure -b oasb-2` | exit 0 at `Conformance: NONE` | identical | #371 |
| `secure --fix` | credential staged from ungitignored `.hackmyagent-backup/` | identical | #389 |
| `fix-all` | `store.key` staged beside `secrets.enc`, no rollback | identical | **#431 (new)** |
| consumer install | 4 high advisories, nested `hackmyagent@0.17.11` | identical | **#432 (new)** |

Three were already filed (#371, #389, #390) and were found by searching before filing.

## Two corrections against issue titles

The notes state measurements rather than repeat claims, and two did not survive checking:

- **#390's title says `scan-soul --ci` exits 0 at 0/100.** Measured, `scan-soul --ci`
  **does** exit 1 on a low-scoring governance file (`4/100` -> exit 1). The case that
  exits 0 is a directory with **no `SOUL.md` at all**, scoring `0/100` because nothing was
  evaluated. Narrower than the title, and a cleaner example of the class.
- **#432 is not "we have 4 vulnerabilities".** The repo's audit gate correctly reports 0;
  it audits this repo's lockfile where `overrides` pins `adm-zip`. `overrides` are not
  published, so the tree we audit is not the tree users install. The defect is the blind
  spot, not the count.

## Verification

- `tsc --noEmit` clean; full suite green at the base commit (241 files / 3348 tests)
- Every issue link resolved; 10 cited (371, 389, 390, 406, 414, 416, 417, 430, 431, 432)
- Each carried item has a reproduction and a named target version (0.27.0), per the
  release-test carry conditions

https://claude.ai/code/session_01AgABLQKM8YyXQFAAmFRCym