### PR TITLE
Stop --fail-below from switching a benchmark gate off (#440)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -159,13 +159,20 @@ All notable changes to HackMyAgent are documented in this file.
     the flagship scoring command and routing it through the same derivation is its own
     change.
   - `attack` can still report `0/100 (SECURE)` for `-t a2a`, `-t mcp` and
-    `--api-format custom`. The empty-body gate keys on the response text being blank, and
+    `--api-format custom`. A first attempt at this (#439) was reverted before shipping:
+    restricting extraction to a fixed set of key names turned a loud false positive into
+    a **silent false negative** — seven realistic response shapes, including a body
+    leaking `sk-live-…` under `--api-format custom`, went from `100/100 CRITICAL` to
+    `NOT MEASURED` with no flag to recover. For a scanner that is the worse direction.
+    The remaining detail: The empty-body gate keys on the response text being blank, and
     only the `openai` and `anthropic` extractors can return blank — the other three end
     in `JSON.stringify(data)`, so an endpoint answering every payload with
     `{"error":"unauthorized"}` is scored rather than withheld. The default `openai`
     format is fixed; these three are not.
-  - `secure -b oasb-1 --fail-below 0` exits 0 on a `Not Passing` rating, by the same
-    `failBelow === undefined &&` construct that was fixed for `-b oasb-2`.
+  - ~~`secure -b oasb-1 --fail-below 0` exits 0 on a `Not Passing` rating.~~ **Fixed
+    (#440).** `--fail-below` adds a score floor and no longer replaces the default
+    non-compliance gate on any benchmark arm. Note the behaviour change: a tree that was
+    already `Not Passing` and was being held green by `--fail-below` now fails.
   - `check --json` emits no `coverage` object on the registry-only paths (`--no-scan`,
     skill-identifier lookup). The downloaded and not-found paths carry it.
 

--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ hackmyagent secure --json                     # JSON output for CI
 hackmyagent secure --ci                       # non-interactive, exit non-zero on findings
 hackmyagent secure --publish                  # push anonymised results to the OpenA2A Registry
 hackmyagent secure -b oasb-1                  # OASB-1 benchmark (L1, L2, L3)
-hackmyagent secure -b oasb-1 --fail-below 70  # CI gate
+hackmyagent secure -b oasb-1 --fail-below 70  # CI gate (adds a floor; the rating gate still applies)
 hackmyagent secure --nanomind                 # AI analyst: per-finding narratives + coverage escalations
 ```
 

--- a/__tests__/cli/verdict-requires-measurement.test.ts
+++ b/__tests__/cli/verdict-requires-measurement.test.ts
@@ -420,6 +420,78 @@ describe('#417 check says a missing target is missing', () => {
   });
 });
 
+describe('#440 no benchmark gate can be switched off by a score flag', () => {
+  it('-b oasb-1 fails on a Not Passing rating with and without --fail-below', () => {
+    // Same shape as #371, in the arm the first sweep stopped short of.
+    // `--fail-below 0` printed `Rating: Not Passing` and exited 0.
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'hma-oasb1-'));
+    fs.writeFileSync(path.join(dir, 'README.md'), '# demo\n');
+    for (const extra of [[], ['--fail-below', '0'], ['--fail-below', '1']]) {
+      const { status, out } = run(['secure', dir, '-b', 'oasb-1', ...extra]);
+      expect(out).toMatch(/Rating:\s+(Not Passing|Needs Improvement)/);
+      expect(status, `with ${extra.join(' ') || '(no flag)'}: a failing rating must exit 1`).toBe(1);
+    }
+  }, 600_000);
+
+  it('no absent-failBelow test guards a gate, in any of its spellings', () => {
+    // "A score flag disables this gate" has now shipped twice, so it is worth a
+    // source guard as well as the behavioural test above.
+    //
+    // The first version of this guard matched one spelling on one line, and an
+    // adversarial reviewer wrote the same defect five other ways that all
+    // sailed through — including `!failBelow &&` (which is worse than the
+    // original, since it also fires on a legitimate `--fail-below 0`) and the
+    // multi-line form this file's own code uses. Newlines are collapsed before
+    // matching, and every spelling below is covered.
+    //
+    // This is still a source gate and proves only what it matches: a defect
+    // written through a renamed local (`const floor = failBelow`) is invisible
+    // to it. The exit-code test above is the real guarantee; this one catches
+    // the shape early and names it.
+    const cli = fs.readFileSync(path.join(__dirname, '..', '..', 'src', 'cli.ts'), 'utf8');
+    const code = cli
+      .split('\n')
+      .filter((l) => !l.trim().startsWith('//') && !l.trim().startsWith('*'))
+      .join('\n')
+      .replace(/\s+/g, ' ');
+
+    const spellings: Array<[string, RegExp]> = [
+      ['failBelow === undefined &&', /failBelow === undefined &&/],
+      ['failBelow == null &&', /failBelow ==+ null &&/],
+      ['!failBelow &&', /![a-zA-Z]*failBelow &&/],
+      ["typeof failBelow === 'undefined' &&", /typeof failBelow === ['"]undefined['"] &&/],
+      ['failBelow === undefined ?', /failBelow === undefined \?/],
+    ];
+    const found = spellings.filter(([, re]) => re.test(code)).map(([label]) => label);
+    expect(found, 'a --fail-below value must never switch a gate off').toEqual([]);
+  });
+
+  it('the guard above actually fires on each spelling it claims to cover', () => {
+    // Non-vacuity. `toEqual([])` is also what a guard that matches nothing
+    // reports, which is exactly how the first version passed while missing
+    // five of six spellings.
+    const spellings = [
+      'if (failBelow === undefined && ratingFails) process.exit(1);',
+      'if (failBelow == null && ratingFails) process.exit(1);',
+      'if (!failBelow && ratingFails) process.exit(1);',
+      "if (typeof failBelow === 'undefined' && ratingFails) process.exit(1);",
+      'const x = failBelow === undefined ? a : b;',
+      'if (failBelow === undefined\n  && ratingFails) process.exit(1);',
+    ];
+    const res = [
+      /failBelow === undefined &&/, /failBelow ==+ null &&/, /![a-zA-Z]*failBelow &&/,
+      /typeof failBelow === ['"]undefined['"] &&/, /failBelow === undefined \?/,
+    ];
+    for (const planted of spellings) {
+      const collapsed = planted.replace(/\s+/g, ' ');
+      expect(
+        res.some((re) => re.test(collapsed)),
+        `the guard does not catch: ${planted}`,
+      ).toBe(true);
+    }
+  });
+});
+
 describe('#371 the OASB-2 conformance gate cannot be switched off by a score flag', () => {
   it('fails on Conformance NONE with and without --fail-below', () => {
     // Adversarial review finding: the gate was written

--- a/docs/use-cases/ci-pipeline.md
+++ b/docs/use-cases/ci-pipeline.md
@@ -47,6 +47,12 @@ HMA uses exit codes to signal scan results:
 
 Any critical or high finding causes exit code `1`, which fails the GitHub Actions step by default.
 
+`--fail-below N` **adds** a score floor. It does not replace the default gate: a
+benchmark whose rating is `Not Passing` or `Needs Improvement`, or whose OASB-2
+conformance is `NONE`, exits 1 whether or not you pass the flag. Before 0.27.0
+`--fail-below 0` silently switched that gate off, so a pipeline could print
+`Rating: Not Passing` and go green.
+
 Exit `2` means HMA could not look at the target, so it reports no score and no
 risk level. Causes: the path or package does not exist, the endpoint under
 `attack` was unreachable, no payload was answered, `attack --local` was used

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -3962,7 +3962,7 @@ Examples:
   .option('--aws-account-id <id>', 'AWS account ID for ASFF format')
   .option('--aws-region <region>', 'AWS region for ASFF format')
   .option('-o, --output <file>', 'Write output to file instead of stdout')
-  .option('--fail-below <percent>', 'Exit 1 if compliance below threshold (0-100)')
+  .option('--fail-below <percent>', 'ADDITIONALLY exit 1 if compliance is below this threshold (0-100). Does not disable the default non-compliance gate')
   .option('-v, --verbose', 'Show all checks including passed ones')
   .option('-b, --benchmark <name>', 'Run benchmark compliance check (e.g., oasb-1)')
   .option('-l, --level <level>', 'Benchmark level: L1 (Essential), L2 (Standard), L3 (Hardened)', 'L1')
@@ -4459,16 +4459,28 @@ Examples:
           }
         }
 
+        // #440 — the non-compliance gate is checked FIRST and independently of
+        // `--fail-below`, the same way the composite arm above does it.
+        //
+        // It used to read `failBelow === undefined && …`, so `--fail-below 0`
+        // switched it off: the command printed `Rating: Not Passing` and exited
+        // 0. That flag reads as "add a score floor", it is a plausible thing to
+        // write while ramping a threshold in CI, and turning it on quietly
+        // removed the only gate the benchmark had. `--fail-below` adds a
+        // condition; it does not replace one.
+        const ratingFails = benchmarkResult.rating === 'Not Passing'
+          || benchmarkResult.rating === 'Needs Improvement';
+        if (ratingFails) {
+          console.error(`Benchmark rating is ${benchmarkResult.rating}. Exiting 1 per "non-compliant in benchmark mode".`);
+        }
+
         // Check fail threshold
         if (failBelow !== undefined && benchmarkResult.compliance < failBelow) {
           console.error(`Compliance ${benchmarkResult.compliance}% is below threshold ${failBelow}%`);
           process.exit(1);
         }
 
-        // Exit with non-zero if failing or needs improvement (default behavior)
-        if (failBelow === undefined && (benchmarkResult.rating === 'Not Passing' || benchmarkResult.rating === 'Needs Improvement')) {
-          process.exit(1);
-        }
+        if (ratingFails) process.exit(1);
         return;
       }
 


### PR DESCRIPTION
Closes #440.

`secure -b oasb-1 --fail-below 0` printed `Rating: Not Passing` and exited 0. Measured on `8ef9171`, same tree:

```
secure <dir> -b oasb-1                    Not Passing   exit 1
secure <dir> -b oasb-1 --fail-below 0     Not Passing   exit 0    <-
secure <dir> -b oasb-1 --fail-below 100   Not Passing   exit 1
```

Same `failBelow === undefined &&` construct #437 fixed on the oasb-2 composite arm and did not sweep. `--fail-below` reads as "add a score floor", it is a plausible thing to write while ramping a threshold in CI, and turning it on removed the only gate the benchmark had. The rating gate is evaluated independently of the flag now, the same way the composite arm does it.

Adversarial review verified the exit-code matrix in **both** directions: on a failing tree `[]/0/50/100` goes `1,0,0,1` → `1,1,1,1`; on a passing tree it stays `0,0,0,0`. No case where this build exits 0 and the base exited 1.

## Behaviour change

A tree that was already `Not Passing` and was being held green by `--fail-below` now fails. `--help` said "Exit 1 if compliance below threshold (0-100)", which was only half of what the flag does; README and `docs/use-cases/ci-pipeline.md` document `--fail-below 70` invocations and now say what changed.

## The class guard was rewritten after review

The first version grepped one spelling on one line. A reviewer wrote the same defect five other ways that all passed — including `!failBelow &&` (worse than the original, since it also fires on a legitimate `0`) and the multi-line form this file's own code uses. It collapses whitespace and checks five spellings, has a non-vacuity test that plants each one, and its comment states plainly that a renamed local still defeats it and the behavioural test is the real guarantee.

## #439 is not in this PR

It was attempted alongside #440 and **reverted before shipping**. Restricting response extraction to a fixed set of key names turned a loud false positive into a silent false negative: seven realistic shapes — including a body leaking `sk-live-…` under `--api-format custom`, and two real A2A task shapes — went from `100/100 CRITICAL` to `NOT MEASURED`, with no flag to recover. For a scanner that is the worse direction, and the headline symptom stayed reachable anyway through the JSON-RPC-shaped and `{"result":null}` variants. Full findings and a sketch of what a correct fix needs are [on the issue](https://github.com/opena2a-org/hackmyagent/issues/439#issuecomment-5220792844).

## Tests

243 files / 3407 passing. Both #440 cases red-proofed against `8ef9171`.
