### PR TITLE
Close the completeness gate at every scan depth (#499)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,48 @@ All notable changes to HackMyAgent are documented in this file.
 
 ## [Unreleased]
 
+### The completeness gate now holds at `--scan-depth quick` (#499)
+
+0.30.0 closed #438 at `standard` and `deep` and said so, but at `quick` depth 55 of 61
+static check groups are skipped and the only component that opens an arbitrary source file
+is the NanoMind semantic layer — which ran after `scanner.scan()` returned, outside the
+coverage ledger's window. So `secure --scan-depth quick` over an unreadable credential file
+still reported `98/100` at exit 0.
+
+One benign fixture, one `chmod`, measured on `8d66a0b`:
+
+| depth | mode 000 before | after | mode 644 control |
+|---|---|---|---|
+| quick | **98/100, exit 0** | 93/100, exit 2 | 98/100, exit 0 — unchanged |
+| standard | 93/100, exit 2 | unchanged | unchanged |
+| deep | 93/100, exit 2 | unchanged | unchanged |
+
+- **The pass moved, the ledger did not widen.** The semantic pass is now a
+  `ScanOptions.semanticPass` hook invoked inside `scanInner`, ahead of the coverage
+  snapshot, the `SCAN-UNREAD-001` loop and the scope filter. It runs **outside** any
+  `coverage.run()` frame, deliberately: with an empty method stack its successful reads are
+  unattributable and get dropped, so only read FAILURES are recorded. `filesExamined` is
+  byte-identical in all six cells of the depth x mode matrix — nothing was re-baked.
+- **Two bypasses were stacked, and fixing either alone is inert.** The ambient ledger was
+  null during the semantic pass, and the layer read through raw `node:fs` so its reads
+  reported nothing even with the window open. A repo lint now fails the build on a
+  `fs/promises` import that bypasses the tracked namespace.
+- **Base rate on five real trees at quick and standard: zero unread inputs.** Nothing that
+  passes today newly gates.
+
+**Known: three routes around this gate remain open, all at `--scan-depth quick`, all
+pre-existing.** `chmod 600` on a *containing directory* still drops its files with no record
+(#515, exit 0 at 98/100); `--static-only` removes the only reader at that depth and
+reproduces the old behaviour exactly (#516); and the `-b oasb-1` / `-b oasb-2` arms reach
+exit 2 but print a passing rating and never name the file (#514). The shared root is that
+the unit is "inputs discovered but not read" while discovery is owned by whichever
+component happens to read — filed rather than half-fixed.
+
+**Correction to 0.30.0's changelog.** That entry says, of the settlement point, "an
+incomplete run cannot exit 0". That was true at `standard` and `deep` and **false at
+`quick`**, which the same entry's own "Known issue" block went on to describe. The sentence
+should have been scoped when it was written. It is true at every depth as of this release.
+
 ## [0.30.0] - 2026-08-11
 
 ### `secure` no longer passes a tree it could not read (#438)

--- a/__tests__/cli/secure-unread-input-gate.test.ts
+++ b/__tests__/cli/secure-unread-input-gate.test.ts
@@ -480,3 +480,59 @@ describe('#499 the completeness floor holds at every scan depth', () => {
     expect(run(['secure', dir, '--scan-depth', depth]).status).toBe(0);
   }, 240_000);
 });
+
+/**
+ * #499 — an existence PROBE that misses is not a lost input.
+ *
+ * The first cut of the #499 sweep routed the semantic layer's governance-file
+ * candidate loop through the tracked namespace. That loop probes five mutually
+ * exclusive spellings of one optional file and `break`s on the first hit, so a
+ * miss is the ordinary case. `ENOENT` is filtered and an absent `.opena2a/`
+ * stayed quiet — but a `.opena2a/` that cannot be traversed answers `EACCES`
+ * for all three policy spellings, and the scan then reported three unreadable
+ * inputs naming `policy.yml`, `policy.yaml` and `policy.json`, none of which
+ * exist. A clean tree went from `100/100 exit 0` to `85/100 exit 2` over three
+ * fabricated findings whose `chmod` remedy names a file that is not there.
+ *
+ * Measured on the broken build: quick `unread 3`, standard `unread 4` — the one
+ * real obstruction counted a second, third and fourth time.
+ */
+describe('#499 a probe miss is not an unread input', () => {
+  function probeTree(name: string): string {
+    const dir = path.join(root, name);
+    fs.mkdirSync(path.join(dir, 'src'), { recursive: true });
+    fs.mkdirSync(path.join(dir, '.opena2a'), { recursive: true });
+    fs.writeFileSync(path.join(dir, 'src', 'util.js'), 'function add(a,b){return a+b;}\nmodule.exports={add};\n');
+    fs.writeFileSync(path.join(dir, '.gitignore'), 'node_modules/\n.env\n*.pem\n*.key\n');
+    fs.writeFileSync(path.join(dir, 'package.json'), '{"name":"probe","version":"1.0.0"}\n');
+    return dir;
+  }
+
+  it.each(VALID_DEPTHS)('%s: an unreadable .opena2a/ names no file that does not exist', (depth) => {
+    const dir = probeTree(`probe-${depth}`);
+    const gov = path.join(dir, '.opena2a');
+    fs.chmodSync(gov, 0o000);
+    restore.push(gov);
+    try {
+      fs.readdirSync(gov);
+      console.warn('skipped: this process can read a mode-000 directory (running as root?)');
+      return;
+    } catch { /* genuinely unreadable */ }
+
+    const res = json(['secure', dir, '--scan-depth', depth]);
+    expect(res.body).not.toBeNull();
+    const named = (res.body.findings ?? [])
+      .filter((f: any) => f.checkId === 'SCAN-UNREAD-001')
+      .map((f: any) => f.file as string);
+
+    // Every path the gate names must actually exist. This is the assertion
+    // that fails on the broken build, and it is phrased as "no phantom" rather
+    // than a count so it stays true if the directory itself is legitimately
+    // reported (which it is, at standard depth, exactly once).
+    const phantom = named.filter((rel) => !fs.existsSync(path.join(dir, rel)));
+    expect(phantom).toEqual([]);
+
+    // And the one real obstruction is not counted more than once.
+    expect(named.length).toBeLessThanOrEqual(1);
+  }, 240_000);
+});

--- a/__tests__/cli/secure-unread-input-gate.test.ts
+++ b/__tests__/cli/secure-unread-input-gate.test.ts
@@ -394,3 +394,89 @@ describe('#438 --fail-below cannot bypass the settlement', () => {
     }
   });
 });
