### PR TITLE
The P3 auto-verdict gate cited a figure that has been withdrawn

### DIFF
--- a/src/nanomind-core/analyst-coverage.ts
+++ b/src/nanomind-core/analyst-coverage.ts
@@ -17,9 +17,22 @@
  *
  * This module is measurement-path only in P1. It is deliberately NOT wired into
  * `orchestrateNanoMind` / `scanner-bridge` — shipped `secure` behavior is
- * unchanged. Wiring an auto-verdict into the product is gated behind P3
- * (the per-sample structural+analyst policy comparison vs the published
- * 82.9% F1 / 1.16% FPR).
+ * unchanged. Wiring an auto-verdict into the product is gated behind P3, the
+ * per-sample structural+analyst policy comparison.
+ *
+ * That P3 gate USED to read "vs the published 82.9% F1 / 1.16% FPR". Those
+ * figures were withdrawn on 2026-08-09: the benign class of the corpus they
+ * were measured on was labeled by the scanner under test, via the rule
+ * `verdict=safe AND score >= 80` as reported by HackMyAgent itself, so every
+ * metric reading that class was fixed by the labeling rule before any scan ran.
+ * The gate cannot be a comparison against a number that does not exist.
+ *
+ * Until a baseline on a corpus we neither own nor labeled is available, the P3
+ * gate is UNDEFINED and no auto-verdict may be wired in on the strength of it.
+ * Recall survives the withdrawal (it reads only the malicious class, which
+ * excluded the self-labeled samples) but recall alone cannot gate an
+ * auto-verdict: the whole risk of auto-applying this analyst is false
+ * positives, and the false-positive figure is precisely the withdrawn one.
  */
 
 /** Routed analyst contribution to a per-artifact verdict. */


### PR DESCRIPTION
analyst-coverage.ts gated wiring the reasoning analyst into the shipped verdict on
"the per-sample structural+analyst policy comparison vs the published 82.9% F1 /
1.16% FPR". Those figures were withdrawn on 2026-08-09: the benign class of the corpus
they came from was labeled by the scanner under test, through the rule "verdict=safe
AND score >= 80" as reported by HackMyAgent itself, so anything the scanner would have
flagged was excluded from the benign class by construction.

This is not a stale comment. It is a release gate whose pass condition is a comparison
against a number that no longer exists, in a public repository, guarding the decision
to let an analyst with a measured ~22% false-positive rate flip a user-visible verdict.
A gate that cannot be evaluated is not a gate.

The gate is now recorded as UNDEFINED until a baseline exists on a corpus we neither
own nor labeled, and the comment says why recall cannot stand in for it: the entire
risk being gated is false positives, and the false-positive figure is the withdrawn one.
