### PR TITLE
Delete the hackmyagent_analyze_file MCP stub (#502)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,28 @@ All notable changes to HackMyAgent are documented in this file.
 
 ## [Unreleased]
 
+### Breaking: the `hackmyagent_analyze_file` MCP stub is deleted (#502)
+
+The tool itself was removed in 0.29.0 (#463). What stayed behind was a stub that answered
+the name with a redirect to `hackmyagent_deep_scan` instead of the server's `Unknown tool:`
+response. That stub is gone. **An MCP client still calling `hackmyagent_analyze_file` now
+gets the standard unknown-tool error, which names the three tools the server does provide
+and points at `tools/list`, instead of the 0.29.0 migration text.** Both responses set
+`isError: true`, so a client that only inspects that field sees no change; a client that
+parsed the redirect text does.
+
+- **The stub was never a deprecation window.** It did not preserve the behaviour — it
+  only stopped `Unknown tool:` being a dead end for one minor cycle, inside the tool whose
+  job is to unblock people. That cycle covered 0.29.0 and 0.30.0. `hackmyagent_analyze_file`
+  has been absent from `tools/list` since 0.29.0, so no host model has been offered it for
+  two minor versions.
+- **`deep_scan` is still the replacement.** Point it at the directory containing the file,
+  or at the file itself when it is one of the artifacts discovery accepts.
+- **One helper went with it.** `discoverableArtifactNames` existed solely to generate the
+  redirect's artifact list and had no other caller; it is deleted rather than left as a
+  dead export whose own comment cites a tool that no longer exists. `FILE_DISCOVERY`
+  remains the single source of truth for what discovery accepts.
+
 ### The completeness gate now holds at `--scan-depth quick` (#499)
 
 0.30.0 closed #438 at `standard` and `deep` and said so, but at `quick` depth 55 of 61

--- a/__tests__/mcp/mcp-root-confinement.test.ts
+++ b/__tests__/mcp/mcp-root-confinement.test.ts
@@ -24,7 +24,6 @@ import * as path from 'path';
 import {
   handleToolCall,
   TOOL_DEFINITIONS_FOR_TEST,
-  analyzeFileRemovalText,
   fixRequestedNote,
   unknownToolText,
 } from '../../src/mcp-server';
@@ -164,17 +163,25 @@ describe('#463 the arbitrary-file reader is gone', () => {
     expect(TOOL_DEFINITIONS_FOR_TEST.map((t) => t.name)).not.toContain('hackmyagent_analyze_file');
   });
 
-  it('returns a redirect rather than reading the file, even inside the root', async () => {
+  // #502 — the 0.29.0 redirect stub is gone as of 0.31.0. The name now falls
+  // through to the server's `default:` arm like any other unknown tool.
+  it('falls through to the standard unknown-tool response, not the removal stub', async () => {
     const res = await handleToolCall('hackmyagent_analyze_file', { file: path.join(root, '.gitignore') }, [root]);
-    expect(res.isError).toBe(true);
-    expect(res.content[0].text).toContain('was removed in hackmyagent 0.29.0');
-    expect(res.content[0].text).toContain('hackmyagent_deep_scan');
-    expect(res.content[0].text).not.toContain('node_modules');
-  });
 
-  it('names real discoverable artifacts in the redirect, generated not hardcoded', () => {
-    const text = analyzeFileRemovalText(['CLAUDE.md', 'mcp.json']);
-    expect(text).toContain('CLAUDE.md, mcp.json');
+    // `isError` alone cannot tell the two apart: the stub set it and so does
+    // `default:`. The text is the only thing that separates them.
+    expect(res.isError).toBe(true);
+    // The stable half of `unknownToolText`. The tool-name sentence it also emits
+    // is generated from TOOL_DEFINITIONS, so pinning the whole string would go
+    // red on any future tool addition.
+    expect(res.content[0].text).toContain('Unknown tool: hackmyagent_analyze_file');
+    expect(res.content[0].text).toContain('tools/list');
+    // Removed, not reworded — the stub's redirect must be absent.
+    expect(res.content[0].text).not.toContain('was removed in hackmyagent 0.29.0');
+    // Not a crash: `handleToolCall`'s catch prefixes thrown errors with `Error:`.
+    expect(res.content[0].text).not.toContain('Error:');
+    // Still reads nothing. `.gitignore` in the fixture holds `node_modules`.
+    expect(res.content[0].text).not.toContain('node_modules');
   });
 
   it('no longer ships the .env credential-enumeration guidance anywhere in the tool surface', () => {

--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -220,28 +220,6 @@ scan below is complete. To apply fixes, run from a terminal:
 \`${cliName} rollback ${cited}\` reverts the most recent --fix.`;
 }
 
-/**
- * `hackmyagent_analyze_file` was removed in 0.29.0 (#463).
- *
- * The stub is one minor cycle of discoverability, not a deprecation window: it
- * does not preserve the behaviour, it only stops `Unknown tool:` being a dead end
- * inside the tool that exists to unblock people. The artifact list is GENERATED,
- * because an enumerated literal in a string rots exactly the way a frozen literal
- * in a charter does.
- */
-export function analyzeFileRemovalText(discoverableArtifacts: string[]): string {
-  return `hackmyagent_analyze_file was removed in hackmyagent 0.29.0.
-
-Use hackmyagent_deep_scan instead. Point it at the directory containing the file,
-or at the file itself when it is one of: ${discoverableArtifacts.join(', ')}. It
-returns the same file contents with per-type analysis guidance, plus the Layer 1
-and Layer 2 findings for the surrounding project.
-
-For a file outside that set, read it with your own file-reading tool.
-hackmyagent_analyze_file returned such files unchanged with generic guidance and
-added no analysis of its own.`;
-}
-
 /** `Unknown tool: X` was a dead end for any typo. This names what is available. */
 export function unknownToolText(name: string): string {
   return `Unknown tool: ${name}
@@ -371,30 +349,7 @@ export async function handleToolCall(
           };
         }
 
-      case 'hackmyagent_analyze_file': {
-        // Removed in 0.29.0 (#463). The stub outlives 0.30.0 deliberately:
-        // deleting it is a behaviour change to the MCP surface and wanted its
-        // own test, which is not something to add during a release cut. Tracked
-        // for 0.31.0.
-        //
-        // The earlier rationale here said `deep_scan` returns the same class of
-        // content "bounded by what HMA decided is security-relevant, instead of
-        // by whatever path the host model asked for". That bounded the NAME. The
-        // attacker picks the TARGET: a link at any of those names pointed
-        // wherever they liked, and `deep_scan` read it. A removed capability may
-        // not be justified on a bound we do not have.
-        //
-        // What actually bounds it is `confineTo` on the deep_scan path above:
-        // every artifact's realpath must be inside a granted root, and anything
-        // withheld is named in the result.
-        const { discoverableArtifactNames } = await import('./semantic/structural/index');
-        return {
-          content: [{ type: 'text', text: analyzeFileRemovalText(discoverableArtifactNames()) }],
-          isError: true,
-        };
-      }
-
-        case 'hackmyagent_benchmark': {
+      case 'hackmyagent_benchmark': {
         const requested = (args?.directory as string) || '.';
         const resolvedDir = await resolveWithinRoots(roots, requested);
         if (!resolvedDir.ok) return refuse(resolvedDir.refusal);

--- a/src/semantic/structural/index.ts
+++ b/src/semantic/structural/index.ts
@@ -76,19 +76,6 @@ const FILE_DISCOVERY: Array<{ glob: string; type: FileType }> = [
   { glob: 'settings.json', type: 'config_file' },
 ];
 
-/**
- * The artifacts `discoverFiles` will accept as a single-file target.
- *
- * Generated, never enumerated by hand. #463's replacement text for the removed
- * `hackmyagent_analyze_file` has to tell the host model which files `deep_scan`
- * accepts directly, and a hand-written list in a string rots the moment
- * `FILE_DISCOVERY` gains an entry — which is how `.mcp.json` came to be missing
- * from discovery in the first place.
- */
-export function discoverableArtifactNames(): string[] {
-  return [...new Set(FILE_DISCOVERY.map((d) => path.basename(d.glob)))];
-}
-
 export class StructuralAnalyzer {
   private credentialAnalyzer = new CredentialContextAnalyzer();
   private mcpAnalyzer = new McpConfigAnalyzer();


### PR DESCRIPTION
Closes #502.

`hackmyagent_analyze_file` was removed as a tool in 0.29.0 (#463) and replaced with a stub returning a redirect instead of `Unknown tool:`. The stub's own comment scheduled its deletion for 0.30.0; that did not happen, deliberately — removing an MCP tool case is a behaviour change to the MCP surface and wanted its own regression test. This is that change.

The stub's rationale is worth preserving as the reason it was always temporary: it was one minor cycle of discoverability, not a deprecation window. It never preserved the behaviour — it only stopped `Unknown tool:` being a dead end inside the tool that exists to unblock people.

## What changed

- The `case 'hackmyagent_analyze_file'` arm is gone, so the name now falls through to the standard `default:` unknown-tool response.
- `analyzeFileRemovalText` is deleted — a fresh repo-wide grep confirmed exactly two consumers, the case arm and one test.
- `discoverableArtifactNames` is deleted too. **This is the part the issue did not anticipate.** Its only consumer in the entire repo was the stub's dynamic import, so deleting the arm orphaned it — and nothing here would ever have flagged that: there is no knip or ts-prune, `npm run lint` is only `tsc --noEmit`, and tsconfig sets no `noUnusedLocals` (which would not reach an exported symbol anyway). Its docblock said its entire reason to exist was serving the removed tool, so keeping it would have meant shipping a dead export with a false comment. `FILE_DISCOVERY` remains the single source of truth and the body was a one-line derivation from it.

## Testing

- The absent-from-`tools/list` half **already existed and already passed** (`__tests__/mcp/mcp-root-confinement.test.ts:164`) — only the unknown-tool-response half is genuinely new.
- The new assertion checks the real `unknownToolText` output rather than a guessed string, and asserts the stable part rather than the tool-name sentence, which is generated from `TOOL_DEFINITIONS` and would make the test brittle to any future tool addition.
- **`isError` deliberately carries no weight**: the stub and the `default:` arm both set `isError: true`, so an assertion on that field cannot tell them apart. The test asserts on the text, and also asserts the response does not contain the catch-handler's `Error:` prefix, so a crash cannot pass.
- **Red-proofed in a copy, not in the tree under test.** The pre-fix source was restored from `git show HEAD:<path>` into a separate directory, the restore was verified to have applied before running, and the new test failed at the intended assertion with the intended message while the other 35 passed.
- Full suite 272 files / 3859 tests green; `tsc --noEmit` clean; golden corpus 12/12; self-scan 1 LOW at 98/100 with 564 files read.

## Breaking

MCP clients still calling `hackmyagent_analyze_file` move from a helpful redirect to an unknown-tool error. A client inspecting only `isError` sees no change; one parsing the text does.