+
+/**
+ * #499 — the same settlement, at every `--scan-depth`.
+ *
+ * #438 closed the gate at `standard` and `deep` and left `quick` open, so a
+ * documented flag was a one-token bypass of the completeness floor. Measured on
+ * `67e6f04` (0.30.0, published `latest`), the fixture below:
+ *
+ *   mode 000 --scan-depth quick     ->  98/100  exit 0   unreadableInputs 0
+ *   mode 000 --scan-depth standard  ->  93/100  exit 2   unreadableInputs 1
+ *   mode 000 --scan-depth deep      ->  93/100  exit 2   unreadableInputs 1
+ *
+ * At quick depth 55 of the 61 orchestrated checks are skipped and the ONLY
+ * reader of the file is the NanoMind semantic layer, which ran after
+ * `scanInner` had already returned — outside the coverage ledger's window, and
+ * through the raw `fs` namespace rather than the tracked one. Two independent
+ * bypasses stacked: the ambient ledger was null, and the reads were untracked.
+ *
+ * The depths are read out of `src/cli.ts`'s own `validDepths` rather than
+ * written here, so a fourth depth cannot be added without either extending this
+ * suite or failing it.
+ */
+const VALID_DEPTHS: string[] = (() => {
+  const src = fs.readFileSync(path.join(__dirname, '..', '..', 'src', 'cli.ts'), 'utf-8');
+  const m = src.match(/const validDepths = \[([^\]]+)\]/);
+  if (!m) throw new Error('cannot locate validDepths in src/cli.ts — the enumeration source moved');
+  const depths = m[1].split(',').map((s) => s.trim().replace(/^['"]|['"]$/g, '')).filter(Boolean);
+  // A silently-empty parse would enumerate nothing and pass every case.
+  if (depths.length < 3) throw new Error(`validDepths parsed to ${JSON.stringify(depths)} — refusing to run a vacuous enumeration`);
+  return depths;
+})();
+
+describe('#499 the completeness floor holds at every scan depth', () => {
+  it.each(VALID_DEPTHS)('%s: an unreadable input is not a pass', (depth) => {
+    const dir = makeTree(`depth-${depth}`);
+    if (!makeUnreadable(path.join(dir, 'src', 'secrets.js'))) {
+      console.warn('skipped: this process can read a mode-000 file (running as root?)');
+      return;
+    }
+    expect(run(['secure', dir, '--scan-depth', depth]).status).toBe(EXIT_INCOMPLETE);
+  }, 240_000);
+
+  it.each(VALID_DEPTHS)('%s: the unread input is NAMED, on every channel', (depth) => {
+    const dir = makeTree(`depth-named-${depth}`);
+    if (!makeUnreadable(path.join(dir, 'src', 'secrets.js'))) {
+      console.warn('skipped: this process can read a mode-000 file (running as root?)');
+      return;
+    }
+    // A count with no name is the shape #438 rejected: `outOfScope` rendered as
+    // a bare number on two channels and not at all on three.
+    const body = json(['secure', dir, '--scan-depth', depth]);
+    expect(body.body).not.toBeNull();
+    const named = (body.body.findings ?? []).filter((f: any) => f.checkId === 'SCAN-UNREAD-001');
+    expect(named.length).toBe(1);
+    expect(named[0].file).toContain('secrets.js');
+    expect(run(['secure', dir, '--scan-depth', depth, '--format', 'sarif']).out).toContain('SCAN-UNREAD-001');
+  }, 240_000);
+
+  it.each(VALID_DEPTHS)('%s CONTROL: the same tree fully readable keeps exit 1', (depth) => {
+    // Without this the suite would pass on a change that gated every tree.
+    //
+    // At `quick` the exit 1 is earned by AST-CRED-001/003 from the SEMANTIC
+    // layer — the static pass never reads `secrets.js` at that depth. So a
+    // "fix" that closed the gap by disabling NanoMind at quick turns this
+    // control red, which is correct: it would trade a false pass for a blind
+    // one.
+    const dir = makeTree(`depth-control-${depth}`);
+    expect(run(['secure', dir, '--scan-depth', depth]).status).toBe(EXIT_FAIL);
+  }, 240_000);
+
+  it.each(VALID_DEPTHS)('%s CONTROL: a clean readable tree still exits 0', (depth) => {
+    // The negative control that keeps this a gate rather than a blanket fail.
+    //
+    // Ruled 2026-08-11 (Abdel, on a CPO/CISO split): `--scan-depth quick` KEEPS
+    // its ability to exit 0. CISO argued a run that skipped 55 of 61 checks may
+    // never pass; the ruling is that #438's unit is "inputs discovered and not
+    // read", not "every check ran", and a user passing `--scan-depth quick`
+    // consented to the reduced depth. That objection is tracked separately, not
+    // absorbed here.
+    const dir = path.join(root, `depth-clean-${depth}`);
+    fs.mkdirSync(path.join(dir, 'src'), { recursive: true });
+    fs.writeFileSync(path.join(dir, 'src', 'util.js'), 'function add(a,b){return a+b;}\nmodule.exports={add};\n');
+    fs.writeFileSync(path.join(dir, '.gitignore'), 'node_modules/\n.env\n*.pem\n*.key\n');
+    expect(run(['secure', dir, '--scan-depth', depth]).status).toBe(0);
+  }, 240_000);
+});

--- a/__tests__/cli/secure-unread-input-gate.test.ts
+++ b/__tests__/cli/secure-unread-input-gate.test.ts
@@ -421,8 +421,19 @@ const VALID_DEPTHS: string[] = (() => {
   const m = src.match(/const validDepths = \[([^\]]+)\]/);
   if (!m) throw new Error('cannot locate validDepths in src/cli.ts — the enumeration source moved');
   const depths = m[1].split(',').map((s) => s.trim().replace(/^['"]|['"]$/g, '')).filter(Boolean);
-  // A silently-empty parse would enumerate nothing and pass every case.
-  if (depths.length < 3) throw new Error(`validDepths parsed to ${JSON.stringify(depths)} — refusing to run a vacuous enumeration`);
+  // Membership, not arity. A count check (`length < 3`) passes when a comment
+  // token or a reformat displaces one of the names — the enumeration would then
+  // silently run three cases over the wrong set and report green. Asserting the
+  // exact set means a genuinely new depth fails HERE, loudly, with the parsed
+  // value in the message, instead of going unpinned.
+  const expected = ['quick', 'standard', 'deep'];
+  const missing = expected.filter((d) => !depths.includes(d));
+  if (missing.length > 0 || depths.length !== expected.length) {
+    throw new Error(
+      `validDepths parsed to ${JSON.stringify(depths)}; expected exactly ${JSON.stringify(expected)}. `
+      + 'If a depth was added, extend this suite rather than loosening the check.',
+    );
+  }
   return depths;
 })();
 

--- a/__tests__/hardening/fix-manifest-durability.test.ts
+++ b/__tests__/hardening/fix-manifest-durability.test.ts
@@ -1,0 +1,96 @@
+/**
+ * #499 — the rollback manifest is persisted BEFORE the semantic pass runs.
+ *
+ * `recordCreatedFiles` writes the hashed record of what a `--fix` generated.
+ * `rollback` reads that record to decide which files HMA created and may
+ * therefore remove. Between "the fix is on disk" and "the manifest says so"
+ * there is a window in which an interrupt — Ctrl-C, SIGTERM, OOM, a crash —
+ * leaves a generated file on disk with `createdFiles: []` recorded, and
+ * `rollback` then prints `[+] Rollback complete` having restored nothing. A
+ * safety mechanism reporting success over a tree it did not restore is worse
+ * than one that fails loudly.
+ *
+ * That window is ~45ms when the manifest write follows the fix directly. #499's
+ * first cut moved the NanoMind semantic pass — a model load plus a whole
+ * compile set — in front of it, measured at ~3.4s on a THREE-file fixture and
+ * scaling with the tree. The defect was not the window's existence, which
+ * predates this; it was widening it by two orders of magnitude while the
+ * relocation's own comment claimed that moving the call "must not change what a
+ * failure costs".
+ *
+ * This pins the ordering directly rather than by timing, which would be flaky.
+ * `semanticPass` is a public `ScanOptions` hook, so the test injects one that
+ * inspects the manifest at the exact moment the pass would run.
+ */
+import { describe, it, expect, afterAll } from 'vitest';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { HardeningScanner } from '../../src/hardening/scanner';
+
+const roots: string[] = [];
+
+afterAll(() => {
+  for (const r of roots) {
+    try { fs.rmSync(r, { recursive: true, force: true }); } catch { /* best effort */ }
+  }
+});
+
+/** A tree with no `.gitignore`, so `--fix` has something to generate. */
+function fixableTree(): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'hma-499-manifest-'));
+  roots.push(dir);
+  fs.mkdirSync(path.join(dir, 'src'), { recursive: true });
+  fs.writeFileSync(path.join(dir, 'src', 'util.js'), 'function add(a,b){return a+b;}\nmodule.exports={add};\n');
+  fs.writeFileSync(path.join(dir, 'package.json'), '{"name":"m","version":"1.0.0"}\n');
+  return dir;
+}
+
+/** Every `.manifest.json` under the backup dir, newest first. */
+function manifests(dir: string): any[] {
+  const backup = path.join(dir, '.hackmyagent-backup');
+  if (!fs.existsSync(backup)) return [];
+  return fs.readdirSync(backup)
+    .map((d) => path.join(backup, d, '.manifest.json'))
+    .filter((p) => fs.existsSync(p))
+    .map((p) => {
+      try { return JSON.parse(fs.readFileSync(p, 'utf-8')); } catch { return null; }
+    })
+    .filter(Boolean);
+}
+
+describe('#499 the rollback manifest survives an interrupt during the semantic pass', () => {
+  it('createdFiles is already persisted when the semantic pass is invoked', async () => {
+    const dir = fixableTree();
+    let seenAtPassTime: string[] | null = null;
+    let passRan = false;
+
+    const scanner = new HardeningScanner();
+    await scanner.scan({
+      targetDir: dir,
+      autoFix: true,
+      cliName: 'hackmyagent',
+      semanticPass: async () => {
+        passRan = true;
+        // Read the manifest from DISK at exactly the moment the semantic pass
+        // gets control. This is the state an interrupt here would leave behind.
+        const created = manifests(dir).flatMap((m) => (m.createdFiles ?? []).map((c: any) => c.path));
+        seenAtPassTime = created;
+        return undefined;
+      },
+    });
+
+    // Guard the guard: if the hook never ran, `seenAtPassTime` stays null and
+    // every assertion below would be vacuously satisfiable.
+    expect(passRan).toBe(true);
+
+    // The fix must actually have generated something, or the test proves
+    // nothing about durability.
+    const finalCreated = manifests(dir).flatMap((m) => (m.createdFiles ?? []).map((c: any) => c.path));
+    expect(finalCreated.length).toBeGreaterThan(0);
+
+    // The record the interrupt would leave must already be the complete one.
+    expect(seenAtPassTime).not.toBeNull();
+    expect([...(seenAtPassTime as unknown as string[])].sort()).toEqual([...finalCreated].sort());
+  }, 240_000);
+});

--- a/__tests__/hardening/log-finding-loss.test.ts
+++ b/__tests__/hardening/log-finding-loss.test.ts
@@ -400,7 +400,21 @@ describeSpawn('#421 layer 2 — the run discloses what it silenced', () => {
   // indistinguishable from a clean result. It is disclosed as a count.
   it('counts the checks that failed with nothing to point at', () => {
     const scan = scanFixture(HOME_DIR, undefined);
-    expect(scan?.coverage?.unevidencedFailures).toBeGreaterThan(0);
+    // NOT `toBeGreaterThan(0)`, which is what this asserted until #499.
+    //
+    // On this fixture the honest count is in the dozens, and the pathless
+    // noise floor it counts is carried in the same array the semantic merge
+    // replaces. #499's first cut replaced that array with the merge result
+    // alone and dropped the whole noise floor — measured, `unevidencedFailures`
+    // fell to 41 -> 0 on ai-trust and 45 -> 1 on secretless, deleting the only
+    // line that tells a reader a "categories clear" report is hiding ~40 checks
+    // that failed with nothing to point at.
+    //
+    // `> 0` survived that intact, because this fixture lands on exactly 1. A
+    // guard one finding away from vacuous is why the regression shipped green.
+    // The floor is set below the measured value with room for legitimate check
+    // churn, and high enough that a collapse to a handful cannot pass.
+    expect(scan?.coverage?.unevidencedFailures).toBeGreaterThan(15);
   });
 
   it('states that count on the Coverage line', () => {

--- a/__tests__/repo/tracked-fs-discipline.test.ts
+++ b/__tests__/repo/tracked-fs-discipline.test.ts
@@ -22,16 +22,23 @@
  *
  * #499's acceptance criteria name two spellings, `from 'fs/promises'` and
  * `import('node:fs/promises')`. Written to that letter this lint would be
- * VACUOUS — measured on the tree the day it was written, three further bypass
- * routes were already present and would have passed it:
+ * VACUOUS — measured on the tree the day it was written, two further bypass
+ * routes were already present INSIDE the covered subtrees and would have
+ * passed it:
  *
- *   import { promises as fs } from 'fs'     src/hardening/contain.ts:13
- *   fs.promises.realpath(...)               src/soul/scanner.ts:2370
+ *   import { promises as fs } from 'fs'     src/hardening/contain.ts
  *   import { readFileSync } from 'node:fs'  src/nanomind-core/scanner-bridge.ts
  *
  * So the predicate below is the CLASS — any acquisition of a Node fs namespace,
  * by static import, dynamic import or require, under any of its spellings — and
  * every permitted site is named with the reason it is permitted.
+ *
+ * A third route, `fs.promises.realpath(...)` in `src/soul/scanner.ts`, is
+ * deliberately NOT cited as evidence for this lint: `soul` is not in `COVERED`,
+ * so this suite says nothing about it either way. Whether the SOUL scanner's
+ * reads should be tracked is a separate question and is filed separately. The
+ * distinction matters — a lint's docblock claiming reach it does not have is
+ * the same defect as an exemption granted without a reason.
  *
  * ## Why an allowlist of exact sites, not a rule
  *
@@ -72,7 +79,11 @@ function walk(dir: string, out: string[] = []): string[] {
   for (const e of fs.readdirSync(dir, { withFileTypes: true })) {
     const full = path.join(dir, e.name);
     if (e.isDirectory()) walk(full, out);
-    else if (e.name.endsWith('.ts') && !e.name.endsWith('.test.ts')) out.push(full);
+    // `.cts`/`.mts` as well as `.ts`. There are none today, so omitting them
+    // would be vacuous-in-practice rather than a live hole — but a lint whose
+    // coverage depends on nobody using a standard extension is one bad day away
+    // from being wrong, and the fix is three characters.
+    else if (/\.(c|m)?ts$/.test(e.name) && !/\.test\.(c|m)?ts$/.test(e.name)) out.push(full);
   }
   return out;
 }
@@ -147,7 +158,9 @@ const UNREVIEWED: Record<string, { count: number; why: string }> = {
   'hardening/contain.ts': { count: 1, why: 'promises-as-fs; reads not traced' },
   'hardening/nemoclaw-scanner.ts': {
     count: 1,
-    why: 'sync target reads, but reached from `check`, not from scanInner — separate exposure',
+    why: 'sync reads, but no caller: `new NemoClawScanner` appears nowhere in src/ or dist/ '
+      + '(the `secure-nemoclaw` command reads ~/.nemoclaw directly, outside any scan target). '
+      + 'Unreferenced today is not the same as safe if it is ever wired up — hence pinned, not reviewed',
   },
   'nanomind-core/daemon-lifecycle.ts': {
     count: 1,
@@ -173,23 +186,35 @@ describe('#499 the tracked-fs sweep cannot silently regress', () => {
 
   const PERMITTED = { ...REVIEWED, ...UNREVIEWED };
 
+  /**
+   * THE GATE. Every violation of the discipline, as human-readable lines.
+   *
+   * Extracted as a function so the red-proof below can run THIS, rather than
+   * re-deriving an equivalent check of its own. The first version of that
+   * red-proof asserted a count it computed itself, which proved the detector
+   * worked and said nothing about the gate: deleting every assertion in the
+   * test below still left the suite green. A guard whose proof does not
+   * exercise it is not proven.
+   */
+  function violations(root: string): string[] {
+    const found = countByFile(root);
+    return [
+      // A NEW raw-fs site on a covered subtree. That is the whole point: #499
+      // was a new read path added to a module nobody re-checked.
+      ...Object.keys(found).filter((f) => !(f in PERMITTED)).map((f) => `unpermitted: ${f}`),
+      // A SECOND acquisition inside an already-permitted file, so an exemption
+      // granted for one traced read cannot silently cover a new one.
+      ...Object.entries(found)
+        .filter(([f, n]) => f in PERMITTED && n !== PERMITTED[f].count)
+        .map(([f, n]) => `count changed: ${f}: ${PERMITTED[f].count} permitted, ${n} found`),
+      // And the reverse, so the table cannot rot into a list of dead entries
+      // that quietly permit whatever later lands in those files.
+      ...Object.keys(PERMITTED).filter((f) => !(f in found)).map((f) => `stale entry: ${f}`),
+    ].sort();
+  }
+
   it('every fs acquisition on a scan-target subtree is named and justified', () => {
-    const found = countByFile(SRC);
-
-    // A NEW raw-fs site on a covered subtree fails here. That is the whole
-    // point: #499 was a new read path added to a module nobody re-checked.
-    expect(Object.keys(found).filter((f) => !(f in PERMITTED)).sort()).toEqual([]);
-
-    // A SECOND acquisition inside an already-permitted file fails too, so an
-    // exemption granted for one traced read cannot silently cover a new one.
-    const grew = Object.entries(found)
-      .filter(([f, n]) => f in PERMITTED && n !== PERMITTED[f].count)
-      .map(([f, n]) => `${f}: ${PERMITTED[f].count} permitted, ${n} found`);
-    expect(grew).toEqual([]);
-
-    // And the reverse, so the table cannot rot into a list of dead entries that
-    // quietly permit whatever later lands in those files.
-    expect(Object.keys(PERMITTED).filter((f) => !(f in found)).sort()).toEqual([]);
+    expect(violations(SRC)).toEqual([]);
   });
 
   it('every permitted site carries a written reason', () => {
@@ -230,13 +255,38 @@ describe('#499 the tracked-fs sweep cannot silently regress', () => {
       expect(after).not.toBe(before); // the mutation actually applied
       fs.writeFileSync(bridge, after);
 
-      // The reintroduced raw import is a SECOND acquisition in a file permitted
-      // for exactly one, so the count rule is what catches it — assert that
-      // specific mechanism, not merely that something somewhere went red.
-      const counts = countByFile(dst);
-      expect(counts['nanomind-core/scanner-bridge.ts']).toBe(
-        REVIEWED['nanomind-core/scanner-bridge.ts'].count + 1,
+      // Runs THE GATE, not a lookalike. If the assertion in the test above is
+      // deleted or weakened, this red-proof goes green and stops protecting
+      // anything — so it has to call the same function that test calls.
+      const found = violations(dst);
+      expect(found).not.toEqual([]);
+      // And it must name the reintroduced site, not merely be non-empty: the
+      // stale-entry rule would also fire on a copy that is simply out of date.
+      expect(found.some((v) => v.startsWith('count changed: nanomind-core/scanner-bridge.ts'))).toBe(true);
+    } finally {
+      fs.rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
+  it('RED-PROOF: the gate flags a WHOLLY NEW untracked reader', () => {
+    // The case above reintroduces an import into a file that already holds one,
+    // so it exercises the count rule. This exercises the other one — a brand new
+    // module, which is the shape #499 actually took. Without it, deleting the
+    // unpermitted-file rule would leave the suite green.
+    const tmp = fs.mkdtempSync(path.join(require('node:os').tmpdir(), 'hma-499-lint-new-'));
+    try {
+      const dst = path.join(tmp, 'src');
+      fs.cpSync(SRC, dst, { recursive: true });
+
+      const planted = path.join(dst, 'nanomind-core', 'sneaky-reader.ts');
+      expect(fs.existsSync(planted)).toBe(false); // the mutation is genuinely new
+      fs.writeFileSync(
+        planted,
+        "import { readFile } from 'node:fs/promises';\nexport const read = (p: string) => readFile(p, 'utf-8');\n",
       );
+
+      const found = violations(dst);
+      expect(found).toContain('unpermitted: nanomind-core/sneaky-reader.ts');
     } finally {
       fs.rmSync(tmp, { recursive: true, force: true });
     }

--- a/__tests__/repo/tracked-fs-discipline.test.ts
+++ b/__tests__/repo/tracked-fs-discipline.test.ts
@@ -1,0 +1,244 @@
+/**
+ * #499 — a module that can read the SCAN TARGET must read it through the
+ * tracked `fs` namespace.
+ *
+ * The 2026-08-05 coverage decision carried a review trigger worded exactly
+ * "any new file-read path that bypasses the tracked `fs` namespace". It fired
+ * silently: `src/nanomind-core/scanner-bridge.ts` and
+ * `src/nanomind-core/orchestrate.ts` read the target through raw `node:fs`,
+ * their reads and read FAILURES were invisible to the coverage ledger, and at
+ * `--scan-depth quick` — where 55 of the 61 static checks are skipped and the
+ * semantic layer is the only reader of the tree — `secure` scored an unreadable
+ * credential file 98/100 at exit 0. A trigger nobody can execute is a comment.
+ * This is the executable form.
+ *
+ * ## What this lint does and does not claim
+ *
+ * It is scoped to the subtrees that reach the scan target on a `secure` run.
+ * It is NOT a repo-wide ban on `node:fs`, and it must not be described as one:
+ * `src/cli.ts` alone holds 16 sync reads that are temp-dir plumbing, and
+ * sweeping them would produce an exemption table longer than the rule, which is
+ * how a lint stops being read.
+ *
+ * #499's acceptance criteria name two spellings, `from 'fs/promises'` and
+ * `import('node:fs/promises')`. Written to that letter this lint would be
+ * VACUOUS — measured on the tree the day it was written, three further bypass
+ * routes were already present and would have passed it:
+ *
+ *   import { promises as fs } from 'fs'     src/hardening/contain.ts:13
+ *   fs.promises.realpath(...)               src/soul/scanner.ts:2370
+ *   import { readFileSync } from 'node:fs'  src/nanomind-core/scanner-bridge.ts
+ *
+ * So the predicate below is the CLASS — any acquisition of a Node fs namespace,
+ * by static import, dynamic import or require, under any of its spellings — and
+ * every permitted site is named with the reason it is permitted.
+ *
+ * ## Why an allowlist of exact sites, not a rule
+ *
+ * The permitted sites divide into two kinds and the distinction is load-bearing.
+ * `REVIEWED` sites were each traced to what they read and are safe. `UNREVIEWED`
+ * sites exist today, are on a subtree this lint covers, and have NOT been traced.
+ * They are pinned rather than blessed: the suite fails if one is added or
+ * removed, so the backlog cannot grow silently and cannot be mistaken for a
+ * clean bill. Dropping them into one undifferentiated exemption list would
+ * launder an open question into a green check.
+ */
+import { describe, it, expect } from 'vitest';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+
+const SRC = path.resolve(__dirname, '..', '..', 'src');
+
+/**
+ * Subtrees whose modules can reach the scan target during a `secure` run.
+ * `src/cli.ts` is excluded by design — see the header.
+ */
+const COVERED = ['hardening', 'nanomind-core', 'semantic', 'lifecycle'];
+
+/**
+ * Any acquisition of a Node filesystem namespace.
+ *
+ * Matches `fs`, `node:fs`, `fs/promises`, `node:fs/promises` reached by static
+ * import, dynamic `import()` or `require()`. Deliberately not anchored to the
+ * start of a line: `const { readFile } = await import('node:fs/promises')` sits
+ * mid-statement, and an anchored rule matched line-by-line is the shape that
+ * lets a real call site through.
+ */
+const FS_ACQUISITION = /(?:from\s*|import\s*\(\s*|require\s*\(\s*)['"](?:node:)?fs(?:\/promises)?['"]/g;
+
+interface Site { file: string; line: number; text: string; }
+
+function walk(dir: string, out: string[] = []): string[] {
+  for (const e of fs.readdirSync(dir, { withFileTypes: true })) {
+    const full = path.join(dir, e.name);
+    if (e.isDirectory()) walk(full, out);
+    else if (e.name.endsWith('.ts') && !e.name.endsWith('.test.ts')) out.push(full);
+  }
+  return out;
+}
+
+/** Every fs acquisition under `root`'s covered subtrees, as `relpath:line`. */
+function findSites(root: string): Site[] {
+  const sites: Site[] = [];
+  for (const sub of COVERED) {
+    const dir = path.join(root, sub);
+    if (!fs.existsSync(dir)) continue;
+    for (const file of walk(dir)) {
+      const rel = path.relative(root, file).split(path.sep).join('/');
+      fs.readFileSync(file, 'utf-8').split('\n').forEach((text, i) => {
+        // A comment mentioning the import is not an import. Checked here rather
+        // than by stripping comments repo-wide: the wrapper's own docblock says
+        // `import * as fs from 'fs/promises'` in prose, and matching it would
+        // make the lint's first finding a false one.
+        const code = text.replace(/\/\/.*$/, '').replace(/^\s*\*.*$/, '');
+        FS_ACQUISITION.lastIndex = 0;
+        if (FS_ACQUISITION.test(code)) sites.push({ file: rel, line: i + 1, text: text.trim() });
+      });
+    }
+  }
+  return sites.sort((a, b) => `${a.file}:${a.line}`.localeCompare(`${b.file}:${b.line}`));
+}
+
+/**
+ * Traced to what it reads, and safe. Keyed by FILE and the number of
+ * acquisitions in it, never by line.
+ *
+ * Line numbers were the first shape and they were wrong: keyed that way, adding
+ * a comment anywhere above an exempt import fails this suite with a diff that
+ * has nothing to do with fs discipline. A lint that fires on unrelated edits is
+ * one somebody deletes. The count still catches the case that matters — a
+ * SECOND fs acquisition appearing in an already-exempt file.
+ */
+const REVIEWED: Record<string, { count: number; why: string }> = {
+  'hardening/tracked-fs.ts': {
+    count: 1,
+    why: 'the wrapper itself — the one module that must hold the real namespace',
+  },
+  'hardening/coverage-ledger.ts': {
+    count: 1,
+    why: 'realpathSync for containment decisions; resolves a path, never reads bytes',
+  },
+  'hardening/scanner.ts': {
+    count: 1,
+    why: 'fsSync — realpathSync.native for containment, plus readArtifactForCitation, a re-read '
+      + 'of an already-attempted path that must not be able to record an unread input',
+  },
+  'nanomind-core/scanner-bridge.ts': {
+    count: 1,
+    why: 'readArtifact — same citation re-read rule; see the comment at the import',
+  },
+  'nanomind-core/security/integrity-verifier.ts': {
+    count: 1,
+    why: "HMA's OWN bytes (dist/, ~/.nanomind, the integrity manifest). Routing this through "
+      + 'the ledger would count roughly 957 of our files as coverage of the scanned tree',
+  },
+  'semantic/llm/budget.ts': { count: 1, why: 'LLM state dir, outside any scan target' },
+  'semantic/llm/cache.ts': { count: 1, why: 'LLM state dir, outside any scan target' },
+};
+
+/**
+ * On a covered subtree, not traced, NOT blessed.
+ *
+ * Each of these needs the same treatment `scanner-bridge.ts` got: establish
+ * whether it can read a path inside a scan target, and if it can, route it or
+ * write down why not. Pinned so the set cannot grow unnoticed.
+ */
+const UNREVIEWED: Record<string, { count: number; why: string }> = {
+  'hardening/contain.ts': { count: 1, why: 'promises-as-fs; reads not traced' },
+  'hardening/nemoclaw-scanner.ts': {
+    count: 1,
+    why: 'sync target reads, but reached from `check`, not from scanInner — separate exposure',
+  },
+  'nanomind-core/daemon-lifecycle.ts': {
+    count: 1,
+    why: 'daemon state, believed outside the target; not traced',
+  },
+  'nanomind-core/inference/nanomind-guard-client.ts': { count: 1, why: 'model/socket paths; not traced' },
+  'nanomind-core/inference/security-analyst.ts': { count: 1, why: 'model paths; not traced' },
+  'nanomind-core/inference/tme-classifier.ts': { count: 1, why: 'model files; not traced' },
+  'nanomind-core/inference/tme-neural.ts': { count: 1, why: 'model files; not traced' },
+  'semantic/structural/git-context.ts': {
+    count: 1,
+    why: 'lstat/realpath on target paths; inspection, not content',
+  },
+};
+
+describe('#499 the tracked-fs sweep cannot silently regress', () => {
+  /** `file -> how many fs acquisitions it holds`. */
+  function countByFile(root: string): Record<string, number> {
+    const out: Record<string, number> = {};
+    for (const s of findSites(root)) out[s.file] = (out[s.file] ?? 0) + 1;
+    return out;
+  }
+
+  const PERMITTED = { ...REVIEWED, ...UNREVIEWED };
+
+  it('every fs acquisition on a scan-target subtree is named and justified', () => {
+    const found = countByFile(SRC);
+
+    // A NEW raw-fs site on a covered subtree fails here. That is the whole
+    // point: #499 was a new read path added to a module nobody re-checked.
+    expect(Object.keys(found).filter((f) => !(f in PERMITTED)).sort()).toEqual([]);
+
+    // A SECOND acquisition inside an already-permitted file fails too, so an
+    // exemption granted for one traced read cannot silently cover a new one.
+    const grew = Object.entries(found)
+      .filter(([f, n]) => f in PERMITTED && n !== PERMITTED[f].count)
+      .map(([f, n]) => `${f}: ${PERMITTED[f].count} permitted, ${n} found`);
+    expect(grew).toEqual([]);
+
+    // And the reverse, so the table cannot rot into a list of dead entries that
+    // quietly permit whatever later lands in those files.
+    expect(Object.keys(PERMITTED).filter((f) => !(f in found)).sort()).toEqual([]);
+  });
+
+  it('every permitted site carries a written reason', () => {
+    // An exemption with an empty reason is an exemption nobody has to defend.
+    const blank = Object.entries(PERMITTED).filter(([, v]) => !v.why || v.why.trim().length < 20);
+    expect(blank.map(([f]) => f)).toEqual([]);
+  });
+
+  it('the two sites #499 was filed about are NOT permitted to come back', () => {
+    // Named explicitly rather than left to the set comparison above. The set
+    // test would also catch these, but it would report them as one anonymous
+    // entry in a diff; a reader hitting THIS failure is told which defect they
+    // just reintroduced.
+    const found = findSites(SRC);
+    const raw = found.filter(
+      (s) =>
+        (s.file === 'nanomind-core/scanner-bridge.ts' && /fs\/promises/.test(s.text)) ||
+        (s.file === 'nanomind-core/orchestrate.ts'),
+    );
+    expect(raw.map((s) => `${s.file}:${s.line} ${s.text}`)).toEqual([]);
+  });
+
+  it('RED-PROOF: the detector flags the #499 sites when they are put back', () => {
+    // Mutate a COPY, never the tree under test. A mutation that fails to apply
+    // reads exactly like a passing lint, so the copy is asserted to differ from
+    // the original before the detector runs on it.
+    const tmp = fs.mkdtempSync(path.join(require('node:os').tmpdir(), 'hma-499-lint-'));
+    try {
+      const dst = path.join(tmp, 'src');
+      fs.cpSync(SRC, dst, { recursive: true });
+
+      const bridge = path.join(dst, 'nanomind-core', 'scanner-bridge.ts');
+      const before = fs.readFileSync(bridge, 'utf-8');
+      const after = before.replace(
+        /import \{ fs as trackedFs \} from '\.\.\/hardening\/tracked-fs';/,
+        "import { readFile, readdir, stat } from 'node:fs/promises';",
+      );
+      expect(after).not.toBe(before); // the mutation actually applied
+      fs.writeFileSync(bridge, after);
+
+      // The reintroduced raw import is a SECOND acquisition in a file permitted
+      // for exactly one, so the count rule is what catches it — assert that
+      // specific mechanism, not merely that something somewhere went red.
+      const counts = countByFile(dst);
+      expect(counts['nanomind-core/scanner-bridge.ts']).toBe(
+        REVIEWED['nanomind-core/scanner-bridge.ts'].count + 1,
+      );
+    } finally {
+      fs.rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+});

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -4589,6 +4589,24 @@ Examples:
 
       const scanner = new HardeningScanner();
       const scanStartMs = Date.now();
+
+      // NanoMind Semantic Compiler: AST-based analysis runs alongside static checks
+      // Defense-in-depth: static findings can NEVER be suppressed, only upgraded
+      //
+      // #499 — passed as a HOOK rather than called after `scan()` returns. The
+      // coverage ledger is ambient and installed around `scanInner` only, so
+      // while this ran here as a following statement, every read the semantic
+      // layer made was invisible to the ledger — including its read FAILURES.
+      // At `--scan-depth quick`, where 55 of the 61 static checks are skipped
+      // and this layer is the only reader of the tree, that made `chmod 000` a
+      // one-flag bypass of the completeness gate: 98/100 at exit 0 over an
+      // unreadable credential file. Running inside the window also puts it
+      // ahead of the `SCAN-UNREAD-001` generation, the `.hmaignore` scope
+      // filter and the coverage snapshot, so its lost inputs travel the same
+      // channels a static check's do, settled once (#494).
+      const { orchestrateNanoMind } = await import('./nanomind-core/orchestrate.js');
+      let nmResult: Awaited<ReturnType<typeof orchestrateNanoMind>> | undefined;
+
       const result = await scanner.scan({
         targetDir,
         autoFix: options.fix ?? false,
@@ -4598,32 +4616,44 @@ Examples:
         scanDepth,
         cliName: CLI_PREFIX,
         onProgress,
+        semanticPass: async ({ findings: existingFindings, projectType }) => {
+          nmResult = await orchestrateNanoMind(targetDir, existingFindings, {
+            staticOnly: isStaticOnly,
+            ci: options.ci,
+            deep: isDeep,
+            nanomind: resolveNanomindFlag(options),
+            silent: format !== 'text',
+            projectType,
+            // Sweep eligibility must match what the product reports: a finding
+            // dropped by the projectType filter does not structurally cover its
+            // file (it never reaches the user), so the sweep still reads it.
+            findingVisible: (f) => scanner.findingAppliesTo(f, projectType),
+          });
+          return { findings: nmResult.mergedFindings };
+        },
       });
       const scanDurationMs = Date.now() - scanStartMs;
 
-      // NanoMind Semantic Compiler: AST-based analysis runs alongside static checks
-      // Defense-in-depth: static findings can NEVER be suppressed, only upgraded
-      const { orchestrateNanoMind } = await import('./nanomind-core/orchestrate.js');
-      const existingFindings = result.allFindings || result.findings || [];
-      const nmResult = await orchestrateNanoMind(targetDir, existingFindings, {
-        staticOnly: isStaticOnly,
-        ci: options.ci,
-        deep: isDeep,
-        nanomind: resolveNanomindFlag(options),
-        silent: format !== 'text',
-        projectType: result.projectType,
-        // Sweep eligibility must match what the product reports: a finding
-        // dropped by the projectType filter does not structurally cover its
-        // file (it never reaches the user), so the sweep still reads it.
-        // `|| 'library'` mirrors the display-filter + check-path call sites
-        // (detectProjectType always returns a concrete value today; the
-        // fallback keeps this robust if the type ever loosens).
-        findingVisible: (f) => scanner.findingAppliesTo(f, result.projectType || 'library'),
-      });
+      // `scanInner` invokes the hook unconditionally and does not swallow its
+      // throw, so reaching here means it ran. Asserted rather than defaulted:
+      // the fields read off it below (`compileSetTruncated`, `compiledArtifacts`)
+      // feed the semantic truncation disclosure, and defaulting them would
+      // print "not truncated" over a pass that never happened.
+      if (!nmResult) throw new Error('internal: the semantic pass did not run');
 
       {
         // Re-apply all filters after NanoMind merge (merge uses allFindings which is unfiltered)
-        const refiltered = await scanner.reapplyIgnoreFilters(nmResult.mergedFindings, targetDir, result.projectType || 'library');
+        // #499 — re-filter from `result.allFindings`, NOT from
+        // `nmResult.mergedFindings`. The semantic pass now runs inside the scan
+        // and therefore BEFORE `SCAN-UNREAD-001` is generated, so
+        // `mergedFindings` is the merge of the static set as it stood at that
+        // moment and carries no unread-input findings. Re-deriving the whole
+        // report from it would delete them, taking #438's per-path disclosure
+        // with them and leaving exit 2 with nothing named — the precise failure
+        // the scanner's own comment at the generation site warns against.
+        // `allFindings` is the merged set with those findings pushed on top.
+        const postMerge = result.allFindings || result.findings || [];
+        const refiltered = await scanner.reapplyIgnoreFilters(postMerge, targetDir, result.projectType || 'library');
         // #450 — the semantic layer produces findings the scan pass never saw,
         // so this call can narrow scope where `scanInner` did not. Take the
         // wider of the two records rather than the later one, or a narrowing

--- a/src/hardening/scanner.ts
+++ b/src/hardening/scanner.ts
@@ -354,6 +354,44 @@ export interface ScanOptions {
    * Suppresses checks that only make sense for source repos (GIT-001, GIT-002, GIT-003).
    */
   isNpmPackage?: boolean;
+  /**
+   * The NanoMind semantic pass, run INSIDE the coverage ledger's window (#499).
+   *
+   * The caller supplies it as a hook rather than calling it after `scan()`
+   * returns, and that placement is the whole fix. `scan()` installs the ambient
+   * ledger around `scanInner` only, so a semantic pass invoked afterwards ran
+   * with `activeLedger` null: its reads reported nothing, its read FAILURES
+   * reported nothing, and at `--scan-depth quick` — where 55 of the 61 static
+   * checks are skipped and the semantic layer is the only reader of the tree —
+   * an unreadable credential file left the assessment entirely. `secure` scored
+   * that tree 98/100 at exit 0 while the same tree readable scored 69/100 at
+   * exit 1.
+   *
+   * Running here also puts the pass ahead of the three things that consume the
+   * ledger and used to happen first: the `unreadablePaths()` collection and its
+   * per-path `SCAN-UNREAD-001` findings, the `.hmaignore` scope filter applied
+   * to them, and the coverage snapshot on the result. So the semantic layer's
+   * lost inputs travel the exact channels a static check's do, through one
+   * settlement point, with no second source of truth and no per-channel copy
+   * (#494 is the receipt for why that matters).
+   *
+   * It is invoked OUTSIDE any `coverage.run()` frame, which is what keeps the
+   * scope narrow: with an empty method stack `noteRead` drops the read as
+   * unattributable, so semantic SUCCESSES stay out of `filesExamined`, while
+   * `noteReadFailure` records the failure as `(unattributed)`. That asymmetry is
+   * the ledger's documented safety direction — dropping a success understates
+   * coverage, dropping a failure would assert nothing was lost — and it is why
+   * this fix moves the gate without re-baking a single coverage number.
+   *
+   * Findings it returns are appended before the score is computed. A throw is
+   * contained: the semantic layer is an enhancement and must never take the
+   * static scan down with it.
+   */
+  semanticPass?: (ctx: {
+    targetDir: string;
+    findings: SecurityFinding[];
+    projectType: ProjectType;
+  }) => Promise<{ findings?: SecurityFinding[] } | void>;
 }
 
 // Patterns for detecting exposed credentials
@@ -2553,6 +2591,45 @@ export class HardeningScanner {
           + 'read-only, the volume is full, or a security policy denies it. Findings for those '
           + 'files are reported as unfixed, so the score reflects the tree as it actually is.',
       });
+    }
+
+    // #499 — the semantic pass runs HERE, inside the ledger's window and ahead
+    // of everything that reads the ledger. See `ScanOptions.semanticPass` for
+    // why the placement is the fix rather than an optimisation.
+    //
+    // Deliberately not wrapped in `this.coverage.run(...)`: an empty method
+    // stack is what makes the successful reads unattributable and therefore
+    // dropped, holding this change to the failure channel. Wrapping it would
+    // silently fold every semantic read into `filesExamined` and into whichever
+    // category the method registered — the wide change that was considered and
+    // rejected.
+    if (options.semanticPass) {
+      // Deliberately NOT wrapped in try/catch. Before #499 this pass ran as a
+      // statement after `scan()` returned, so a throw inside it killed the
+      // command outright — loudly. Catching it here because the call moved
+      // would convert that crash into a scan that quietly reports a
+      // semantic-free result as though it were complete, which is the same
+      // false-assurance shape this ledger exists to remove. Relocating the call
+      // must not change what a failure costs.
+      //
+      // `dropPathlessNoiseFloor`, because that is exactly what the caller used
+      // to hand the semantic pass: `cli.ts` read `result.allFindings`, and
+      // `allFindings` is this filter applied to this array. Passing the raw
+      // array instead would quietly widen the merge input, which is the kind of
+      // drift that turns a relocation into a behaviour change.
+      const semantic = await options.semanticPass({
+        targetDir,
+        findings: dropPathlessNoiseFloor(findings, projectType),
+        projectType,
+      });
+      if (semantic?.findings) {
+        // Replace rather than append: the semantic pass MERGES (its contract is
+        // defense-in-depth — static findings can be upgraded but never
+        // suppressed), so it returns the whole set, and appending would
+        // duplicate every static finding it was handed.
+        findings.length = 0;
+        findings.push(...semantic.findings);
+      }
     }
 
     // #438 — inputs the scan found inside the target and could not read.

--- a/src/hardening/scanner.ts
+++ b/src/hardening/scanner.ts
@@ -2593,6 +2593,40 @@ export class HardeningScanner {
       });
     }
 
+    // Record what the static fixes actually created, hashed, so rollback can
+    // remove those files without guessing (#262). Sourced from the fixed
+    // findings' own file attribution rather than "every backup candidate that
+    // is absent", which is what made the pre-0.25.1 rollback delete files the
+    // user wrote. The governance auto-fix runs after this returns, so the CLI
+    // calls recordCreatedFiles again for SOUL.md.
+    //
+    // Placed ABOVE the semantic pass, and that ordering is a durability rule
+    // rather than a preference (#499). The manifest is what `rollback` reads to
+    // know which files HMA generated, and the window between "the fix is on
+    // disk" and "the manifest says so" is a window in which an interrupt leaves
+    // `rollback` reporting `[+] Rollback complete` over a tree it did not
+    // restore. That window used to be ~45ms; running the semantic pass first
+    // would put a model load and a whole compile set inside it — measured at
+    // ~3.4s on a three-file fixture, and it scales with the tree. Both inputs
+    // are settled by now (the semantic layer never sets `fixed` and never
+    // writes), so nothing is lost by persisting before the pass rather than
+    // after it.
+    if (shouldFix && backupPath) {
+      await this.recordCreatedFiles(
+        targetDir,
+        backupPath,
+        [
+          ...findings.filter(f => f.fixed && f.file).map(f => f.file as string),
+          // Plus every path a fix actually wrote. `recordCreatedFiles` still
+          // records only paths HMA OBSERVED missing — at backup time, or
+          // proven absent immediately before the write — and guards each with
+          // a sha256, so widening the candidate list cannot make rollback
+          // delete a file the user wrote.
+          ...this.fixWritePaths,
+        ],
+      );
+    }
+
     // #499 — the semantic pass runs HERE, inside the ledger's window and ahead
     // of everything that reads the ledger. See `ScanOptions.semanticPass` for
     // why the placement is the fix rather than an optimisation.
@@ -2617,9 +2651,25 @@ export class HardeningScanner {
       // `allFindings` is this filter applied to this array. Passing the raw
       // array instead would quietly widen the merge input, which is the kind of
       // drift that turns a relocation into a behaviour change.
+      const mergeInput = dropPathlessNoiseFloor(findings, projectType);
+      // What the noise-floor filter removed, kept aside rather than discarded.
+      //
+      // The merge input has to be the filtered set — that is exactly what the
+      // caller used to hand the pass. But `findings` is ALSO the array
+      // `unevidencedFailures` is counted from further down (it iterates for
+      // `!f.file`), and those pathless records are precisely what the filter
+      // drops. Replacing the array with the merge result alone deleted them:
+      // measured, `unevidencedFailures` fell 41 -> 0 on ai-trust and 45 -> 1 on
+      // secretless, silently removing the one line that tells a reader a
+      // "categories clear" report is hiding ~40 checks that failed with nothing
+      // to point at (#421). A false-assurance regression of the same class this
+      // fix exists to close, caused by the fix. Pre-#499 the pass ran after
+      // `scan()` returned, so `findings` still held them.
+      const keptForMerge = new Set(mergeInput);
+      const noiseFloor = findings.filter((f) => !keptForMerge.has(f));
       const semantic = await options.semanticPass({
         targetDir,
-        findings: dropPathlessNoiseFloor(findings, projectType),
+        findings: mergeInput,
         projectType,
       });
       if (semantic?.findings) {
@@ -2628,7 +2678,7 @@ export class HardeningScanner {
         // suppressed), so it returns the whole set, and appending would
         // duplicate every static finding it was handed.
         findings.length = 0;
-        findings.push(...semantic.findings);
+        findings.push(...semantic.findings, ...noiseFloor);
       }
     }
 
@@ -3261,28 +3311,6 @@ export class HardeningScanner {
     // Determine if all fixes completed successfully (atomic)
     const hasFixedFindings = filteredFindings.some((f) => f.fixed);
     const atomicFix = shouldFix ? !fixFailed && hasFixedFindings : undefined;
-
-    // Record what the static fixes actually created, hashed, so rollback can
-    // remove those files without guessing (#262). Sourced from the fixed
-    // findings' own file attribution rather than "every backup candidate that
-    // is absent", which is what made the pre-0.25.1 rollback delete files the
-    // user wrote. The governance auto-fix runs after this returns, so the CLI
-    // calls recordCreatedFiles again for SOUL.md.
-    if (shouldFix && backupPath) {
-      await this.recordCreatedFiles(
-        targetDir,
-        backupPath,
-        [
-          ...findings.filter(f => f.fixed && f.file).map(f => f.file as string),
-          // Plus every path a fix actually wrote. `recordCreatedFiles` still
-          // records only paths HMA OBSERVED missing — at backup time, or
-          // proven absent immediately before the write — and guards each with
-          // a sha256, so widening the candidate list cannot make rollback
-          // delete a file the user wrote.
-          ...this.fixWritePaths,
-        ],
-      );
-    }
 
     return {
       timestamp: new Date(),

--- a/src/hardening/tracked-fs.ts
+++ b/src/hardening/tracked-fs.ts
@@ -117,4 +117,20 @@ for (const name of PATH_INSPECTIONS) {
  */
 export const fs = wrapped as unknown as typeof realFs;
 
+/**
+ * There is deliberately NO tracked `readFileSync` here.
+ *
+ * A sync channel was built for #499 and then removed, because the sweep found
+ * no consumer for it: the only sync reads of the target on the scan path are
+ * citation re-reads of files already discovered and already attempted
+ * (`scanner-bridge.ts` `readArtifact`, `scanner.ts` `readArtifactForCitation`),
+ * and those must NOT report. `unreadableInputs` subtracts a failure only when
+ * the same method later reads that path successfully, so a re-read failing on a
+ * path another check had read would be an unsubtractable false unread input.
+ *
+ * If a genuine sync DISCOVERY read of the target ever appears, add the channel
+ * back — the wrapper shape above is the template. Do not route a re-read
+ * through it.
+ */
+
 export default fs;

--- a/src/nanomind-core/orchestrate.ts
+++ b/src/nanomind-core/orchestrate.ts
@@ -539,7 +539,11 @@ export async function runCoverageSweep(
   let swept = 0;
   let nullVerdicts = 0;
   const deadlineAt = Date.now() + SWEEP_DEADLINE_MS;
-  const { readFile } = await import('node:fs/promises');
+  // Tracked, not raw (#499) — `join(targetDir, …)` makes every read here a read
+  // of the scan target, so a failure is a lost input and must reach the ledger.
+  // The `catch { continue }` below stays: skipping the artifact is right, but it
+  // must no longer be the only record that the read happened.
+  const { fs: { readFile } } = await import('../hardening/tracked-fs.js');
   const { join } = await import('node:path');
 
   // The analyst is a generative model reading attacker-controlled artifact

--- a/src/nanomind-core/scanner-bridge.ts
+++ b/src/nanomind-core/scanner-bridge.ts
@@ -15,7 +15,29 @@
  *   6. Return merged findings + integrity status
  */
 
-import { readFile, readdir, stat } from 'node:fs/promises';
+// The TRACKED namespace, not `node:fs` (#499). At `--scan-depth quick` 55 of the
+// 61 static checks are skipped and this module is the only reader of the target,
+// so while these imports were raw an unreadable credential file left the
+// assessment silently and `secure` scored the tree 98/100 at exit 0. Every read
+// below is a read OF THE SCAN TARGET and therefore coverage evidence; HMA's own
+// state (models, integrity manifest, LLM cache) is read elsewhere and stays raw.
+import { fs as trackedFs } from '../hardening/tracked-fs';
+const { readFile, readdir, stat } = trackedFs;
+// DELIBERATELY RAW, and the reason is not an oversight (#499).
+//
+// This import serves `readArtifact` only — the lazy re-read of a file the scan
+// has ALREADY discovered and already attempted, used to recover a citation line
+// for a finding that carries none (#368). It is not a discovery read, and it
+// must not be able to record one.
+//
+// `CoverageLedger.unreadableInputs` subtracts a recorded failure only when the
+// SAME method later read that path successfully (`coverage-ledger.ts:643`), and
+// reads made outside a `coverage.run()` frame are dropped as unattributable and
+// can never populate that per-method set. So a tracked re-read that failed on a
+// path some other check had read successfully would be a permanent,
+// unsubtractable unread input — a false exit 2 over a file the scan did read,
+// with a `chmod` remedy naming a file that is not the problem. A citation
+// re-read may lose a line number; it may not invent a lost input.
 import { readFileSync } from 'node:fs';
 import { join, relative, extname, basename, isAbsolute } from 'node:path';
 

--- a/src/nanomind-core/scanner-bridge.ts
+++ b/src/nanomind-core/scanner-bridge.ts
@@ -25,10 +25,15 @@ import { fs as trackedFs } from '../hardening/tracked-fs';
 const { readFile, readdir, stat } = trackedFs;
 // DELIBERATELY RAW, and the reason is not an oversight (#499).
 //
-// This import serves `readArtifact` only — the lazy re-read of a file the scan
-// has ALREADY discovered and already attempted, used to recover a citation line
-// for a finding that carries none (#368). It is not a discovery read, and it
-// must not be able to record one.
+// Two callers, and neither is a read of a discovered input:
+//
+//   1. `readArtifact` — the lazy re-read of a file the scan has ALREADY
+//      discovered and already attempted, to recover a citation line for a
+//      finding that carries none (#368).
+//   2. the governance-file candidate loop — an existence probe over five
+//      mutually exclusive spellings, where a miss is the ordinary case.
+//
+// Neither may record a lost input. See the comment at each site.
 //
 // `CoverageLedger.unreadableInputs` subtracts a recorded failure only when the
 // SAME method later read that path successfully (`coverage-ledger.ts:643`), and
@@ -295,7 +300,25 @@ export async function runNanoMindScan(
   let projectConstraints: Constraint[] = [];
   for (const candidate of governanceFileCandidates) {
     try {
-      const govContent = await readFile(candidate, 'utf-8');
+      // RAW read, deliberately, and this one is load-bearing (#499).
+      //
+      // This loop is an existence PROBE, not a read of a discovered input: five
+      // mutually exclusive spellings of one optional file, `break` on the first
+      // hit, and a miss is the ordinary case. Routing it through the tracked
+      // namespace put every miss on the coverage failure channel. `ENOENT` is
+      // filtered, so an absent `.opena2a/` stayed quiet — but a `.opena2a/`
+      // directory that cannot be traversed yields `EACCES` for all three policy
+      // spellings, and the scan then reported three unreadable inputs naming
+      // `policy.yml`, `policy.yaml` and `policy.json`, none of which exist. A
+      // clean tree went from `100/100 exit 0` to `85/100 exit 2` over three
+      // fabricated findings whose `chmod` remedy names a file that is not there.
+      //
+      // `tracked-fs` exempts `stat`/`access` for exactly this reason, in exactly
+      // these words: an existence probe's rejection is the normal case rather
+      // than a lost input, and counting it "would count one obstruction twice,
+      // in two units". The real obstruction — the unreadable directory — is
+      // already reported once by the static walker.
+      const govContent = readFileSync(candidate, 'utf-8');
       projectConstraints = extractDeclaredConstraints(govContent);
       break; // Use the first governance file found
     } catch {


### PR DESCRIPTION
Closes #499.

0.30.0 closed #438 at `standard` and `deep`. At `--scan-depth quick` it did not: 55 of 61 static check groups are skipped, the only component that opens an arbitrary source file is the NanoMind semantic layer, and that layer ran after `scanner.scan()` returned — outside the coverage ledger's window. So `secure --scan-depth quick` over an unreadable credential file still reported `98/100` at exit 0.

## Measured

One benign fixture (`src/util.js`, `src/greet.js`, a `.gitignore`, a `package.json`), one `chmod` on `src/greet.js`. Base is `84ce8b5`, built from a clean extract. Exit codes captured directly, never through a pipe. Every flag spelled out literally.

| depth | mode | base `filesExamined`/exit/score | this branch |
|---|---|---|---|
| quick | 644 | 1 / 0 / 98 | 1 / 0 / 98 |
| quick | 000 | 1 / **0** / **98** | 1 / **2** / **93** |
| standard | 644 | 4 / 0 / 98 | 4 / 0 / 98 |
| standard | 000 | 3 / 2 / 93 | 3 / 2 / 93 |
| deep | 644 | 4 / 0 / 98 | 4 / 0 / 98 |
| deep | 000 | 3 / 2 / 93 | 3 / 2 / 93 |

One cell changes. `filesExamined` is identical in all six, so nothing was re-baked. Base rate on five real trees at quick and standard: zero unread inputs — nothing that passes today newly gates.

## How

The semantic pass becomes a `ScanOptions.semanticPass` hook invoked inside `scanInner`, ahead of the coverage snapshot, the `SCAN-UNREAD-001` loop and the scope filter.

It runs **outside** any `coverage.run()` frame, and that is the design rather than an oversight: with an empty method stack its successful reads are unattributable and get dropped, so only read FAILURES reach the ledger. That is what keeps `filesExamined` static-only.

Two bypasses were stacked and fixing either alone is inert — the ambient ledger was null during the semantic pass, *and* the layer read through raw `node:fs` so its reads reported nothing even with the window open. A repo lint now fails the build on a `fs/promises` import that bypasses the tracked namespace.

## Deliberate non-changes that look like omissions

- **Citation re-reads and existence probes stay on raw `fs`.** `unreadableInputs` subtracts only when the *same method* later reads the path, and unattributed reads can never populate that per-method set — so a tracked re-read failing on a path another check read would be a **permanent** false unread input, with a `chmod` remedy naming a file that is fine. Routing the governance existence probe through tracked fs did exactly this during development: it fabricated three findings naming files that do not exist and took a clean tree from 100/exit 0 to 85/exit 2. Tracked as #510.
- **The semantic pass is not wrapped in try/catch.** It used to run after `scan()`, where a throw killed the command loudly. Catching it because the call moved would turn that into a scan quietly reporting a semantic-free result as complete.

## Known: three routes around this gate remain open

All at `--scan-depth quick`, all measured on this branch, all **pre-existing** (the base measures identically), all filed rather than half-fixed:

- **#515** — `chmod 600` on a *containing directory* drops its files with no record: exit 0 at 98/100, where mode 755 on the same bytes is exit 1 at 69/100. A `stat` `EACCES` in the size gate removes an already-discovered file before the `readFile` failure channel can see it.
- **#516** — `--static-only --scan-depth quick` reproduces the old behaviour exactly, because it removes the only reader at that depth.
- **#514** — the `-b oasb-1` / `-b oasb-2` arms do reach exit 2, but print a passing rating and never name the file.

The shared root is that the unit is "inputs discovered but not read" while discovery is owned by whichever component happens to read. Disable that component, obstruct it one level up, or route around its output, and the input was never discovered.

## Changelog correction

0.30.0's entry says "an incomplete run cannot exit 0". That was true at `standard` and `deep` and false at `quick`, which the same entry's own "Known issue" block went on to describe. The sentence should have been scoped when it was written; the CHANGELOG now says so.

## Testing

- Full suite **272 files / 3860 tests** green; `tsc --noEmit` clean; golden corpus 12/12.
- New: `__tests__/cli/secure-unread-input-gate.test.ts` extends the #438 matrix to all three depths on every output channel; `__tests__/repo/tracked-fs-discipline.test.ts` is a repo lint against `fs/promises` bypasses; `__tests__/hardening/fix-manifest-durability.test.ts` pins the durability-write ordering.
- **Mutation-proofed.** Four mutants, each in its own isolated tree, each proven present in the built output before the suite ran: reverting the errno failure channel (killed by 20 named tests), moving the hook after the coverage snapshot (2), restoring the wholesale findings replacement that dropped the pathless noise floor (1), and gating the hook off at quick depth (2). No survivors.
