### PR TITLE
Stop fix-all --dry-run reporting a tree as fixed that it never wrote to (#504, in part)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,40 @@ All notable changes to HackMyAgent are documented in this file.
 
 ## [Unreleased]
 
+### `fix-all --dry-run` no longer reports a tree as fixed that it never wrote to (#504, in part)
+
+`--dry-run` and `--scan-only` both write nothing, and they disagreed on the exit code. One
+fixture — a `.env` and an `mcp.json`, each holding an Anthropic key:
+
+| command | exit | summary line |
+|---|---|---|
+| `fix-all <dir> --scan-only` | 1 | 2 CRITICAL `CRED-001` outstanding |
+| `fix-all <dir> --dry-run` | **0** | `Findings: 3 total \| 2 fixed` |
+
+Nothing was written in either run, and `fix-all --help` states "Exit code 1 if critical/high
+issues remain after fixing". After a dry run they all remain.
+
+- **The cause was one shared set.** Each plugin's dry-run branch returns a synthetic preview
+  remediation per auto-fixable finding, and those populated the same `fixedIds` set the real
+  fix pass uses — so a previewed finding was filtered out of `remainingFindings`, which both
+  the exit code and the `--json` payload read. Preview remediations are now excluded from
+  that set. The "Fixes Available" block still renders the full preview: it reads the
+  unfiltered list, so gating correctly costs nothing that `--dry-run` exists for.
+- **The summary no longer says "fixed" over a tree it did not touch.** A dry run now reports
+  `N fixable (nothing written)`.
+
+**This is a breaking change for any CI job running `fix-all --dry-run` as a soft preview** —
+a tree with outstanding critical or high findings now exits 1 there, as it already did under
+`--scan-only`.
+
+**The other half of #504 is not in this release.** `fix-all` still does not detect credentials
+in ordinary source files, so a tree whose credentials live in `.py`/`.js` still passes
+`fix-all` while `secure` reports CRITICAL on the same bytes. Two attempts at that half were
+built and rejected in review: the first fired CRITICAL on AWS's own documented example keys,
+and the second silently removed `secure`'s existing detection of live credentials in
+`_test.go`, `test_*.py` and `*.test.tsx` by widening a pattern the two commands share. The
+measurements from both attempts are recorded on the issue so the third does not repeat them.
+
 ### Breaking: the `hackmyagent_analyze_file` MCP stub is deleted (#502)
 
 The tool itself was removed in 0.29.0 (#463). What stayed behind was a stub that answered

--- a/__tests__/cli/fix-all-dry-run-gate-parity.test.ts
+++ b/__tests__/cli/fix-all-dry-run-gate-parity.test.ts
@@ -1,0 +1,163 @@
+import { describe, it, expect, beforeAll } from 'vitest';
+import { spawnSync } from 'node:child_process';
+import { mkdtempSync, writeFileSync, mkdirSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { assertDistFreshIfPresent } from '../helpers/dist-freshness';
+
+/**
+ * #504, the dry-run half.
+ *
+ * `fix-all --dry-run` writes nothing, so nothing it previews is resolved. Each
+ * plugin's dry-run branch returns a synthetic "would fix" remediation per
+ * auto-fixable finding, and those were counted as fixed — clearing the finding
+ * out of `remainingFindings`, which both the exit code and the JSON payload
+ * read.
+ *
+ * Measured on the fixture below, pre-fix:
+ *   fix-all --scan-only -> exit 1, 2 CRITICAL CRED-001
+ *   fix-all --dry-run   -> exit 0, "Findings: 3 total | 2 fixed"
+ *
+ * Neither mode writes anything, so the two must gate identically.
+ * `fix-all --help` states "Exit code 1 if critical/high issues remain after
+ * fixing", and after a dry run they all remain.
+ */
+
+const CLI = join(__dirname, '..', '..', 'dist', 'cli.js');
+
+/**
+ * Two credentials in files `fix-all`'s credential plugin already reads on
+ * `main` — a `.env` and an `mcp.json`. Deliberately NOT source files: the
+ * source-coverage half of #504 is a separate change, and pinning it here would
+ * make this suite fail for an unrelated reason.
+ *
+ * The key shape matters. `sk-ant-api03-` followed by 95 filler characters is
+ * what the catalog matches; a shorter string is silently below the length
+ * threshold and the fixture stops carrying a finding at all, at which point
+ * both modes exit 0 and every assertion below passes vacuously.
+ */
+function makeFixture(): string {
+  const dir = mkdtempSync(join(tmpdir(), 'hma-504-parity-'));
+  mkdirSync(join(dir, 'src'), { recursive: true });
+  writeFileSync(join(dir, '.gitignore'), 'node_modules/\n');
+  writeFileSync(join(dir, 'package.json'), '{"name":"p","version":"1.0.0"}\n');
+  writeFileSync(join(dir, '.env'), `ANTHROPIC_API_KEY=sk-ant-api03-${'C'.repeat(95)}\n`);
+  writeFileSync(
+    join(dir, 'mcp.json'),
+    JSON.stringify(
+      { servers: { x: { env: { ANTHROPIC_API_KEY: `sk-ant-api03-${'D'.repeat(95)}` } } } },
+      null,
+      2
+    ) + '\n'
+  );
+  return dir;
+}
+
+function run(dir: string, ...args: string[]) {
+  const res = spawnSync(process.execPath, [CLI, 'fix-all', dir, ...args], {
+    encoding: 'utf-8',
+    env: { ...process.env, NO_COLOR: '1' },
+  });
+  return { status: res.status, stdout: res.stdout ?? '', stderr: res.stderr ?? '' };
+}
+
+describe('#504 fix-all --dry-run gates identically to --scan-only', () => {
+  beforeAll(() => {
+    assertDistFreshIfPresent();
+  });
+
+  it('the fixture really does carry gating findings, in both modes', () => {
+    // Non-vacuity control. Every assertion below compares two exit codes, and
+    // 0 === 0 passes just as happily as 1 === 1. If the fixture stops carrying
+    // a critical finding — a pattern change, a length threshold, a new
+    // suppression — the parity assertions go quietly meaningless. This fails
+    // loudly instead.
+    const dir = makeFixture();
+    try {
+      const scanOnly = run(dir, '--scan-only');
+      expect(scanOnly.stdout).toContain('CRED-001');
+      expect(scanOnly.status).toBe(1);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('--dry-run and --scan-only return the same exit code on identical trees', () => {
+    // Fresh fixture per invocation: fix-all writes, and even in dry-run the
+    // plugins may create state (a credvault store key) that changes the next
+    // run's findings.
+    const a = makeFixture();
+    const b = makeFixture();
+    try {
+      const scanOnly = run(a, '--scan-only');
+      const dryRun = run(b, '--dry-run');
+      expect(dryRun.status).toBe(scanOnly.status);
+      expect(dryRun.status).toBe(1);
+    } finally {
+      rmSync(a, { recursive: true, force: true });
+      rmSync(b, { recursive: true, force: true });
+    }
+  });
+
+  it('--dry-run still lists the findings as outstanding, not as resolved', () => {
+    const dir = makeFixture();
+    try {
+      const { stdout } = run(dir, '--dry-run');
+      // The findings are still outstanding, so they appear in the remaining
+      // block rather than being silently cleared.
+      expect(stdout).toContain('CRED-001');
+      // And the summary must not claim they were fixed over a tree it did not
+      // write to.
+      expect(stdout).not.toMatch(/\|\s*\d+\s+fixed/);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('--dry-run still previews the available fixes', () => {
+    // The point of --dry-run is the preview. Gating it correctly must not cost
+    // the feature: a fix that made the exit code right by dropping the preview
+    // would pass the parity assertions above and be useless.
+    const dir = makeFixture();
+    try {
+      const { stdout } = run(dir, '--dry-run');
+      expect(stdout).toMatch(/Would fix|Fixes Available/i);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('--dry-run writes nothing', () => {
+    const dir = makeFixture();
+    try {
+      const before = spawnSync('shasum', ['-a', '256', join(dir, '.env'), join(dir, 'mcp.json')], {
+        encoding: 'utf-8',
+      }).stdout;
+      run(dir, '--dry-run');
+      const after = spawnSync('shasum', ['-a', '256', join(dir, '.env'), join(dir, 'mcp.json')], {
+        encoding: 'utf-8',
+      }).stdout;
+      expect(after).toBe(before);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('a clean tree still exits 0 in both modes', () => {
+    // The fix must not turn --dry-run into an unconditional failure.
+    const a = mkdtempSync(join(tmpdir(), 'hma-504-clean-'));
+    const b = mkdtempSync(join(tmpdir(), 'hma-504-clean-'));
+    try {
+      for (const d of [a, b]) {
+        writeFileSync(join(d, '.gitignore'), 'node_modules/\n');
+        writeFileSync(join(d, 'package.json'), '{"name":"c","version":"1.0.0"}\n');
+      }
+      const scanOnly = run(a, '--scan-only');
+      const dryRun = run(b, '--dry-run');
+      expect(dryRun.status).toBe(scanOnly.status);
+    } finally {
+      rmSync(a, { recursive: true, force: true });
+      rmSync(b, { recursive: true, force: true });
+    }
+  });
+});

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -8175,7 +8175,20 @@ Examples:
         // same tree. A finding that was remediated but is not auto-fixable is
         // still outstanding: the remediation recorded an attempt, not a
         // resolution.
-        const fixedIds = new Set(allRemediations.map((r) => r.findingId));
+        // A dry run writes nothing, so nothing it "remediated" is resolved.
+        // Each plugin's dry-run branch returns a synthetic preview remediation
+        // per auto-fixable finding, and counting those here cleared the finding
+        // from `remainingFindings` — which both the exit code and the JSON
+        // payload read. Measured on one fixture (`.env` + `mcp.json`, each
+        // holding an Anthropic key): `--scan-only` exited 1 with 2 CRITICAL
+        // while `--dry-run` exited 0 and reported "2 fixed" over a tree it had
+        // not touched. `fix-all --help` promises "Exit code 1 if critical/high
+        // issues remain after fixing", and after a dry run they all remain.
+        //
+        // The preview list itself is unaffected: the "Fixes Available" block
+        // renders `allRemediations`, which is deliberately not filtered here.
+        const appliedRemediations = options.dryRun ? [] : allRemediations;
+        const fixedIds = new Set(appliedRemediations.map((r) => r.findingId));
         const remainingFindings = allFindings.filter(
           (f) => !fixedIds.has(f.id) || !f.autoFixable
         );
@@ -8217,7 +8230,10 @@ Examples:
 
         // Summary
         console.log(`━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━`);
-        console.log(`\nFindings: ${allFindings.length} total | ${allRemediations.length} fixed\n`);
+        console.log(
+          `\nFindings: ${allFindings.length} total | ${allRemediations.length} ` +
+          `${options.dryRun ? 'fixable (nothing written)' : 'fixed'}\n`
+        );
 
         // Show remaining issues (not auto-fixed)
         // `remainingFindings` is computed once, above the JSON branch, so


### PR DESCRIPTION
Addresses acceptance criterion 3 of #504. **The source-file coverage half is deliberately not here** — see the end of this description.

`--dry-run` and `--scan-only` both write nothing, and they disagreed on the exit code. One fixture, a `.env` and an `mcp.json` each holding an Anthropic key, exit codes captured directly:

| command | exit | summary |
|---|---|---|
| `fix-all <dir> --scan-only` | 1 | 2 CRITICAL `CRED-001` outstanding |
| `fix-all <dir> --dry-run` | **0** | `Findings: 3 total \| 2 fixed` |

`fix-all --help` states "Exit code 1 if critical/high issues remain after fixing". After a dry run they all remain.

## Cause

One shared set. Each plugin's dry-run branch returns a synthetic preview remediation per auto-fixable finding, and those populated the same `fixedIds` set the real fix pass uses — so a previewed finding was filtered out of `remainingFindings`, which both the exit code and the `--json` payload read.

Preview remediations are now excluded from that set. The "Fixes Available" block reads the unfiltered list, so gating correctly costs nothing `--dry-run` exists for. The summary now reads `N fixable (nothing written)`.

Fixed at the call site rather than in four plugins — `secretless`, `signcrypt` and `skillguard` emit the same synthetic remediations and were all affected.

## Breaking

Any CI job running `fix-all --dry-run` as a soft preview now exits 1 on a tree with outstanding critical or high findings, as it already did under `--scan-only`.

## Testing

`__tests__/cli/fix-all-dry-run-gate-parity.test.ts`, six cases, **red-proofed against `db68d4c`**: exactly the two behavioural cases fail pre-fix and all four controls pass, which is what makes them controls rather than the thing under test.

```
✓ the fixture really does carry gating findings, in both modes
× --dry-run and --scan-only return the same exit code on identical trees
× --dry-run still lists the findings as outstanding, not as resolved
✓ --dry-run still previews the available fixes
✓ --dry-run writes nothing
✓ a clean tree still exits 0 in both modes
```

The first case exists because every parity assertion compares two exit codes, and `0 === 0` passes as happily as `1 === 1` — if the fixture ever stops carrying a critical finding, the parity cases go quietly meaningless. It fails loudly instead.

Full suite 273 files / 3865 tests green; `tsc --noEmit` clean; golden corpus 12/12; self-scan 1 LOW at 98/100 with 565 files read.

## Why the rest of #504 is not here

`fix-all` still misses credentials in ordinary source files. Two attempts were built and rejected in adversarial review:

1. The first fired CRITICAL on AWS's own documented example keys — including inside a constant named `KNOWN_EXAMPLE_KEYS`, under a docblock reading "These are NOT real secrets" — and rewrote them on disk in write mode. Measured 18 credential findings across ten repos, 14 of them false.
2. The second fixed that (18 → 4 findings, all four verified genuine) but **silently removed `secure`'s existing detection** of live credentials in `_test.go`, `test_*.py`, `*.test.tsx` and `*_test.rs`, by widening a `TEST_FILE_PATTERN` the two commands share. Making the flagship command weaker is not an acceptable price for widening this one.

The rule set before that round was that a second consecutive defect found inside a fix means cutting back to the minimum rather than starting a third round. This is that minimum: it was never contested by either review, it is independent of the credential-detection question, and it closes one of the four acceptance criteria cleanly.

The measurements from both attempts — the ten-repo false-positive sweep, the placeholder-gate design, and a counted inventory of test-file naming conventions across the org — are recorded on #504 so the third attempt does not rediscover them.
