### PR TITLE
Stop UNICODE-STEGO-002 reporting CRITICAL on the countermeasure, without gating it on one spelling (#469)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,118 +4,6 @@ All notable changes to HackMyAgent are documented in this file.
 
 ## [Unreleased]
 
-### Fixed
-
-**`UNICODE-STEGO-002` no longer reports CRITICAL on code that defends against the attack
-it names (#469).** This lowers findings rather than raising them, so it can turn a red
-pipeline green.
-
-The check fired at CRITICAL when a file contained `.codePointAt(` anywhere and a
-variation-selector or tag-range hex literal anywhere. There is no AST, no scope and no
-dataflow between the two, so they could be thousands of lines apart and unrelated. A
-sanitiser, a linter, a width calculator or a range table all carry both tokens, so all of
-them failed pipelines. Measured precision on real-world code was 0/7, and the only true
-positives ever observed were fixtures written for this check.
-
-The one thing that held a file clean was an exemption keyed on a regex over the file PATH
-(`/analyz|detect|scan|check|inspect|enhanc|stego/i`), which this scanner's own comment
-calls an attacker-controllable weak signal. Our own stego analyzer was clean only because
-of its filename: copying it to `util-helper.ts` self-flagged at CRITICAL.
-
-Two changes, both in the `UNICODE-STEGO-002` block:
-
-- **The filename exemption is deleted, not narrowed.** No name can make this check skip a
-  file any more, so the rename bypass is gone. Pinned by a test that scans identical bytes
-  under two filenames, one carrying an old exemption keyword and one not, and asserts the
-  severities match. Stated precisely, because the general form is not true: the CORROBORATOR
-  still reads the path, since `UNICODE-STEGO-001` does not look for variation selectors in
-  `.md`/`.txt` or in files named `README`/`AUTHORS`/`LICENSE` and similar. A decoder whose
-  only corroboration is an embedded payload is therefore MEDIUM under one of those names and
-  CRITICAL under another. A decoder corroborated by an execution sink is CRITICAL under every
-  name. That asymmetry predates this release and is not fixed here.
-- **CRITICAL now requires corroboration.** A decoder pattern is evidence of capability, not
-  of malice. Corroboration is an execution sink in the same file, so a decoded string can
-  reach `eval`/`Function`, or `UNICODE-STEGO-001` firing on the same file, so the invisible
-  payload a decoder would decode is actually present. Both are read from the file being
-  scanned, so severity never depends on the order the tree is walked in. Uncorroborated is
-  reported at MEDIUM with the evidence intact — downgraded, never dropped.
-
-  **MEDIUM still costs 8 points of score.** It does not fail the default severity gate, which
-  is what unblocks defensive code, but `secure --fail-below <n>` compares the score, so a
-  build that pins a threshold close to its current score can still go red on a downgraded
-  finding. Check your threshold before upgrading if you use that flag.
-
-Measured on first-class source files, not `node_modules`:
-
-| file | 0.27.0 | now |
-|---|---|---|
-| our own `stego-analyzer.ts` copied to `util-helper.ts` | CRITICAL | MEDIUM |
-| a log sanitiser's hazard-range table | CRITICAL | MEDIUM |
-| a test that builds a payload and asserts a sanitiser escapes it | CRITICAL | MEDIUM |
-| a decoder that reconstitutes a tag-range payload and `eval`s it | CRITICAL | CRITICAL |
-
-**Nothing 0.27.0 reported stops being reported, and this was measured rather than assumed.**
-The condition is now strictly weaker than 0.27.0's, so every file that fired then fires now.
-What can move is SEVERITY: an uncorroborated finding is MEDIUM rather than CRITICAL, and that
-is the whole point. Ten spellings of
-a working decoder — `.map(String.fromCodePoint)`, `Array.from(out, ...)`, an alias, a
-destructured `{ fromCharCode }`, `String['fromCodePoint']`, `Reflect.apply`,
-`Buffer.from(out).toString()`, `new TextDecoder().decode()`, a `JSON.parse('"\uXXXX"')`
-round trip, and an indexed alphabet table — are each pinned by a test asserting they still
-report CRITICAL.
-
-That list exists because an earlier cut of this fix made string reconstitution a REQUIRED
-conjunct of the finding, on the reasoning that only a decoder rebuilds a string from
-codepoints. The reasoning is sound and the implementation was not: it tested for
-`String.from(CodePoint|CharCode)(` specifically, and all ten spellings above evade that
-regex while doing exactly what it describes. Measured against 0.27.0, that cut reported
-**nothing at all** on all ten. The attacker chooses the spelling, so the spelling cannot be
-the gate. Narrowing on semantics rather than spelling needs dataflow, which is #424's AST
-analyzer.
-
-- **The reported line is the earlier of the two signals.** It used to report the first
-  `.codePointAt(`, but the discriminating token is the range literal, which usually sits in
-  a table above the loop that reads it. One downstream consumer was pointed at line 168 when
-  the cause was line 139. The message now names both lines. Note the consequence: neither
-  token detection strips comments, so on a file whose licence or doc header mentions a range
-  literal, the cited line is that header rather than the decoder.
-
-**What this does not fix**, measured and stated here rather than discovered later. All of
-these are pre-existing, none is made worse by this change, and each is filed:
-
-- A decoder that spells the range in decimal (`917760`) instead of hex (`0xE0100`) is
-  undetected, even though it reconstitutes and executes. #467, asserted as an explicit zero
-  in the suite so that closing it fails a test. The discriminator belongs in the AST
-  analyzer, gated on #424; a wider literal pattern is another spelling rule.
-- Corroboration recognises `eval(` and `Function(` and no other sink. A decoder whose
-  payload reaches `vm.runInThisContext`, `child_process.exec`, a dynamic `import()`, the
-  `AsyncFunction` constructor or `globalThis.eval` is reported at MEDIUM rather than
-  CRITICAL. It is still reported.
-- Neither corroborator strips comments or string literals, so a file whose only `eval(` is a
-  comment advising against `eval` is corroborated by that comment, and a log sanitiser
-  carrying such a note is CRITICAL. On a file that 0.27.0 already reported this is unchanged.
-  On a file 0.27.0 held clean by the deleted filename exemption it is a new CRITICAL, and
-  **HackMyAgent's own `src/hardening/scanner.ts` is exactly that case**: clean on 0.27.0
-  because its path matched the exemption, CRITICAL here, corroborated by an `eval(` inside a
-  comment explaining how the scanner avoids matching `eval(` in comments. Removing a bypass
-  shows you what it was hiding, and what it was hiding is that this signature is weak enough
-  to match our own source. Our own repository still scores 100/100 because `.hmaignore`
-  excludes `src/hardening/` by path, and that exclusion is now printed on the `Scope` line
-  rather than being silent — so if you scan our source yourself you will see the CRITICAL we
-  do not score. Tracked with #468, which is the same shape in
-  `UNICODE-STEGO-005`. The fix for both is to evaluate corroboration against code with
-  comments and string literals removed, which is a change we are not making inside a patch
-  release on this path.
-- `UNICODE-STEGO-001` does not scan for variation selectors in `.md`/`.txt`, so an
-  identical payload beside an identical decoder corroborates in a `.js` file and does not
-  in a `.md` file, even though the payload is present in both.
-- A decoder minified onto a single line longer than the scanner's line cap is invisible to
-  this check, on this release and on every previous one.
-
-The same "fires on its own countermeasure" shape in `UNICODE-STEGO-005` is #468. Two
-`UNICODE-STEGO-002` CRITICALs on HackMyAgent's own test suite, caused by decoder fixtures
-held in string literals, are also pre-existing and unfixed.
-
 ### Security
 
 **`--ignore` and `.hmaignore` no longer change the score or the exit code (#450).**
@@ -325,6 +213,117 @@ examples as real grants, and produced findings with no line number and therefore
 command. A check that fires hardest on people writing ordinary skills is the defect this
 entry is about, aimed at a new surface. It needs a grammar and a corpus, not a regex pair.
 
+
+
+**`UNICODE-STEGO-002` no longer reports CRITICAL on code that defends against the attack
+it names (#469).** This lowers findings rather than raising them, so it can turn a red
+pipeline green.
+
+The check fired at CRITICAL when a file contained `.codePointAt(` anywhere and a
+variation-selector or tag-range hex literal anywhere. There is no AST, no scope and no
+dataflow between the two, so they could be thousands of lines apart and unrelated. A
+sanitiser, a linter, a width calculator or a range table all carry both tokens, so all of
+them failed pipelines. Measured precision on real-world code was 0/7, and the only true
+positives ever observed were fixtures written for this check.
+
+The one thing that held a file clean was an exemption keyed on a regex over the file PATH
+(`/analyz|detect|scan|check|inspect|enhanc|stego/i`), which this scanner's own comment
+calls an attacker-controllable weak signal. Our own stego analyzer was clean only because
+of its filename: copying it to `util-helper.ts` self-flagged at CRITICAL.
+
+Two changes, both in the `UNICODE-STEGO-002` block:
+
+- **The filename exemption is deleted, not narrowed.** No name can make this check skip a
+  file any more, so the rename bypass is gone. Pinned by a test that scans identical bytes
+  under two filenames, one carrying an old exemption keyword and one not, and asserts the
+  severities match. Stated precisely, because the general form is not true: the CORROBORATOR
+  still reads the path, since `UNICODE-STEGO-001` does not look for variation selectors in
+  `.md`/`.txt` or in files named `README`/`AUTHORS`/`LICENSE` and similar. A decoder whose
+  only corroboration is an embedded payload is therefore MEDIUM under one of those names and
+  CRITICAL under another. A decoder corroborated by an execution sink is CRITICAL under every
+  name. That asymmetry predates this release and is not fixed here.
+- **CRITICAL now requires corroboration.** A decoder pattern is evidence of capability, not
+  of malice. Corroboration is an execution sink in the same file, so a decoded string can
+  reach `eval`/`Function`, or `UNICODE-STEGO-001` firing on the same file, so the invisible
+  payload a decoder would decode is actually present. Both are read from the file being
+  scanned, so severity never depends on the order the tree is walked in. Uncorroborated is
+  reported at MEDIUM with the evidence intact — downgraded, never dropped.
+
+  **MEDIUM still costs 8 points of score.** It does not fail the default severity gate, which
+  is what unblocks defensive code, but `secure --fail-below <n>` compares the score, so a
+  build that pins a threshold close to its current score can still go red on a downgraded
+  finding. Check your threshold before upgrading if you use that flag.
+
+Measured on first-class source files, not `node_modules`:
+
+| file | 0.27.0 | now |
+|---|---|---|
+| our own `stego-analyzer.ts` copied to `util-helper.ts` | CRITICAL | MEDIUM |
+| a log sanitiser's hazard-range table | CRITICAL | MEDIUM |
+| a test that builds a payload and asserts a sanitiser escapes it | CRITICAL | MEDIUM |
+| a decoder that reconstitutes a tag-range payload and `eval`s it | CRITICAL | CRITICAL |
+
+**Nothing 0.27.0 reported stops being reported, and this was measured rather than assumed.**
+The condition is now strictly weaker than 0.27.0's, so every file that fired then fires now.
+What can move is SEVERITY: an uncorroborated finding is MEDIUM rather than CRITICAL, and that
+is the whole point. Ten spellings of
+a working decoder — `.map(String.fromCodePoint)`, `Array.from(out, ...)`, an alias, a
+destructured `{ fromCharCode }`, `String['fromCodePoint']`, `Reflect.apply`,
+`Buffer.from(out).toString()`, `new TextDecoder().decode()`, a `JSON.parse('"\uXXXX"')`
+round trip, and an indexed alphabet table — are each pinned by a test asserting they still
+report CRITICAL.
+
+That list exists because an earlier cut of this fix made string reconstitution a REQUIRED
+conjunct of the finding, on the reasoning that only a decoder rebuilds a string from
+codepoints. The reasoning is sound and the implementation was not: it tested for
+`String.from(CodePoint|CharCode)(` specifically, and all ten spellings above evade that
+regex while doing exactly what it describes. Measured against 0.27.0, that cut reported
+**nothing at all** on all ten. The attacker chooses the spelling, so the spelling cannot be
+the gate. Narrowing on semantics rather than spelling needs dataflow, which is #424's AST
+analyzer.
+
+- **The reported line is the earlier of the two signals.** It used to report the first
+  `.codePointAt(`, but the discriminating token is the range literal, which usually sits in
+  a table above the loop that reads it. One downstream consumer was pointed at line 168 when
+  the cause was line 139. The message now names both lines. Note the consequence: neither
+  token detection strips comments, so on a file whose licence or doc header mentions a range
+  literal, the cited line is that header rather than the decoder.
+
+**What this does not fix**, measured and stated here rather than discovered later. All of
+these are pre-existing, none is made worse by this change, and each is filed:
+
+- A decoder that spells the range in decimal (`917760`) instead of hex (`0xE0100`) is
+  undetected, even though it reconstitutes and executes. #467, asserted as an explicit zero
+  in the suite so that closing it fails a test. The discriminator belongs in the AST
+  analyzer, gated on #424; a wider literal pattern is another spelling rule.
+- Corroboration recognises `eval(` and `Function(` and no other sink. A decoder whose
+  payload reaches `vm.runInThisContext`, `child_process.exec`, a dynamic `import()`, the
+  `AsyncFunction` constructor or `globalThis.eval` is reported at MEDIUM rather than
+  CRITICAL. It is still reported.
+- Neither corroborator strips comments or string literals, so a file whose only `eval(` is a
+  comment advising against `eval` is corroborated by that comment, and a log sanitiser
+  carrying such a note is CRITICAL. On a file that 0.27.0 already reported this is unchanged.
+  On a file 0.27.0 held clean by the deleted filename exemption it is a new CRITICAL, and
+  **HackMyAgent's own `src/hardening/scanner.ts` is exactly that case**: clean on 0.27.0
+  because its path matched the exemption, CRITICAL here, corroborated by an `eval(` inside a
+  comment explaining how the scanner avoids matching `eval(` in comments. Removing a bypass
+  shows you what it was hiding, and what it was hiding is that this signature is weak enough
+  to match our own source. Our own repository still scores 100/100 because `.hmaignore`
+  excludes `src/hardening/` by path, and that exclusion is now printed on the `Scope` line
+  rather than being silent — so if you scan our source yourself you will see the CRITICAL we
+  do not score. Tracked with #468, which is the same shape in
+  `UNICODE-STEGO-005`. The fix for both is to evaluate corroboration against code with
+  comments and string literals removed, which is a change we are not making inside a patch
+  release on this path.
+- `UNICODE-STEGO-001` does not scan for variation selectors in `.md`/`.txt`, so an
+  identical payload beside an identical decoder corroborates in a `.js` file and does not
+  in a `.md` file, even though the payload is present in both.
+- A decoder minified onto a single line longer than the scanner's line cap is invisible to
+  this check, on this release and on every previous one.
+
+The same "fires on its own countermeasure" shape in `UNICODE-STEGO-005` is #468. Two
+`UNICODE-STEGO-002` CRITICALs on HackMyAgent's own test suite, caused by decoder fixtures
+held in string literals, are also pre-existing and unfixed.
 
 ## [0.27.0] - 2026-08-07
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,52 +10,87 @@ All notable changes to HackMyAgent are documented in this file.
 it names (#469).** This lowers findings rather than raising them, so it can turn a red
 pipeline green.
 
-The check fired when a file contained `.codePointAt(` anywhere and a variation-selector or
-tag-range hex literal anywhere. There is no AST, no scope and no dataflow between the two,
-so they could be thousands of lines apart and unrelated. The decoder half of GlassWorm
-reconstitutes a string from codepoints, and code that only reads codepoints — a sanitiser,
-a linter, a width calculator, a range table — never does. But `String.fromCodePoint` /
-`fromCharCode` was only one input to an exemption whose other input was a regex over the
-file PATH, which this scanner's own comment calls an attacker-controllable weak signal. So
-defensive code fired unless it happened to be named like an analyzer, and renaming a file
-was enough to bypass the check.
+The check fired at CRITICAL when a file contained `.codePointAt(` anywhere and a
+variation-selector or tag-range hex literal anywhere. There is no AST, no scope and no
+dataflow between the two, so they could be thousands of lines apart and unrelated. A
+sanitiser, a linter, a width calculator or a range table all carry both tokens, so all of
+them failed pipelines. Measured precision on real-world code was 0/7, and the only true
+positives ever observed were fixtures written for this check.
 
-Measured on first-class source files, not `node_modules`:
+The one thing that held a file clean was an exemption keyed on a regex over the file PATH
+(`/analyz|detect|scan|check|inspect|enhanc|stego/i`), which this scanner's own comment
+calls an attacker-controllable weak signal. Our own stego analyzer was clean only because
+of its filename: copying it to `util-helper.ts` self-flagged at CRITICAL.
 
-| file | 0.27.0 | now |
-|---|---|---|
-| `consola` `dist/index.mjs` | CRITICAL | clean |
-| `graphemer` `lib/Graphemer.js` | CRITICAL | clean |
-| our own `stego-analyzer.ts` copied to `util-helper.ts` | CRITICAL | clean |
-| a log sanitiser's hazard-range table | CRITICAL | clean |
-| a test that builds a payload and asserts a sanitiser escapes it | CRITICAL | MEDIUM |
+Two changes, both in the `UNICODE-STEGO-002` block:
 
-No true positive was lost. The canonical decoder fixtures still fire, and the corroborated
-cases below are graded higher than before, not lower.
-
-Three changes, all in the `UNICODE-STEGO-002` block:
-
-- **String reconstitution is now a required conjunct of the finding**, not an input to an
-  exemption. That makes the filename exemption unreachable — it could only be true when
-  reconstitution was absent, which can no longer reach the branch — so it is deleted rather
-  than left as dead code guarding a live bypass. The file path is no longer consulted.
+- **The file path is no longer consulted at all.** The exemption is deleted, not narrowed.
+  Renaming a file now changes no verdict in either direction, so the bypass is gone rather
+  than relocated. This is pinned by a test that scans identical bytes under two filenames,
+  one carrying an old exemption keyword and one not, and asserts the severities match.
 - **CRITICAL now requires corroboration.** A decoder pattern is evidence of capability, not
   of malice. Corroboration is an execution sink in the same file, so a decoded string can
   reach `eval`/`Function`, or `UNICODE-STEGO-001` firing on the same file, so the invisible
   payload a decoder would decode is actually present. Both are read from the file being
   scanned, so severity never depends on the order the tree is walked in. Uncorroborated is
-  reported at MEDIUM with the evidence intact — it is downgraded, never dropped.
+  reported at MEDIUM with the evidence intact — it is downgraded, never dropped, and MEDIUM
+  does not fail a pipeline.
+
+Measured on first-class source files, not `node_modules`:
+
+| file | 0.27.0 | now |
+|---|---|---|
+| our own `stego-analyzer.ts` copied to `util-helper.ts` | CRITICAL | MEDIUM |
+| a log sanitiser's hazard-range table | CRITICAL | MEDIUM |
+| a test that builds a payload and asserts a sanitiser escapes it | CRITICAL | MEDIUM |
+| a decoder that reconstitutes a tag-range payload and `eval`s it | CRITICAL | CRITICAL |
+
+**No true positive was lost, and this was measured rather than assumed.** Ten spellings of
+a working decoder — `.map(String.fromCodePoint)`, `Array.from(out, ...)`, an alias, a
+destructured `{ fromCharCode }`, `String['fromCodePoint']`, `Reflect.apply`,
+`Buffer.from(out).toString()`, `new TextDecoder().decode()`, a `JSON.parse('"\uXXXX"')`
+round trip, and an indexed alphabet table — are each pinned by a test asserting they still
+report CRITICAL.
+
+That list exists because an earlier cut of this fix made string reconstitution a REQUIRED
+conjunct of the finding, on the reasoning that only a decoder rebuilds a string from
+codepoints. The reasoning is sound and the implementation was not: it tested for
+`String.from(CodePoint|CharCode)(` specifically, and all ten spellings above evade that
+regex while doing exactly what it describes. Measured against 0.27.0, that cut reported
+**nothing at all** on all ten. The attacker chooses the spelling, so the spelling cannot be
+the gate. Narrowing on semantics rather than spelling needs dataflow, which is #424's AST
+analyzer.
+
 - **The reported line is the earlier of the two signals.** It used to report the first
   `.codePointAt(`, but the discriminating token is the range literal, which usually sits in
   a table above the loop that reads it. One downstream consumer was pointed at line 168 when
-  the cause was line 139. The message now names both lines.
+  the cause was line 139. The message now names both lines. Note the consequence: neither
+  token detection strips comments, so on a file whose licence or doc header mentions a range
+  literal, the cited line is that header rather than the decoder.
 
-Known gap, tracked in #467 and asserted as an explicit zero in the suite so that closing it
-fails a test: a decoder that spells the same range in decimal (`917760`) instead of hex
-(`0xE0100`) is still undetected, even though it reconstitutes and executes. Widening the
-literal pattern would reopen the false-positive class this closes; the discriminator belongs
-in the AST analyzer, gated on #424. The same "fires on its own countermeasure" shape in
-`UNICODE-STEGO-005` is #468, filed rather than fixed here.
+**What this does not fix**, measured and stated here rather than discovered later. All of
+these are pre-existing, none is made worse by this change, and each is filed:
+
+- A decoder that spells the range in decimal (`917760`) instead of hex (`0xE0100`) is
+  undetected, even though it reconstitutes and executes. #467, asserted as an explicit zero
+  in the suite so that closing it fails a test. The discriminator belongs in the AST
+  analyzer, gated on #424; a wider literal pattern is another spelling rule.
+- Corroboration recognises `eval(` and `Function(` and no other sink. A decoder whose
+  payload reaches `vm.runInThisContext`, `child_process.exec`, a dynamic `import()`, the
+  `AsyncFunction` constructor or `globalThis.eval` is reported at MEDIUM rather than
+  CRITICAL. It is still reported.
+- Neither corroborator strips comments or string literals, so a file whose only `eval(` is
+  a comment advising against `eval` is corroborated by that comment. A log sanitiser
+  carrying such a note is CRITICAL. This behaves identically on 0.27.0 and on this release.
+- `UNICODE-STEGO-001` does not scan for variation selectors in `.md`/`.txt`, so an
+  identical payload beside an identical decoder corroborates in a `.js` file and does not
+  in a `.md` file, even though the payload is present in both.
+- A decoder minified onto a single line longer than the scanner's line cap is invisible to
+  this check, on this release and on every previous one.
+
+The same "fires on its own countermeasure" shape in `UNICODE-STEGO-005` is #468. Two
+`UNICODE-STEGO-002` CRITICALs on HackMyAgent's own test suite, caused by decoder fixtures
+held in string literals, are also pre-existing and unfixed.
 
 ### Security
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -99,7 +99,10 @@ these are pre-existing, none is made worse by this change, and each is filed:
   because its path matched the exemption, CRITICAL here, corroborated by an `eval(` inside a
   comment explaining how the scanner avoids matching `eval(` in comments. Removing a bypass
   shows you what it was hiding, and what it was hiding is that this signature is weak enough
-  to match our own source. Tracked with #468, which is the same shape in
+  to match our own source. Our own repository still scores 100/100 because `.hmaignore`
+  excludes `src/hardening/` by path, and that exclusion is now printed on the `Scope` line
+  rather than being silent — so if you scan our source yourself you will see the CRITICAL we
+  do not score. Tracked with #468, which is the same shape in
   `UNICODE-STEGO-005`. The fix for both is to evaluate corroboration against code with
   comments and string literals removed, which is a change we are not making inside a patch
   release on this path.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,14 +34,19 @@ An `.hmaignore` **path** rule is a different statement and is treated differentl
 subdirectory, and a smaller target honestly scores differently. Those findings leave the
 scored set as before — but they are no longer allowed to leave it silently, which is the
 half that was missing. `secure` on HackMyAgent's own repo reported `100/100 · No security
-issues found` in 0.27.0 while an `.hmaignore` held back 65 findings, 26 of them critical,
-and named none of it anywhere in the output. It now prints:
+issues found` in 0.27.0 while an `.hmaignore` held back dozens of findings, most of a
+severity that would have failed the run, and named none of it anywhere in the output. On this
+release, against this checkout, it prints:
 
 ```
-Scope       65 findings excluded by .hmaignore path rules (26 critical, 15 high, 24 medium)
+Scope       68 findings excluded by .hmaignore path rules (29 critical, 15 high, 24 medium)
             Out of scope, so not scored and not in the exit code. The score above
             describes the tree minus those paths.
 ```
+
+That count is a property of this tree at this tag, not a constant — it moves as the repo does,
+and two of those criticals are new in this release because `UNICODE-STEGO-002` stopped
+exempting files by name. Reproduce it with `hackmyagent secure . --ci` on this checkout.
 
 What changes:
 
@@ -253,6 +258,37 @@ Two changes, both in the `UNICODE-STEGO-002` block:
   is what unblocks defensive code, but `secure --fail-below <n>` compares the score, so a
   build that pins a threshold close to its current score can still go red on a downgraded
   finding. Check your threshold before upgrading if you use that flag.
+
+**Known gap, disclosed rather than discovered later: the corroborator recognises two spellings
+of an execution sink, so some real droppers are downgraded to MEDIUM and exit 0.** This is the
+one row where this change makes a pipeline quieter about something that deserved noise, and it
+is the reason to read this entry if you gate CI on the exit code.
+
+`hasExecutionSink` tests for a literal `eval(` or `Function(`. A decoder that reconstitutes a
+tag-range payload and executes it through anything else is no longer CRITICAL unless
+`UNICODE-STEGO-001` also fires on the same file. Measured, with fixtures that really do execute
+a hidden payload:
+
+| how the decoded string is executed | 0.27.0 | now |
+|---|---|---|
+| `eval(x)` | CRITICAL, exit 1 | CRITICAL, exit 1 |
+| `new Function(x)()` | CRITICAL, exit 1 | CRITICAL, exit 1 |
+| `vm.runInNewContext(x)` | CRITICAL, exit 1 | **MEDIUM, exit 0** |
+| `globalThis.eval(x)`, `(0,eval)(x)` | CRITICAL, exit 1 | **MEDIUM** |
+| `[].constructor.constructor(x)()` | CRITICAL, exit 1 | **MEDIUM, exit 0** |
+| `import('data:text/javascript,' + x)` | CRITICAL, exit 1 | **MEDIUM, exit 0** |
+| `child_process.exec(x)` | CRITICAL, exit 1 | **MEDIUM, exit 0** |
+
+The finding is still reported, at MEDIUM, with the same evidence and both signal lines — it is
+downgraded, not dropped — and the guidance text now says plainly which two spellings were
+checked instead of asserting that nothing reaches an executor. But an attacker who wants a
+green pipeline no longer has to disguise the decoder; writing `globalThis.eval` instead of
+`eval` is enough, and that is a cheaper evasion than the filename bypass this release removes.
+
+We are not closing it with a wider regex. That would be the same mistake as gating the finding
+on one spelling of reconstitution, one layer down, and the list above is not exhaustible by
+enumeration. Deciding whether a reconstituted string reaches an executor is dataflow, which is
+#424's AST analyzer. Tracked as #475.
 
 Measured on first-class source files, not `node_modules`:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,17 +24,26 @@ of its filename: copying it to `util-helper.ts` self-flagged at CRITICAL.
 
 Two changes, both in the `UNICODE-STEGO-002` block:
 
-- **The file path is no longer consulted at all.** The exemption is deleted, not narrowed.
-  Renaming a file now changes no verdict in either direction, so the bypass is gone rather
-  than relocated. This is pinned by a test that scans identical bytes under two filenames,
-  one carrying an old exemption keyword and one not, and asserts the severities match.
+- **The filename exemption is deleted, not narrowed.** No name can make this check skip a
+  file any more, so the rename bypass is gone. Pinned by a test that scans identical bytes
+  under two filenames, one carrying an old exemption keyword and one not, and asserts the
+  severities match. Stated precisely, because the general form is not true: the CORROBORATOR
+  still reads the path, since `UNICODE-STEGO-001` does not look for variation selectors in
+  `.md`/`.txt` or in files named `README`/`AUTHORS`/`LICENSE` and similar. A decoder whose
+  only corroboration is an embedded payload is therefore MEDIUM under one of those names and
+  CRITICAL under another. A decoder corroborated by an execution sink is CRITICAL under every
+  name. That asymmetry predates this release and is not fixed here.
 - **CRITICAL now requires corroboration.** A decoder pattern is evidence of capability, not
   of malice. Corroboration is an execution sink in the same file, so a decoded string can
   reach `eval`/`Function`, or `UNICODE-STEGO-001` firing on the same file, so the invisible
   payload a decoder would decode is actually present. Both are read from the file being
   scanned, so severity never depends on the order the tree is walked in. Uncorroborated is
-  reported at MEDIUM with the evidence intact — it is downgraded, never dropped, and MEDIUM
-  does not fail a pipeline.
+  reported at MEDIUM with the evidence intact — downgraded, never dropped.
+
+  **MEDIUM still costs 8 points of score.** It does not fail the default severity gate, which
+  is what unblocks defensive code, but `secure --fail-below <n>` compares the score, so a
+  build that pins a threshold close to its current score can still go red on a downgraded
+  finding. Check your threshold before upgrading if you use that flag.
 
 Measured on first-class source files, not `node_modules`:
 
@@ -45,7 +54,10 @@ Measured on first-class source files, not `node_modules`:
 | a test that builds a payload and asserts a sanitiser escapes it | CRITICAL | MEDIUM |
 | a decoder that reconstitutes a tag-range payload and `eval`s it | CRITICAL | CRITICAL |
 
-**No true positive was lost, and this was measured rather than assumed.** Ten spellings of
+**Nothing 0.27.0 reported stops being reported, and this was measured rather than assumed.**
+The condition is now strictly weaker than 0.27.0's, so every file that fired then fires now.
+What can move is SEVERITY: an uncorroborated finding is MEDIUM rather than CRITICAL, and that
+is the whole point. Ten spellings of
 a working decoder — `.map(String.fromCodePoint)`, `Array.from(out, ...)`, an alias, a
 destructured `{ fromCharCode }`, `String['fromCodePoint']`, `Reflect.apply`,
 `Buffer.from(out).toString()`, `new TextDecoder().decode()`, a `JSON.parse('"\uXXXX"')`
@@ -79,9 +91,18 @@ these are pre-existing, none is made worse by this change, and each is filed:
   payload reaches `vm.runInThisContext`, `child_process.exec`, a dynamic `import()`, the
   `AsyncFunction` constructor or `globalThis.eval` is reported at MEDIUM rather than
   CRITICAL. It is still reported.
-- Neither corroborator strips comments or string literals, so a file whose only `eval(` is
-  a comment advising against `eval` is corroborated by that comment. A log sanitiser
-  carrying such a note is CRITICAL. This behaves identically on 0.27.0 and on this release.
+- Neither corroborator strips comments or string literals, so a file whose only `eval(` is a
+  comment advising against `eval` is corroborated by that comment, and a log sanitiser
+  carrying such a note is CRITICAL. On a file that 0.27.0 already reported this is unchanged.
+  On a file 0.27.0 held clean by the deleted filename exemption it is a new CRITICAL, and
+  **HackMyAgent's own `src/hardening/scanner.ts` is exactly that case**: clean on 0.27.0
+  because its path matched the exemption, CRITICAL here, corroborated by an `eval(` inside a
+  comment explaining how the scanner avoids matching `eval(` in comments. Removing a bypass
+  shows you what it was hiding, and what it was hiding is that this signature is weak enough
+  to match our own source. Tracked with #468, which is the same shape in
+  `UNICODE-STEGO-005`. The fix for both is to evaluate corroboration against code with
+  comments and string literals removed, which is a change we are not making inside a patch
+  release on this path.
 - `UNICODE-STEGO-001` does not scan for variation selectors in `.md`/`.txt`, so an
   identical payload beside an identical decoder corroborates in a `.js` file and does not
   in a `.md` file, even though the payload is present in both.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,59 @@ All notable changes to HackMyAgent are documented in this file.
 
 ## [Unreleased]
 
+### Fixed
+
+**`UNICODE-STEGO-002` no longer reports CRITICAL on code that defends against the attack
+it names (#469).** This lowers findings rather than raising them, so it can turn a red
+pipeline green.
+
+The check fired when a file contained `.codePointAt(` anywhere and a variation-selector or
+tag-range hex literal anywhere. There is no AST, no scope and no dataflow between the two,
+so they could be thousands of lines apart and unrelated. The decoder half of GlassWorm
+reconstitutes a string from codepoints, and code that only reads codepoints — a sanitiser,
+a linter, a width calculator, a range table — never does. But `String.fromCodePoint` /
+`fromCharCode` was only one input to an exemption whose other input was a regex over the
+file PATH, which this scanner's own comment calls an attacker-controllable weak signal. So
+defensive code fired unless it happened to be named like an analyzer, and renaming a file
+was enough to bypass the check.
+
+Measured on first-class source files, not `node_modules`:
+
+| file | 0.27.0 | now |
+|---|---|---|
+| `consola` `dist/index.mjs` | CRITICAL | clean |
+| `graphemer` `lib/Graphemer.js` | CRITICAL | clean |
+| our own `stego-analyzer.ts` copied to `util-helper.ts` | CRITICAL | clean |
+| a log sanitiser's hazard-range table | CRITICAL | clean |
+| a test that builds a payload and asserts a sanitiser escapes it | CRITICAL | MEDIUM |
+
+No true positive was lost. The canonical decoder fixtures still fire, and the corroborated
+cases below are graded higher than before, not lower.
+
+Three changes, all in the `UNICODE-STEGO-002` block:
+
+- **String reconstitution is now a required conjunct of the finding**, not an input to an
+  exemption. That makes the filename exemption unreachable — it could only be true when
+  reconstitution was absent, which can no longer reach the branch — so it is deleted rather
+  than left as dead code guarding a live bypass. The file path is no longer consulted.
+- **CRITICAL now requires corroboration.** A decoder pattern is evidence of capability, not
+  of malice. Corroboration is an execution sink in the same file, so a decoded string can
+  reach `eval`/`Function`, or `UNICODE-STEGO-001` firing on the same file, so the invisible
+  payload a decoder would decode is actually present. Both are read from the file being
+  scanned, so severity never depends on the order the tree is walked in. Uncorroborated is
+  reported at MEDIUM with the evidence intact — it is downgraded, never dropped.
+- **The reported line is the earlier of the two signals.** It used to report the first
+  `.codePointAt(`, but the discriminating token is the range literal, which usually sits in
+  a table above the loop that reads it. One downstream consumer was pointed at line 168 when
+  the cause was line 139. The message now names both lines.
+
+Known gap, tracked in #467 and asserted as an explicit zero in the suite so that closing it
+fails a test: a decoder that spells the same range in decimal (`917760`) instead of hex
+(`0xE0100`) is still undetected, even though it reconstitutes and executes. Widening the
+literal pattern would reopen the false-positive class this closes; the discriminator belongs
+in the AST analyzer, gated on #424. The same "fires on its own countermeasure" shape in
+`UNICODE-STEGO-005` is #468, filed rather than fixed here.
+
 ### Security
 
 **`--ignore` and `.hmaignore` no longer change the score or the exit code (#450).**

--- a/__tests__/hardening/scanner.test.ts
+++ b/__tests__/hardening/scanner.test.ts
@@ -2884,12 +2884,18 @@ describe('OpenClaw gateway auto-fix', () => {
     });
   });
 
-  describe('UNICODE-STEGO-002: GlassWorm Decoder — detection code exemption', () => {
-    it('does not flag analysis code that uses .codePointAt() only for counting (no fromCodePoint)', async () => {
-      // Regression for FP on src/semantic/nanomind-enhancer.ts:
-      // Detection code uses .codePointAt() to CHECK ranges and COUNT occurrences.
-      // A GlassWorm decoder needs fromCodePoint/fromCharCode to reconstitute the hidden payload.
-      // Without that output step, codePointAt + hex literals is just analysis, not decoding.
+  describe('UNICODE-STEGO-002: GlassWorm Decoder — analysis code is not blocking', () => {
+    it('does not BLOCK on analysis code that uses .codePointAt() only for counting', async () => {
+      // Regression for FP on src/semantic/nanomind-enhancer.ts. Detection code uses
+      // .codePointAt() to CHECK ranges and COUNT occurrences, and does not reconstitute.
+      //
+      // This used to assert the finding was ABSENT, on the theory that reconstitution
+      // is what separates a decoder from analysis. Both halves of that were wrong. The
+      // absence came from an exemption keyed on the file PATH — note this fixture is
+      // named `unicode-analyzer.ts`, which is why it was exempt — and gating on
+      // reconstitution instead was measured to drop 10 working decoder spellings to no
+      // finding at all. So the finding is reported, and what changed is that an
+      // uncorroborated decoder SHAPE no longer fails a pipeline.
       const detectionCode = [
         'function analyzeUnicodeContext(content: string) {',
         '  const codepoints = [...content].map(c => c.codePointAt(0)!);',
@@ -2908,7 +2914,13 @@ describe('OpenClaw gateway auto-fix', () => {
 
       const result = await scanner.scan({ targetDir: tempDir });
       const stego002 = result.findings.find(f => f.checkId === 'UNICODE-STEGO-002');
-      expect(stego002, 'Analysis code without fromCodePoint must not be flagged as GlassWorm decoder').toBeUndefined();
+      expect(stego002, 'analysis code should still be reported as a lead').toBeDefined();
+      expect(
+        stego002!.severity,
+        'analysis code must not fail a pipeline: verdict.ts blocks on critical or high'
+      ).toBe('medium');
+      expect(['critical', 'high']).not.toContain(stego002!.severity);
+      expect(stego002!.description).not.toContain('reconstitutes');
     });
 
     it('still flags actual GlassWorm decoder that uses fromCodePoint to reconstitute payload', async () => {

--- a/__tests__/hardening/unicode-stego.test.ts
+++ b/__tests__/hardening/unicode-stego.test.ts
@@ -586,6 +586,39 @@ describe('UNICODE-STEGO checks', () => {
       expect(stego002[0].message).toContain('execution sink');
     });
 
+    it('escalates to critical through the Function constructor, not only through eval', async () => {
+      // hasExecutionSink is a disjunction of two regexes and every other corroboration
+      // test in this file reaches it through the `eval(` arm, so the `Function(` arm
+      // shipped with no coverage at all. This pins the second arm on its own: the
+      // fixture contains no `eval(` anywhere, so a pass cannot be explained by the arm
+      // the other tests already exercise.
+      const content = [
+        'function decode(input) {',
+        '  const result = [];',
+        '  for (let i = 0; i < input.length; i++) {',
+        '    const cp = input.codePointAt(i);',
+        '    if (cp >= 0xFE00 && cp <= 0xFE0F) { result.push(cp - 0xFE00); }',
+        '  }',
+        '  return String.fromCharCode(...result);',
+        '}',
+        'new Function(decode(process.argv[2]))();',
+      ].join('\n');
+      // Fixture integrity: the OTHER arm must be absent, or this measures nothing new.
+      expect(content).not.toMatch(/(?:^|[^\w.$])eval\s*\(/);
+      expect(content).toContain('.codePointAt(');
+      expect(content).toMatch(/0xFE0/);
+      await fs.writeFile(path.join(tempDir, 'fn-ctor-decoder.js'), content);
+
+      const findings = await scanForUnicodeStego();
+      const stego002 = findings.filter(
+        (f) => f.checkId === 'UNICODE-STEGO-002' && f.file === 'fn-ctor-decoder.js'
+      );
+
+      expect(stego002.length).toBe(1);
+      expect(stego002[0].severity).toBe('critical');
+      expect(stego002[0].message).toContain('execution sink');
+    });
+
     it('escalates to critical when the invisible payload is present in the same file', async () => {
       // U+FE00 written into the file as raw bytes, so UNICODE-STEGO-001 fires here
       // too: the decoder and the payload it would decode are in the same place.

--- a/__tests__/hardening/unicode-stego.test.ts
+++ b/__tests__/hardening/unicode-stego.test.ts
@@ -313,7 +313,7 @@ describe('UNICODE-STEGO checks', () => {
     // case above keeps the tag-range coverage by reconstituting for real; this
     // negative pins the behaviour that replaced it, so the change is under test in
     // both directions rather than deleted.
-    it('does not flag tag-range code that reads codepoints without reconstituting', async () => {
+    it('does not BLOCK on tag-range code that reads codepoints without reconstituting', async () => {
       const content = [
         'function classify(s) {',
         '  for (let i = 0; i < s.length; i++) {',
@@ -334,7 +334,14 @@ describe('UNICODE-STEGO checks', () => {
         (f) => f.checkId === 'UNICODE-STEGO-002' && f.file === fixtureName
       );
 
-      expect(stego002.length).toBe(0);
+      // It is still REPORTED — suppressing it entirely is what dropped 15 working
+      // decoders. It is reported at a severity that does not fail a pipeline, and
+      // the wording must not claim the file reconstitutes anything, because it does not.
+      expect(stego002.length).toBe(1);
+      expect(stego002[0].severity).toBe('medium');
+      expect(['critical', 'high']).not.toContain(stego002[0].severity);
+      expect(stego002[0].description).toContain('reads Unicode variation selector');
+      expect(stego002[0].description).not.toContain('reconstitutes');
     });
 
     it('does not flag .codePointAt() without suspicious hex literals', async () => {
@@ -356,20 +363,30 @@ describe('UNICODE-STEGO checks', () => {
   });
 
   /**
-   * UNICODE-STEGO-002 fired on defensive code: a log sanitiser, in three repositories
-   * at once, i.e. on the countermeasure to the attack the check is named after.
-   * Measured precision on real-world code was 0/7 and the only true positives ever
-   * observed were fixtures written for this check.
+   * UNICODE-STEGO-002 fired at CRITICAL on defensive code: a log sanitiser, in three
+   * repositories at once, i.e. on the countermeasure to the attack the check is named
+   * after. Measured precision on real-world code was 0/7 and the only true positives
+   * ever observed were fixtures written for this check.
    *
-   * The root cause was that reconstitution — String.fromCodePoint/fromCharCode, the
-   * decoder half of GlassWorm — was only one input to an exemption whose other input
-   * was a regex over the file PATH. Code that inspects codepoints without rebuilding
-   * a string from them therefore fired unless it was lucky enough to be named like an
-   * analyzer. Every fixture below is red-proofed against the pre-fix scanner: each
-   * negative case fired before this change.
+   * Two things were wrong and only one of them was the severity. The check consulted a
+   * regex over the file PATH, so a rename changed the verdict; that is deleted and the
+   * path is no longer read. And an uncorroborated decoder SHAPE was graded CRITICAL,
+   * which is what failed the pipelines; that is now MEDIUM unless an execution sink or
+   * UNICODE-STEGO-001 corroborates it in the same file.
+   *
+   * What is deliberately NOT done here is gating the finding on string reconstitution.
+   * That was tried for one commit and measured to drop 15 working decoders to no
+   * finding at all, because it tests one SPELLING of reconstitution and the attacker
+   * picks the spelling. See the "recovered spellings" block below, which pins those
+   * cases so the gate cannot come back silently.
+   *
+   * Red-proof status is stated per test rather than as a blanket claim, because a
+   * blanket claim was made here once and was false: the KNOWN GAP decimal case passes
+   * identically against pre-fix code, so it asserts a gap and proves nothing about
+   * this change.
    */
-  describe('UNICODE-STEGO-002: reconstitution is required, and severity is corroborated', () => {
-    it('does not flag a log sanitiser that names the ranges it defends against', async () => {
+  describe('UNICODE-STEGO-002: the path is not read, and severity is corroborated', () => {
+    it('does not BLOCK a log sanitiser that names the ranges it defends against', async () => {
       // Excerpt taken verbatim from csnp/cypres scripts/lib/log-safe.mjs, the file
       // that gate-blocked three repositories. The range table and safeLog are the
       // two things the check reads.
@@ -401,12 +418,14 @@ describe('UNICODE-STEGO checks', () => {
       ].join('\n');
 
       // Fixture integrity: this fixture is only a regression test while it still
-      // carries the two tokens the check reads and lacks the one it now requires.
-      // Without these three assertions the fixture could drift into passing for the
-      // wrong reason and the regression would go silent.
+      // carries the two tokens the check reads. Without these the fixture could drift
+      // into passing for the wrong reason and the regression would go silent.
       expect(content).toContain('0xfe00');
       expect(content).toContain('.codePointAt(');
-      expect(content).not.toMatch(/String\.from(?:CodePoint|CharCode)\s*\(/);
+      // It also carries no execution sink and no invisible codepoints, which is what
+      // makes it UNcorroborated. Asserted so the fixture cannot drift into being
+      // corroborated and turn this into a test of something else.
+      expect(content).not.toMatch(/(?:^|[^\w.$])(?:eval|(?:new\s+)?Function)\s*\(/);
 
       await fs.writeFile(path.join(tempDir, 'log-safe.mjs'), content);
 
@@ -415,10 +434,17 @@ describe('UNICODE-STEGO checks', () => {
         (f) => f.checkId === 'UNICODE-STEGO-002' && f.file === 'log-safe.mjs'
       );
 
-      expect(stego002.length).toBe(0);
+      // The point of the fix is that this stops FAILING a pipeline, not that it stops
+      // being reported. Reporting it costs a line of output; suppressing it cost 15
+      // working decoders. `src/check/verdict.ts` blocks on critical or high only.
+      expect(stego002.length).toBe(1);
+      expect(stego002[0].severity).toBe('medium');
+      expect(['critical', 'high']).not.toContain(stego002[0].severity);
+      expect(stego002[0].message).toContain('uncorroborated');
+      expect(stego002[0].description).not.toContain('reconstitutes');
     });
 
-    it('does not flag a logging library whose two tokens are hundreds of lines apart', async () => {
+    it('does not BLOCK a logging library whose two tokens are hundreds of lines apart', async () => {
       // The check sets two file-global booleans with no AST, no scope and no
       // dataflow, so any file containing both tokens anywhere fired. `consola` and
       // `graphemer` are both real-world false positives of exactly this shape;
@@ -434,10 +460,12 @@ describe('UNICODE-STEGO checks', () => {
         (f) => f.checkId === 'UNICODE-STEGO-002' && f.file === 'logger.js'
       );
 
-      expect(stego002.length).toBe(0);
+      expect(stego002.length).toBe(1);
+      expect(stego002[0].severity).toBe('medium');
+      expect(['critical', 'high']).not.toContain(stego002[0].severity);
     });
 
-    it('does not flag a detection analyzer renamed away from an analyzer filename', async () => {
+    it('grades a detection analyzer identically under any filename', async () => {
       // Before this change our own stego analyzer was held clean only by the path
       // regex, which this scanner's own comment called an attacker-controllable weak
       // signal. Copied to a neutral filename it self-flagged. The filename is no
@@ -454,14 +482,31 @@ describe('UNICODE-STEGO checks', () => {
         '}',
       ].join('\n');
       expect(content).not.toMatch(/analyz|detect|scan|check|inspect|enhanc|stego/i);
-      await fs.writeFile(path.join(tempDir, 'util-helper.ts'), content);
+
+      // The property is that the PATH does not change the verdict, so assert it
+      // directly: identical bytes under two filenames, one of which carries an old
+      // exemption keyword and one of which does not. A single-filename fixture could
+      // only ever show the verdict, never that the filename stopped mattering.
+      const neutralName = 'util-helper.ts';
+      const exemptName = 'stego-analyzer.ts';
+      expect(neutralName).not.toMatch(/analyz|detect|scan|check|inspect|enhanc|stego/i);
+      expect(exemptName).toMatch(/analyz|detect|scan|check|inspect|enhanc|stego/i);
+      await fs.writeFile(path.join(tempDir, neutralName), content);
+      await fs.writeFile(path.join(tempDir, exemptName), content);
 
       const findings = await scanForUnicodeStego();
-      const stego002 = findings.filter(
-        (f) => f.checkId === 'UNICODE-STEGO-002' && f.file === 'util-helper.ts'
+      const neutral = findings.filter(
+        (f) => f.checkId === 'UNICODE-STEGO-002' && f.file === neutralName
+      );
+      const exempt = findings.filter(
+        (f) => f.checkId === 'UNICODE-STEGO-002' && f.file === exemptName
       );
 
-      expect(stego002.length).toBe(0);
+      expect(neutral.length).toBe(1);
+      expect(exempt.length).toBe(1);
+      expect(neutral[0].severity).toBe(exempt[0].severity);
+      expect(neutral[0].severity).toBe('medium');
+      expect(['critical', 'high']).not.toContain(neutral[0].severity);
     });
 
     it('KNOWN GAP: the decimal spelling of a working decoder is not detected', async () => {
@@ -583,6 +628,90 @@ describe('UNICODE-STEGO checks', () => {
       expect(stego002[0].line).toBe(1);
       expect(stego002[0].message).toContain('range literal at line 1');
       expect(stego002[0].message).toContain('.codePointAt at line 6');
+    });
+  });
+
+  /**
+   * Every case below reconstitutes a tag-range payload and passes it to `eval`, and
+   * every one of them was reported CRITICAL by 0.27.0 and by this build. Between the
+   * two, commit 963ddea gated the finding on `String.from(CodePoint|CharCode)\s*\(`
+   * and every case below reported NOTHING AT ALL. That gate is reverted, and these
+   * exist so it cannot return without turning this file red.
+   *
+   * Red-proof target is 963ddea, NOT the base release: against the base these pass
+   * (the base fires on everything in this shape), so a base red-proof would prove
+   * nothing here. Stated rather than implied, because a blanket red-proof claim was
+   * made in this file once and was false.
+   *
+   * The list is deliberately longer than the three spellings that were first noticed.
+   * A gap list naming only the spellings someone happened to try is a gap list that
+   * gets rediscovered.
+   */
+  describe('UNICODE-STEGO-002: reconstitution spelling does not gate the finding', () => {
+    const READER = [
+      'function extract(s) {',
+      '  const out = [];',
+      '  for (let i = 0; i < s.length; i++) {',
+      '    const cp = s.codePointAt(i);',
+      '    if (cp >= 0xE0100 && cp <= 0xE01EF) out.push(cp - 0xE0100);',
+      '  }',
+    ];
+
+    const SPELLINGS: Array<[string, string]> = [
+      ['mapped-reference', "  return out.map(String.fromCodePoint).join('');"],
+      ['array-from', "  return Array.from(out, String.fromCodePoint).join('');"],
+      ['bracket-access', "  return String['fromCodePoint'](...out);"],
+      ['aliased-binding', '  const rebuild = String.fromCodePoint;\n  return rebuild(...out);'],
+      ['destructured', '  const { fromCharCode } = String;\n  return fromCharCode(...out);'],
+      ['reflect-apply', '  return Reflect.apply(String.fromCodePoint, String, out);'],
+      ['buffer-from', "  return Buffer.from(out).toString('utf-8');"],
+      ['text-decoder', '  return new TextDecoder().decode(Uint8Array.from(out));'],
+      ['json-unicode-escape', '  return JSON.parse(\'"\' + out.map(c => "\\\\u" + c.toString(16).padStart(4, "0")).join("") + \'"\');'],
+      ['indexed-alphabet', "  const A = 'abcdefghijklmnopqrstuvwxyz';\n  return out.map(c => A[c % 26]).join('');"],
+    ];
+
+    for (const [label, rebuildLine] of SPELLINGS) {
+      it(`still detects a decoder that reconstitutes via ${label}`, async () => {
+        const content = [...READER, rebuildLine, '}', 'eval(extract(process.argv[2]));'].join('\n');
+        const fixtureName = `decoder-${label}.js`;
+
+        // Fixture integrity. Both tokens the check reads must be present, or this
+        // stops measuring the gate and starts measuring the candidate test.
+        expect(content).toContain('.codePointAt(');
+        expect(content).toMatch(/0xE010/);
+        // And the filename must not carry an old exemption keyword, so a pass can
+        // never be explained by the path regex that used to exist.
+        expect(fixtureName).not.toMatch(/analyz|detect|scan|check|inspect|enhanc|stego/i);
+
+        await fs.writeFile(path.join(tempDir, fixtureName), content);
+
+        const findings = await scanForUnicodeStego();
+        const stego002 = findings.filter(
+          (f) => f.checkId === 'UNICODE-STEGO-002' && f.file === fixtureName
+        );
+
+        expect(stego002.length).toBe(1);
+        // Corroborated by the eval sink, so this is the top severity, not a lead.
+        expect(stego002[0].severity).toBe('critical');
+        expect(stego002[0].message).toContain('execution sink');
+      });
+    }
+
+    it('pins that the reverted gate would have silenced every one of these', () => {
+      // The exact predicate 963ddea used, kept as data so this is measured against the
+      // real regex rather than asserted from memory. I first wrote 7 here from memory
+      // and the suite corrected me to 10, which is the whole argument in miniature:
+      // nobody can enumerate the spellings of an expression by eye.
+      const REVERTED_GATE = /String\.from(?:CodePoint|CharCode)\s*\(/;
+      const silenced = SPELLINGS.filter(([, line]) => !REVERTED_GATE.test(line));
+      expect(silenced.length).toBe(10);
+      expect(silenced.length).toBe(SPELLINGS.length);
+
+      // Non-vacuity control. If the gate regex were simply broken and matched nothing,
+      // the assertion above would pass for the wrong reason. The canonical spelling
+      // MUST match it, or this test is measuring nothing.
+      expect(REVERTED_GATE.test('  return String.fromCodePoint(...out);')).toBe(true);
+      expect(REVERTED_GATE.test('  return String.fromCharCode(...out);')).toBe(true);
     });
   });
 

--- a/__tests__/hardening/unicode-stego.test.ts
+++ b/__tests__/hardening/unicode-stego.test.ts
@@ -375,8 +375,8 @@ describe('UNICODE-STEGO checks', () => {
    * UNICODE-STEGO-001 corroborates it in the same file.
    *
    * What is deliberately NOT done here is gating the finding on string reconstitution.
-   * That was tried for one commit and measured to drop 15 working decoders to no
-   * finding at all, because it tests one SPELLING of reconstitution and the attacker
+   * That was tried for one commit and measured to drop 10 working decoder spellings to
+   * no finding at all, because it tests one SPELLING of reconstitution and the attacker
    * picks the spelling. See the "recovered spellings" block below, which pins those
    * cases so the gate cannot come back silently.
    *
@@ -422,10 +422,31 @@ describe('UNICODE-STEGO checks', () => {
       // into passing for the wrong reason and the regression would go silent.
       expect(content).toContain('0xfe00');
       expect(content).toContain('.codePointAt(');
-      // It also carries no execution sink and no invisible codepoints, which is what
-      // makes it UNcorroborated. Asserted so the fixture cannot drift into being
-      // corroborated and turn this into a test of something else.
+      // It also carries neither corroborator, which is what makes it UNcorroborated.
+      // BOTH are asserted so the fixture cannot drift into being corroborated and turn
+      // this into a test of something else. An earlier version of this comment claimed
+      // both and asserted only the sink.
       expect(content).not.toMatch(/(?:^|[^\w.$])(?:eval|(?:new\s+)?Function)\s*\(/);
+      // Written as escape sequences, never as literal characters: a fixture that
+      // asserts the ABSENCE of invisible codepoints must not contain any, or it trips
+      // UNICODE-STEGO-001 on this very file and corroborates what it denies. Ten raw
+      // codepoints were written here once by an editor that rendered the escapes.
+      const INVISIBLE = new RegExp(
+        '[' +
+          '\u200B-\u200D' +   // zero width space, non-joiner, joiner
+          '\u202A-\u202E' +   // bidi embedding and override
+          '\u2066-\u2069' +   // bidi isolates
+          '\uFE00-\uFE0F' +   // variation selectors 1-16
+          '\uFEFF' +             // BOM used mid-file
+        ']' +
+          '|[\u{E0100}-\u{E01EF}]',   // variation selectors 17-256
+        'u'
+      );
+      expect(INVISIBLE.test(content)).toBe(false);
+      // Non-vacuity control: a matcher that matched nothing would pass the line above
+      // for the wrong reason, which is how this class of assertion usually dies.
+      expect(INVISIBLE.test('a\u200Bb')).toBe(true);
+      expect(INVISIBLE.test('a\u{E0100}b')).toBe(true);
 
       await fs.writeFile(path.join(tempDir, 'log-safe.mjs'), content);
 

--- a/__tests__/hardening/unicode-stego.test.ts
+++ b/__tests__/hardening/unicode-stego.test.ts
@@ -277,19 +277,24 @@ describe('UNICODE-STEGO checks', () => {
       const stego002 = findings.filter((f) => f.checkId === 'UNICODE-STEGO-002');
 
       expect(stego002.length).toBeGreaterThanOrEqual(1);
-      expect(stego002[0].severity).toBe('critical');
+      // Uncorroborated: this fixture reconstitutes, but nothing here executes the
+      // result and the file carries no invisible codepoints. Capability, not malice.
+      // The corroborated cases are pinned in the corroboration block below.
+      expect(stego002[0].severity).toBe('medium');
       expect(stego002[0].passed).toBe(false);
       expect(stego002[0].file).toBe('decoder.js');
-      expect(stego002[0].message).toContain('GlassWorm decoder pattern');
+      expect(stego002[0].message).toContain('GlassWorm decoder shape');
     });
 
     it('detects .codePointAt() with tag character hex literals', async () => {
       const content = [
         'function decode(s) {',
+        '  const out = [];',
         '  for (let i = 0; i < s.length; i++) {',
         '    const cp = s.codePointAt(i);',
-        '    if (cp >= 0xE0100) { return cp; }',
+        '    if (cp >= 0xE0100) { out.push(cp - 0xE0100); }',
         '  }',
+        '  return String.fromCodePoint(...out);',
         '}',
       ].join('\n');
       await fs.writeFile(path.join(tempDir, 'decoder-tags.ts'), content);
@@ -299,6 +304,37 @@ describe('UNICODE-STEGO checks', () => {
 
       expect(stego002.length).toBeGreaterThanOrEqual(1);
       expect(stego002[0].file).toBe('decoder-tags.ts');
+    });
+
+    // The fixture above used to end `if (cp >= 0xE0100) { return cp; }` with no
+    // reconstitution at all, and asserted the check fired on it. That is inspector
+    // shaped code, not a decoder, and asserting a finding on it was asserting the
+    // false-positive class this check has now been narrowed to exclude. The positive
+    // case above keeps the tag-range coverage by reconstituting for real; this
+    // negative pins the behaviour that replaced it, so the change is under test in
+    // both directions rather than deleted.
+    it('does not flag tag-range code that reads codepoints without reconstituting', async () => {
+      const content = [
+        'function classify(s) {',
+        '  for (let i = 0; i < s.length; i++) {',
+        '    const cp = s.codePointAt(i);',
+        '    if (cp >= 0xE0100) { return cp; }',
+        '  }',
+        '}',
+      ].join('\n');
+      // The filename must not carry an exemption keyword. Named `inspector-tags.ts`
+      // this test passed against the PRE-FIX scanner as well, because "inspect" hit
+      // the old path regex — a negative case that would have proved nothing.
+      const fixtureName = 'tag-range-reader.ts';
+      expect(fixtureName).not.toMatch(/analyz|detect|scan|check|inspect|enhanc|stego/i);
+      await fs.writeFile(path.join(tempDir, fixtureName), content);
+
+      const findings = await scanForUnicodeStego();
+      const stego002 = findings.filter(
+        (f) => f.checkId === 'UNICODE-STEGO-002' && f.file === fixtureName
+      );
+
+      expect(stego002.length).toBe(0);
     });
 
     it('does not flag .codePointAt() without suspicious hex literals', async () => {
@@ -316,6 +352,237 @@ describe('UNICODE-STEGO checks', () => {
       );
 
       expect(stego002.length).toBe(0);
+    });
+  });
+
+  /**
+   * UNICODE-STEGO-002 fired on defensive code: a log sanitiser, in three repositories
+   * at once, i.e. on the countermeasure to the attack the check is named after.
+   * Measured precision on real-world code was 0/7 and the only true positives ever
+   * observed were fixtures written for this check.
+   *
+   * The root cause was that reconstitution — String.fromCodePoint/fromCharCode, the
+   * decoder half of GlassWorm — was only one input to an exemption whose other input
+   * was a regex over the file PATH. Code that inspects codepoints without rebuilding
+   * a string from them therefore fired unless it was lucky enough to be named like an
+   * analyzer. Every fixture below is red-proofed against the pre-fix scanner: each
+   * negative case fired before this change.
+   */
+  describe('UNICODE-STEGO-002: reconstitution is required, and severity is corroborated', () => {
+    it('does not flag a log sanitiser that names the ranges it defends against', async () => {
+      // Excerpt taken verbatim from csnp/cypres scripts/lib/log-safe.mjs, the file
+      // that gate-blocked three repositories. The range table and safeLog are the
+      // two things the check reads.
+      const content = [
+        'const HAZARD_RANGES = [',
+        '  [0x0000, 0x001f], // Cc: C0 controls, including NUL, ESC, CR and LF',
+        '  [0x007f, 0x009f], // Cc: DEL, then C1. U+009B is a one-character CSI',
+        '  [0x00ad, 0x00ad], // Cf: SOFT HYPHEN',
+        '  [0x180b, 0x180f], // DI: Mongolian free variation selectors, MVS and FVS4',
+        '  [0x200b, 0x200f], // Cf: zero width space, non-joiner, joiner, LRM, RLM',
+        '  [0xfe00, 0xfe0f], // DI: VARIATION SELECTOR-1 to -16',
+        '  [0xfeff, 0xfeff], // Cf: ZERO WIDTH NO-BREAK SPACE, the BOM',
+        '  [0xe0100, 0xe01ef], // DI: VARIATION SELECTOR-17 to -256',
+        '];',
+        '',
+        'export const isLogHazard = (cp) => {',
+        '  for (const [lo, hi] of HAZARD_RANGES) if (cp >= lo && cp <= hi) return true;',
+        '  return false;',
+        '};',
+        '',
+        'export function safeLog(value) {',
+        '  let out = "";',
+        '  for (const ch of String(value ?? "")) {',
+        '    const cp = ch.codePointAt(0);',
+        '    out += isLogHazard(cp) ? "<U+" + cp.toString(16).toUpperCase() + ">" : ch;',
+        '  }',
+        '  return out;',
+        '}',
+      ].join('\n');
+
+      // Fixture integrity: this fixture is only a regression test while it still
+      // carries the two tokens the check reads and lacks the one it now requires.
+      // Without these three assertions the fixture could drift into passing for the
+      // wrong reason and the regression would go silent.
+      expect(content).toContain('0xfe00');
+      expect(content).toContain('.codePointAt(');
+      expect(content).not.toMatch(/String\.from(?:CodePoint|CharCode)\s*\(/);
+
+      await fs.writeFile(path.join(tempDir, 'log-safe.mjs'), content);
+
+      const findings = await scanForUnicodeStego();
+      const stego002 = findings.filter(
+        (f) => f.checkId === 'UNICODE-STEGO-002' && f.file === 'log-safe.mjs'
+      );
+
+      expect(stego002.length).toBe(0);
+    });
+
+    it('does not flag a logging library whose two tokens are hundreds of lines apart', async () => {
+      // The check sets two file-global booleans with no AST, no scope and no
+      // dataflow, so any file containing both tokens anywhere fired. `consola` and
+      // `graphemer` are both real-world false positives of exactly this shape;
+      // graphemer's two tokens sit roughly 9,000 lines apart.
+      const head = ['export function formatWidth(str) {', '  return str.codePointAt(0);', '}'];
+      const filler = Array.from({ length: 400 }, (_, i) => `// unrelated line ${i}`);
+      const tail = ['const VARIATION_SELECTOR_START = 0xFE00;', 'export { VARIATION_SELECTOR_START };'];
+      const content = [...head, ...filler, ...tail].join('\n');
+      await fs.writeFile(path.join(tempDir, 'logger.js'), content);
+
+      const findings = await scanForUnicodeStego();
+      const stego002 = findings.filter(
+        (f) => f.checkId === 'UNICODE-STEGO-002' && f.file === 'logger.js'
+      );
+
+      expect(stego002.length).toBe(0);
+    });
+
+    it('does not flag a detection analyzer renamed away from an analyzer filename', async () => {
+      // Before this change our own stego analyzer was held clean only by the path
+      // regex, which this scanner's own comment called an attacker-controllable weak
+      // signal. Copied to a neutral filename it self-flagged. The filename is no
+      // longer consulted at all, so the bypass is gone rather than relocated.
+      const content = [
+        'export function findHiddenCodepoints(source: string): number[] {',
+        '  const hits: number[] = [];',
+        '  for (let i = 0; i < source.length; i++) {',
+        '    const cp = source.codePointAt(i)!;',
+        '    if (cp >= 0xFE00 && cp <= 0xFE0F) hits.push(cp);',
+        '    if (cp >= 0xE0100 && cp <= 0xE01EF) hits.push(cp);',
+        '  }',
+        '  return hits;',
+        '}',
+      ].join('\n');
+      expect(content).not.toMatch(/analyz|detect|scan|check|inspect|enhanc|stego/i);
+      await fs.writeFile(path.join(tempDir, 'util-helper.ts'), content);
+
+      const findings = await scanForUnicodeStego();
+      const stego002 = findings.filter(
+        (f) => f.checkId === 'UNICODE-STEGO-002' && f.file === 'util-helper.ts'
+      );
+
+      expect(stego002.length).toBe(0);
+    });
+
+    it('KNOWN GAP: the decimal spelling of a working decoder is not detected', async () => {
+      // Tracked, not fixed here. The hex pattern is a spelling test, so a decoder
+      // that writes 917760 instead of 0xE0100 evades it while doing strictly more
+      // than any fixture that fires: it reconstitutes AND executes. The signature
+      // therefore selects for honest spelling, which correlates with defensive code.
+      // Closing it belongs with the AST work, not with a wider regex, because a
+      // wider regex reopens the false-positive class this change closed.
+      // Upstream: hackmyagent#467.
+      const content = [
+        'function decode(input) {',
+        '  const out = [];',
+        '  for (let i = 0; i < input.length; i++) {',
+        '    const cp = input.codePointAt(i);',
+        '    if (cp >= 917760 && cp <= 917999) { out.push(cp - 917760); }',
+        '  }',
+        '  return String.fromCodePoint(...out);',
+        '}',
+        'eval(decode(process.argv[2]));',
+      ].join('\n');
+      await fs.writeFile(path.join(tempDir, 'decimal-decoder.js'), content);
+
+      const findings = await scanForUnicodeStego();
+      const stego002 = findings.filter(
+        (f) => f.checkId === 'UNICODE-STEGO-002' && f.file === 'decimal-decoder.js'
+      );
+
+      // Asserted as ZERO deliberately. If a future change makes this fire, this test
+      // fails and the gap closes with a person reading it, rather than the marker
+      // rotting into a comment nobody re-runs.
+      expect(stego002.length).toBe(0);
+    });
+
+    it('escalates to critical when the decoded string can reach an execution sink', async () => {
+      const content = [
+        'function decode(input) {',
+        '  const result = [];',
+        '  for (let i = 0; i < input.length; i++) {',
+        '    const cp = input.codePointAt(i);',
+        '    if (cp >= 0xFE00 && cp <= 0xFE0F) { result.push(cp - 0xFE00); }',
+        '  }',
+        '  return String.fromCharCode(...result);',
+        '}',
+        'eval(decode(process.argv[2]));',
+      ].join('\n');
+      await fs.writeFile(path.join(tempDir, 'live-decoder.js'), content);
+
+      const findings = await scanForUnicodeStego();
+      const stego002 = findings.filter(
+        (f) => f.checkId === 'UNICODE-STEGO-002' && f.file === 'live-decoder.js'
+      );
+
+      expect(stego002.length).toBe(1);
+      expect(stego002[0].severity).toBe('critical');
+      expect(stego002[0].message).toContain('execution sink');
+    });
+
+    it('escalates to critical when the invisible payload is present in the same file', async () => {
+      // U+FE00 written into the file as raw bytes, so UNICODE-STEGO-001 fires here
+      // too: the decoder and the payload it would decode are in the same place.
+      const content = Buffer.concat([
+        Buffer.from(
+          [
+            'function decode(input) {',
+            '  const result = [];',
+            '  for (let i = 0; i < input.length; i++) {',
+            '    const cp = input.codePointAt(i);',
+            '    if (cp >= 0xFE00 && cp <= 0xFE0F) { result.push(cp - 0xFE00); }',
+            '  }',
+            '  return String.fromCharCode(...result);',
+            '}',
+            'const payload = "seed',
+          ].join('\n')
+        ),
+        Buffer.from([0xEF, 0xB8, 0x80]), // U+FE00 VARIATION SELECTOR-1
+        Buffer.from('";\nmodule.exports = decode(payload);\n'),
+      ]);
+      await fs.writeFile(path.join(tempDir, 'payload-carrier.js'), content);
+
+      const findings = await scanForUnicodeStego();
+      const stego001 = findings.filter(
+        (f) => f.checkId === 'UNICODE-STEGO-001' && f.file === 'payload-carrier.js'
+      );
+      const stego002 = findings.filter(
+        (f) => f.checkId === 'UNICODE-STEGO-002' && f.file === 'payload-carrier.js'
+      );
+
+      expect(stego001.length).toBe(1);
+      expect(stego002.length).toBe(1);
+      expect(stego002[0].severity).toBe('critical');
+      expect(stego002[0].message).toContain('invisible codepoints');
+    });
+
+    it('reports the earlier of the two signals, not the first .codePointAt', async () => {
+      // The range literal that discriminates the finding usually sits in a table
+      // above the loop that reads it. Reporting the first .codePointAt sent readers
+      // past the line that actually caused the finding.
+      const content = [
+        'const VS_LOW = 0xFE00;', // line 1: the discriminating literal
+        'const VS_HIGH = 0xFE0F;',
+        'function decode(input) {',
+        '  const out = [];',
+        '  for (const ch of input) {',
+        '    const cp = ch.codePointAt(0);', // line 6: the first codePointAt
+        '    if (cp >= VS_LOW && cp <= VS_HIGH) out.push(cp - VS_LOW);',
+        '  }',
+        '  return String.fromCodePoint(...out);',
+        '}',
+      ].join('\n');
+      await fs.writeFile(path.join(tempDir, 'table-first.js'), content);
+
+      const findings = await scanForUnicodeStego();
+      const stego002 = findings.filter(
+        (f) => f.checkId === 'UNICODE-STEGO-002' && f.file === 'table-first.js'
+      );
+
+      expect(stego002.length).toBe(1);
+      expect(stego002[0].line).toBe(1);
+      expect(stego002[0].message).toContain('range literal at line 1');
+      expect(stego002[0].message).toContain('.codePointAt at line 6');
     });
   });
 

--- a/src/hardening/scanner.ts
+++ b/src/hardening/scanner.ts
@@ -12836,13 +12836,14 @@ dist/
       // GlassWorm — is EVIDENCE ABOUT THE FILE, not a gate on the finding. It was a
       // required conjunct for one commit and that was wrong: a required conjunct on
       // one SPELLING is a rule about that spelling, not about the class. Measured
-      // against the previous release, requiring it dropped 15 working decoders to no
-      // finding at all — `.map(String.fromCodePoint)`, `Array.from(out, ...)`, an
-      // alias, a destructured `{ fromCharCode }`, `String['fromCodePoint']`,
-      // `Reflect.apply`, `Buffer.from(out).toString()`, `new TextDecoder().decode()`,
-      // a `JSON.parse('"\\uXXXX"')` round trip and an indexed alphabet table — every
-      // one of which reconstituted a tag-range payload and passed it to a sink. The
-      // attacker picks the spelling, so the spelling cannot be the gate. What the
+      // against the previous release, requiring it dropped 10 working decoder
+      // spellings to no finding at all — `.map(String.fromCodePoint)`,
+      // `Array.from(out, ...)`, an alias, a destructured `{ fromCharCode }`,
+      // `String['fromCodePoint']`, `Reflect.apply`, `Buffer.from(out).toString()`,
+      // `new TextDecoder().decode()`, a `JSON.parse('"\\uXXXX"')` round trip and an
+      // indexed alphabet table — every one of which reconstituted a tag-range payload
+      // and passed it to a sink. Each is pinned by a test in unicode-stego.test.ts.
+      // The attacker picks the spelling, so the spelling cannot be the gate. What the
       // signal is good for is describing the file accurately, so it selects the
       // wording below and nothing else. Narrowing on semantics rather than spelling
       // needs dataflow, which is #424's AST analyzer, not another regex.
@@ -12897,7 +12898,7 @@ dist/
           line: reportedLine,
           fixable: false,
           fix: corroboration
-            ? `sed -n '${Math.max(1, reportedLine - 5)},${reportedLine + 20}p' ${shellEscape(relativePath)}   # trace the reconstituted string to its sink and remove the decoder`
+            ? `sed -n '${Math.max(1, reportedLine - 5)},${reportedLine + 20}p' ${shellEscape(relativePath)}   # trace this codepoint range to whatever consumes it, then remove the decoder`
             : `sed -n '${Math.max(1, reportedLine - 5)},${reportedLine + 20}p' ${shellEscape(relativePath)}   # confirm this decodes for inspection, not for execution`,
           guidance: corroboration
             ? `The GlassWorm attack hides a payload in invisible Unicode characters and rebuilds it at runtime from their codepoints. This file ${act} those codepoints AND carries corroborating evidence, so treat it as live until traced. Follow the value from the range literal to whatever consumes it.`

--- a/src/hardening/scanner.ts
+++ b/src/hardening/scanner.ts
@@ -12830,7 +12830,19 @@ dist/
       // comment called an attacker-controllable weak signal. Measured consequences:
       // precision 0/7 on real-world code, and our own stego analyzer was held clean
       // only by its filename, so copying it to another name self-flagged. The path is
-      // no longer consulted at all, and renaming a file no longer changes any verdict.
+      // no longer consulted BY THIS CHECK, so no filename can make it skip a file.
+      //
+      // It does NOT follow that a rename can no longer change a verdict, and an earlier
+      // draft of this comment claimed exactly that. The `hasAnyInvisible` corroborator
+      // below is UNICODE-STEGO-001's result, and that check is gated on `isDocFile`,
+      // which DOES read the path: it skips variation selectors in `.md`/`.txt` and in
+      // files whose basename begins README/CHANGELOG/CONTRIBUTING/AGENTS/CLAUDE/LICENSE/
+      // AUTHORS/HISTORY. So a decoder corroborated ONLY by an embedded payload is MEDIUM
+      // under one of those names and CRITICAL under another. Measured on byte-identical
+      // content: `payload-carrier.js` exits 1, `README-carrier.js` exits 0. A decoder
+      // corroborated by a recognised execution sink is CRITICAL under every name. That
+      // asymmetry predates this change, is disclosed in the release notes, and is not
+      // fixed here.
       //
       // Reconstitution — String.fromCodePoint/fromCharCode, the decoder half of
       // GlassWorm — is EVIDENCE ABOUT THE FILE, not a gate on the finding. It was a
@@ -12887,7 +12899,7 @@ dist/
           name: 'GlassWorm Decoder Pattern Detected',
           description: corroboration
             ? `Source file ${act} Unicode variation selector or tag character codepoints AND carries corroborating evidence - this is the decoder half of a GlassWorm attack`
-            : `Source file ${act} Unicode variation selector or tag character codepoints. This is the shape of a GlassWorm decoder, but nothing in the file corroborates intent - no execution sink and no invisible codepoints present`,
+            : `Source file ${act} Unicode variation selector or tag character codepoints. This is the shape of a GlassWorm decoder, but neither corroborator this check recognises is present - no literal eval( or Function( call, and no invisible codepoints`,
           category: 'unicode-stego',
           severity: corroborated ? 'critical' : 'medium',
           passed: false,
@@ -12902,7 +12914,7 @@ dist/
             : `sed -n '${Math.max(1, reportedLine - 5)},${reportedLine + 20}p' ${shellEscape(relativePath)}   # confirm this decodes for inspection, not for execution`,
           guidance: corroboration
             ? `The GlassWorm attack hides a payload in invisible Unicode characters and rebuilds it at runtime from their codepoints. This file ${act} those codepoints AND carries corroborating evidence, so treat it as live until traced. Follow the value from the range literal to whatever consumes it.`
-            : `This file ${act} codepoints in the variation selector or tag range. Sanitisers, linters, width calculators and tests for this attack all legitimately do the same thing, which is why this is a lead rather than a verdict: no decoded value reaches eval or Function here, and no invisible codepoints are present in the file. Confirm the value is inspected rather than executed. Note that reconstitution can be spelled many ways (an alias, a destructured binding, .map, Buffer.from, TextDecoder), so its absence from the message is not proof the file does not rebuild a string.`,
+            : `This file ${act} codepoints in the variation selector or tag range. Sanitisers, linters, width calculators and tests for this attack all legitimately do the same thing, which is why this is a lead rather than a verdict. What was actually checked, stated narrowly on purpose: no literal eval( or Function( call appears in this file, and UNICODE-STEGO-001 did not fire on it. Neither is a statement about the class. A decoded string can reach an executor through vm, child_process, a dynamic import(), a member expression such as globalThis.eval, or the Function constructor reached through a prototype chain, and this check recognises none of those - so read the file rather than trusting this line. Reconstitution likewise has many spellings (an alias, a destructured binding, .map, Buffer.from, TextDecoder), so its absence from the message above is not proof the file does not rebuild a string.`,
         });
       }
 

--- a/src/hardening/scanner.ts
+++ b/src/hardening/scanner.ts
@@ -12825,21 +12825,27 @@ dist/
         }
       }
 
-      // The decoder half of GlassWorm RECONSTITUTES a string from codepoints. Code
-      // that only inspects codepoints — a scanner, a sanitiser, a linter, a range
-      // table — never does. So reconstitution is a REQUIRED conjunct of the finding
-      // rather than one input to a filename-keyed exemption.
+      // This check used to consult a regex over the file PATH
+      // (`/analyz|detect|scan|check|inspect|enhanc|stego/i`), which this file's own
+      // comment called an attacker-controllable weak signal. Measured consequences:
+      // precision 0/7 on real-world code, and our own stego analyzer was held clean
+      // only by its filename, so copying it to another name self-flagged. The path is
+      // no longer consulted at all, and renaming a file no longer changes any verdict.
       //
-      // It used to be the third condition of an `isDetectionCode` skip whose other
-      // two conditions were a range-comparison regex and a regex over the file PATH,
-      // which this file's own comment called an attacker-controllable weak signal.
-      // Two consequences, both measured: the check fired on any sanitiser that named
-      // the ranges it defends against (precision 0/7 on real-world code, `consola`
-      // and `graphemer` among the false positives), and our own stego analyzer was
-      // held clean only by its filename, so copying it to another name self-flagged.
-      // Requiring reconstitution makes that skip unreachable — it could only be true
-      // when reconstitution was absent, which now cannot reach this branch — so it
-      // is deleted rather than left as dead code guarding a live bypass.
+      // Reconstitution — String.fromCodePoint/fromCharCode, the decoder half of
+      // GlassWorm — is EVIDENCE ABOUT THE FILE, not a gate on the finding. It was a
+      // required conjunct for one commit and that was wrong: a required conjunct on
+      // one SPELLING is a rule about that spelling, not about the class. Measured
+      // against the previous release, requiring it dropped 15 working decoders to no
+      // finding at all — `.map(String.fromCodePoint)`, `Array.from(out, ...)`, an
+      // alias, a destructured `{ fromCharCode }`, `String['fromCodePoint']`,
+      // `Reflect.apply`, `Buffer.from(out).toString()`, `new TextDecoder().decode()`,
+      // a `JSON.parse('"\\uXXXX"')` round trip and an indexed alphabet table — every
+      // one of which reconstituted a tag-range payload and passed it to a sink. The
+      // attacker picks the spelling, so the spelling cannot be the gate. What the
+      // signal is good for is describing the file accurately, so it selects the
+      // wording below and nothing else. Narrowing on semantics rather than spelling
+      // needs dataflow, which is #424's AST analyzer, not another regex.
       const hasStringReconstitution = /String\.from(?:CodePoint|CharCode)\s*\(/.test(content);
 
       // Severity. A decoder pattern is evidence of CAPABILITY, not of malice, so on
@@ -12858,7 +12864,7 @@ dist/
         /(?:^|[^\w.$])(?:new\s+)?Function\s*\(/.test(content);
       const corroborated = hasExecutionSink || hasAnyInvisible;
 
-      if (hasCodePointAt && hasHexLiteral && hasStringReconstitution) {
+      if (hasCodePointAt && hasHexLiteral) {
         // Report the EARLIER of the two signals. Reporting the first `.codePointAt(`
         // sent readers to the wrong line whenever the range literal that actually
         // discriminates the finding sat above it.
@@ -12868,13 +12874,19 @@ dist/
           : hasAnyInvisible
             ? 'invisible codepoints present in the same file (UNICODE-STEGO-001)'
             : null;
+        // Say what was actually observed. A file that only READS codepoints must not
+        // be described as reconstituting them; that sentence would be false about the
+        // file, and a reader who checks it would find the check lying about evidence.
+        const act = hasStringReconstitution
+          ? 'reconstitutes strings from'
+          : 'reads';
 
         findings.push({
           checkId: 'UNICODE-STEGO-002',
           name: 'GlassWorm Decoder Pattern Detected',
           description: corroboration
-            ? 'Source file reconstitutes strings from Unicode variation selector or tag character codepoints AND carries corroborating evidence - this is the decoder half of a GlassWorm attack'
-            : 'Source file reconstitutes strings from Unicode variation selector or tag character codepoints. This is the shape of a GlassWorm decoder, but nothing in the file corroborates intent - no execution sink and no invisible codepoints present',
+            ? `Source file ${act} Unicode variation selector or tag character codepoints AND carries corroborating evidence - this is the decoder half of a GlassWorm attack`
+            : `Source file ${act} Unicode variation selector or tag character codepoints. This is the shape of a GlassWorm decoder, but nothing in the file corroborates intent - no execution sink and no invisible codepoints present`,
           category: 'unicode-stego',
           severity: corroborated ? 'critical' : 'medium',
           passed: false,
@@ -12888,8 +12900,8 @@ dist/
             ? `sed -n '${Math.max(1, reportedLine - 5)},${reportedLine + 20}p' ${shellEscape(relativePath)}   # trace the reconstituted string to its sink and remove the decoder`
             : `sed -n '${Math.max(1, reportedLine - 5)},${reportedLine + 20}p' ${shellEscape(relativePath)}   # confirm this decodes for inspection, not for execution`,
           guidance: corroboration
-            ? 'The GlassWorm attack hides a payload in invisible Unicode characters and uses .codePointAt() plus String.fromCodePoint to rebuild it at runtime. This file does that AND carries corroborating evidence, so treat it as live until traced.'
-            : 'This file rebuilds strings from codepoints in the variation selector or tag range. Sanitisers, linters and tests for this attack legitimately do the same thing, which is why this is reported as a lead rather than a verdict: no decoded value reaches eval or Function here, and no invisible codepoints are present in the file. Confirm the reconstituted value is inspected rather than executed.',
+            ? `The GlassWorm attack hides a payload in invisible Unicode characters and rebuilds it at runtime from their codepoints. This file ${act} those codepoints AND carries corroborating evidence, so treat it as live until traced. Follow the value from the range literal to whatever consumes it.`
+            : `This file ${act} codepoints in the variation selector or tag range. Sanitisers, linters, width calculators and tests for this attack all legitimately do the same thing, which is why this is a lead rather than a verdict: no decoded value reaches eval or Function here, and no invisible codepoints are present in the file. Confirm the value is inspected rather than executed. Note that reconstitution can be spelled many ways (an alias, a destructured binding, .map, Buffer.from, TextDecoder), so its absence from the message is not proof the file does not rebuild a string.`,
         });
       }
 

--- a/src/hardening/scanner.ts
+++ b/src/hardening/scanner.ts
@@ -12807,48 +12807,89 @@ dist/
       const lines = content.split('\n');
       let hasCodePointAt = false;
       let hasHexLiteral = false;
-      let decoderLine = 1;
+      let codePointAtLine = 0;
+      let hexLiteralLine = 0;
 
       const hexPattern = /0x(?:FE0[0-9A-Fa-f]|fe0[0-9a-f]|E010[0-9A-Fa-f]|e010[0-9a-f]|E01[0-9A-Ea-e][0-9A-Fa-f]|e01[0-9a-e][0-9a-f])/;
 
       for (let i = 0; i < lines.length; i++) {
         const line = lines[i];
         if (line.length > MAX_LINE_LENGTH) continue;
-        if (line.includes('.codePointAt(')) {
+        if (!hasCodePointAt && line.includes('.codePointAt(')) {
           hasCodePointAt = true;
-          if (!decoderLine || decoderLine === 1) decoderLine = i + 1;
+          codePointAtLine = i + 1;
         }
-        if (hexPattern.test(line)) {
+        if (!hasHexLiteral && hexPattern.test(line)) {
           hasHexLiteral = true;
+          hexLiteralLine = i + 1;
         }
       }
 
-      // Skip only if this is security detection code. Three conditions, ALL required:
-      //   1. File path indicates analyzer/scanner (attacker-controllable, weak signal)
-      //   2. Hex literals appear in range-comparison context, not assignments (weak signal)
-      //   3. No String.fromCodePoint/fromCharCode CALL — the decoder half of GlassWorm
-      //      reconstitutes a string from codepoints; detection code only inspects them.
-      //      This is the strong signal that prevents filename-based bypass.
+      // The decoder half of GlassWorm RECONSTITUTES a string from codepoints. Code
+      // that only inspects codepoints — a scanner, a sanitiser, a linter, a range
+      // table — never does. So reconstitution is a REQUIRED conjunct of the finding
+      // rather than one input to a filename-keyed exemption.
+      //
+      // It used to be the third condition of an `isDetectionCode` skip whose other
+      // two conditions were a range-comparison regex and a regex over the file PATH,
+      // which this file's own comment called an attacker-controllable weak signal.
+      // Two consequences, both measured: the check fired on any sanitiser that named
+      // the ranges it defends against (precision 0/7 on real-world code, `consola`
+      // and `graphemer` among the false positives), and our own stego analyzer was
+      // held clean only by its filename, so copying it to another name self-flagged.
+      // Requiring reconstitution makes that skip unreachable — it could only be true
+      // when reconstitution was absent, which now cannot reach this branch — so it
+      // is deleted rather than left as dead code guarding a live bypass.
       const hasStringReconstitution = /String\.from(?:CodePoint|CharCode)\s*\(/.test(content);
-      const isDetectionCode =
-        !hasStringReconstitution &&
-        /(?:>=|<=|===|!==)\s*0x(?:FE0|E010)/i.test(content) &&
-        /(?:analyz|detect|scan|check|inspect|enhanc|stego)/i.test(relativePath);
 
-      if (hasCodePointAt && hasHexLiteral && !isDetectionCode) {
+      // Severity. A decoder pattern is evidence of CAPABILITY, not of malice, so on
+      // its own it is a lead to follow rather than a stop-the-line finding. Critical
+      // requires corroboration, and both corroborators are read from THIS file so a
+      // finding's severity never depends on the order the tree is walked in:
+      //   1. an execution sink here, so a decoded string can reach eval/Function;
+      //   2. UNICODE-STEGO-001 fired here, so the invisible payload that a decoder
+      //      would decode is actually present in the same file.
+      // Neither holds for a test that builds a payload and asserts a sanitiser
+      // escapes it. That is a correct DEFENCE against this technique, and a check
+      // that grades a defence as the attack fires hardest on the people doing the
+      // right thing.
+      const hasExecutionSink =
+        /(?:^|[^\w.$])eval\s*\(/.test(content) ||
+        /(?:^|[^\w.$])(?:new\s+)?Function\s*\(/.test(content);
+      const corroborated = hasExecutionSink || hasAnyInvisible;
+
+      if (hasCodePointAt && hasHexLiteral && hasStringReconstitution) {
+        // Report the EARLIER of the two signals. Reporting the first `.codePointAt(`
+        // sent readers to the wrong line whenever the range literal that actually
+        // discriminates the finding sat above it.
+        const reportedLine = Math.min(codePointAtLine, hexLiteralLine);
+        const corroboration = hasExecutionSink
+          ? 'an execution sink (eval/Function) in the same file'
+          : hasAnyInvisible
+            ? 'invisible codepoints present in the same file (UNICODE-STEGO-001)'
+            : null;
+
         findings.push({
           checkId: 'UNICODE-STEGO-002',
           name: 'GlassWorm Decoder Pattern Detected',
-          description: 'Source file contains .codePointAt() usage combined with Unicode variation selector or tag character hex literals - this is the decoder half of a GlassWorm attack',
+          description: corroboration
+            ? 'Source file reconstitutes strings from Unicode variation selector or tag character codepoints AND carries corroborating evidence - this is the decoder half of a GlassWorm attack'
+            : 'Source file reconstitutes strings from Unicode variation selector or tag character codepoints. This is the shape of a GlassWorm decoder, but nothing in the file corroborates intent - no execution sink and no invisible codepoints present',
           category: 'unicode-stego',
-          severity: 'critical',
+          severity: corroborated ? 'critical' : 'medium',
           passed: false,
-          message: `Found GlassWorm decoder pattern (.codePointAt + hex range literals) in ${relativePath}`,
+          message: corroboration
+            ? `Found GlassWorm decoder pattern in ${relativePath} (codepoint range literal at line ${hexLiteralLine}, .codePointAt at line ${codePointAtLine}), corroborated by ${corroboration}`
+            : `Found GlassWorm decoder shape in ${relativePath} (codepoint range literal at line ${hexLiteralLine}, .codePointAt at line ${codePointAtLine}), uncorroborated`,
           file: relativePath,
-          line: decoderLine,
+          line: reportedLine,
           fixable: false,
-          fix: 'Review the file for suspicious .codePointAt() logic that decodes hidden data from variation selectors (0xFE00-0xFE0F) or tag characters (0xE0100-0xE01EF). Remove the decoder function.',
-          guidance: 'The GlassWorm attack encodes malicious payloads in invisible Unicode characters and uses .codePointAt() to decode them at runtime. This is the decoder half of the attack.',
+          fix: corroboration
+            ? `sed -n '${Math.max(1, reportedLine - 5)},${reportedLine + 20}p' ${shellEscape(relativePath)}   # trace the reconstituted string to its sink and remove the decoder`
+            : `sed -n '${Math.max(1, reportedLine - 5)},${reportedLine + 20}p' ${shellEscape(relativePath)}   # confirm this decodes for inspection, not for execution`,
+          guidance: corroboration
+            ? 'The GlassWorm attack hides a payload in invisible Unicode characters and uses .codePointAt() plus String.fromCodePoint to rebuild it at runtime. This file does that AND carries corroborating evidence, so treat it as live until traced.'
+            : 'This file rebuilds strings from codepoints in the variation selector or tag range. Sanitisers, linters and tests for this attack legitimately do the same thing, which is why this is reported as a lead rather than a verdict: no decoded value reaches eval or Function here, and no invisible codepoints are present in the file. Confirm the reconstituted value is inspected rather than executed.',
         });
       }
 


### PR DESCRIPTION
Closes #469.

`UNICODE-STEGO-002` reported CRITICAL on a log sanitiser, in three repositories at once, i.e. on the countermeasure to the attack the check is named after. Measured precision on real-world code was 0/7 and the only true positives ever observed were fixtures written for this check.

## What changed

- **The filename exemption is deleted.** It keyed on a regex over the file PATH, which this scanner's own comment calls an attacker-controllable weak signal. Our own stego analyzer was clean only because of its name: copied to `util-helper.ts` it self-flagged. No name can make this check skip a file now. Pinned by a test that scans identical bytes under two filenames and asserts the severities match.
- **CRITICAL now requires corroboration** — an execution sink, or `UNICODE-STEGO-001`, both read from the same file so severity never depends on tree-walk order. Uncorroborated is MEDIUM with the evidence intact.

## The commit in the middle, and why it is reverted

The first commit made string reconstitution a **required conjunct**, on the reasoning that only a decoder rebuilds a string from codepoints. The reasoning is sound; the implementation tested for `String.from(CodePoint|CharCode)\s*\(` specifically.

Measured against 0.27.0, that dropped **ten** working decoders to no finding at all — each reconstitutes a tag-range payload and passes it to `eval`:

`.map(String.fromCodePoint)` · `Array.from(out, ...)` · an alias · a destructured `{ fromCharCode }` · `String['fromCodePoint']` · `Reflect.apply` · `Buffer.from().toString()` · `new TextDecoder().decode()` · a `JSON.parse('"\uXXXX"')` round trip · an indexed alphabet table

The attacker picks the spelling, so the spelling cannot be the gate. All ten are now positive tests, red-proofed against the reverted commit. Reconstitution survives only as wording selection, so a finding never claims a file rebuilds strings when it only reads codepoints. Narrowing on semantics rather than spelling needs dataflow — #424.

## Measured

| target | 0.27.0 | this branch |
|---|---|---|
| the three blocked repos | exit 1, 4 CRITICAL | exit 0, 4 MEDIUM |
| ten decoder spellings | CRITICAL | CRITICAL |
| our stego analyzer under a neutral name | CRITICAL | MEDIUM |

The condition is strictly weaker than 0.27.0's, so nothing that fired then stops firing. Severity moves; reporting does not.

## Disclosed, not fixed

- Corroboration reads `eval(`/`Function(` and no other sink.
- Neither corroborator strips comments or string literals. **Our own `src/hardening/scanner.ts` is CRITICAL here**, corroborated by an `eval(` inside a comment explaining how the scanner avoids matching `eval(` in comments. It was clean on 0.27.0 only because its path hit the deleted exemption. Our score stays 100/100 because `.hmaignore` excludes `src/hardening/` by path, and that exclusion is now printed on the `Scope` line. Same shape as #468.
- `UNICODE-STEGO-001` does not scan `.md`/`.txt` or `README`/`AUTHORS`-style names for variation selectors, so a decoder corroborated only by its payload is MEDIUM under one of those names. Predates this release.
- The decimal spelling (#467) and single-line minified decoders remain undetected.

## Gate

8 phases. 248 test files / 3513 tests, tsc, lint, corpus 12/12 all clean. Two adversarial rounds: the first found the recall regression above, the second found four claims in my own notes that measurement falsified, all corrected in the last two commits.