### PR TITLE
Release 0.28.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -385,6 +385,54 @@ The same "fires on its own countermeasure" shape in `UNICODE-STEGO-005` is #468.
 `UNICODE-STEGO-002` CRITICALs on HackMyAgent's own test suite, caused by decoder fixtures
 held in string literals, are also pre-existing and unfixed.
 
+### Known issues
+
+The release walkthrough for this version installed the packed tarball as a fresh user and
+exercised 21 commands. Everything below **reproduces identically on published `0.27.0`** —
+none is a regression from this release, and each was measured on both versions rather than
+asserted. They are listed because two of them are the same defect class this release is
+about, and a release whose subject is "the score and the exit code must mean something"
+cannot be silent about the places where they still do not. **All four are scheduled for
+0.29.0**, and #368 and #390 are on their second carry, so they are fixed there rather than
+listed again.
+
+**The score does not respond to what is in the file:**
+
+- **Four hardcoded secrets in one file produce one finding and the same score as one secret**
+  (#478). `AST-CRED-003` reports a single instance naming only the first key, with
+  `instanceCount: null`. Removing three of the four moves the score by zero, which reads as
+  "my fix did not work". Each secret type is detected correctly in isolation, so this is
+  aggregation, not pattern coverage.
+- **The CRITICAL credential finding is less specific than the HIGH above it** (#368, second
+  carry). `AST-CRED-003 Hardcoded Secret Detected` prints the file with **no line number and
+  no `Verify:` line**, directly above `AST-CRED-001` which prints `config.js:3` and a runnable
+  `Verify:`. The masked preview and the secret type exist in the JSON and are dropped by the
+  text renderer. A CRITICAL that cannot say which line it means, sitting above a HIGH that
+  can, inverts the severity signal.
+
+**Two analyzers, one artifact, opposite verdicts:**
+
+- **`fix-all --scan-only` declares Credential Protection clean and exits 0 on a tree where
+  `secure` reports a CRITICAL hardcoded secret** (#477). `secure --fix` routes users there in
+  its own output — "Run `hackmyagent fix-all` to apply all available fixes" — so following the
+  tool's instruction moves you from the analyzer that found the credential to the one that
+  says the tree is clean.
+
+**A verdict on something never measured:**
+
+- **`scan-soul --ci` exits 0 when there is no governance file at all** (#390, second carry;
+  the other half of that issue, a governance file conforming to nothing, is fixed in this
+  release). The worst possible posture is the one case CI passes, and the command prints a
+  fabricated `0/100` with a full per-domain table for a file it never found. Every other
+  command — `check`, `detect`, `attack`, `red-team` — exits 2 with `NOT MEASURED` in the same
+  situation.
+
+Two smaller ones worth naming because they mislead rather than merely annoy: the `Path
+forward` projection on a mixed-severity tree can promise `100` where the measured result after
+those fixes is `98`, because it does not account for a residual LOW; and a `Verify:` line in
+some credential fix text hardcodes `.` rather than the directory that was scanned, so copying
+it audits the current directory instead of the target.
+
 ## [0.27.0] - 2026-08-07
 
 Four changes here can turn a green pipeline red, and they are the reason to read this

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,30 @@ All notable changes to HackMyAgent are documented in this file.
 
 ## [Unreleased]
 
+## [0.28.0] - 2026-08-08
+
+Four changes, and they move pipelines in both directions. Two can turn a green pipeline red,
+two can turn a red one green, and the green-going ones are the ones to read carefully — a
+finding getting quieter deserves more scrutiny than a finding getting louder, not less.
+
+| What changes | 0.27.0 | 0.28.0 |
+|---|---|---|
+| `--ignore` or an `.hmaignore` `!CHECK-ID` rule | removed the check's penalties, so suppressing a failing check made the tree score better | **suppression no longer moves the score or the exit code**, and every suppressed ID is named in the output |
+| An `.hmaignore` **path** rule | findings left the scored set silently | still out of scope, but disclosed on a `Scope` line with a severity breakdown, and as `outOfScope` in `--json` |
+| An MCP server declaring no tool key | a fabricated `['*']` produced a CRITICAL "Full Wildcard Tool Access" citing the server-key line | treated as the MCP default it is; a benign read-only server goes **69/100 to 96/100** |
+| A file carrying `.codePointAt(` and a codepoint range literal | **CRITICAL**, on a filename-keyed exemption an attacker controls | **MEDIUM unless corroborated**, and no filename can make the check skip a file |
+
+Why this is a minor rather than a patch: `--json` gains three fields (`outOfScope`,
+`suppressed`, `coverage.semanticFamilyCoverage`), the text output gains `Scope` and
+`Suppressed` lines and a semantic-coverage qualifier, and scores move in both directions. This
+is a `0.x` release, so a `^0.27.0` range does not resolve to it and nobody is upgraded without
+choosing to. Pipelines on `@latest` or `npx` pick it up on the next run.
+
+**Read the `UNICODE-STEGO-002` entry under `Fixed` before upgrading if you gate CI on the exit
+code.** It lowers severities, and its corroborator recognises two spellings of an execution
+sink, so some real droppers now report MEDIUM and exit 0. That gap is measured, disclosed in
+that entry, and tracked as #475 rather than papered over.
+
 ### Security
 
 **`--ignore` and `.hmaignore` no longer change the score or the exit code (#450).**

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "hackmyagent",
-  "version": "0.27.0",
+  "version": "0.28.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "hackmyagent",
-      "version": "0.27.0",
+      "version": "0.28.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.30.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hackmyagent",
-  "version": "0.27.0",
+  "version": "0.28.0",
   "description": "Find it. Break it. Fix it. The hacker's toolkit for AI agents.",
   "bin": {
     "hackmyagent": "dist/cli.js"


### PR DESCRIPTION
Cuts `[Unreleased]` to `0.28.0`. Four units since 0.27.0:

| commit | unit |
|---|---|
| `f5dc3c0` | #450 - `--ignore` and `.hmaignore` no longer launder the score or the exit code |
| `c982b58` | #449 - `AST-SCOPE-001` no longer reports a wildcard the artifact does not declare |
| `252dd9b` | #456 - the semantic coverage line says how much of the analyzer suite read each artifact |
| `646a5ef` | #469 - `UNICODE-STEGO-002` requires corroboration for CRITICAL, and no filename exempts a file |

Minor rather than patch: `--json` gains `outOfScope`, `suppressed` and `coverage.semanticFamilyCoverage`, the text output gains `Scope` and `Suppressed` lines plus a semantic-coverage qualifier, and scores move in both directions.

Two changes can turn a green pipeline red (#450) and two can turn a red one green (#449, #469). The header says so and points readers gating on the exit code at the `UNICODE-STEGO-002` entry, whose execution-sink corroborator recognises two spellings — measured, disclosed in that entry, tracked as #475, and left for the dataflow work in #424 rather than closed with a wider regex.

Verified on this branch: 251 files / 3577 tests exit 0, tsc 0, lint 0, self-scan 100/100 exit 0. The `.hmaignore` sample count in the #450 entry was stale before this release and is now measured against this tree (68 / 29 critical / 15 high / 24 medium) and labelled tree-dependent.

Post-publish, still owed: `opena2a-website` canonical-numbers, the Homebrew formula and its README, and the `opena2a-architecture` operations page (stale at 0.26.0).