### PR TITLE
Audit the tree a consumer resolves, and drop the dependency that poisoned it (#432)

### DIFF
--- a/.github/workflows/dependency-audit.yml
+++ b/.github/workflows/dependency-audit.yml
@@ -79,3 +79,30 @@ jobs:
       # The gate.
       - name: Fail on high or critical advisories
         run: npm audit --package-lock-only --audit-level=high
+
+  # #432 — the job above audits this repo's lockfile, where `overrides` pins
+  # `adm-zip`. It reported 0 while `npm install hackmyagent@0.26.1` gave a user
+  # 4 high advisories and a nested `hackmyagent@0.17.11`, because `overrides`
+  # are not published: the artifact we audit is not the artifact we ship.
+  #
+  # This job resolves the tree a consumer gets and gates on that. Kept separate
+  # rather than folded into `audit` so the two numbers stay legible as the two
+  # different measurements they are — a reviewer seeing "0 here, 3 there" should
+  # be able to tell which tree each one describes.
+  #
+  # Fork-safe on the same terms as the job above: the script packs and resolves
+  # with `--ignore-scripts` and `--package-lock-only`, so no dependency's
+  # install script runs and nothing is fetched into an executable position.
+  consumer-audit:
+    name: Consumer resolution audit
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          # No `cache: npm`, and no `npm ci`: the script uses only node builtins
+          # and the npm CLI, and `npm pack` does not need `dist/` present to
+          # resolve a dependency set.
+      - name: Audit the tree a consumer resolves
+        run: npm run audit:consumer

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,75 @@
 
 All notable changes to HackMyAgent are documented in this file.
 
+## [Unreleased]
+
+### Security
+
+- **Installing HackMyAgent no longer resolves a second, nine-month-old copy of itself, and
+  drops one of the four high advisories a consumer inherited.** Measured on a fresh
+  `npm init -y` tree, published `0.26.1` versus this build:
+
+  ```
+                                 0.26.1   this build
+  npm audit --audit-level=high   4 high   3 high
+  nested hackmyagent             0.17.11  none
+  ```
+
+  `hackmyagent` declared a runtime dependency on `ai-trust`, which depends back on
+  `hackmyagent@0.17.11`. Every consumer resolved that copy, and its deprecation notice —
+  describing defects in a version they never asked for and could not easily tell they were
+  not running — was the first screen after install. The dependency was never imported:
+  there was no `require`, no `import` and no subprocess call to it anywhere in `src/`. The
+  Registry lookups behind `trust` were already this tool's own code.
+
+  HackMyAgent is standalone. Nothing an `ai-trust` user wants is behind a second install:
+  `hackmyagent trust <package>` is the registry lookup, `hackmyagent trust --audit <file>`
+  audits a dependency file, and `hackmyagent check <package>` scans one.
+
+- **The dependency audit gate now measures the tree a consumer resolves, not this repo's
+  lockfile.** The gate added in 0.26.0 ran `npm audit --package-lock-only` here and
+  reported `0`. That number was correct and it was not the number a user got, because the
+  `overrides` block that produced it is not published — npm applies `overrides` only to the
+  tree that declares them, so the artifact being audited was never the artifact being
+  shipped. 0.26.0 added that gate because "nothing in CI would have caught either
+  recurrence"; this was the same blind spot one level out, and the gate could not see it.
+
+  `npm run audit:consumer` packs the repo, resolves the tarball as a dependency of an empty
+  scratch package, and audits that. It fails on any high or critical advisory not named in
+  an explicit allowlist, on an allowlist entry that no longer matches or has passed its
+  review date, and on any nested copy of `hackmyagent` at any version. It installs nothing
+  and runs no package's scripts, so it is safe on pull requests from forks for the same
+  reason the original job is.
+
+  Pinned in both directions: it fails on published `0.26.1` and passes on this build.
+
+### Known issues
+
+- **`npm install hackmyagent` still reports 3 high advisories, all of them the same one.**
+  `adm-zip <0.6.0` (GHSA-xcpc-8h2w-3j85), reached only through `onnxruntime-node`, which
+  this tool needs for local NanoMind inference. There is no version that resolves clean:
+  `onnxruntime-node@1.27.0` is the latest release and pins `adm-zip: ^0.5.16`, while the
+  patched release is `0.6.0` — outside that caret — and an `overrides` entry here does not
+  reach anyone who installs this package. The extract path carrying the advisory runs in
+  `onnxruntime-node`'s postinstall when it downloads execution-provider binaries; the base
+  package ships those binaries, so that script exits before requiring `adm-zip` on a
+  default install. Recorded with its reasoning and a review date in
+  `scripts/audit-consumer-resolution.mjs`, and the gate fails if it is still waived after
+  that date.
+
+### Fixed
+
+- **Four printed lines told the reader to run a CLI that installing this tool does not give
+  them.** `trust` and `trust --audit` cited `ai-trust check <name> --scan-if-missing` and
+  `ai-trust audit <file> --scan-missing`. A dependency does not put its `bin` on a
+  consumer's PATH, so those never ran for anyone who installed only `hackmyagent` — they
+  were dead ends before the dependency was removed and unambiguous ones after. They now
+  cite `check` and `trust`, which this tool registers.
+
+  The #372 gate did not catch them because `ai-trust` was on its foreign-executable skip
+  list, which exists for command lines that genuinely belong to another tool. It came off
+  that list, so the gate now covers this class.
+
 ## [0.26.1] - 2026-08-07
 
 ### Security

--- a/__tests__/helpers/printed-flag-citations.ts
+++ b/__tests__/helpers/printed-flag-citations.ts
@@ -47,6 +47,19 @@ export interface PrintedFlag {
  * Executables whose flags belong to them. A segment naming one of these is
  * quoting another tool's command line, not ours.
  *
+ * `ai-trust` was on this list and came off with #432. Being on it made the
+ * gate skip four printed lines — `ai-trust check <name> --scan-if-missing`,
+ * `ai-trust audit <file> --scan-missing` — which were dead ends for every
+ * reader: a dependency does not put its `bin` on a consumer's PATH, so the
+ * suggestion never ran for anyone who installed only `hackmyagent`. Removing
+ * the runtime dependency made that unambiguous, and the citations now name
+ * `check` and `trust`, which this tool registers itself.
+ *
+ * The entries that remain are cited through a runner that does resolve them
+ * (`npx opena2a-cli protect .`) or are genuinely another tool's command line.
+ * Adding a name here suppresses a real class of defect, so it needs the same
+ * justification: the reader can run it as printed.
+ *
  * Program names that are also ordinary English words are deliberately NOT on
  * this list — `go`, `find`, `ls`, `ps`, `gh`, `az`, `ag`, `helm`. With them on
  * it, "If you go further, use `--x`" and "To find more, use `--x`" were both
@@ -57,7 +70,7 @@ export interface PrintedFlag {
  * silently skips is indistinguishable from a guard that passes.
  */
 const FOREIGN_EXECUTABLE =
-  /\b(npm|npx|pnpm|yarn|pip|pip3|pipx|python|python3|node|deno|bun|cargo|git|curl|wget|docker|podman|kubectl|aws|gcloud|terraform|grep|rg|sed|awk|tar|unzip|ssh|scp|openssl|gpg|chmod|chown|snyk|semgrep|trivy|gitleaks|glab|brew|apt|apt-get|yum|dnf|jq|yq|shasum|sha256sum|systemctl|journalctl|arp-guard|ai-trust|opena2a|secretless|secretless-ai)\b/;
+  /\b(npm|npx|pnpm|yarn|pip|pip3|pipx|python|python3|node|deno|bun|cargo|git|curl|wget|docker|podman|kubectl|aws|gcloud|terraform|grep|rg|sed|awk|tar|unzip|ssh|scp|openssl|gpg|chmod|chown|snyk|semgrep|trivy|gitleaks|glab|brew|apt|apt-get|yum|dnf|jq|yq|shasum|sha256sum|systemctl|journalctl|arp-guard|opena2a|secretless|secretless-ai)\b/;
 
 /** Call shapes whose string arguments reach a user. */
 const PRINT_CALL =

--- a/__tests__/supply-chain/consumer-dependency-set.test.ts
+++ b/__tests__/supply-chain/consumer-dependency-set.test.ts
@@ -1,0 +1,131 @@
+/**
+ * #432 — invariants behind the consumer-resolution gate, checked offline.
+ *
+ * `scripts/audit-consumer-resolution.mjs` is the real gate, but it resolves a
+ * tree against the live registry, so it lives in CI and not in `npm test`. If
+ * that were the only check, the dependency edge this issue removed could come
+ * back in a PR and nothing on a developer's machine would say so until CI ran.
+ *
+ * These pin the parts that need no network. Every one of them fails on
+ * `6c48698` (0.26.1), which is the shape the fix has to have.
+ */
+import { describe, it, expect } from 'vitest';
+import { readFileSync, readdirSync, statSync } from 'node:fs';
+import path from 'node:path';
+
+const REPO_ROOT = path.resolve(__dirname, '..', '..');
+const pkg = JSON.parse(readFileSync(path.join(REPO_ROOT, 'package.json'), 'utf8'));
+
+/**
+ * `ai-trust` depends back on `hackmyagent`, so declaring it in any dependency
+ * field resolves a second, nine-month-old copy of this tool into every
+ * consumer's tree — with its own deprecation notice as the first screen after
+ * install — and drags `onnxruntime-node -> adm-zip` in a second time.
+ *
+ * HackMyAgent is standalone. The capability a reader would have reached for
+ * `ai-trust` to get is served by this tool's own `trust` and `check`.
+ */
+describe('#432 the ai-trust edge stays removed', () => {
+  const FIELDS = [
+    'dependencies',
+    'devDependencies',
+    'optionalDependencies',
+    'peerDependencies',
+  ] as const;
+
+  for (const field of FIELDS) {
+    it(`does not declare ai-trust in ${field}`, () => {
+      expect(Object.keys(pkg[field] ?? {})).not.toContain('ai-trust');
+    });
+  }
+
+  it('does not resolve ai-trust anywhere in the committed lockfile', () => {
+    const lock = JSON.parse(readFileSync(path.join(REPO_ROOT, 'package-lock.json'), 'utf8'));
+    const entries = Object.keys(lock.packages ?? {}).filter((p) =>
+      p.split('node_modules/').pop() === 'ai-trust'
+    );
+    expect(entries, `ai-trust is back in the lockfile at: ${entries.join(', ')}`).toEqual([]);
+  });
+
+  it('resolves no second copy of hackmyagent in the committed lockfile', () => {
+    const lock = JSON.parse(readFileSync(path.join(REPO_ROOT, 'package-lock.json'), 'utf8'));
+    const nested = Object.keys(lock.packages ?? {}).filter(
+      (p) => p !== '' && p.endsWith('node_modules/hackmyagent')
+    );
+    expect(nested, `nested hackmyagent copies: ${nested.join(', ')}`).toEqual([]);
+  });
+});
+
+/**
+ * The four lines that sent a reader to another CLI. A dependency does not put
+ * its `bin` on a consumer's PATH, so `ai-trust check <name> --scan-if-missing`
+ * never ran for anyone who installed only `hackmyagent` — it was a dead end
+ * before the edge was removed, and an obvious one after.
+ *
+ * Source strings, not `console.log` calls: the citations lived inside array
+ * pushes and template literals, which a print-call grep does not see. That is
+ * the same constraint `__tests__/helpers/printed-flag-citations.ts` documents.
+ */
+describe('#432 no printed string sends the reader to the ai-trust CLI', () => {
+  function sourceFiles(dir: string): string[] {
+    return readdirSync(dir).flatMap((entry) => {
+      const full = path.join(dir, entry);
+      if (statSync(full).isDirectory()) return sourceFiles(full);
+      return full.endsWith('.ts') ? [full] : [];
+    });
+  }
+
+  it('cites no ai-trust subcommand in src/', () => {
+    // A comment may still discuss the tool; a printed line may not invoke it.
+    // Matches `ai-trust <verb>` only, so prose naming the project is untouched.
+    const INVOCATION = /\bai-trust\s+(?:check|audit|scan|trust|verify)\b/;
+
+    const offenders: string[] = [];
+    for (const file of sourceFiles(path.join(REPO_ROOT, 'src'))) {
+      const lines = readFileSync(file, 'utf8').split('\n');
+      lines.forEach((line, i) => {
+        if (!INVOCATION.test(line)) return;
+        // Strip the comment forms this file uses before judging.
+        const code = line.replace(/^\s*(?:\/\/|\*|\/\*).*$/, '');
+        if (!INVOCATION.test(code)) return;
+        offenders.push(`${path.relative(REPO_ROOT, file)}:${i + 1}: ${line.trim()}`);
+      });
+    }
+
+    expect(
+      offenders,
+      `these lines tell a reader to run a CLI that installing hackmyagent does ` +
+        `not give them:\n${offenders.join('\n')}`
+    ).toEqual([]);
+  });
+});
+
+describe('#432 the consumer-resolution gate stays wired', () => {
+  it('exposes the gate as an npm script', () => {
+    expect(pkg.scripts?.['audit:consumer']).toBe('node scripts/audit-consumer-resolution.mjs');
+  });
+
+  it('runs that script from the dependency-audit workflow', () => {
+    const wf = readFileSync(
+      path.join(REPO_ROOT, '.github', 'workflows', 'dependency-audit.yml'),
+      'utf8'
+    );
+    expect(wf).toContain('npm run audit:consumer');
+  });
+
+  /**
+   * The reason this gate exists at all. If a future edit "simplifies" the
+   * script into auditing the repo's own lockfile, it becomes a duplicate of
+   * the job above it and the blind spot returns silently.
+   */
+  it('resolves a packed tarball rather than this repo lockfile', () => {
+    const script = readFileSync(
+      path.join(REPO_ROOT, 'scripts', 'audit-consumer-resolution.mjs'),
+      'utf8'
+    );
+    expect(script).toContain('npm');
+    expect(script).toContain('pack');
+    expect(script).toContain('--ignore-scripts');
+    expect(script).toContain('--package-lock-only');
+  });
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,6 @@
         "@opena2a/registry-client": "0.2.0",
         "@opena2a/shared": "^0.1.0",
         "@opena2a/telemetry": "0.3.0",
-        "ai-trust": "^0.2.6",
         "commander": "^12.0.0",
         "js-yaml": "^4.3.1",
         "onnxruntime-node": "^1.27.0"
@@ -1248,25 +1247,6 @@
         "node": ">=14.0"
       }
     },
-    "node_modules/ai-trust": {
-      "version": "0.2.25",
-      "resolved": "https://registry.npmjs.org/ai-trust/-/ai-trust-0.2.25.tgz",
-      "integrity": "sha512-BoVwQKH18j72kW0eLwQR5FdwmP0EWgZJzj0tf7q75vdWky4UcTFH6QDhMvjShW7q/tdzV5MQAKW3P57UNLPLtQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@opena2a/contribute": "^0.1.0",
-        "@opena2a/shared": "^0.1.0",
-        "chalk": "^5.3.0",
-        "commander": "^12.1.0",
-        "hackmyagent": "^0.17.1"
-      },
-      "bin": {
-        "ai-trust": "dist/index.js"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
     "node_modules/ajv": {
       "version": "8.20.0",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
@@ -2013,30 +1993,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/hackmyagent": {
-      "version": "0.17.11",
-      "resolved": "https://registry.npmjs.org/hackmyagent/-/hackmyagent-0.17.11.tgz",
-      "integrity": "sha512-pZ5SSHWIB6b9XskrpCdKhbrr37naFVGMCpRvtbuCaq72tOMrTYj9TvA1G9OO7y3qm5k/t3NTeq3MELI8EIuzoA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@modelcontextprotocol/sdk": "^1.12.1",
-        "@noble/ed25519": "^2.3.0",
-        "@noble/post-quantum": "^0.2.1",
-        "@opena2a/aim-core": "^0.1.2",
-        "@opena2a/contribute": "^0.1.0",
-        "@opena2a/shared": "^0.1.0",
-        "ai-trust": "^0.2.6",
-        "commander": "^12.0.0",
-        "js-yaml": "^4.1.1",
-        "onnxruntime-node": "^1.24.3"
-      },
-      "bin": {
-        "hackmyagent": "dist/cli.js"
-      },
-      "engines": {
-        "node": ">=18.0.0"
       }
     },
     "node_modules/has-property-descriptors": {

--- a/package.json
+++ b/package.json
@@ -34,7 +34,8 @@
     "test": "vitest run",
     "test:watch": "vitest",
     "clean": "rm -rf dist",
-    "release-smoke:corpus": "tsx scripts/release-smoke-corpus.ts"
+    "release-smoke:corpus": "tsx scripts/release-smoke-corpus.ts",
+    "audit:consumer": "node scripts/audit-consumer-resolution.mjs"
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.30.0",
@@ -49,7 +50,6 @@
     "@opena2a/registry-client": "0.2.0",
     "@opena2a/shared": "^0.1.0",
     "@opena2a/telemetry": "0.3.0",
-    "ai-trust": "^0.2.6",
     "commander": "^12.0.0",
     "js-yaml": "^4.3.1",
     "onnxruntime-node": "^1.27.0"

--- a/scripts/audit-consumer-resolution.mjs
+++ b/scripts/audit-consumer-resolution.mjs
@@ -1,0 +1,268 @@
+#!/usr/bin/env node
+/**
+ * #432 — audit the tree a CONSUMER resolves, not the tree this repo pins.
+ *
+ * `.github/workflows/dependency-audit.yml` runs `npm audit --package-lock-only`
+ * against this repo's lockfile and reports 0. That number is correct and it is
+ * not the number a user gets:
+ *
+ *   $ npm install hackmyagent@0.26.1 && npm audit --audit-level=high
+ *   4 high severity vulnerabilities
+ *
+ * The `overrides` block in package.json pins `adm-zip` for THIS tree. npm
+ * applies `overrides` only to the tree that declares them, and they are not
+ * carried in the published tarball, so the artifact we audit resolves
+ * differently from the artifact we ship. 0.26.0 added that gate because
+ * "nothing in CI would have caught either recurrence"; this is the same lesson
+ * one level out, and the gate still could not see it, because it audits the
+ * wrong tree.
+ *
+ * So this script packs the repo, resolves the tarball as a dependency of an
+ * empty scratch package, and audits THAT.
+ *
+ * ## Why it never installs
+ *
+ * The existing job avoids `npm ci` deliberately: it runs on `pull_request`,
+ * which includes forks, and installing a fork's branch executes whatever that
+ * branch put in a `postinstall` — least acceptable in the CI of a tool whose
+ * subject is supply-chain risk. That argument does not weaken just because
+ * this gate needs a consumer tree, so both `npm pack` and the resolve run with
+ * `--ignore-scripts`, and the resolve is `--package-lock-only`: npm computes
+ * the tree and writes a lockfile without fetching or executing a package.
+ *
+ * Verified equivalent to the real thing before being adopted: on 0.26.1's
+ * dependency set the lock-only form and a genuine `npm install` of the tarball
+ * both report the same 4 high and the same single advisory, and with the
+ * `ai-trust` edge removed both report the same 3.
+ *
+ * ## Why the gate is an allowlist and not a count
+ *
+ * One advisory in the consumer tree has no fix available at any version:
+ * `onnxruntime-node@1.27.0` is the latest release and pins `adm-zip: ^0.5.16`,
+ * while the patched `adm-zip` is `0.6.0` — a caret on `0.5.x` cannot reach it,
+ * and no `overrides` we write reaches a consumer. A gate that can only be red
+ * gets switched off within a release, so it would protect nothing.
+ *
+ * Instead every high/critical advisory must be named in ALLOWED below with a
+ * reason and a review date. Anything unlisted fails. An entry that stops
+ * matching also fails, so the list cannot quietly accumulate advisories that
+ * were fixed years ago — a stale waiver reads exactly like a considered one.
+ */
+import { execFileSync } from 'node:child_process';
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync, readFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+
+/**
+ * Advisories accepted in the consumer tree, keyed by GHSA id.
+ *
+ * An entry is a statement that a user installing this tool gets this advisory
+ * and we decided to ship anyway. It needs to survive a reader asking "why is
+ * my audit red because of your CLI", so `reason` names the blocker, not the
+ * severity.
+ */
+const ALLOWED = [
+  {
+    id: 'GHSA-xcpc-8h2w-3j85',
+    package: 'adm-zip',
+    reason:
+      'adm-zip <0.6.0, reached only through onnxruntime-node, which HackMyAgent ' +
+      'needs for local NanoMind inference. onnxruntime-node@1.27.0 is the latest ' +
+      'release and pins adm-zip ^0.5.16; the patched 0.6.0 is outside that caret, ' +
+      'so no version of the dependency resolves clean and `overrides` do not reach ' +
+      'a consumer. Tracked upstream at microsoft/onnxruntime. The extract path that ' +
+      'carries the advisory runs in onnxruntime-node postinstall when it downloads ' +
+      'execution-provider binaries; the base package ships those binaries, so the ' +
+      'script exits before requiring adm-zip on a default install.',
+    reviewBy: '2026-11-01',
+  },
+];
+
+/** Packages that must never appear in a consumer tree, at any version. */
+const FORBIDDEN_PACKAGES = [
+  {
+    name: 'hackmyagent',
+    where: 'nested',
+    reason:
+      'A second, older copy of this tool. 0.26.1 shipped `ai-trust` as a runtime ' +
+      'dependency, which depends back on hackmyagent@0.17.11, so every consumer ' +
+      'resolved a nine-month-old copy and read its deprecation notice — describing ' +
+      'defects in a version they never asked for — as the first screen after install.',
+  },
+];
+
+function run(cmd, args, opts = {}) {
+  return execFileSync(cmd, args, { encoding: 'utf8', stdio: ['ignore', 'pipe', 'pipe'], ...opts });
+}
+
+/** Resolve a consumer's tree for `spec` and return npm's audit report. */
+function auditConsumerTree(spec, scratch) {
+  writeFileSync(
+    path.join(scratch, 'package.json'),
+    JSON.stringify({ name: 'consumer-resolution-probe', version: '1.0.0', private: true }) + '\n'
+  );
+  run('npm', [
+    'install',
+    '--package-lock-only',
+    '--ignore-scripts',
+    '--no-audit',
+    '--no-fund',
+    spec,
+  ], { cwd: scratch });
+
+  let raw;
+  try {
+    raw = run('npm', ['audit', '--package-lock-only', '--json'], { cwd: scratch });
+  } catch (e) {
+    // `npm audit` exits non-zero when it finds anything. The report is still
+    // on stdout and is the entire point of the call.
+    raw = e.stdout ?? '';
+  }
+
+  let report;
+  try {
+    report = JSON.parse(raw);
+  } catch {
+    // A gate that could not take its measurement has not passed. `npm audit`
+    // reaches the live advisory database, so an unreachable registry, a proxy,
+    // or a rate limit all land here — and every one of them would otherwise
+    // surface as a raw SyntaxError that reads like a bug in this script.
+    throw new Error(
+      'npm audit produced no parseable report, so the consumer tree was never measured. ' +
+        'This is not a pass. Check network access to the npm advisory database and re-run.\n' +
+        `npm said: ${(raw || '(nothing)').slice(0, 500)}`
+    );
+  }
+  const lock = JSON.parse(readFileSync(path.join(scratch, 'package-lock.json'), 'utf8'));
+  return { report, lock };
+}
+
+/** Every GHSA id at `high` or `critical`, with the package it lands on. */
+function highAndCritical(report) {
+  const out = new Map();
+  for (const [name, v] of Object.entries(report.vulnerabilities ?? {})) {
+    if (v.severity !== 'high' && v.severity !== 'critical') continue;
+    for (const via of v.via ?? []) {
+      if (typeof via !== 'object' || !via.url) continue;
+      const id = via.url.split('/').pop();
+      if (!out.has(id)) out.set(id, { id, severity: via.severity ?? v.severity, packages: new Set() });
+      out.get(id).packages.add(name);
+    }
+  }
+  return out;
+}
+
+/**
+ * Copies of `name` that are not the root package under test.
+ *
+ * Read off the lockfile rather than the audit report on purpose: a nested old
+ * copy is wrong whether or not it currently carries an advisory, and reading
+ * it from the advisory list would make the check disappear the day upstream
+ * patches something.
+ */
+function nestedCopies(lock, name) {
+  return Object.keys(lock.packages ?? {}).filter(
+    (p) => p !== `node_modules/${name}` && p.endsWith(`node_modules/${name}`)
+  );
+}
+
+function main() {
+  const argv = process.argv.slice(2);
+  const targetArg = argv.indexOf('--target');
+  const explicitTarget = targetArg !== -1 ? argv[targetArg + 1] : null;
+
+  const scratch = mkdtempSync(path.join(tmpdir(), 'hma-consumer-audit-'));
+  const failures = [];
+  try {
+    let spec = explicitTarget;
+    if (!spec) {
+      const tarball = run('npm', ['pack', '--ignore-scripts', '--pack-destination', scratch], {
+        cwd: REPO_ROOT,
+      })
+        .trim()
+        .split('\n')
+        .pop();
+      spec = path.join(scratch, tarball);
+      console.log(`Packed ${tarball}`);
+    }
+    console.log(`Resolving a consumer tree for: ${explicitTarget ?? path.basename(spec)}\n`);
+
+    const probe = path.join(scratch, 'probe');
+    mkdirSync(probe, { recursive: true });
+    const { report, lock } = auditConsumerTree(spec, probe);
+
+    const counts = report.metadata?.vulnerabilities ?? {};
+    console.log(
+      `Consumer resolution: ${counts.critical ?? 0} critical, ${counts.high ?? 0} high, ` +
+        `${counts.moderate ?? 0} moderate, ${counts.low ?? 0} low`
+    );
+    console.log('(This repo\'s own lockfile is audited separately and reports fewer — ' +
+      '`overrides` are not published.)\n');
+
+    const found = highAndCritical(report);
+    const allowedById = new Map(ALLOWED.map((a) => [a.id, a]));
+
+    // 1. Every high/critical advisory must be allowlisted.
+    for (const adv of found.values()) {
+      const allow = allowedById.get(adv.id);
+      if (!allow) {
+        failures.push(
+          `Unlisted ${adv.severity} advisory in the consumer tree: ${adv.id} ` +
+            `(via ${[...adv.packages].join(', ')}).\n` +
+            `    A consumer installing this tool inherits it. Either raise the floor to a ` +
+            `patched version, drop the dependency, or add it to ALLOWED in ${path.relative(REPO_ROOT, fileURLToPath(import.meta.url))} ` +
+            `with a reason a user would accept and a review date.`
+        );
+        continue;
+      }
+      // No silent caps: say what was waived, every run.
+      console.log(`  allowed  ${adv.id}  ${allow.package}  (review by ${allow.reviewBy})`);
+      console.log(`           ${allow.reason.replace(/\s+/g, ' ')}\n`);
+    }
+
+    // 2. An allowlist entry that no longer matches is removed, not left to rot.
+    for (const allow of ALLOWED) {
+      if (found.has(allow.id)) continue;
+      failures.push(
+        `Stale allowlist entry: ${allow.id} (${allow.package}) is no longer in the consumer ` +
+          `tree. Delete it — a waiver nobody rechecks reads the same as a considered one.`
+      );
+    }
+
+    // 3. Allowlist entries expire.
+    const today = new Date().toISOString().slice(0, 10);
+    for (const allow of ALLOWED) {
+      if (allow.reviewBy >= today) continue;
+      failures.push(
+        `Allowlist entry ${allow.id} (${allow.package}) passed its review date ` +
+          `${allow.reviewBy}. Re-check whether upstream now resolves clean, then either ` +
+          `fix it or move the date with a fresh reason.`
+      );
+    }
+
+    // 4. Forbidden packages, advisory or not.
+    for (const forbidden of FORBIDDEN_PACKAGES) {
+      const copies = nestedCopies(lock, forbidden.name);
+      if (copies.length === 0) continue;
+      const versions = copies.map((p) => `${lock.packages[p]?.version ?? '?'} at ${p}`);
+      failures.push(
+        `Nested copy of \`${forbidden.name}\` in the consumer tree: ${versions.join(', ')}.\n` +
+          `    ${forbidden.reason.replace(/\s+/g, ' ')}`
+      );
+    }
+  } finally {
+    rmSync(scratch, { recursive: true, force: true });
+  }
+
+  if (failures.length > 0) {
+    console.error('\nConsumer-resolution audit FAILED:\n');
+    for (const f of failures) console.error(`  - ${f}\n`);
+    process.exit(1);
+  }
+  console.log('Consumer-resolution audit passed.');
+}
+
+main();

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -183,7 +183,7 @@ import { shouldShowDeepProgress } from './ui/progress-gate';
 import { generateVerifyCommand } from './ui/verify-command';
 import { commandSucceeded } from './telemetry/command-success';
 import { escapeForDisplay, escapePathForDisplay } from './ui/display-safe';
-import { shellQuote, citationPath, citationTarget } from './ui/shell-quote';
+import { shellQuote, citationPath, citationTarget, commandNaming } from './ui/shell-quote';
 import { CONCEPT_EXPLAINERS, inferConceptFromFix } from './ui/concept-explainers';
 import type { ConceptId } from './types/finding-evidence';
 import { trustAapGate } from './aap';
@@ -8255,7 +8255,13 @@ Examples:
   });
 
 // ---------------------------------------------------------------------------
-// trust — Trust verification via OpenA2A Registry (powered by ai-trust)
+// trust — Trust verification via the OpenA2A Registry.
+//
+// This talks to the Registry directly. The `ai-trust` dependency that used to
+// sit in package.json was never the mechanism here — nothing imported it — and
+// it came off with #432, so "powered by ai-trust" was wrong even while it was
+// declared. Anything a reader would install that CLI for is served by this
+// command, `trust --audit <file>`, and `check <package>`.
 // ---------------------------------------------------------------------------
 
 const REGISTRY_DEFAULT_URL = 'https://api.oa2a.org';
@@ -8387,16 +8393,24 @@ function formatTrustScanAge(lastScannedAt?: string): string | null {
 
 function formatTrustCheck(answer: TrustAnswer): string {
   if (!answer.found) {
+    // `answer.name` is the name a registry response came back with, so it is
+    // spliced through `commandNaming` rather than into the template: a name
+    // carrying a display hazard yields `undefined` and the citation is dropped
+    // instead of printing a command that would act on something else. The name
+    // is already on the line above, so the reader is not left without a
+    // subject — and the whole-project scan below is a path forward either way.
+    const scanIt = commandNaming(answer.name, (cited) => npxCitation(`check ${cited}`));
     return [
       '',
       `  ${answer.name}`,
       `  ${colors.dim}Type: ${answer.packageType || 'unknown'}${colors.reset}`,
       `  ${colors.dim}Status: Not found in registry${colors.reset}`,
+      ...(scanIt
+        ? ['', '  To scan it locally:', `    ${colors.cyan}${scanIt}${colors.reset}`]
+        : []),
       '',
-      '  To scan it locally:',
-      `    ${colors.cyan}ai-trust check ${answer.name} --scan-if-missing${colors.reset}`,
-      '',
-      '  Or scan your full project:',
+      // "Or" only reads as an alternative when there is a first option above.
+      scanIt ? '  Or scan your full project:' : '  Scan your full project:',
       `    ${colors.cyan}${npxCitation('secure .')}${colors.reset}`,
       '',
     ].join('\n');
@@ -8529,11 +8543,10 @@ function formatTrustBatch(
   // Next steps
   lines.push('');
   if (notFound.length > 0) {
-    lines.push(`  ${colors.dim}Scan unknown packages: ai-trust audit <file> --scan-missing${colors.reset}`);
-    lines.push(`  ${colors.dim}Or individually: ai-trust check <name> --scan-if-missing${colors.reset}`);
+    lines.push(`  ${colors.dim}Scan unknown packages: ${npxCitation('check <name>')}${colors.reset}`);
   }
   if (belowThreshold.length > 0) {
-    lines.push(`  ${colors.dim}Inspect flagged packages: ai-trust check <name>${colors.reset}`);
+    lines.push(`  ${colors.dim}Inspect flagged packages: ${npxCitation('trust <name>')}${colors.reset}`);
   }
   lines.push(`  ${colors.dim}Full project security scan: ${npxCitation('secure .')}${colors.reset}`);
 


### PR DESCRIPTION
Closes #432.

`npm install hackmyagent@0.26.1` gives a user 4 high advisories and a second, nine-month-old copy of this tool. The repo's own audit gate reports 0 and is correct: it audits this lockfile, where `overrides` pins `adm-zip`, and **`overrides` are not published**. The artifact audited was never the artifact shipped.

0.26.0 added that gate because *"nothing in CI would have caught either recurrence"*. This is the same blind spot one level out, and the gate could not see it.

## Measured

Fresh `npm init -y` tree, published `0.26.1` vs this build:

```
                               0.26.1   this build
npm audit --audit-level=high   4 high   3 high
nested hackmyagent             0.17.11  none
```

## Drop `ai-trust`

It was never imported — no `require`, no `import`, no subprocess call anywhere in `src/`, `scripts/` or `dist/`. Only comment text and four help strings citing its CLI. It depends back on `hackmyagent@0.17.11`, so every consumer resolved that copy, and its deprecation notice — describing defects in a version they never asked for and could not easily tell they were not running — was the first screen after install.

The Registry lookups behind `trust` were already this tool's own code. HackMyAgent is standalone: `trust <package>` is the lookup, `trust --audit <file>` audits a dependency file, `check <package>` scans one.

## Audit a consumer resolution

`npm run audit:consumer` packs the repo, resolves the tarball as a dependency of an empty scratch package, and audits that.

It installs nothing and runs no package's scripts (`--ignore-scripts`, `--package-lock-only`), so the fork-safety argument behind the original job holds here too. Verified equivalent to a real `npm install` of the tarball in both directions before being adopted.

**The gate is an allowlist, not a count**, because a count cannot go green: `onnxruntime-node@1.27.0` is the latest release and pins `adm-zip: ^0.5.16` while the patched release is `0.6.0`. A permanently-red gate gets switched off within a release. Every high/critical advisory must be named with a reason and a review date; an entry that stops matching, or passes its date, fails the gate.

It also fails on a nested copy of `hackmyagent` at any version, advisory or not — **and that is the check that catches this issue**: on `0.26.1` all four advisories trace to the single allowlisted GHSA, so the advisory check alone would pass.

## Dead-end citations

Four printed lines cited `ai-trust check <name> --scan-if-missing` and `ai-trust audit <file> --scan-missing`. A dependency does not put its `bin` on a consumer's PATH, so these never ran for anyone who installed only `hackmyagent`. They now cite `check` and `trust`.

The #372 gate did not catch them because `ai-trust` was on its foreign-executable skip list. It comes off, so the class is covered rather than the instance.

`answer.name` reaches its citation through `commandNaming` rather than the template — it is a name a registry response came back with, and the source gate was right to refuse the raw splice.

## Known issue, disclosed not hidden

3 high advisories remain in a consumer tree, all the same one: `adm-zip <0.6.0` (GHSA-xcpc-8h2w-3j85) via `onnxruntime-node`, which this tool needs for local NanoMind inference. No version resolves clean and `overrides` do not reach a consumer. The extract path runs in `onnxruntime-node`'s postinstall when it downloads execution-provider binaries; the base package ships those binaries, so the script exits before requiring `adm-zip` on a default install. Allowlisted to `2026-11-01` with its reasoning; the gate fails if it is still waived after that.

**Open question for a maintainer:** whether `onnxruntime-node` should stay a hard dependency at all. It is now the sole advisory source, and `require('onnxruntime-node')` sits in a `catch` that sets `useOnnx = false` — so making it optional would silently drop every user to vocabulary scoring. That is a product decision, not a supply-chain one, and is not taken here.

## Verification

- Gate red-proofed both branches: exits 1 on `--target hackmyagent@0.26.1` (nested-copy branch), and exits 1 with `ALLOWED` emptied (advisory branch, mutant run from inside the repo so `REPO_ROOT` resolves).
- Offline regression fails 6 of its 10 assertions on `6c48698`.
- Full suite 242 files / 3359 passed, `tsc --noEmit` clean.
- Self-scan 100/100, 520 files read, 61 of 61 check groups ran.