### PR TITLE
The review's primary API request used a version the server rejects, so every review ran the fallback

### DIFF
--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -228,10 +228,11 @@ jobs:
             -X POST "https://api.anthropic.com/v1/messages" \
             -H "Content-Type: application/json" \
             -H "x-api-key: ${ANTHROPIC_API_KEY}" \
-            -H "anthropic-version: 2025-04-15" \
+            -H "anthropic-version: 2023-06-01" \
             -d @/tmp/request.json)
 
           echo "API response HTTP code: $HTTP_CODE"
+          echo "primary" > /tmp/review_path.txt
 
           # Extract response text (skip thinking blocks)
           REVIEW_TEXT=""
@@ -242,6 +243,7 @@ jobs:
           # Fallback: retry without extended thinking if first attempt failed
           if [ -z "$REVIEW_TEXT" ]; then
             echo "First attempt failed (HTTP $HTTP_CODE), retrying without extended thinking..."
+            echo "fallback" > /tmp/review_path.txt
 
             jq -n \
               --rawfile system /tmp/system_prompt.txt \
@@ -263,7 +265,7 @@ jobs:
             echo "Fallback API response HTTP code: $HTTP_CODE"
 
             if [ "$HTTP_CODE" = "200" ]; then
-              REVIEW_TEXT=$(jq -r '.content[0].text // empty' /tmp/api_response.json)
+              REVIEW_TEXT=$(jq -r '[.content[] | select(.type == "text") | .text] | join("\n") // empty' /tmp/api_response.json)
             fi
           fi
 
@@ -344,7 +346,12 @@ jobs:
             cat /tmp/review_body.txt
             echo ""
             echo "---"
-            echo "*Reviewed ${FILE_COUNT} files changed (${DIFF_SIZE} bytes)*"
+            REVIEW_PATH=$(cat /tmp/review_path.txt 2>/dev/null || echo "unknown")
+            if [ "$REVIEW_PATH" = "fallback" ]; then
+              echo "*Reviewed ${FILE_COUNT} files changed (${DIFF_SIZE} bytes) — produced by the FALLBACK request, without extended thinking. The primary request failed; see the run log.*"
+            else
+              echo "*Reviewed ${FILE_COUNT} files changed (${DIFF_SIZE} bytes)*"
+            fi
           } > /tmp/full_review.txt
 
           BODY=$(cat /tmp/full_review.txt)


### PR DESCRIPTION
Closes the same defect fixed in opena2a-org/secretless-ai#153 (merged `5ff64d7`).

The review's primary API request has never succeeded. Every automated review this repo has ever produced came from the fallback, and nothing said so.

`pr-review.yml` sent `anthropic-version: 2025-04-15` on the first request. That is not a valid version, so the call returned 400 on every run, `REVIEW_TEXT` came back empty, and the workflow took its documented retry:

```
API response HTTP code: 400
First attempt failed (HTTP 400), retrying without extended thinking...
Fallback API response HTTP code: 200
```

Probed directly, both ways:

```
anthropic-version: 2025-04-15   HTTP 400  "2025-04-15" is not a valid version
anthropic-version: 2023-06-01   HTTP 200
```

The same fallback line appears in `hackmyagent` and `nanomind` runs, so this is the shared workflow rather than one repo's misconfiguration. Older runs elsewhere are past log retention.

## What it cost

The two requests are not equivalent, which is the whole reason the primary exists:

| | primary (never ran) | fallback (always ran) |
|---|---|---|
| `max_tokens` | 16000 | 8192 |
| extended thinking | enabled, 10000 budget | none |

Every review that has gated a merge here ran without extended thinking and at half the output budget. The reviews were real and the verdicts were real — but the configuration this file describes has never been the one that ran.

## The three changes

1. **`anthropic-version` on the primary request → `2023-06-01`**, the value the fallback already uses successfully on every run. This is the defect.

2. **The fallback's response extraction moves to the primary's filtered form.** `.content[0].text` is correct only while nothing returns a leading `thinking` block. Measured against a live response with thinking enabled, that field is `null` — which would empty `REVIEW_TEXT` and block every pull request in the repo. Fixing the header without this would move that landmine rather than remove it, because the primary path is now the one that runs.

3. **The posted review names the fallback when the fallback produced it.** A retry that fires on 100% of runs is indistinguishable from a primary that works, which is exactly how this survived unnoticed across eight repositories. The run log already said so; nobody reads a green run's log.

## Verification

The corrected primary request was POSTed to the live API **before this change was written**, using the workflow's exact request shape and this repo's real over-cap diff (PR #149, 149,315 bytes):

```
HTTP 200
content block types : ['thinking', 'text']
first line          : VERDICT-<nonce>: APPROVE
parses as a verdict : YES
usage               : 47,377 input tokens, 1,117 thinking tokens
fallback .content[0].text would be: null
```

That last line is change 2's justification, measured rather than reasoned.

Also checked: the primary path's extraction has never executed in production, so this PR enables a code path that has only ever been exercised by hand — which is why it was exercised by hand first, and why this PR is the end-to-end proof. `pull_request` runs the workflow from the merge ref, so **this PR is reviewed by its own fixed code.** If the check below reports a verdict without a fallback notice in the footer, the fix works.

Suite: 275 files, 3880 passed / 3 skipped / 10 todo, all green. No test reads `.github/workflows/pr-review.yml`. YAML parses and every `run` block passes `bash -n`.

The change was applied by a scripted patcher rather than by hand, because it has to land in several repositories identically. That patcher was validated against four controls first — all five changes applied to an unfixed copy leaving zero defects, refusal rather than double-apply on a re-run, refusal on an unrelated workflow, and a byte-identical no-op on an already-fixed file. Two bugs in it were caught by those controls before it touched any repository: it duplicated an inserted line on re-run, and then, after that was fixed, it silently skipped both real changes because their replacement text already occurs elsewhere in the file legitimately (`2023-06-01` is what the fallback correctly uses; the filtered `jq` form is what the primary correctly uses).

Scoped to this file alone, per the `[CHIEF-CISO]` ruling that any `pr-review.yml` change lands in its own PR and never on the PR it unblocks. The 120,000-byte diff cap is a separate defect (tracked at opena2a-org/secretless-ai#150) and is deliberately **not** touched here.

Measured across the org rather than assumed: this defect is on `main` in **three** repositories — this one, `nanomind`, and `ai-trust`. It is *not* present in `agent-identity-management`, `agent-runtime-protection`, `damn-vulnerable-ai-agent` or `oasb`, which already send a valid version. The copies have drifted (6 KB to 18.6 KB), so "the same file in eight repos" was an inference and the measurement corrected it.
