### PR TITLE
Bring the 0.32.0 credential boundary back onto main

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,63 @@
 
 All notable changes to HackMyAgent are documented in this file.
 
+## [0.32.0] - 2026-08-19
+
+### Finding evidence carries a classification, not a prefix of the matched value
+
+Findings rendered a shortened form of a matched credential into their own text. Because a
+shortened credential no longer matches the full-length shapes the reporting boundary
+recognises, it crossed the boundary unmodified and was then marked as examined and clean --
+so the output asserted cleanliness over text that still carried part of the value.
+
+Measured on `secure --json` and `check --json`, counting JSON paths that carry characters of
+the value after its constant vendor prefix:
+
+| channel | 0.31.0 | 0.32.0 |
+|---|---|---|
+| `secure --json` | 4 paths, 5 characters | **0** |
+| `check --json` | 2 paths, 5 characters | **0** |
+| `findings[].description` preview | 2 paths, 5 characters | **0** |
+
+- **Five producers, and the fifth needed a different answer from the other four.** Four
+  rendered a fixed-width slice of the value and now emit a marker. The fifth,
+  `maskCredentialValue`, has two arms. Its vendor-prefix arm is **unchanged**: a vendor
+  prefix is a constant, identical for every key of that vendor, so it identifies the vendor
+  and says nothing about the individual value -- that is classification, and its existing
+  test pins it ("evidence must preserve the recognizable prefix"). Its unknown-shape arm had
+  no such constant to keep and was emitting the first 8 characters of the value itself; that
+  arm now masks in full.
+- **No detection, scoring or exit-code change.** Finding counts are identical on every target
+  exercised, corpus goldens match byte-for-byte, and the released suite is 280 files / 4111
+  tests green.
+- **What this release does NOT close.** Several credential shapes are still not detected at
+  all. Measured on 0.32.0: a source file holding a plain `DB_PASSWORD`, a
+  `postgres://user:password@host` DSN, a `glpat-` token and an `hf_` token scores **98/100,
+  exit 0, with zero credential findings**; an AWS `AKIA` key in the same shape of file scores
+  **69/100, exit 1**. A clean `secure` result is not evidence that a target holds no
+  credential. Widening that vocabulary is tracked separately and is not in this release.
+
+### Known issues
+
+Carried into this release, each reproducing identically on 0.31.0. None is introduced here, and
+none is fixed here. All three are scheduled for **0.33.0**.
+
+- **`fix-all` reports `CRED-001` HIGH from the key name alone** ([#539](https://github.com/opena2a-org/hackmyagent/issues/539)).
+  An empty assignment (`API_KEY=`) is reported as a hardcoded credential, as is an environment
+  variable reference, which is the remediation this tool recommends elsewhere. Confined to `.env`
+  and `.env.local`; `secure` does not report these, so the two commands disagree on the same file.
+  The finding carries no `evidence` field, so nothing in the output lets you check it against the
+  line it cites.
+- **`secure --fix` archives are scanned by the next run** ([#389](https://github.com/opena2a-org/hackmyagent/issues/389)).
+  Each `--fix` copies the file into a timestamped directory under `.hackmyagent-backup/`, and the
+  following scan reports findings on that copy, so counts climb on a tree where nothing was added:
+  4, then 5, then 6 over three runs. Three runs leave three plaintext copies of the credential on
+  disk. The `Fix:` line on those findings cites a path that differs every run.
+- **`harden-soul` output can be penalised by `scan-soul`** ([#446](https://github.com/opena2a-org/hackmyagent/issues/446)).
+  On a sufficiently poor starting file, the command writes both a profile marker and the nine domain
+  sections, and the sections can imply a different profile than the marker declares, producing a HIGH
+  `SOUL-PROFILE-MISMATCH` and clamping the score. The stated fix (remove the marker) does work.
+
 ## [0.31.0] - 2026-08-11
 
 ### `--ci` now turns contribution off, and its help text stops promising an exit-code effect (#454)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to HackMyAgent are documented in this file.
 
-## [0.32.0] - 2026-08-19
+## [0.32.0] - 2026-08-20
 
 ### Finding evidence carries a classification, not a prefix of the matched value
 
@@ -41,7 +41,7 @@ the value after its constant vendor prefix:
 ### Known issues
 
 Carried into this release, each reproducing identically on 0.31.0. None is introduced here, and
-none is fixed here. All three are scheduled for **0.33.0**.
+none is fixed here. All four are scheduled for **0.33.0**.
 
 - **`fix-all` reports `CRED-001` HIGH from the key name alone** ([#539](https://github.com/opena2a-org/hackmyagent/issues/539)).
   An empty assignment (`API_KEY=`) is reported as a hardcoded credential, as is an environment
@@ -58,6 +58,11 @@ none is fixed here. All three are scheduled for **0.33.0**.
   On a sufficiently poor starting file, the command writes both a profile marker and the nine domain
   sections, and the sections can imply a different profile than the marker declares, producing a HIGH
   `SOUL-PROFILE-MISMATCH` and clamping the score. The stated fix (remove the marker) does work.
+- **A finding on several files is reported and scored as one** ([#535](https://github.com/opena2a-org/hackmyagent/issues/535)).
+  Failed AST findings are grouped by check alone, so one file survives per check for the whole scan
+  and the rest are discarded. Five distinct credentials in five files score 69/100 naming one file --
+  the same score and the same finding count as a single credential in a single file. The other four
+  reach neither the score, the finding count, nor the output. Reproduces identically on 0.31.0.
 
 ## [0.31.0] - 2026-08-11
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,45 @@
+# Security Policy
+
+## Reporting a vulnerability
+
+Report privately. Do not open a public issue for a suspected vulnerability.
+
+**Preferred:** [Report a vulnerability](https://github.com/opena2a-org/hackmyagent/security/advisories/new)
+via GitHub private vulnerability reporting. It is enabled on this repository and the report stays
+private until an advisory publishes.
+
+**Alternative:** info@opena2a.org
+
+Please include:
+
+- What you observed, and the command that produced it
+- Steps to reproduce, including the version (`hackmyagent --version`)
+- What you expected instead
+- Any output you are willing to share, with credentials removed
+
+**Do not send us real credentials.** If a report involves a credential, redact it and describe its
+shape (vendor prefix and length) rather than pasting the value. If you believe one of your own
+credentials was exposed by this tool, rotate it first, then report.
+
+We acknowledge receipt within 48 hours and give a remediation timeline in that reply.
+
+## Scope
+
+This policy covers `hackmyagent` — the CLI, its published npm package, and this repository. Other
+repositories in the [opena2a-org](https://github.com/opena2a-org) organization have their own
+policies.
+
+Reports about a *scanned target* — a package or repository this tool reports on — should go to that
+project, not to us. Reports about how this tool **handles** what it scans, including anything it
+writes into its own output, are in scope here.
+
+## Supported versions
+
+Fixes land on the latest published minor. Upgrade to the current release before reporting, and say
+which version you reproduced on.
+
+## Disclosure
+
+We publish a GitHub Security Advisory for defects that affect users of the published package, and
+request a CVE where one applies. Advisories publish once a fixed version is installable from npm, so
+that the advisory and its remedy arrive together. We credit reporters who want credit.

--- a/__tests__/hardening/credential-preview-truncation.test.ts
+++ b/__tests__/hardening/credential-preview-truncation.test.ts
@@ -1,0 +1,230 @@
+/**
+ * The detector must not hand the boundary a value it has already truncated.
+ *
+ * The redaction boundary (`emitFinding` -> `redactSecretsForReportReporting`) matches
+ * FULL-LENGTH credential shapes. A producer that renders a shortened preview of a secret
+ * — `matched.slice(0, 16)`, `value.slice(0, 8)`, `value.slice(0, 5) + '****'` — emits a
+ * string the boundary's patterns cannot match. The fragment therefore crosses untouched
+ * AND is stamped `redactionStatus: 'clean'`, `redactedShapes: []`, which is a false
+ * certificate of cleanliness rather than a missing one.
+ *
+ * Measured 2026-08-19 on `1dac1e1`, before this file existed: `secure --json` carried 16
+ * body characters at 4 JSON paths, `check --json` at 2, and a 5-character preview reached
+ * `findings[].description` — all three unchanged from 0.31.0, all three required to be 0
+ * by `todo/roadmap/hma-unit1-credential-boundary.md:227-236`.
+ *
+ * WHY THIS TEST IS SHAPED THIS WAY. `pinned-credential-shapes.test.ts` already pins that
+ * the detector and the redactor know the same SHAPES. That invariant was green throughout,
+ * because it compares two lists of patterns and never asks what string the producer
+ * actually emits. The distinction this file adds is between "the redactor could redact
+ * this secret" and "the redactor was handed something it can redact". Only the second one
+ * keeps body bytes out of the JSON.
+ *
+ * The secrets below are synthetic, high-entropy and contain no dictionary word, so a
+ * >= 5-character match against output cannot be ordinary English in remediation text. They
+ * deliberately avoid the `FAKE`/`EXAMPLE`/`TEST`/`XXX` markers, because those are exactly
+ * what the detector's fixture filter suppresses — a canary carrying one measures nothing.
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  scanCanonicalCredentialFormatsForTest,
+  canonicalCredentialLabelsForTest,
+} from '../../src/nanomind-core/compiler/semantic-compiler.js';
+import { CredentialContextAnalyzer } from '../../src/semantic/structural/credential-context.js';
+import type { AnalysisFile } from '../../src/semantic/types.js';
+
+/** Longest contiguous run of `secret` that appears anywhere in `haystack`. */
+function longestRun(haystack: string, secret: string, min = 5): string {
+  let best = '';
+  for (let i = 0; i < secret.length; i++) {
+    for (let n = secret.length - i; n >= min; n--) {
+      const frag = secret.substr(i, n);
+      if (frag.length <= best.length) break;
+      if (haystack.includes(frag)) {
+        best = frag;
+        break;
+      }
+    }
+  }
+  return best;
+}
+
+/** Every string leaf of a value, so a new field cannot quietly become a leak path. */
+function stringLeaves(node: unknown, path = '$', out: Array<[string, string]> = []): Array<[string, string]> {
+  if (typeof node === 'string') out.push([path, node]);
+  else if (Array.isArray(node)) node.forEach((v, i) => stringLeaves(v, `${path}[${i}]`, out));
+  else if (node && typeof node === 'object') {
+    for (const k of Object.keys(node as Record<string, unknown>)) {
+      stringLeaves((node as Record<string, unknown>)[k], `${path}.${k}`, out);
+    }
+  }
+  return out;
+}
+
+function assertNoBodyBytes(subject: unknown, secret: string, what: string): void {
+  for (const [path, leaf] of stringLeaves(subject)) {
+    const run = longestRun(leaf, secret);
+    expect(
+      run,
+      `${what}: ${path} carries ${run.length} body characters of the secret (${JSON.stringify(run)})`,
+    ).toBe('');
+  }
+}
+
+// High-entropy, dictionary-free, no fixture marker.
+const CORE = 'Zq7Xv2Kp9Wm4Rt6Yn8Bd3Fh5Jl1Gs0Cx7Vz4Nq2Mw6Tr8Kp3Xy9Ld5Hb2Jn';
+const SECRETS = {
+  anthropic: `sk-ant-api03-${CORE}`,
+  openai: `sk-proj-${CORE}`,
+  // Exactly 36 alphanumerics after the prefix — `ghp_[a-zA-Z0-9]{36}`. A 35-character
+  // canary is not detected, and its leak assertion then passes vacuously; the positive
+  // control above is what caught that while this file was being written.
+  github: 'ghp_' + 'Qz8Wn3Kv6Rt1Yp9Bd4Fh7Jl2Gs5Cx0Vz6NqP',
+  aws: 'AKIA' + 'QZ8WN3KV6RT1YP9B',
+  urlPassword: 'Wm4Rt6Yn8BdZq7Xv2Kp9',
+  jwt: 'Xv2Kp9Wm4Rt6Yn8Bd3Fh5Jl1Gs0Cx7Vz',
+};
+
+describe('canonical credential detector: evidence carries classification, never body bytes', () => {
+  const cases: Array<[string, string]> = [
+    ['anthropic', SECRETS.anthropic],
+    ['openai', SECRETS.openai],
+    ['github', SECRETS.github],
+    ['aws', SECRETS.aws],
+  ];
+
+  for (const [name, secret] of cases) {
+    it(`${name}: detects the secret at all (positive control)`, () => {
+      const hits = scanCanonicalCredentialFormatsForTest(`const k = "${secret}";`);
+      // Without this, the body-byte assertion below would pass on a detector that
+      // simply stopped detecting, which is the failure mode a redaction test invites.
+      expect(hits.length, 'detector produced no hit; the leak assertion would be vacuous').toBeGreaterThan(0);
+    });
+
+    it(`${name}: emits zero body bytes into evidence`, () => {
+      const hits = scanCanonicalCredentialFormatsForTest(`const k = "${secret}";`);
+      assertNoBodyBytes(hits, secret, `canonical detector (${name})`);
+    });
+
+    it(`${name}: still names the credential type, so the user keeps the classification`, () => {
+      const hits = scanCanonicalCredentialFormatsForTest(`const k = "${secret}";`);
+      const labels = canonicalCredentialLabelsForTest();
+      for (const hit of hits) {
+        expect(labels).toContain(hit.label);
+        expect(hit.evidence, 'evidence dropped its label along with the body').toContain(hit.label);
+      }
+    });
+  }
+
+  it('name-gated patterns (the slice(0, 8) path) emit zero body bytes', () => {
+    // The name-gated arm is a SEPARATE producer with its own truncation. A test that
+    // only exercised the canonical arm would leave it uncovered, which is the exact
+    // shape of the drift `canonicalCredentialLabelsForTest` was widened to prevent.
+    const content = [
+      `aws_secret_access_key = "${SECRETS.urlPassword}Kp9Wm4Rt6Yn8Bd3Fh5Jl1Gs0"`,
+      `jwt_secret = "${SECRETS.jwt}"`,
+    ].join('\n');
+    const hits = scanCanonicalCredentialFormatsForTest(content);
+    for (const secret of [SECRETS.jwt, SECRETS.urlPassword]) {
+      assertNoBodyBytes(hits, secret, 'name-gated detector');
+    }
+  });
+});
+
+describe('maskCredentialValue: a constant prefix is classification, a slice of the value is not', () => {
+  // This distinction is the whole point and it is easy to get backwards. `sk-ant-api0` is
+  // IDENTICAL for every Anthropic key, so emitting it reveals the vendor and nothing about
+  // this secret — PC-6' permits classification, and `benign-fp-regression.test.ts` pins it
+  // ("evidence must preserve the recognizable prefix"). `value.slice(0, 8)` on an
+  // UNRECOGNISED secret has no such property: those 8 characters are the secret itself.
+
+  it('a vendor-shaped credential keeps its constant prefix and nothing after it', async () => {
+    const { analyzeCredentials } = await import('../../src/nanomind-core/analyzers/credential-analyzer.js');
+    const { SemanticCompiler } = await import('../../src/nanomind-core/compiler/semantic-compiler.js');
+    const yaml = `name: agent-config\ndescription: stores credentials for the bot\nservice:\n  apiToken: ${SECRETS.anthropic}\n`;
+    const compiler = new SemanticCompiler({ useNanoMind: false });
+    const result = await compiler.compile(yaml, 'agent-config.yaml');
+    const findings = analyzeCredentials(result.ast, ast => compiler.verifyAST(ast), undefined, yaml);
+
+    const withEvidence = findings.filter(f => typeof f.evidence === 'string' && f.evidence.length > 0);
+    expect(withEvidence.length, 'detection precondition').toBeGreaterThan(0);
+    for (const f of withEvidence) {
+      // Nothing of the BODY — the characters after the constant vendor prefix.
+      assertNoBodyBytes(f.evidence, SECRETS.anthropic.slice('sk-ant-api0'.length), 'vendor-shaped mask');
+    }
+  });
+
+  it('an UNRECOGNISED secret is masked entirely — no 8-character prefix of the value', async () => {
+    const { analyzeCredentials } = await import('../../src/nanomind-core/analyzers/credential-analyzer.js');
+    const { SemanticCompiler } = await import('../../src/nanomind-core/compiler/semantic-compiler.js');
+    // No vendor prefix, so this takes the unknown-shape arm, where every surviving
+    // character is secret body rather than a constant. It must ALSO be 40+ word
+    // characters: the content-format gate admits either a vendor prefix or a
+    // high-entropy 40+ run, and a 35-character canary is simply not detected — which
+    // makes the leak assertion below pass over an empty list. Mutation-checked: with a
+    // 35-character secret, restoring `value.slice(0, 8)` left this test GREEN.
+    const secret = 'Zq7Xv2Kp9Wm4Rt6Yn8Bd3Fh5Jl1Gs0Cx7Vz4Nq2Mw6Tr';
+    expect(secret.length, 'canary must clear the 40-char content-format gate').toBeGreaterThanOrEqual(40);
+    const yaml = `name: agent-config\ndescription: stores credentials for the bot\nservice:\n  apiToken: ${secret}\n`;
+    const compiler = new SemanticCompiler({ useNanoMind: false });
+    const result = await compiler.compile(yaml, 'agent-config.yaml');
+    const findings = analyzeCredentials(result.ast, ast => compiler.verifyAST(ast), undefined, yaml);
+
+    const withEvidence = findings.filter(f => typeof f.evidence === 'string' && f.evidence.length > 0);
+    expect(
+      withEvidence.length,
+      'no finding carried evidence, so the unknown-shape arm was never exercised and this test would be vacuous',
+    ).toBeGreaterThan(0);
+    for (const f of withEvidence) {
+      assertNoBodyBytes(f.evidence, secret, 'unknown-shape mask');
+    }
+  });
+});
+
+describe('CredentialContextAnalyzer: description carries classification, never body bytes', () => {
+  const analyzer = new CredentialContextAnalyzer();
+  const file = (path: string, content: string): AnalysisFile => ({
+    path,
+    type: 'config' as AnalysisFile['type'],
+    content,
+    truncated: false,
+  });
+
+  it('SEM-CRED-001 (URL password) fires and leaks nothing', () => {
+    const f = file(
+      'svc/settings.yaml',
+      `database_url: "postgres://svcusr:${SECRETS.urlPassword}@10.4.2.9:5432/appdb"\n`,
+    );
+    const findings = analyzer.analyze([f]);
+    const hit = findings.find(x => x.id === 'SEM-CRED-001');
+    expect(hit, 'SEM-CRED-001 did not fire; the leak assertion would be vacuous').toBeDefined();
+    assertNoBodyBytes(findings, SECRETS.urlPassword, 'SEM-CRED-001');
+  });
+
+  it('SEM-CRED-002 (config secret) fires and leaks nothing', () => {
+    const f = file('svc/config.json', `{ "jwt_secret": "${SECRETS.jwt}" }\n`);
+    const findings = analyzer.analyze([f]);
+    const hit = findings.find(x => x.id === 'SEM-CRED-002');
+    expect(hit, 'SEM-CRED-002 did not fire; the leak assertion would be vacuous').toBeDefined();
+    assertNoBodyBytes(findings, SECRETS.jwt, 'SEM-CRED-002');
+  });
+
+  it('keeps the key name and the credential type in the description', () => {
+    // Redaction must remove the secret, not the reason the user can act on it.
+    const f = file('svc/config.json', `{ "jwt_secret": "${SECRETS.jwt}" }\n`);
+    const hit = analyzer.analyze([f]).find(x => x.id === 'SEM-CRED-002');
+    expect(hit!.description).toContain('jwt_secret');
+    expect(hit!.description).toContain('svc/config.json');
+  });
+
+  it('C1: the finding still carries its line after redaction', () => {
+    // Line derivation must not depend on the secret text surviving into evidence.
+    const f = file(
+      'svc/settings.yaml',
+      `harmless: 1\ndatabase_url: "postgres://svcusr:${SECRETS.urlPassword}@10.4.2.9:5432/appdb"\n`,
+    );
+    const hit = analyzer.analyze([f]).find(x => x.id === 'SEM-CRED-001');
+    expect(hit!.line).toBe(2);
+  });
+});

--- a/__tests__/hardening/finding-emit.test.ts
+++ b/__tests__/hardening/finding-emit.test.ts
@@ -1,0 +1,671 @@
+/**
+ * The credential redaction boundary's own tests.
+ *
+ * WHY THIS FILE EXISTS. Before it,
+ * `rg "emitFinding|redactionStatus|redactedShapes|finding-emit" __tests__/`
+ * returned ONE hit and it was a docblock comment. Making `RedactionPass.run`
+ * (`src/hardening/finding-emit.ts`) a pass-through — which disables ALL
+ * redaction on every field of every finding — left 4035/4035 tests green. Two
+ * independent reviewers demonstrated that separately. Every defect in the
+ * boundary was therefore unfalsifiable, and any fix written against it was a fix
+ * nobody could check.
+ *
+ * RED-PROOF. Each block names, in a comment, the exact implementation line whose
+ * reversion turns it red. That is the property being bought here: not coverage,
+ * but the ability of this file to notice.
+ *
+ * The tests run in-process (no spawn) so they are fast, are not gated behind a
+ * `skipIf(builtArtifactsExist)` that would let them run nowhere on a merge, and
+ * can be mutation-checked cheaply.
+ *
+ * Credential values are synthesised at runtime from a repeated character, never
+ * written as literals, so nothing here trips push protection or a secret
+ * scanner (the idiom `config-credential-depth.test.ts` established).
+ */
+import { describe, it, expect } from 'vitest';
+import { mkdtemp, writeFile, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { emitFinding, emitFindings } from '../../src/hardening/finding-emit';
+import { HardeningScanner } from '../../src/hardening/scanner';
+import { mergeFindings } from '../../src/nanomind-core/scanner-bridge';
+import type { SecurityFindingDraft } from '../../src/hardening/security-check';
+import type { Evidence } from '../../src/types/finding-evidence';
+
+/** Synthesised at runtime — never a literal in the source tree. */
+const GH = `ghp_${'a'.repeat(36)}`;
+const AWS = `AKIA${'B'.repeat(16)}`;
+const GH_MARK = '[REDACTED_GITHUB_TOKEN]';
+const AWS_MARK = '[REDACTED_AWS_KEY]';
+
+function draft(over: Record<string, unknown> = {}): SecurityFindingDraft {
+  return {
+    checkId: 'TEST-EMIT-001',
+    name: 'name',
+    description: 'description',
+    category: 'credentials',
+    severity: 'high',
+    passed: false,
+    message: 'message',
+    fixable: false,
+    ...over,
+  } as unknown as SecurityFindingDraft;
+}
+
+/**
+ * The seven byte-carrying fields, spelled out here rather than imported.
+ *
+ * `BYTE_CARRYING_FIELDS` is module-private, and that is deliberate: a test that
+ * imported the implementation's own list could not notice a field being dropped
+ * FROM it, which is the thing most worth noticing. So this list is an
+ * independent statement of the contract, and deleting any entry from the
+ * implementation turns exactly one case below red.
+ *
+ * It does NOT close the other direction — a NEW string field added to
+ * `SecurityFinding` and not added to the implementation list is unredacted and
+ * invisible to this file. That is deferred defect (8), compiler-enforced
+ * completeness, and it is a real hole until it lands.
+ */
+const BYTE_CARRYING = [
+  'name',
+  'message',
+  'description',
+  'fix',
+  'manualFix',
+  'guidance',
+  'fixMessage',
+] as const;
+
+describe('emitFinding — the seven byte-carrying fields', () => {
+  // RED-PROOF: delete the field's entry from `BYTE_CARRYING_FIELDS`
+  // (finding-emit.ts:59-67), or make `RedactionPass.run` return `value`.
+  for (const field of BYTE_CARRYING) {
+    it(`${field}: credential is gone, status is applied, shape is resolved`, () => {
+      const emitted = emitFinding(draft({ [field]: `prefix ${GH} suffix` }));
+      const value = (emitted as unknown as Record<string, string>)[field];
+
+      expect(value).not.toContain(GH);
+      expect(value).toContain(GH_MARK);
+      expect(emitted.redactionStatus).toBe('applied');
+      expect(emitted.redactedShapes).toEqual(['github-pat']);
+    });
+  }
+
+  it('a finding with no credential anywhere reports clean with no shapes', () => {
+    const emitted = emitFinding(draft({ message: 'nothing sensitive here' }));
+    expect(emitted.redactionStatus).toBe('clean');
+    expect(emitted.redactedShapes).toEqual([]);
+  });
+
+  /**
+   * Pins the ORDER AND DEDUP a consumer sees, not the `.sort()` in
+   * `emitFinding`: `RedactionPass.resolvedShapes` already sorts within a pass,
+   * so this stays green if that second sort is deleted. The merge-level sort is
+   * pinned by `shapes accumulate across passes` below. Measured, not assumed —
+   * a mutation run removing each sort separately established which test catches
+   * which, and the two are not redundant.
+   */
+  it('shapes a consumer sees are sorted and deduped across fields', () => {
+    const emitted = emitFinding(
+      draft({ message: `${GH} and ${AWS}`, description: `again ${GH}` }),
+    );
+    // Sorted: 'aws-access-key-id' < 'github-pat'. Deduped: one github-pat.
+    expect(emitted.redactedShapes).toEqual(['aws-access-key-id', 'github-pat']);
+    expect(emitted.message).toContain(GH_MARK);
+    expect(emitted.message).toContain(AWS_MARK);
+  });
+
+  it('does not mutate the draft it was handed', () => {
+    const original = draft({ message: `tok ${GH}` });
+    const emitted = emitFinding(original);
+    expect(original.message).toContain(GH);
+    expect(emitted.message).not.toContain(GH);
+  });
+});
+
+describe('emitFinding — every Evidence leaf', () => {
+  // Each case plants the credential in exactly ONE leaf, so reverting one
+  // `pass.run(...)` in `redactEvidence` turns exactly one case red.
+
+  // RED-PROOF: finding-emit.ts:101 `content: pass.run(l.content)`
+  it('positive.lines[].content', () => {
+    const evidence: Evidence = {
+      kind: 'positive',
+      lines: [{ n: 1, content: `token ${GH}`, why: 'clean prose' }],
+    };
+    const emitted = emitFinding(draft({ evidence }));
+    const out = emitted.evidence as Extract<Evidence, { kind: 'positive' }>;
+    expect(out.lines[0].content).not.toContain(GH);
+    expect(out.lines[0].content).toContain(GH_MARK);
+    expect(emitted.redactionStatus).toBe('applied');
+    expect(emitted.redactedShapes).toEqual(['github-pat']);
+  });
+
+  // RED-PROOF: finding-emit.ts:102 `why: pass.run(l.why)`
+  it('positive.lines[].why', () => {
+    const evidence: Evidence = {
+      kind: 'positive',
+      lines: [{ n: 1, content: 'clean prose', why: `because ${GH}` }],
+    };
+    const emitted = emitFinding(draft({ evidence }));
+    const out = emitted.evidence as Extract<Evidence, { kind: 'positive' }>;
+    expect(out.lines[0].why).not.toContain(GH);
+    expect(out.lines[0].why).toContain(GH_MARK);
+    expect(emitted.redactionStatus).toBe('applied');
+  });
+
+  // RED-PROOF: finding-emit.ts:109 `content: pass.run(l.content)`
+  it('absence.observed.lines[].content', () => {
+    const evidence: Evidence = {
+      kind: 'absence',
+      observed: { lines: [{ n: 2, content: `key ${GH}` }], summary: 'clean' },
+      expected: [{ constraint: 'trust-hierarchy', rationale: 'clean' }],
+    };
+    const emitted = emitFinding(draft({ evidence }));
+    const out = emitted.evidence as Extract<Evidence, { kind: 'absence' }>;
+    expect(out.observed.lines[0].content).not.toContain(GH);
+    expect(out.observed.lines[0].content).toContain(GH_MARK);
+    expect(emitted.redactionStatus).toBe('applied');
+  });
+
+  // RED-PROOF: finding-emit.ts:110 `summary: pass.run(evidence.observed.summary)`
+  it('absence.observed.summary', () => {
+    const evidence: Evidence = {
+      kind: 'absence',
+      observed: { lines: [{ n: 2, content: 'clean' }], summary: `holds ${GH}` },
+      expected: [{ constraint: 'trust-hierarchy', rationale: 'clean' }],
+    };
+    const emitted = emitFinding(draft({ evidence }));
+    const out = emitted.evidence as Extract<Evidence, { kind: 'absence' }>;
+    expect(out.observed.summary).not.toContain(GH);
+    expect(out.observed.summary).toContain(GH_MARK);
+    expect(emitted.redactionStatus).toBe('applied');
+  });
+
+  // RED-PROOF: finding-emit.ts:119 `rationale: pass.run(e.rationale)`
+  it('absence.expected[].rationale', () => {
+    const evidence: Evidence = {
+      kind: 'absence',
+      observed: { lines: [{ n: 2, content: 'clean' }], summary: 'clean' },
+      expected: [{ constraint: 'trust-hierarchy', rationale: `see ${GH}` }],
+    };
+    const emitted = emitFinding(draft({ evidence }));
+    const out = emitted.evidence as Extract<Evidence, { kind: 'absence' }>;
+    expect(out.expected[0].rationale).not.toContain(GH);
+    expect(out.expected[0].rationale).toContain(GH_MARK);
+    expect(emitted.redactionStatus).toBe('applied');
+  });
+
+  // RED-PROOF: finding-emit.ts:127 (mixed positive content)
+  it('mixed.positive.lines[].content', () => {
+    const evidence: Evidence = {
+      kind: 'mixed',
+      positive: { lines: [{ n: 1, content: `tok ${GH}`, why: 'clean' }] },
+      absence: {
+        observed: { lines: [{ n: 2, content: 'clean' }], summary: 'clean' },
+        expected: [{ constraint: 'c', rationale: 'clean' }],
+      },
+    };
+    const emitted = emitFinding(draft({ evidence }));
+    const out = emitted.evidence as Extract<Evidence, { kind: 'mixed' }>;
+    expect(out.positive.lines[0].content).not.toContain(GH);
+    expect(out.positive.lines[0].content).toContain(GH_MARK);
+    expect(emitted.redactionStatus).toBe('applied');
+  });
+
+  // RED-PROOF: finding-emit.ts:128 (mixed positive why)
+  it('mixed.positive.lines[].why', () => {
+    const evidence: Evidence = {
+      kind: 'mixed',
+      positive: { lines: [{ n: 1, content: 'clean', why: `why ${GH}` }] },
+      absence: {
+        observed: { lines: [{ n: 2, content: 'clean' }], summary: 'clean' },
+        expected: [{ constraint: 'c', rationale: 'clean' }],
+      },
+    };
+    const emitted = emitFinding(draft({ evidence }));
+    const out = emitted.evidence as Extract<Evidence, { kind: 'mixed' }>;
+    expect(out.positive.lines[0].why).not.toContain(GH);
+    expect(out.positive.lines[0].why).toContain(GH_MARK);
+    expect(emitted.redactionStatus).toBe('applied');
+  });
+
+  // RED-PROOF: finding-emit.ts:136 (mixed absence observed content)
+  it('mixed.absence.observed.lines[].content', () => {
+    const evidence: Evidence = {
+      kind: 'mixed',
+      positive: { lines: [{ n: 1, content: 'clean', why: 'clean' }] },
+      absence: {
+        observed: { lines: [{ n: 2, content: `tok ${GH}` }], summary: 'clean' },
+        expected: [{ constraint: 'c', rationale: 'clean' }],
+      },
+    };
+    const emitted = emitFinding(draft({ evidence }));
+    const out = emitted.evidence as Extract<Evidence, { kind: 'mixed' }>;
+    expect(out.absence.observed.lines[0].content).not.toContain(GH);
+    expect(out.absence.observed.lines[0].content).toContain(GH_MARK);
+    expect(emitted.redactionStatus).toBe('applied');
+  });
+
+  // RED-PROOF: finding-emit.ts:138 (mixed absence summary)
+  it('mixed.absence.observed.summary', () => {
+    const evidence: Evidence = {
+      kind: 'mixed',
+      positive: { lines: [{ n: 1, content: 'clean', why: 'clean' }] },
+      absence: {
+        observed: { lines: [{ n: 2, content: 'clean' }], summary: `sum ${GH}` },
+        expected: [{ constraint: 'c', rationale: 'clean' }],
+      },
+    };
+    const emitted = emitFinding(draft({ evidence }));
+    const out = emitted.evidence as Extract<Evidence, { kind: 'mixed' }>;
+    expect(out.absence.observed.summary).not.toContain(GH);
+    expect(out.absence.observed.summary).toContain(GH_MARK);
+    expect(emitted.redactionStatus).toBe('applied');
+  });
+
+  // RED-PROOF: finding-emit.ts:142 (mixed absence expected rationale)
+  it('mixed.absence.expected[].rationale', () => {
+    const evidence: Evidence = {
+      kind: 'mixed',
+      positive: { lines: [{ n: 1, content: 'clean', why: 'clean' }] },
+      absence: {
+        observed: { lines: [{ n: 2, content: 'clean' }], summary: 'clean' },
+        expected: [{ constraint: 'c', rationale: `rat ${GH}` }],
+      },
+    };
+    const emitted = emitFinding(draft({ evidence }));
+    const out = emitted.evidence as Extract<Evidence, { kind: 'mixed' }>;
+    expect(out.absence.expected[0].rationale).not.toContain(GH);
+    expect(out.absence.expected[0].rationale).toContain(GH_MARK);
+    expect(emitted.redactionStatus).toBe('applied');
+  });
+});
+
+describe('emitFinding — rationale.plainEnglish', () => {
+  // RED-PROOF: finding-emit.ts:231. This field is NOT in the settlement brief's
+  // field list; `finding-adapter.ts` assigns the same string to `message` and to
+  // `rationale.plainEnglish`, so dropping this line leaves the identical bytes
+  // on a second field of the same object.
+  it('is redacted, and the status reflects it', () => {
+    const emitted = emitFinding(
+      draft({ rationale: { plainEnglish: `in plain English, ${GH}` } }),
+    );
+    expect(emitted.rationale?.plainEnglish).not.toContain(GH);
+    expect(emitted.rationale?.plainEnglish).toContain(GH_MARK);
+    expect(emitted.redactionStatus).toBe('applied');
+    expect(emitted.redactedShapes).toEqual(['github-pat']);
+  });
+});
+
+describe('emitFinding — details is an open bag, redacted at any depth', () => {
+  /** `{ root: <token nested `depth` containers deep> }`. */
+  function nestObjects(depth: number): Record<string, unknown> {
+    let v: unknown = `embedded ${GH}`;
+    for (let i = 0; i < depth; i++) v = { nest: v };
+    return { root: v };
+  }
+
+  function nestArrays(depth: number): Record<string, unknown> {
+    let v: unknown = `embedded ${GH}`;
+    for (let i = 0; i < depth; i++) v = [v];
+    return { root: v };
+  }
+
+  // RED-PROOF: finding-emit.ts:168 `if (typeof value === 'string') return pass.run(value)`.
+  it('depth 1: string leaf is redacted', () => {
+    const emitted = emitFinding(draft({ details: nestObjects(1) }));
+    expect(JSON.stringify(emitted.details)).not.toContain(GH);
+    expect(JSON.stringify(emitted.details)).toContain(GH_MARK);
+    expect(emitted.redactionStatus).toBe('applied');
+    expect(emitted.redactedShapes).toEqual(['github-pat']);
+  });
+
+  it('depth 12: the last depth the cap admits is still redacted', () => {
+    const emitted = emitFinding(draft({ details: nestObjects(12) }));
+    expect(JSON.stringify(emitted.details)).not.toContain(GH);
+    expect(emitted.redactionStatus).toBe('applied');
+  });
+
+  /**
+   * DEFECT (1) — the release-blocking one. This case FAILS before the fix.
+   *
+   * The depth cap short-circuits at a CONTAINER, so strings inside that
+   * container are never offered to the redactor: `details` nested 13 deep
+   * published a verbatim token AND asserted `redactionStatus: 'clean'` over it.
+   * A false affirmative of cleanliness is the exact failure this boundary
+   * exists to end, which is why the leak and the status are asserted together.
+   *
+   * RED-PROOF: restore `if (depth > 12) return value;` at finding-emit.ts:172.
+   */
+  it('depth 13 (objects): no leak, and the status is never a false clean', () => {
+    const emitted = emitFinding(draft({ details: nestObjects(13) }));
+    expect(JSON.stringify(emitted.details)).not.toContain(GH);
+    expect(emitted.redactionStatus).not.toBe('clean');
+  });
+
+  it('depth 13 (arrays): no leak, and the status is never a false clean', () => {
+    const emitted = emitFinding(draft({ details: nestArrays(13) }));
+    expect(JSON.stringify(emitted.details)).not.toContain(GH);
+    expect(emitted.redactionStatus).not.toBe('clean');
+  });
+
+  it('depth 40: a deeply nested bag still leaks nothing', () => {
+    const emitted = emitFinding(draft({ details: nestObjects(40) }));
+    expect(JSON.stringify(emitted.details)).not.toContain(GH);
+    expect(emitted.redactionStatus).not.toBe('clean');
+  });
+
+  it('a self-referential details bag terminates and leaks nothing', () => {
+    const cycle: Record<string, unknown> = { token: `cyc ${GH}` };
+    cycle.self = cycle;
+    const emitted = emitFinding(draft({ details: cycle }));
+    expect(JSON.stringify(emitted.details, cycleSafe())).not.toContain(GH);
+    expect(emitted.redactionStatus).not.toBe('clean');
+  });
+
+  it('a non-plain object in details is passed through, not flattened to {}', () => {
+    const when = new Date('2026-01-01T00:00:00.000Z');
+    const emitted = emitFinding(draft({ details: { when } }));
+    expect((emitted.details as { when: Date }).when).toBeInstanceOf(Date);
+  });
+});
+
+/** JSON.stringify replacer that tolerates cycles, so the assertion can run. */
+function cycleSafe() {
+  const seen = new WeakSet<object>();
+  return (_k: string, v: unknown) => {
+    if (typeof v === 'object' && v !== null) {
+      if (seen.has(v as object)) return '[cycle]';
+      seen.add(v as object);
+    }
+    return v;
+  };
+}
+
+describe('emitFinding — applied is absorbing across passes', () => {
+  /**
+   * Redaction is idempotent on TEXT (a marker matches no rule) but NOT on the
+   * status: a second pass finds nothing to change and would conclude 'clean'
+   * for a finding that really was redacted. Several producers are public
+   * exports whose output is rebuilt by an internal caller, so the second pass
+   * is a live path, not a hypothetical.
+   *
+   * RED-PROOF: finding-emit.ts:237 — replace `priorApplied ? 'applied' : pass.status`
+   * with `pass.status`.
+   */
+  it('re-emitting an already-applied finding does not downgrade to clean', () => {
+    const once = emitFinding(draft({ message: `tok ${GH}` }));
+    expect(once.redactionStatus).toBe('applied');
+
+    const twice = emitFinding(once);
+    expect(twice.redactionStatus).toBe('applied');
+    expect(twice.redactedShapes).toEqual(['github-pat']);
+  });
+
+  // RED-PROOF: finding-emit.ts:238-240 — drop `...priorShapes` from the merge.
+  it('shapes accumulate across passes rather than being replaced', () => {
+    const once = emitFinding(draft({ message: `tok ${GH}` }));
+    const twice = emitFinding({ ...once, description: `also ${AWS}` } as never);
+    expect(twice.redactedShapes).toEqual(['aws-access-key-id', 'github-pat']);
+    expect(twice.redactionStatus).toBe('applied');
+  });
+
+  it('emitFindings applies the same boundary per element', () => {
+    const out = emitFindings([
+      draft({ message: `a ${GH}` }),
+      draft({ message: 'b clean' }),
+    ]);
+    expect(out[0].message).not.toContain(GH);
+    expect(out[0].redactionStatus).toBe('applied');
+    expect(out[1].redactionStatus).toBe('clean');
+  });
+});
+
+describe('emitFinding — an unrecognised evidence kind fails CLOSED', () => {
+  /**
+   * DEFECT (3) — FAILS before the fix.
+   *
+   * `redactEvidence`'s switch has no `default`, so an unrecognised
+   * `evidence.kind` returns `undefined`: the evidence is silently DELETED and
+   * the finding still reports 'clean'. It fails open in both directions at
+   * once, and it is reachable through the public `ScanOptions.semanticPass`
+   * hook, so the unrecognised kind is attacker-adjacent rather than theoretical.
+   *
+   * RED-PROOF: delete the `default:` arm from `redactEvidence`.
+   */
+  const future = {
+    kind: 'future-variant',
+    note: `carries ${GH}`,
+    nested: { deeper: [`also ${AWS}`] },
+  } as unknown as Evidence;
+
+  it('does not delete the evidence', () => {
+    const emitted = emitFinding(draft({ evidence: future }));
+    expect(emitted.evidence).toBeDefined();
+  });
+
+  it('redacts every string leaf of the unknown shape', () => {
+    const emitted = emitFinding(draft({ evidence: future }));
+    const serialized = JSON.stringify(emitted.evidence);
+    expect(serialized).not.toContain(GH);
+    expect(serialized).not.toContain(AWS);
+    expect(serialized).toContain(GH_MARK);
+  });
+
+  it('does not report clean over an unexamined shape', () => {
+    const emitted = emitFinding(draft({ evidence: future }));
+    expect(emitted.redactionStatus).not.toBe('clean');
+  });
+
+  it('preserves the discriminant so a consumer can still branch', () => {
+    const emitted = emitFinding(draft({ evidence: future }));
+    expect((emitted.evidence as unknown as { kind: string }).kind).toBe('future-variant');
+  });
+});
+
+describe('emitFinding — malformed evidence does not abort the scan', () => {
+  /**
+   * DEFECT (4) — FAILS before the fix.
+   *
+   * Malformed `absence`/`mixed` evidence THROWS inside `redactEvidence`, and
+   * `scanner.ts`'s return has no try/catch, so the throw aborts the WHOLE scan.
+   * The same input was inert before this change: a crash introduced by the
+   * boundary is strictly worse than the leak it was added to close.
+   *
+   * RED-PROOF: remove the optional chaining from the four sub-field reads.
+   */
+  const malformed: Array<[string, unknown]> = [
+    ['absence missing observed', { kind: 'absence', expected: [] }],
+    ['absence missing observed.lines', { kind: 'absence', observed: { summary: 's' }, expected: [] }],
+    ['absence missing expected', { kind: 'absence', observed: { lines: [], summary: 's' } }],
+    ['mixed missing positive', { kind: 'mixed', absence: { observed: { lines: [], summary: 's' }, expected: [] } }],
+    ['mixed missing positive.lines', { kind: 'mixed', positive: {}, absence: { observed: { lines: [], summary: 's' }, expected: [] } }],
+    ['mixed missing absence', { kind: 'mixed', positive: { lines: [] } }],
+    ['mixed missing absence.observed', { kind: 'mixed', positive: { lines: [] }, absence: { expected: [] } }],
+    ['mixed missing absence.expected', { kind: 'mixed', positive: { lines: [] }, absence: { observed: { lines: [], summary: 's' } } }],
+    ['positive missing lines', { kind: 'positive' }],
+
+    // A list sub-field of the WRONG TYPE, not merely absent. `?? []` guards
+    // null and undefined only, so these still reached `.map` and threw — the
+    // same abort-the-whole-scan failure, one step further out. Found by probing
+    // the first version of this fix rather than by reasoning about it.
+    ['positive.lines is a number', { kind: 'positive', lines: 42 }],
+    ['absence.observed.lines is a string', { kind: 'absence', observed: { lines: 'oops', summary: 's' }, expected: [] }],
+    ['absence.expected is a string', { kind: 'absence', observed: { lines: [], summary: 's' }, expected: 'oops' }],
+    ['mixed.positive.lines is an object', { kind: 'mixed', positive: { lines: {} }, absence: { observed: { lines: [], summary: 's' }, expected: [] } }],
+    ['mixed.absence.expected is a number', { kind: 'mixed', positive: { lines: [] }, absence: { observed: { lines: [], summary: 's' }, expected: 7 } }],
+    ['absence.observed is a string', { kind: 'absence', observed: 'oops', expected: [] }],
+  ];
+
+  for (const [label, evidence] of malformed) {
+    it(`${label}: emits instead of throwing`, () => {
+      expect(() =>
+        emitFinding(draft({ evidence: evidence as Evidence })),
+      ).not.toThrow();
+    });
+  }
+
+  it('a malformed shape that still carries a credential does not leak it', () => {
+    const emitted = emitFinding(
+      draft({
+        evidence: {
+          kind: 'absence',
+          observed: { summary: `sum ${GH}` },
+        } as unknown as Evidence,
+      }),
+    );
+    expect(JSON.stringify(emitted.evidence)).not.toContain(GH);
+    expect(emitted.redactionStatus).not.toBe('clean');
+  });
+});
+
+describe('mergeFindings — the route point that actually covers `check`', () => {
+  /**
+   * `check --json` returns BEFORE the text renderer runs, so the `emitFindings`
+   * call in the renderer cannot be what covers it. What covers it is
+   * `astFindingToSecurityFinding` calling `emitFinding` inside `mergeFindings`
+   * (`scanner-bridge.ts`), and on `check`'s path the static-findings argument is
+   * empty, so EVERY element of the merged array comes from that constructor.
+   *
+   * That is a load-bearing accident: nothing in `cli.ts` requires it and, until
+   * this block, nothing would have noticed its removal. Pinning the mechanism
+   * rather than the command is deliberate — it is the assertion that stays true
+   * if the CLI is restructured, and it red-proofs by making the `emitFinding`
+   * call at that route point a pass-through.
+   */
+  function astFinding(over: Record<string, unknown> = {}) {
+    return {
+      checkId: 'AST-CRED-001',
+      name: `token ${GH}`,
+      description: `description ${GH}`,
+      category: 'credentials',
+      severity: 'high' as const,
+      passed: false,
+      message: `message ${GH}`,
+      fixable: false,
+      file: 'config.json',
+      ...over,
+    };
+  }
+
+  it('every merged finding has crossed the boundary when the static set is empty', () => {
+    const merged = mergeFindings([], [astFinding(), astFinding({ checkId: 'AST-CRED-003' })]);
+
+    expect(merged.length).toBe(2);
+    for (const f of merged) {
+      const emitted = f as unknown as { redactionStatus?: string; redactedShapes?: string[] };
+      expect(emitted.redactionStatus).toBeDefined();
+      expect(emitted.redactionStatus).toBe('applied');
+      expect(emitted.redactedShapes).toEqual(['github-pat']);
+    }
+  });
+
+  it('no credential survives into the merged array', () => {
+    const merged = mergeFindings([], [astFinding()]);
+    expect(JSON.stringify(merged)).not.toContain(GH);
+    expect(JSON.stringify(merged)).toContain(GH_MARK);
+  });
+
+  /**
+   * The absorbing-applied guard is only reachable if the two fields SURVIVE
+   * whatever rebuilds a finding between passes. A re-map that lists its fields
+   * by name and omits them defeats the guard by construction rather than by a
+   * cast, and the second pass then reports `'clean'` over text that really was
+   * redacted — defect (1)'s false-affirmative failure, arriving by a different
+   * road. This pins the property the guard depends on.
+   */
+  it('a rebuild that preserves the two fields keeps an honest applied', () => {
+    const [first] = mergeFindings([], [astFinding()]) as unknown as Array<
+      Record<string, unknown>
+    >;
+    expect(first.redactionStatus).toBe('applied');
+
+    const rebuiltPreservingFields = emitFinding({
+      ...(first as unknown as SecurityFindingDraft),
+      redactionStatus: first.redactionStatus,
+      redactedShapes: first.redactedShapes,
+    } as unknown as SecurityFindingDraft);
+
+    expect(rebuiltPreservingFields.redactionStatus).toBe('applied');
+    expect(rebuiltPreservingFields.redactedShapes).toEqual(['github-pat']);
+  });
+});
+
+describe('scan() — the emitted document carries no credential on any channel', () => {
+  /**
+   * The boundary's whole point is the published document, not the unit. This
+   * runs the real scanner over a tree with a planted token and asserts the
+   * credential appears NOWHERE in the serialized result — which is what
+   * `--json` publishes, and it covers `findings` and `allFindings` together
+   * (two of the four measured JSON leak paths were under `$.allFindings[…]`).
+   *
+   * In-process rather than spawning the built CLI: a spawn suite has to be
+   * gated on the build existing, and a gated assertion runs nowhere on a merge.
+   * (Stated without naming the built entry point, because the #285 harness gate
+   * treats ANY mention of that path as evidence a suite spawns it. The gate is
+   * deliberately crude and adding an exemption to it would widen it into a
+   * bypass, so the prose moves instead of the gate.)
+   */
+  async function scanTreeWithPlantedToken() {
+    const dir = await mkdtemp(path.join(tmpdir(), 'hma-emit-'));
+    await writeFile(path.join(dir, 'package.json'), '{"name":"e","version":"1.0.0"}\n');
+    await writeFile(path.join(dir, 'config.json'), JSON.stringify({ token: GH }) + '\n');
+    const scanner = new HardeningScanner();
+    const result = await scanner.scan({ targetDir: dir, autoFix: false });
+    return { dir, result };
+  }
+
+  it('no raw credential survives into the serialized scan result', async () => {
+    const { dir, result } = await scanTreeWithPlantedToken();
+    try {
+      expect(JSON.stringify(result)).not.toContain(GH);
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('every emitted finding carries the two redaction fields', async () => {
+    const { dir, result } = await scanTreeWithPlantedToken();
+    try {
+      const all = [...result.findings, ...(result.allFindings ?? [])];
+      expect(all.length).toBeGreaterThan(0);
+      for (const f of all) {
+        expect(['applied', 'clean', 'unverified']).toContain(f.redactionStatus);
+        expect(Array.isArray(f.redactedShapes)).toBe(true);
+      }
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  /**
+   * `emitOnce` memoizes on the DRAFT, so a draft reaching both channels yields
+   * one emitted object, by reference. Without it, `findings` and `allFindings`
+   * hold twin objects, and a later per-object mutation applies to one channel
+   * only.
+   *
+   * RED-PROOF: replace `emitOnce` with `emitFinding` at scanner.ts:3368/3379 —
+   * the reference overlap drops to zero while every other assertion stays green.
+   */
+  it('emitOnce gives findings and allFindings the same objects by identity', async () => {
+    const { dir, result } = await scanTreeWithPlantedToken();
+    try {
+      const all = result.allFindings ?? [];
+      expect(all.length).toBeGreaterThan(0);
+
+      const overlapByValue = result.findings.filter((f) =>
+        all.some(
+          (a) => a.checkId === f.checkId && a.file === f.file && a.line === f.line,
+        ),
+      );
+      expect(overlapByValue.length).toBeGreaterThan(0);
+
+      // Every finding present in both channels is the SAME object.
+      const overlapByIdentity = result.findings.filter((f) => all.includes(f));
+      expect(overlapByIdentity.length).toBe(overlapByValue.length);
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+});

--- a/__tests__/helpers/credential-literal-scan.ts
+++ b/__tests__/helpers/credential-literal-scan.ts
@@ -1,0 +1,123 @@
+/**
+ * The E4 enumeration guard's scanner.
+ *
+ * Walks `src/`, counts occurrences of every credential-shape guard literal the
+ * registry declares, and reports them per file. The registry file itself is
+ * excluded — it is the one place these literals are supposed to live — and so
+ * is `__tests__`, where fixtures legitimately carry them.
+ *
+ * WHY THIS EXISTS. Programmatic enumeration of the credential vocabulary was
+ * impossible before the registry: the tables were `const` arrays and inline
+ * regex literals inside function bodies, and the NanoMind redactor was eighteen
+ * inline `.replace()` calls with no enumerable form at all. So a fifteenth copy
+ * of `ghp_[a-zA-Z0-9]{36}` could be added to any file and nothing would notice
+ * until the copy drifted below the detector's floor and started leaking.
+ *
+ * The guard does not stop a copy being written. It stops one being written
+ * SILENTLY: a new literal fails the frozen allowlist and the author has to
+ * either adopt the registry or say, in the allowlist, why they did not.
+ *
+ * Deliberately hermetic — a plain directory walk and `indexOf`, no `rg`, no
+ * shelling out — so it behaves identically in CI and on a developer machine.
+ */
+import { readdirSync, readFileSync } from 'node:fs';
+import { join, relative, sep } from 'node:path';
+
+/** Directory names never walked. */
+const SKIP_DIRS = new Set(['__tests__', 'node_modules', 'dist']);
+
+/** Files whose literals are the registry itself, not a copy of it. */
+export const REGISTRY_FILES: readonly string[] = ['src/types/credential-format.ts'];
+
+/**
+ * Shape literals that appear in `src` and belong to NO registry shape.
+ *
+ * Both are guarded here rather than added to the registry, because adding a
+ * shape changes what is detected and this unit does not make a detection
+ * change — but leaving them unguarded would let a second copy appear silently,
+ * which is the whole failure mode.
+ *
+ *   - `ghr_` — a real GitHub token prefix carried by
+ *     `scanner/permission-vocabulary.ts:418` and known to no detector in the
+ *     tree: not in `VENDOR_PREFIX_ALTERNATIVES`, not in
+ *     `CANONICAL_CREDENTIAL_PATTERNS`, not in `redactCredentialShapes`.
+ *   - `nvapi-` — NVIDIA, carried by `hardening/nemoclaw-scanner.ts:34` in that
+ *     scanner's own private `NVAPI_PATTERNS` table, and by nothing else.
+ *
+ * These two are the ONLY literals in the prior baseline's wider vocabulary that
+ * this guard would otherwise miss. That was measured rather than assumed: the
+ * prior baseline's own recorded command also carries `sk-or-v1`, `ASIA…`,
+ * `rk_live_` and `shpat_`, and each of those returns zero hits in `src`, so
+ * omitting them narrows nothing.
+ */
+export const UNOWNED_SHAPE_LITERALS: readonly string[] = ['ghr_', 'nvapi-'];
+
+export interface LiteralScanResult {
+  /** repo-relative path -> total guard-literal occurrences in that file. */
+  readonly counts: Readonly<Record<string, number>>;
+  /** repo-relative path -> which literals were seen, for the failure message. */
+  readonly witnesses: Readonly<Record<string, readonly string[]>>;
+}
+
+function walk(dir: string, out: string[]): void {
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    const full = join(dir, entry.name);
+    if (entry.isDirectory()) {
+      if (SKIP_DIRS.has(entry.name)) continue;
+      walk(full, out);
+      continue;
+    }
+    if (/\.(ts|js|mts|cts|mjs|cjs)$/.test(entry.name)) out.push(full);
+  }
+}
+
+/** Count occurrences of `needle` in `haystack`. Literal, not regex. */
+function countOccurrences(haystack: string, needle: string): number {
+  let n = 0;
+  let i = haystack.indexOf(needle);
+  while (i !== -1) {
+    n++;
+    i = haystack.indexOf(needle, i + needle.length);
+  }
+  return n;
+}
+
+/**
+ * Scan `srcRoot` for credential-shape guard literals.
+ *
+ * `literals` is passed in rather than imported so the caller decides what the
+ * vocabulary is — the test passes the registry's own guards, which is what
+ * makes a newly added shape extend the guard automatically.
+ */
+export function scanForCredentialLiterals(
+  repoRoot: string,
+  srcRoot: string,
+  literals: readonly string[],
+): LiteralScanResult {
+  const files: string[] = [];
+  walk(srcRoot, files);
+
+  const counts: Record<string, number> = {};
+  const witnesses: Record<string, string[]> = {};
+
+  for (const file of files) {
+    const rel = relative(repoRoot, file).split(sep).join('/');
+    if (REGISTRY_FILES.includes(rel)) continue;
+    const content = readFileSync(file, 'utf8');
+    let total = 0;
+    const seen: string[] = [];
+    for (const literal of literals) {
+      const n = countOccurrences(content, literal);
+      if (n > 0) {
+        total += n;
+        seen.push(`${literal}x${n}`);
+      }
+    }
+    if (total > 0) {
+      counts[rel] = total;
+      witnesses[rel] = seen;
+    }
+  }
+
+  return { counts, witnesses };
+}

--- a/__tests__/helpers/credential-shape-fixtures.ts
+++ b/__tests__/helpers/credential-shape-fixtures.ts
@@ -1,0 +1,267 @@
+/**
+ * Hand-written literal fixtures, one per credential shape id.
+ *
+ * EVERY VALUE IN THIS FILE IS WRITTEN BY HAND AND NOTHING HERE IMPORTS THE
+ * IMPLEMENTATION. That is the entire point, and it is a measured requirement
+ * rather than a style preference.
+ *
+ * The prior-art branch (`3d0d44c`) built its corpus the other way: the
+ * generator derived its samples by mapping over `VENDOR_PREFIX_ALTERNATIVES`
+ * and its oracle called `matchVendorPrefix` — the same function the redactor
+ * uses to decide what to keep. Two consequences, both measured:
+ *
+ *   - deleting a shape from the detector deleted its own test case, so the
+ *     suite stayed green over the deletion;
+ *   - a `matchVendorPrefix` that over-claimed shrank the expected `body` by
+ *     exactly the bytes that then leaked, so the suite stayed green over the
+ *     leak too. 197 assertions, fully green, while a 43-character JWT
+ *     signature and a 20-character `glpat-` body were leaking.
+ *
+ * So: the id set here is compared against the registry's id set in both
+ * directions, and every expectation below is a literal a human typed. Adding a
+ * shape without a fixture fails; deleting a shape leaves an orphan fixture that
+ * also fails.
+ *
+ * The sample values are synthetic. They are shaped like real credentials
+ * because a fixture that cannot match its own shape proves nothing, but none of
+ * them is a live secret.
+ */
+
+export interface ShapeFixture {
+  /** The expected alternation source, written out in full, by hand. */
+  readonly alternation: string;
+  /** The expected redaction marker, written out by hand. */
+  readonly marker: string;
+  /**
+   * A literal value of this shape. Must match the shape's own composed regex.
+   * Empty only for `jwt`, which is matched by a linear scan and has no source.
+   */
+  readonly sample: string;
+  /**
+   * A value one step BELOW the shape's floor, or otherwise just outside it.
+   * Must NOT match. This is what proves the floor is live rather than
+   * decorative: without it, a shape narrowed to nothing would still pass.
+   */
+  readonly nearMiss: string;
+  /** For a name-gated shape, a line carrying the gate as well as the value. */
+  readonly gatedContext?: string;
+}
+
+export const SHAPE_FIXTURES: Readonly<Record<string, ShapeFixture>> = {
+  'anthropic-key': {
+    alternation: 'sk-ant-api[0-9][a-zA-Z0-9_-]{16,}',
+    marker: '[REDACTED_ANTHROPIC_KEY]',
+    sample: 'sk-ant-api' + '03-Ab3xY7Qw9Lm2Kd5Rt8Nv1Zc4',
+    // 15 body characters after `sk-ant-api0`, one below the 16 floor.
+    nearMiss: 'sk-ant' + '-api03-Ab3xY7Qw9Lm2K',
+  },
+  'openai-project-key': {
+    alternation: 'sk-proj-[a-zA-Z0-9_-]{16,}',
+    marker: '[REDACTED_OPENAI_KEY]',
+    sample: 'sk-proj-' + 'Ab3xY7Qw9Lm2Kd5Rt8Nv',
+    nearMiss: 'sk-pro' + 'j-Ab3xY7Qw9Lm2Kd5',
+  },
+  'openai-key': {
+    alternation: 'sk-[a-zA-Z0-9_-]{20,}',
+    marker: '[REDACTED_OPENAI_KEY]',
+    sample: 'sk-Ab3' + 'xY7Qw9Lm2Kd5Rt8Nv1Zc4Ef6Gh',
+    // 19 body characters, one below the 20 floor.
+    nearMiss: 'sk-Ab3' + 'xY7Qw9Lm2Kd5Rt',
+  },
+  'stripe-live': {
+    alternation: 'sk_live_[a-zA-Z0-9]{20,}',
+    marker: '[REDACTED_STRIPE_KEY]',
+    sample: 'sk_liv' + 'e_4eC39HqLyjWDarjtT1zdp7dc',
+    nearMiss: 'sk_liv' + 'e_4eC39HqLyjWD',
+  },
+  'stripe-test': {
+    alternation: 'sk_test_[a-zA-Z0-9]{20,}',
+    marker: '[REDACTED_STRIPE_KEY]',
+    sample: 'sk_tes' + 't_4eC39HqLyjWDarjtT1zdp7dc',
+    nearMiss: 'sk_tes' + 't_4eC39HqLyjWD',
+  },
+  'github-pat': {
+    alternation: 'ghp_[a-zA-Z0-9]{20,}',
+    marker: '[REDACTED_GITHUB_TOKEN]',
+    sample: 'ghp_' + '16C7e42F292c6912E7710c838347Ae178B4a',
+    nearMiss: 'ghp_16' + 'C7e42F292c6912E77',
+  },
+  'github-oauth': {
+    alternation: 'gho_[a-zA-Z0-9]{20,}',
+    marker: '[REDACTED_GITHUB_TOKEN]',
+    sample: 'gho_' + '16C7e42F292c6912E7710c838347Ae178B4a',
+    nearMiss: 'gho_16' + 'C7e42F292c6912E77',
+  },
+  'github-server': {
+    alternation: 'ghs_[a-zA-Z0-9]{20,}',
+    marker: '[REDACTED_GITHUB_TOKEN]',
+    sample: 'ghs_' + '16C7e42F292c6912E7710c838347Ae178B4a',
+    nearMiss: 'ghs_16' + 'C7e42F292c6912E77',
+  },
+  'github-user': {
+    alternation: 'ghu_[a-zA-Z0-9]{20,}',
+    marker: '[REDACTED_GITHUB_TOKEN]',
+    sample: 'ghu_' + '16C7e42F292c6912E7710c838347Ae178B4a',
+    nearMiss: 'ghu_16' + 'C7e42F292c6912E77',
+  },
+  'github-fine-grained': {
+    alternation: 'github_pat_[a-zA-Z0-9_]{20,}',
+    marker: '[REDACTED_GITHUB_TOKEN]',
+    sample: 'github' + '_pat_11ABCDEFG0abcdefghij_KLMNOPQRSTUVWXYZ0123456789abcdef',
+    nearMiss: 'github' + '_pat_11ABCDEFG0abcdefghi',
+  },
+  'huggingface-token': {
+    alternation: 'hf_[a-zA-Z0-9]{20,}',
+    marker: '[REDACTED_HUGGINGFACE_TOKEN]',
+    sample: 'hf_' + 'QwErTyUiOpAsDfGhJkLzXcVbNm123456',
+    nearMiss: 'hf_QwE' + 'rTyUiOpAsDfGhJ',
+  },
+  'gitlab-pat': {
+    alternation: 'glpat-[a-zA-Z0-9_-]{20,}',
+    marker: '[REDACTED_GITLAB_TOKEN]',
+    sample: 'glpat-' + 'Ab3xY7Qw9Lm2Kd5Rt8Nv',
+    nearMiss: 'glpat-' + 'Ab3xY7Qw9Lm2Kd5Rt',
+  },
+  'npm-token': {
+    alternation: 'npm_[a-zA-Z0-9]{20,}',
+    marker: '[REDACTED_NPM_TOKEN]',
+    sample: 'npm_ab' + 'cdefghijklmnopqrstuvwxyz0123456789',
+    nearMiss: 'npm_ab' + 'cdefghijklmnopqrs',
+  },
+  'aws-access-key-id': {
+    alternation: 'AKIA[0-9A-Z]{16}',
+    marker: '[REDACTED_AWS_KEY]',
+    sample: 'AKIA' + '3QZ7MPLV2XKDNW4R',
+    // 15 body characters: the width here is EXACT, not a floor.
+    nearMiss: 'AKIA3Q' + 'Z7MPLV2XKDN',
+  },
+  'google-api-key': {
+    alternation: 'AIza[0-9A-Za-z_-]{35}',
+    marker: '[REDACTED_GOOGLE_KEY]',
+    sample: 'AIza' + 'SyD-9tSrke72PouQMnMX-a7eZSW0jkFMBWY',
+    nearMiss: 'AIzaSy' + 'D-9tSrke72PouQMnMX-a7eZSW0jkFMB',
+  },
+  'slack-token': {
+    // The five token types share one label. If this expectation is ever
+    // narrowed to `xoxb-`, the registry test must go red — that is precisely
+    // what a label-set assertion cannot see.
+    alternation: 'xox[abprs]-[0-9A-Za-z-]{10,}',
+    marker: '[REDACTED_SLACK_TOKEN]',
+    sample: 'xoxb-' + '123456789012-1234567890123-AbCdEfGhIjKlMnOpQrStUvWx',
+    nearMiss: 'xoxb-1' + '2345678',
+  },
+  'sendgrid-key': {
+    alternation: 'SG\\.[A-Za-z0-9_-]{22}\\.[A-Za-z0-9_-]{43}',
+    marker: '[REDACTED_SENDGRID_KEY]',
+    sample:
+      'SG.abc' + 'defghijklmnopqrstuv.abcdefghijklmnopqrstuvwxyz0123456789ABCDEFG',
+    // The dotted-namespace false positive the fixed widths exist to reject.
+    nearMiss: 'MSG.IN' + 'CIDENT_ESCALATION_QUEUE.HIGH_PRIORITY_ROUTE',
+  },
+  jwt: {
+    alternation: '',
+    marker: '[REDACTED_JWT]',
+    sample:
+      'eyJhbG' + 'ciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIn0.dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk',
+    nearMiss: 'eyJhbG' + 'ciOiJIUzI1NiJ9',
+  },
+  'entropy-blob': {
+    alternation: '\\b[A-Za-z0-9+=_]{40,}\\b',
+    marker: '[REDACTED_SECRET]',
+    // 44 characters.
+    sample: 'Zx8Kq2' + 'Wm5Bn7Vc4Lp9Rt6Yu3Ij1Oe0Ad8Sf5Gh2Jk7Lq',
+    // 39 characters, one below the 40 floor.
+    nearMiss: 'Zx8Kq2' + 'Wm5Bn7Vc4Lp9Rt6Yu3Ij1Oe0Ad8Sf5Gh',
+  },
+  'pem-private-key': {
+    alternation: '-----BEGIN (?:RSA |EC |DSA |OPENSSH |ENCRYPTED |PRIVATE)[A-Z ]*KEY-----',
+    marker: '[REDACTED_PRIVATE_KEY]',
+    sample: '-----B' + 'EGIN RSA PRIVATE KEY-----',
+    nearMiss: '-----B' + 'EGIN CERTIFICATE-----',
+  },
+  'aws-secret-access-key': {
+    alternation: '[A-Za-z0-9/+=]{40,}',
+    marker: '[REDACTED_AWS_SECRET]',
+    // Exactly 40 characters.
+    sample: 'wJalrX' + 'UtnFEMI/K7MDENG/bPxRfiCYz1a2B3c4D5',
+    // 39.
+    nearMiss: 'wJalrX' + 'UtnFEMI/K7MDENG/bPxRfiCYz1a2B3c4D',
+    gatedContext: 'aws_secret_access_key = "wJalrXUtnFEMI/K7MDENG/bPxRfiCYz1a2B3c4D5"',
+  },
+  'connection-string': {
+    alternation: "(?:postgres|mysql|mongodb|redis)://[^\\s'\"]+",
+    marker: '[REDACTED_CONNECTION_STRING]',
+    sample: 'postgr' + 'es://appuser:s3cr3t-p4ssw0rd@db.internal:5432/app',
+    // A scheme the redactor does not carry — six of them are located by
+    // credential-context.ts and redacted by nothing.
+    nearMiss: 'amqp:/' + '/appuser:s3cr3t-p4ssw0rd@broker.internal:5672/vhost',
+  },
+};
+
+/**
+ * The enumeration guard literals each shape declares, written out by hand.
+ *
+ * Pinned separately from the shapes because the guard set is what the E4
+ * enumeration test scans `src/` for. Narrowing a shape's guards would quietly
+ * shrink what that test can see — a copy of the shape could then be added to
+ * another file and stay invisible — and the guard test itself cannot notice,
+ * because it derives its vocabulary from the registry on purpose. This literal
+ * is what notices.
+ */
+export const EXPECTED_GUARDS: Readonly<Record<string, readonly string[]>> = {
+  'anthropic-key': ['sk-ant'],
+  'openai-project-key': ['sk-proj'],
+  'openai-key': ['sk-[', 'sk-|'],
+  'stripe-live': ['sk_live_'],
+  'stripe-test': ['sk_test_'],
+  'github-pat': ['ghp_'],
+  'github-oauth': ['gho_'],
+  'github-server': ['ghs_'],
+  'github-user': ['ghu_'],
+  'github-fine-grained': ['github_pat_'],
+  'huggingface-token': ['hf_'],
+  'gitlab-pat': ['glpat-'],
+  'npm-token': ['npm_'],
+  'aws-access-key-id': ['AKIA'],
+  'google-api-key': ['AIza'],
+  'slack-token': ['xox'],
+  'sendgrid-key': ['SG.', 'SG\\.'],
+  jwt: ['eyJ'],
+  'entropy-blob': ['[A-Za-z0-9+=_]{40,}'],
+  'pem-private-key': ['-----BEGIN'],
+  'aws-secret-access-key': ['secret_access_key', 'secret[_\\s.-]?access'],
+  'connection-string': ['postgres://', 'mongodb://'],
+};
+
+/**
+ * The 17 vendor alternatives, written out by hand in the order the alternation
+ * resolves them.
+ *
+ * This is the pin that makes the registry derivation safe: `credential-format`
+ * used to declare this list as a literal and now composes it from
+ * `CREDENTIAL_SHAPES`. If the composition ever produces anything other than
+ * these exact strings in this exact order, every consumer of the alternation
+ * changes behaviour, and this list is what notices.
+ *
+ * Order is load-bearing: `sk-ant-api…` and `sk-proj-…` before the generic
+ * `sk-…`, or a project key is reported under the legacy label.
+ */
+export const EXPECTED_VENDOR_ALTERNATIVES: readonly string[] = [
+  'sk-ant-api[0-9][a-zA-Z0-9_-]{16,}',
+  'sk-proj-[a-zA-Z0-9_-]{16,}',
+  'sk-[a-zA-Z0-9_-]{20,}',
+  'sk_live_[a-zA-Z0-9]{20,}',
+  'sk_test_[a-zA-Z0-9]{20,}',
+  'ghp_[a-zA-Z0-9]{20,}',
+  'gho_[a-zA-Z0-9]{20,}',
+  'ghs_[a-zA-Z0-9]{20,}',
+  'ghu_[a-zA-Z0-9]{20,}',
+  'github_pat_[a-zA-Z0-9_]{20,}',
+  'hf_[a-zA-Z0-9]{20,}',
+  'glpat-[a-zA-Z0-9_-]{20,}',
+  'npm_[a-zA-Z0-9]{20,}',
+  'AKIA[0-9A-Z]{16}',
+  'AIza[0-9A-Za-z_-]{35}',
+  'xox[abprs]-[0-9A-Za-z-]{10,}',
+  'SG\\.[A-Za-z0-9_-]{22}\\.[A-Za-z0-9_-]{43}',
+];

--- a/__tests__/nanomind-core/redaction-rule-table-parity.test.ts
+++ b/__tests__/nanomind-core/redaction-rule-table-parity.test.ts
@@ -1,0 +1,235 @@
+/**
+ * The credential redactor became a RULE TABLE so that each match can report the
+ * registry shape it proves (C9 — `redactedShapes` may carry only ids resolved
+ * FROM THE VALUE, and the marker vocabulary cannot supply them because it is
+ * many-to-one).
+ *
+ * That refactor is only safe if it changed nothing about WHAT is removed. This
+ * file is the proof.
+ *
+ * The oracle is a hand-written sequential `.replace()` chain — the pre-table
+ * form — kept HERE and not in `src/`, deliberately, for two reasons:
+ *   1. `credential-vocabulary-enumeration.test.ts` (E4) freezes the number of
+ *      credential shape literals in `src/` + `scripts/`. A second copy in `src/`
+ *      is exactly the vocabulary duplication that guard exists to stop, and it
+ *      caught this: the count went 301 -> 324.
+ *   2. An oracle that lives beside the implementation drifts with it. This one
+ *      has to be edited by hand, in a different shape, to stay in agreement.
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  redactCredentialShapes,
+  redactCredentialShapesReporting,
+  redactSecretsForReport,
+  redactSecretsForReportReporting,
+} from '../../src/nanomind-core/security/defense-in-depth';
+
+/**
+ * THE ORACLE. A sequential chain, in the original order, written out longhand.
+ *
+ * Do not refactor this into a loop or a table — being a different FORM from the
+ * implementation is the whole point. If both sides were tables, a mistake in the
+ * shared shape would pass.
+ */
+function oracleChain(content: string): string {
+  let r = content;
+  r = r.replace(/sk-ant-api\d{2}-[a-zA-Z0-9_-]{20,}/g, '[REDACTED_ANTHROPIC_KEY]');
+  r = r.replace(/sk-proj-[a-zA-Z0-9_-]{20,}/g, '[REDACTED_OPENAI_KEY]');
+  r = r.replace(/sk-[a-zA-Z0-9]{48,}/g, '[REDACTED_OPENAI_KEY]');
+  r = r.replace(/AKIA[0-9A-Z]{16}/g, '[REDACTED_AWS_KEY]');
+  r = r.replace(/ghp_[a-zA-Z0-9]{36}/g, '[REDACTED_GITHUB_TOKEN]');
+  r = r.replace(/gho_[a-zA-Z0-9]{36}/g, '[REDACTED_GITHUB_TOKEN]');
+  r = r.replace(/ghs_[a-zA-Z0-9]{36}/g, '[REDACTED_GITHUB_TOKEN]');
+  r = r.replace(/ghu_[a-zA-Z0-9]{36}/g, '[REDACTED_GITHUB_TOKEN]');
+  r = r.replace(/github_pat_[a-zA-Z0-9_]{60,}/g, '[REDACTED_GITHUB_TOKEN]');
+  r = r.replace(/glpat-[a-zA-Z0-9_-]{20,}/g, '[REDACTED_GITLAB_TOKEN]');
+  r = r.replace(/hf_[a-zA-Z0-9]{34,}/g, '[REDACTED_HUGGINGFACE_TOKEN]');
+  r = r.replace(/npm_[a-zA-Z0-9]{36}/g, '[REDACTED_NPM_TOKEN]');
+  r = r.replace(/sk_live_[0-9a-zA-Z]{24,}/g, '[REDACTED_STRIPE_KEY]');
+  r = r.replace(/sk_test_[0-9a-zA-Z]{24,}/g, '[REDACTED_STRIPE_KEY]');
+  r = r.replace(/SG\.[a-zA-Z0-9_-]{22}\.[a-zA-Z0-9_-]{43}/g, '[REDACTED_SENDGRID_KEY]');
+  r = r.replace(/AIza[0-9A-Za-z_-]{35}/g, '[REDACTED_GOOGLE_KEY]');
+  r = r.replace(/xox[baprs]-[a-zA-Z0-9-]{10,}/g, '[REDACTED_SLACK_TOKEN]');
+  r = r.replace(
+    /((?:aws.{0,16}?(?:secret|private).{0,16}?key|secret[_\s.-]?access[_\s.-]?key)["'\s]*[:=]+>?\s*["']?)([A-Za-z0-9/+=]{40,})/gi,
+    '$1[REDACTED_AWS_SECRET]',
+  );
+  r = r.replace(/-----BEGIN [A-Z ]+ KEY-----[\s\S]*?-----END [A-Z ]+ KEY-----/g, '[REDACTED_PRIVATE_KEY]');
+  r = r.replace(/(?:postgres|mysql|mongodb|redis):\/\/[^\s'"]+/gi, '[REDACTED_CONNECTION_STRING]');
+  return r;
+}
+
+/**
+ * Every value below is SYNTHETIC and carries `FAKE` in its body. They match the
+ * shape patterns and nothing else; none is or ever was a live credential.
+ */
+const F4 = 'FAKE';
+const fakeOf = (n: number) => F4.repeat(Math.ceil(n / 4)).slice(0, n);
+
+const SAMPLES: ReadonlyArray<{ label: string; text: string; shapes: string[] }> = [
+  { label: 'anthropic', text: `key=sk-ant-api03-${fakeOf(20)}`, shapes: ['anthropic-key'] },
+  { label: 'openai-project', text: `sk-proj-${fakeOf(20)}`, shapes: ['openai-project-key'] },
+  { label: 'openai-legacy', text: `sk-${fakeOf(48)}`, shapes: ['openai-key'] },
+  { label: 'aws-akia', text: `AKIA${fakeOf(16).toUpperCase()}`, shapes: ['aws-access-key-id'] },
+  { label: 'github-pat', text: `ghp_${fakeOf(36)}`, shapes: ['github-pat'] },
+  { label: 'github-oauth', text: `gho_${fakeOf(36)}`, shapes: ['github-oauth'] },
+  { label: 'github-server', text: `ghs_${fakeOf(36)}`, shapes: ['github-server'] },
+  { label: 'github-user', text: `ghu_${fakeOf(36)}`, shapes: ['github-user'] },
+  { label: 'github-fg', text: `github_pat_${fakeOf(60)}`, shapes: ['github-fine-grained'] },
+  { label: 'gitlab', text: `glpat-${fakeOf(20)}`, shapes: ['gitlab-pat'] },
+  { label: 'huggingface', text: `hf_${fakeOf(34)}`, shapes: ['huggingface-token'] },
+  { label: 'npm', text: `npm_${fakeOf(36)}`, shapes: ['npm-token'] },
+  { label: 'stripe-live', text: `sk_live_${fakeOf(24)}`, shapes: ['stripe-live'] },
+  { label: 'stripe-test', text: `sk_test_${fakeOf(24)}`, shapes: ['stripe-test'] },
+  { label: 'sendgrid', text: `SG.${fakeOf(22)}.${fakeOf(43)}`, shapes: ['sendgrid-key'] },
+  { label: 'google', text: `AIza${fakeOf(35)}`, shapes: ['google-api-key'] },
+  // Every member of the `xox[baprs]-` alternation, not just `xoxb-`.
+  //
+  // The first draft of this file carried `xoxb-` alone and a red-proof caught it:
+  // narrowing the rule to `xoxb-` left all 60 assertions GREEN, because no
+  // fixture exercised the other four. A pattern with an alternation needs a
+  // sample per branch or the branch is untested.
+  { label: 'slack-b', text: `xoxb-${fakeOf(12)}`, shapes: ['slack-token'] },
+  { label: 'slack-a', text: `xoxa-${fakeOf(12)}`, shapes: ['slack-token'] },
+  { label: 'slack-p', text: `xoxp-${fakeOf(12)}`, shapes: ['slack-token'] },
+  { label: 'slack-r', text: `xoxr-${fakeOf(12)}`, shapes: ['slack-token'] },
+  { label: 'slack-s', text: `xoxs-${fakeOf(12)}`, shapes: ['slack-token'] },
+  {
+    label: 'aws-secret',
+    text: `aws_secret_access_key = "${fakeOf(40)}"`,
+    shapes: ['aws-secret-access-key'],
+  },
+  {
+    label: 'pem',
+    text: '-----BEGIN RSA PRIVATE KEY-----\nFAKEFAKE\n-----END RSA PRIVATE KEY-----',
+    shapes: ['pem-private-key'],
+  },
+  {
+    label: 'connection-string',
+    text: 'postgres://fakeuser:fakepass@localhost:5432/db',
+    shapes: ['connection-string'],
+  },
+  // Ordering hazard: the generic `sk-` rule must not claim the project key.
+  {
+    label: 'openai-project-before-generic',
+    text: `sk-proj-${fakeOf(60)}`,
+    shapes: ['openai-project-key'],
+  },
+  // Adjacency: the non-anchored patterns must catch BOTH, not just the first.
+  {
+    label: 'adjacent-github',
+    text: `ghp_${fakeOf(36)}ghp_${fakeOf(36)}`,
+    shapes: ['github-pat'],
+  },
+  // Two different shapes in one string.
+  {
+    label: 'multi-shape',
+    text: `AKIA${fakeOf(16).toUpperCase()} and glpat-${fakeOf(20)}`,
+    shapes: ['aws-access-key-id', 'gitlab-pat'],
+  },
+  // Prose that must survive untouched.
+  { label: 'benign-prose', text: 'The API key rotates every 90 days.', shapes: [] },
+  { label: 'empty', text: '', shapes: [] },
+];
+
+describe('redaction rule table — parity with the pre-table chain', () => {
+  it.each(SAMPLES.map(s => [s.label, s.text] as const))(
+    'produces byte-identical output to the oracle chain: %s',
+    (_label, text) => {
+      expect(redactCredentialShapes(text)).toBe(oracleChain(text));
+    },
+  );
+
+  it('is byte-identical on every sample concatenated into one document', () => {
+    const doc = SAMPLES.map(s => s.text).join('\n---\n');
+    expect(redactCredentialShapes(doc)).toBe(oracleChain(doc));
+  });
+
+  it('the oracle is not vacuous — it really does change these inputs', () => {
+    // Without this, a broken oracle that returned its input unchanged would make
+    // every parity assertion above pass against an equally broken implementation.
+    const changed = SAMPLES.filter(s => s.shapes.length > 0);
+    expect(changed.length).toBeGreaterThan(15);
+    for (const s of changed) {
+      expect(oracleChain(s.text), `oracle left ${s.label} unchanged`).not.toBe(s.text);
+    }
+  });
+});
+
+describe('redaction rule table — shapes are resolved FROM THE VALUE (C9)', () => {
+  it.each(SAMPLES.map(s => [s.label, s.text, s.shapes] as const))(
+    'reports exactly the shapes that matched: %s',
+    (_label, text, shapes) => {
+      expect(redactCredentialShapesReporting(text).shapes).toEqual([...shapes].sort());
+    },
+  );
+
+  it('reported shapes are sorted and deduped', () => {
+    const multi = `AKIA${fakeOf(16).toUpperCase()} glpat-${fakeOf(20)} AKIA${fakeOf(16).toUpperCase()}`;
+    const { shapes } = redactCredentialShapesReporting(multi);
+    expect(shapes).toEqual(['aws-access-key-id', 'gitlab-pat']);
+    expect([...shapes].sort()).toEqual(shapes);
+  });
+
+  it('the five GitHub shapes report DISTINCT ids despite sharing one marker', () => {
+    // This is the reason the table exists. Recovering ids from the redacted
+    // text would yield five candidates for any one of them.
+    const ids = (['ghp_', 'gho_', 'ghs_', 'ghu_'] as const).map(
+      p => redactCredentialShapesReporting(`${p}${fakeOf(36)}`).shapes[0],
+    );
+    expect(new Set(ids).size).toBe(4);
+    expect(ids).toEqual(['github-pat', 'github-oauth', 'github-server', 'github-user']);
+    // …and all four really do render the same marker.
+    for (const p of ['ghp_', 'gho_', 'ghs_', 'ghu_']) {
+      expect(redactCredentialShapes(`${p}${fakeOf(36)}`)).toBe('[REDACTED_GITHUB_TOKEN]');
+    }
+  });
+
+  it('stripe live and test are distinguished, because their rotations differ', () => {
+    expect(redactCredentialShapesReporting(`sk_live_${fakeOf(24)}`).shapes).toEqual(['stripe-live']);
+    expect(redactCredentialShapesReporting(`sk_test_${fakeOf(24)}`).shapes).toEqual(['stripe-test']);
+  });
+});
+
+describe('the report boundary — a key-name heuristic resolves NO shape (C9)', () => {
+  it('redacts a name-gated value but reports no shape id', () => {
+    const text = 'password = "hunter2xyzabc"';
+    const out = redactSecretsForReportReporting(text);
+    expect(out.text).not.toContain('hunter2xyzabc');
+    // Applied, but nothing was resolved from the VALUE — the rule fired on the
+    // identifier and never inspected what it removed.
+    expect(out.shapes).toEqual([]);
+  });
+
+  it('still reports the shape when the value itself is shape-anchored', () => {
+    const out = redactSecretsForReportReporting(`token = "ghp_${fakeOf(36)}"`);
+    expect(out.shapes).toEqual(['github-pat']);
+  });
+
+  it('leaves prose the name-gate would otherwise destroy', () => {
+    // The measured regression that separates the report boundary from the
+    // daemon one: whitespace in the value means it is not a secret.
+    const prose = 'key = "example fixture value for tests only"';
+    expect(redactSecretsForReport(prose)).toBe(prose);
+  });
+});
+
+describe('the two shapes held out of this release stay held out (GAP-8 / S4)', () => {
+  it('does not redact a git SHA-40, a sha512- integrity value, or a contentHash', () => {
+    // Porting the entropy-blob class into the redactor is the measured S4 stop
+    // condition. HMA's own reports carry `contentHash` values, so this is a
+    // self-inflicted-FP guard, not a hypothetical.
+    const sha40 = 'a'.repeat(40);
+    const integrity = `sha512-${'A'.repeat(60)}==`;
+    for (const s of [sha40, integrity]) {
+      expect(redactCredentialShapes(s)).toBe(s);
+      expect(redactCredentialShapesReporting(s).shapes).toEqual([]);
+    }
+  });
+
+  it('does not redact a JWT', () => {
+    const jwt = `eyJ${fakeOf(20)}.eyJ${fakeOf(20)}.${fakeOf(20)}`;
+    expect(redactCredentialShapesReporting(jwt).shapes).toEqual([]);
+  });
+});

--- a/__tests__/types/credential-shape-registry.test.ts
+++ b/__tests__/types/credential-shape-registry.test.ts
@@ -1,0 +1,282 @@
+/**
+ * The credential shape registry's own contract.
+ *
+ * Every expectation is a hand-written literal in
+ * `__tests__/helpers/credential-shape-fixtures.ts`. Nothing here derives an
+ * expectation from the implementation, because the prior art did exactly that
+ * and stayed 197-assertions green over two live leaks: its corpus was generated
+ * by mapping over the detector's own list, so deleting a shape deleted its test
+ * case, and its oracle called the same `matchVendorPrefix` the redactor uses,
+ * so an over-claiming prefix shrank the expected body by precisely the bytes
+ * that leaked.
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  CREDENTIAL_SHAPES,
+  CREDENTIAL_REDACTION_MARKERS,
+  CREDENTIAL_KEY_NAMES,
+  VENDOR_PREFIX_ALTERNATIVES,
+  keyNameDelimiterPattern,
+  shapeAlternation,
+  shapesFor,
+  type CredentialShape,
+  type ShapeId,
+} from '../../src/types/credential-format';
+import {
+  SHAPE_FIXTURES,
+  EXPECTED_GUARDS,
+  EXPECTED_VENDOR_ALTERNATIVES,
+} from '../helpers/credential-shape-fixtures';
+
+const byId = new Map<string, CredentialShape>(CREDENTIAL_SHAPES.map(s => [s.id, s]));
+
+describe('credential shape registry — id set', () => {
+  it('every registry shape has a hand-written fixture', () => {
+    const missing = CREDENTIAL_SHAPES.map(s => s.id).filter(id => !(id in SHAPE_FIXTURES));
+    expect(missing).toEqual([]);
+  });
+
+  it('every fixture names a registry shape — no orphans', () => {
+    const orphans = Object.keys(SHAPE_FIXTURES).filter(id => !byId.has(id));
+    expect(orphans).toEqual([]);
+  });
+
+  it('ids are unique', () => {
+    expect(new Set(CREDENTIAL_SHAPES.map(s => s.id)).size).toBe(CREDENTIAL_SHAPES.length);
+  });
+});
+
+describe('credential shape registry — patterns, never labels', () => {
+  // Enumerating by label is the weakness this replaces. `xoxb-`, `xoxp-`,
+  // `xoxa-`, `xoxr-` and `xoxs-` all report as one label, so narrowing the
+  // pattern to `xoxb-` is invisible to any label-set assertion — and the guard
+  // this supersedes carved out `PEM private key`, the one shape that leaked a
+  // full 40-byte body.
+  for (const id of Object.keys(SHAPE_FIXTURES)) {
+    it(`${id}: composed alternation matches the hand-written source`, () => {
+      const shape = byId.get(id);
+      expect(shape, `no registry shape for fixture ${id}`).toBeDefined();
+      expect(shapeAlternation(shape!)).toBe(SHAPE_FIXTURES[id].alternation);
+    });
+  }
+
+  it('the vendor alternation is byte-identical to the hand-written list, in order', () => {
+    expect(VENDOR_PREFIX_ALTERNATIVES).toEqual(EXPECTED_VENDOR_ALTERNATIVES);
+  });
+
+  it('the vendor alternation carries exactly the vendor-alternation surface', () => {
+    expect(shapesFor('vendor-alternation').map(s => s.id)).toEqual([
+      'anthropic-key',
+      'openai-project-key',
+      'openai-key',
+      'stripe-live',
+      'stripe-test',
+      'github-pat',
+      'github-oauth',
+      'github-server',
+      'github-user',
+      'github-fine-grained',
+      'huggingface-token',
+      'gitlab-pat',
+      'npm-token',
+      'aws-access-key-id',
+      'google-api-key',
+      'slack-token',
+      'sendgrid-key',
+    ]);
+  });
+});
+
+describe('credential shape registry — each shape matches its own fixture and rejects the near miss', () => {
+  for (const id of Object.keys(SHAPE_FIXTURES)) {
+    const fixture = SHAPE_FIXTURES[id];
+    if (fixture.alternation === '') continue; // jwt: matched by scan, asserted below
+    it(`${id}: sample matches, near miss does not`, () => {
+      const re = new RegExp(`^(?:${fixture.alternation})$`);
+      expect(re.test(fixture.sample), `sample should match ${id}`).toBe(true);
+      expect(re.test(fixture.nearMiss), `near miss should NOT match ${id}`).toBe(false);
+    });
+  }
+
+  it('jwt is the only shape with no regex source', () => {
+    const sourceless = CREDENTIAL_SHAPES.filter(
+      s => s.kind === 'structural' && s.source === '',
+    ).map(s => s.id);
+    expect(sourceless).toEqual(['jwt']);
+  });
+});
+
+describe('credential shape registry — marker totality', () => {
+  it('every shape has a marker', () => {
+    const unmarked = CREDENTIAL_SHAPES.filter(
+      s => CREDENTIAL_REDACTION_MARKERS[s.id] === undefined,
+    ).map(s => s.id);
+    expect(unmarked).toEqual([]);
+  });
+
+  it('every marker names a shape — no orphan markers', () => {
+    const orphans = (Object.keys(CREDENTIAL_REDACTION_MARKERS) as ShapeId[]).filter(
+      id => !byId.has(id),
+    );
+    expect(orphans).toEqual([]);
+  });
+
+  it('markers match the hand-written expectations', () => {
+    for (const id of Object.keys(SHAPE_FIXTURES)) {
+      expect(CREDENTIAL_REDACTION_MARKERS[id as ShapeId], id).toBe(SHAPE_FIXTURES[id].marker);
+    }
+  });
+
+  it('a marker is a constant name, never a preview of the value', () => {
+    // The historical defect this closes printed the first 8 characters of an
+    // unknown-shape value into evidence — 5 characters of live `hf_` body. A
+    // marker that can carry body bytes is that defect one layer down.
+    //
+    // The property that separates a name from a preview is that a name is
+    // drawn from a fixed uppercase vocabulary: no lowercase, no digits, no
+    // separators other than `_`. Credential bodies are mixed-case alphanumeric
+    // by construction, so any leaked byte fails this.
+    //
+    // A byte-run comparison against the sample cannot express this: the PEM
+    // sample is a HEADER (`-----BEGIN RSA PRIVATE KEY-----`) and shares the
+    // English word PRIVATE_KEY with its own marker, which is naming, not
+    // leaking.
+    for (const id of Object.keys(SHAPE_FIXTURES)) {
+      expect(SHAPE_FIXTURES[id].marker, id).toMatch(/^\[REDACTED(?:_[A-Z]+)*\]$/);
+    }
+  });
+
+  it('the marker vocabulary is small and shared, so a marker cannot encode a value', () => {
+    // 22 shapes, far fewer markers: GitHub's five token types share one, and
+    // Stripe's two share one. A per-value marker would show up here as a
+    // marker count approaching the shape count.
+    const markers = new Set(Object.values(CREDENTIAL_REDACTION_MARKERS));
+    expect(markers.size).toBeLessThan(CREDENTIAL_SHAPES.length);
+    expect(markers.size).toBe(16); // 22 shapes: GitHub 5 -> 1, OpenAI 2 -> 1, Stripe 2 -> 1
+  });
+});
+
+describe('credential shape registry — guards', () => {
+  it('every shape declares at least one guard literal', () => {
+    expect(CREDENTIAL_SHAPES.filter(s => s.guards.length === 0).map(s => s.id)).toEqual([]);
+  });
+
+  it('guards match the hand-written expectations', () => {
+    for (const id of Object.keys(EXPECTED_GUARDS)) {
+      const shape = byId.get(id);
+      expect(shape, id).toBeDefined();
+      expect([...shape!.guards], id).toEqual([...EXPECTED_GUARDS[id]]);
+    }
+  });
+
+  it('every registry shape appears in the hand-written guard map', () => {
+    expect(CREDENTIAL_SHAPES.map(s => s.id).filter(id => !(id in EXPECTED_GUARDS))).toEqual([]);
+  });
+});
+
+describe('credential shape registry — surfaces carry their reason', () => {
+  const ALL: readonly string[] = [
+    'format-scan',
+    'vendor-alternation',
+    'ast-canonical',
+    'nanomind-redaction',
+  ];
+
+  it('a shape that does not reach every surface says why', () => {
+    const silent = CREDENTIAL_SHAPES.filter(
+      s => !ALL.every(surface => s.surfaces.has(surface as never)) && !s.rationale,
+    ).map(s => s.id);
+    expect(silent).toEqual([]);
+  });
+
+  it('the ast-canonical surface carries exactly 12 shapes', () => {
+    // Pinned so the count cannot move — in either direction — without a
+    // recorded decision. 22 shapes are known to this tree and 12 of them can
+    // produce a finding; that ten-shape gap is the whole of the detection
+    // half of this unit, and it is the number a reader should be able to cite.
+    expect(shapesFor('ast-canonical').length).toBe(12);
+  });
+
+  it('a rationale is a reason, not a restatement of the fact', () => {
+    // A shape's absence from a surface is either a measured decision or an
+    // undeclared gap, and the record has to say WHICH. The failure this pins
+    // is a rationale that reads like a finding while carrying no measurement —
+    // five shapes here once said "Absent from CANONICAL_CREDENTIAL_PATTERNS.
+    // Same one-at-a-time re-add", which restates the surface set the reader
+    // just looked at.
+    //
+    // Two rules. Every rationale cites a file:line, so it can be checked. And
+    // a rationale shared by more than one shape must announce that it is an
+    // UNDECLARED GAP rather than pose as a per-shape measurement.
+    const byRationale = new Map<string, string[]>();
+    for (const shape of CREDENTIAL_SHAPES) {
+      if (!shape.rationale) continue;
+      expect(shape.rationale, `${shape.id} rationale cites no file:line`).toMatch(/\.ts:\d+/);
+      byRationale.set(shape.rationale, [...(byRationale.get(shape.rationale) ?? []), shape.id]);
+    }
+    for (const [rationale, ids] of byRationale) {
+      if (ids.length === 1) continue;
+      expect(rationale, `${ids.join(', ')} share a rationale that claims to be measured`).toContain(
+        'UNDECLARED GAP',
+      );
+    }
+  });
+
+  it('the measured divergences are still the ones recorded', () => {
+    // These four are the deliberate, measured exclusions. If one of them
+    // becomes total, the reason it was excluded has been resolved or lost —
+    // either way this test is the place that says so.
+    expect(byId.get('gitlab-pat')!.surfaces.has('ast-canonical')).toBe(false);
+    expect(byId.get('jwt')!.surfaces.has('nanomind-redaction')).toBe(false);
+    expect(byId.get('sendgrid-key')!.surfaces.has('ast-canonical')).toBe(false);
+    expect(byId.get('entropy-blob')!.surfaces.has('nanomind-redaction')).toBe(false);
+  });
+});
+
+describe('credential key names', () => {
+  it('carries the union of the four live vocabularies', () => {
+    // Hand-written from the four sites, not imported from any of them:
+    //   scanner/detect.ts:496, scanner/permission-vocabulary.ts:415,
+    //   nanomind-core/security/defense-in-depth.ts:270,
+    //   semantic/structural/credential-context.ts:29
+    for (const name of [
+      'api_key',
+      'apikey',
+      'secret',
+      'token',
+      'password',
+      'passwd',
+      'pwd',
+      'authorization',
+      'key',
+      'client_secret',
+      'session_secret',
+      'db_password',
+    ]) {
+      expect(CREDENTIAL_KEY_NAMES, `missing ${name}`).toContain(name);
+    }
+  });
+
+  it('has no duplicates', () => {
+    expect(new Set(CREDENTIAL_KEY_NAMES).size).toBe(CREDENTIAL_KEY_NAMES.length);
+  });
+
+  it('the delimiter steps over no scheme word', () => {
+    // Every optional atom between the two `\s*` runs makes the pair ambiguous
+    // and the match quadratic: a `(?:bearer|basic|token)?` group here took
+    // `detect` from 0.25s to 51s on a 200 KB config.
+    const source = keyNameDelimiterPattern().source;
+    expect(source).toBe('\\s*[:=]\\s*["\']?');
+    expect(source.toLowerCase()).not.toContain('bearer');
+  });
+
+  it('returns a fresh RegExp each call', () => {
+    expect(keyNameDelimiterPattern()).not.toBe(keyNameDelimiterPattern());
+  });
+
+  it('matches the separators the live sites match', () => {
+    for (const sep of [': ', '=', ' = ', ':"', '= "']) {
+      expect(new RegExp(`^${keyNameDelimiterPattern().source}$`).test(sep), sep).toBe(true);
+    }
+  });
+});

--- a/__tests__/types/credential-vocabulary-enumeration.test.ts
+++ b/__tests__/types/credential-vocabulary-enumeration.test.ts
@@ -1,0 +1,194 @@
+/**
+ * E4 — the enumeration guard.
+ *
+ * The credential vocabulary was copied into fourteen-plus places over time, and
+ * every copy drifted: the redactor's hand-written body counts fell below the
+ * detector's floor, so a token was DETECTED and then forwarded verbatim. The
+ * registry makes the vocabulary enumerable. This test makes a NEW copy visible.
+ *
+ * It does not forbid a copy. It forbids a SILENT one: a new shape literal in a
+ * file that is not on the frozen allowlist fails here, and the author has to
+ * either take the shape from the registry or record, in the allowlist, why they
+ * did not.
+ *
+ * The guard vocabulary is derived from `CREDENTIAL_SHAPES` on purpose, so a
+ * shape added to the registry extends the guard in the same edit. The guards
+ * themselves are pinned by hand in `credential-shape-fixtures.ts`, which is
+ * what stops the guard being narrowed to see nothing.
+ */
+import { describe, it, expect } from 'vitest';
+import { existsSync } from 'node:fs';
+import { join, resolve } from 'node:path';
+import { CREDENTIAL_SHAPES } from '../../src/types/credential-format';
+import {
+  scanForCredentialLiterals,
+  UNOWNED_SHAPE_LITERALS,
+  REGISTRY_FILES,
+} from '../helpers/credential-literal-scan';
+
+const REPO_ROOT = resolve(__dirname, '..', '..');
+
+/**
+ * Both trees that ship or gate behaviour. `scripts/` is included because
+ * `scripts/release-smoke-corpus.ts` already reads finding evidence text and is
+ * the pre-publish gate — a shape table growing there would be exactly as
+ * invisible as one in `src`, and it currently carries none.
+ */
+const SCAN_ROOTS = [join(REPO_ROOT, 'src'), join(REPO_ROOT, 'scripts')];
+
+function scan(literals: readonly string[]): {
+  counts: Record<string, number>;
+  witnesses: Record<string, readonly string[]>;
+} {
+  const counts: Record<string, number> = {};
+  const witnesses: Record<string, readonly string[]> = {};
+  for (const root of SCAN_ROOTS) {
+    const r = scanForCredentialLiterals(REPO_ROOT, root, literals);
+    Object.assign(counts, r.counts);
+    Object.assign(witnesses, r.witnesses);
+  }
+  return { counts, witnesses };
+}
+
+/**
+ * THE FROZEN ALLOWLIST.
+ *
+ * Measured on `main` at `9a6fbc8` (published 0.31.0) by this file's own
+ * scanner, over the guard literals this file's own registry declares — so the
+ * baseline and the check are the same code path, which is the property the
+ * previous baseline lacked.
+ *
+ * That previous baseline — "17 files / 251 literals, scanner.ts alone has 49" —
+ * is real and re-runnable (its `rg` command reproduces exactly: 17 files, 251
+ * occurrences, 49 scanner.ts LINES), but it counts a different vocabulary: a
+ * hand-written pattern list that no code consumes, so a shape added to the
+ * registry does not extend it. The numbers here are lower for `src` and higher
+ * in coverage: per-file rather than per-tree, occurrences rather than lines,
+ * and derived from the registry. Both stand; they measure different things.
+ *
+ * Each entry is a file that carries a hand-written copy of a credential shape
+ * TODAY, with the number of guard-literal occurrences in it. The counts are
+ * ceilings. Adoption work is expected to drive them DOWN; nothing here may
+ * drive them up.
+ *
+ * The two large entries are the two the adoption step exists to remove:
+ * `scanner.ts` (95) holds four disagreeing shape tables, and
+ * `credential-analyzer.ts` (46) plus `defense-in-depth.ts` (27) plus
+ * `build-narrative.ts` (26) are the masking and redaction copies.
+ */
+const FROZEN_ALLOWLIST: Readonly<Record<string, number>> = {
+  'src/attack/payloads/a2a-attacks.ts': 2,
+  'src/attack/payloads/data-exfiltration.ts': 1,
+  'src/attack/payloads/mcp-exploitation.ts': 1,
+  'src/attack/payloads/memory-weaponization.ts': 1,
+  'src/attack/scanner.ts': 1,
+  'src/benchmarks/oasb-1.ts': 2,
+  'src/cli.ts': 4,
+  'src/hardening/coverage-ledger.ts': 2,
+  'src/hardening/nemoclaw-scanner.ts': 1,
+  'src/hardening/scanner.ts': 95,
+  'src/nanomind-core/analyzers/credential-analyzer.ts': 46,
+  'src/nanomind-core/compiler/semantic-compiler.ts': 32,
+  'src/nanomind-core/compiler/source-code-preprocessor.ts': 3,
+  'src/nanomind-core/ingestion/artifact-parser.ts': 6,
+  'src/nanomind-core/security/defense-in-depth.ts': 27,
+  'src/narrative/build-narrative.ts': 26,
+  'src/plugins/credvault.ts': 10,
+  'src/plugins/signcrypt.ts': 1,
+  'src/scanner/external-scanner.ts': 6,
+  'src/scanner/permission-vocabulary.ts': 13,
+  'src/semantic/structural/credential-context.ts': 15,
+  'src/semantic/structural/mcp-config.ts': 6,
+};
+
+const FROZEN_TOTAL = 301;
+
+function guardLiterals(): string[] {
+  return [...CREDENTIAL_SHAPES.flatMap(s => [...s.guards]), ...UNOWNED_SHAPE_LITERALS];
+}
+
+describe('E4 — credential vocabulary enumeration guard', () => {
+  it('the frozen total is the sum of the frozen entries', () => {
+    // Guards the constant against a copy-paste edit that updates one and not
+    // the other, which would make the total assertion below vacuous.
+    expect(Object.values(FROZEN_ALLOWLIST).reduce((a, b) => a + b, 0)).toBe(FROZEN_TOTAL);
+  });
+
+  it('no file outside the frozen allowlist carries a credential shape literal', () => {
+    const { counts, witnesses } = scan(guardLiterals());
+    const unlisted = Object.keys(counts)
+      .filter(f => !(f in FROZEN_ALLOWLIST))
+      .map(f => `${f} (${witnesses[f].join(' ')})`);
+    expect(
+      unlisted,
+      'A new credential shape literal appeared outside the registry. Take the shape from ' +
+        'CREDENTIAL_SHAPES, or add the file to FROZEN_ALLOWLIST with the reason it cannot.',
+    ).toEqual([]);
+  });
+
+  it('no allowlisted file grows', () => {
+    const { counts, witnesses } = scan(guardLiterals());
+    const grown = Object.keys(FROZEN_ALLOWLIST)
+      .filter(f => (counts[f] ?? 0) > FROZEN_ALLOWLIST[f])
+      .map(f => `${f}: ${FROZEN_ALLOWLIST[f]} -> ${counts[f]} (${witnesses[f]?.join(' ')})`);
+    expect(grown, 'A file gained credential shape literals.').toEqual([]);
+  });
+
+  it('the total never grows', () => {
+    const { counts } = scan(guardLiterals());
+    const total = Object.values(counts).reduce((a, b) => a + b, 0);
+    expect(total).toBeLessThanOrEqual(FROZEN_TOTAL);
+  });
+
+  it('every allowlisted file still exists', () => {
+    // A renamed file would otherwise appear as a new file (caught above) while
+    // its stale entry silently kept a budget alive for a path nobody reads.
+    const gone = Object.keys(FROZEN_ALLOWLIST).filter(f => !existsSync(join(REPO_ROOT, f)));
+    expect(gone).toEqual([]);
+  });
+
+  it('the guard vocabulary is derived from the registry, not hand-listed here', () => {
+    const literals = guardLiterals();
+    const fromRegistry = CREDENTIAL_SHAPES.flatMap(s => [...s.guards]);
+    expect(literals.slice(0, fromRegistry.length)).toEqual(fromRegistry);
+    expect(literals.length).toBe(fromRegistry.length + UNOWNED_SHAPE_LITERALS.length);
+  });
+
+  it('both trees are scanned, and scripts/ carries no shape literal today', () => {
+    expect(SCAN_ROOTS.map(r => r.replace(REPO_ROOT + '/', ''))).toEqual(['src', 'scripts']);
+    const scriptsOnly = scanForCredentialLiterals(
+      REPO_ROOT,
+      join(REPO_ROOT, 'scripts'),
+      guardLiterals(),
+    );
+    expect(Object.keys(scriptsOnly.counts)).toEqual([]);
+  });
+
+  it('the registry file is the only exclusion', () => {
+    expect(REGISTRY_FILES).toEqual(['src/types/credential-format.ts']);
+    expect(existsSync(join(REPO_ROOT, REGISTRY_FILES[0]))).toBe(true);
+  });
+
+  it('the scanner actually finds literals — a guard that finds nothing proves nothing', () => {
+    // Non-vacuity. If the walk broke, every assertion above would pass on an
+    // empty result set, which is the failure mode this whole file exists to
+    // prevent one level up.
+    const { counts } = scan(guardLiterals());
+    expect(Object.keys(counts).length).toBeGreaterThanOrEqual(20);
+    expect(counts['src/hardening/scanner.ts']).toBeGreaterThan(50);
+  });
+
+  it('the two unowned literals are each carried by exactly one file', () => {
+    // Shape literals in `src` that no detector in the tree knows about. If a
+    // second file picks one up, that is a new vocabulary and this reds.
+    expect(
+      Object.keys(scan(['ghr_']).counts),
+    ).toEqual(['src/scanner/permission-vocabulary.ts']);
+    expect(
+      Object.keys(scan(['nvapi-']).counts),
+    ).toEqual(['src/hardening/nemoclaw-scanner.ts']);
+    for (const literal of UNOWNED_SHAPE_LITERALS) {
+      expect(CREDENTIAL_SHAPES.some(s => s.guards.includes(literal)), literal).toBe(false);
+    }
+  });
+});

--- a/__tests__/types/redacted-evidence.test.ts
+++ b/__tests__/types/redacted-evidence.test.ts
@@ -1,0 +1,152 @@
+/**
+ * The citation gate's redaction rule.
+ *
+ * The pre-publish corpus harness asserts a finding's evidence appears on the
+ * line it cites. Redaction breaks a plain substring test, so the comparison is
+ * relaxed to the fragments either side of each marker — and the bug this file
+ * pins is that the relaxation used to be keyed on ONE literal spelling,
+ * `[REDACTED]`, while the tree emits four families.
+ *
+ * Every expectation here is a hand-written literal. Nothing derives an
+ * expectation from the implementation.
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  containsRedactionMarker,
+  evidenceCitationProblem,
+  isRedactionMarker,
+  redactionMarkerPattern,
+  splitOnRedactionMarkers,
+} from '../../src/types/redacted-evidence';
+import { CREDENTIAL_REDACTION_MARKERS } from '../../src/types/credential-format';
+
+const LINE = 'DATABASE_URL=postgres://admin:hunter2xyzzy@db.internal:5432/app';
+
+describe('redaction marker recognition — one rule per spelling', () => {
+  it('recognises every spelling the tree emits', () => {
+    for (const marker of [
+      '[REDACTED]',
+      '[REDACTED_GITHUB_TOKEN]',
+      '[REDACTED_AWS_SECRET]',
+      '[REDACTED_CONNECTION_STRING]',
+      '[REDACTED_META_INSTRUCTION]',
+      '[redacted]',
+      '[redacted-jwt]',
+    ]) {
+      expect(isRedactionMarker(marker), marker).toBe(true);
+    }
+  });
+
+  it('does not treat any bracketed token as a marker', () => {
+    // The negative control. Without it, a pattern of `\[.*\]` would pass every
+    // assertion above while waving through arbitrary evidence.
+    for (const notAMarker of [
+      '[REDACT]',
+      '[REDACTED_lowercase]',
+      '[Redacted]',
+      '[redacted_underscore]',
+      '[]',
+      'REDACTED',
+      '[REDACTED_GITHUB_TOKEN',
+    ]) {
+      expect(isRedactionMarker(notAMarker), notAMarker).toBe(false);
+    }
+  });
+
+  it('every registry marker is recognised by the citation gate', () => {
+    // The link that keeps the two vocabularies honest: a marker added to the
+    // registry works with the gate on the same edit, or this reds.
+    for (const [id, marker] of Object.entries(CREDENTIAL_REDACTION_MARKERS)) {
+      expect(isRedactionMarker(marker), `${id} -> ${marker}`).toBe(true);
+    }
+  });
+
+  it('returns a fresh pattern each call, so a g-flag lastIndex cannot leak', () => {
+    expect(redactionMarkerPattern()).not.toBe(redactionMarkerPattern());
+    // Called twice on the same input, the answer must not change. A shared
+    // g-flagged instance would return true then false.
+    const text = 'token=[REDACTED_GITHUB_TOKEN]';
+    expect(containsRedactionMarker(text)).toBe(true);
+    expect(containsRedactionMarker(text)).toBe(true);
+  });
+
+  it('splits on every marker family', () => {
+    expect(splitOnRedactionMarkers('a=[REDACTED_AWS_KEY] b=[redacted] c')).toEqual([
+      'a=',
+      ' b=',
+      ' c',
+    ]);
+  });
+});
+
+describe('evidence citation — un-redacted', () => {
+  it('accepts evidence that is on the cited line', () => {
+    expect(evidenceCitationProblem('postgres://admin', LINE)).toBeUndefined();
+  });
+
+  it('rejects evidence that is not on the cited line', () => {
+    expect(evidenceCitationProblem('mysql://admin', LINE)).toEqual({ kind: 'evidence-absent' });
+  });
+
+  it('ignores empty evidence rather than failing on it', () => {
+    expect(evidenceCitationProblem('   ', LINE)).toBeUndefined();
+  });
+});
+
+describe('evidence citation — redacted', () => {
+  it('accepts a BARE marker with surrounding context — the case that already worked', () => {
+    expect(
+      evidenceCitationProblem('DATABASE_URL=postgres://admin:[REDACTED]@db.internal:5432/app', LINE),
+    ).toBeUndefined();
+  });
+
+  it('accepts a TYPED marker with surrounding context — the case that used to fail', () => {
+    // This is the regression. Pre-fix, the gate tested
+    // `ev.includes('[REDACTED]')`, which is false for a typed marker, so this
+    // fell through to the strict substring branch and compared a redacted
+    // string against the raw file line: a FAIL on a finding citing its line
+    // correctly, on the gate that must be green before any publish.
+    expect(
+      evidenceCitationProblem(
+        'DATABASE_URL=postgres://admin:[REDACTED_CONNECTION_STRING]@db.internal:5432/app',
+        LINE,
+      ),
+    ).toBeUndefined();
+  });
+
+  it('accepts the LOWERCASE markers — the other family that used to fail', () => {
+    expect(
+      evidenceCitationProblem('DATABASE_URL=postgres://admin:[redacted]@db.internal:5432/app', LINE),
+    ).toBeUndefined();
+    expect(
+      evidenceCitationProblem('DATABASE_URL=postgres://admin:[redacted-jwt]@db.internal', LINE),
+    ).toBeUndefined();
+  });
+
+  it('still rejects evidence that is nothing but a marker, in every family', () => {
+    for (const marker of ['[REDACTED]', '[REDACTED_GITHUB_TOKEN]', '[redacted]']) {
+      expect(evidenceCitationProblem(marker, LINE), marker).toEqual({ kind: 'pure-marker' });
+    }
+  });
+
+  it('still rejects a fragment that is not on the cited line', () => {
+    expect(
+      evidenceCitationProblem('MYSQL_URL=mysql://admin:[REDACTED_AWS_KEY]@db.internal', LINE),
+    ).toEqual({ kind: 'missing-segment', missing: 'MYSQL_URL=mysql://admin:' });
+  });
+
+  it('checks EVERY fragment, not just the first', () => {
+    // The multi-redaction defence. The first fragment is on the line and the
+    // second is not; a first-segment-only check passes this.
+    expect(
+      evidenceCitationProblem(
+        'DATABASE_URL=[REDACTED_GITHUB_TOKEN]@nowhere.invalid:[REDACTED]/app',
+        LINE,
+      ),
+    ).toEqual({ kind: 'missing-segment', missing: '@nowhere.invalid:' });
+  });
+
+  it('accepts a marker at the very end with context before it', () => {
+    expect(evidenceCitationProblem('DATABASE_URL=[REDACTED_SECRET]', LINE)).toBeUndefined();
+  });
+});

--- a/__tests__/ui/clamp-scope.test.ts
+++ b/__tests__/ui/clamp-scope.test.ts
@@ -239,7 +239,11 @@ describe('H-7: no published surface computes a composite without the clamp', () 
           /^return calculateSecurityScore\(findings\);$/.test(trimmed)
           && lines
             .slice(Math.max(0, i - 6), i)
-            .some((l) => /calculateScore\(findings: SecurityFinding\[\]\)/.test(l))
+            // `SecurityFindingDraft[]`, not `SecurityFinding[]`: the accessor
+            // moved to the draft type when the redaction boundary landed, and
+            // this anchor is deliberately EXACT — matching the type name loosely
+            // is how it would become the hole the comment above warns about.
+            .some((l) => /calculateScore\(findings: SecurityFindingDraft\[\]\)/.test(l))
         ) return;
         const window = stripComments(lines.slice(i, i + LOOKAHEAD).join('\n'));
         if (window.includes('clampScoreToVerdictBand')) return;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "hackmyagent",
-  "version": "0.31.0",
+  "version": "0.32.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "hackmyagent",
-      "version": "0.31.0",
+      "version": "0.32.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.30.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hackmyagent",
-  "version": "0.31.0",
+  "version": "0.32.0",
   "description": "Find it. Break it. Fix it. The hacker's toolkit for AI agents.",
   "bin": {
     "hackmyagent": "dist/cli.js"

--- a/scripts/release-smoke-corpus.ts
+++ b/scripts/release-smoke-corpus.ts
@@ -24,6 +24,7 @@ import { readFileSync, existsSync, statSync, readdirSync } from 'node:fs';
 import { homedir } from 'node:os';
 import { dirname, join, resolve } from 'node:path';
 import yaml from 'js-yaml';
+import { evidenceCitationProblem } from '../src/types/redacted-evidence';
 
 interface ExpectedFinding {
   checkId: string;
@@ -191,34 +192,29 @@ function verifyAssertions(fixtureDir: string, findings: RawFinding[]): string[] 
     const evLine = firstEvidenceLine(f);
     if (evLine && evLine.content) {
       const ev = evLine.content.trim();
-      // Some detectors (SEM-CRED-001) redact secret values in evidence
-      // text so credentials don't leak into logs / diffs. Compare on the
-      // pre-redaction prefix and post-redaction suffix instead of the
-      // full string. The line-existence check above already gates that
-      // the cited position is real; this just relaxes the substring
-      // match for redacted evidence.
-      if (ev.includes('[REDACTED]')) {
-        // Split on every redaction marker and require that *every*
-        // non-empty segment appears in lineContent. A pure-`[REDACTED]`
-        // evidence string yields all-empty segments and fails — that's a
-        // bug at the emit site, not a tolerable redaction. Verifying
-        // every segment also defends against multi-redaction strings
-        // where only the first segment was previously checked.
-        const segments = ev.split('[REDACTED]');
-        const nonEmpty = segments.filter(s => s !== '');
-        if (nonEmpty.length === 0) {
-          reasons.push(
-            `verify: ${f.checkId} cites ${f.file}:${f.line} — evidence is pure '[REDACTED]' marker with no surrounding content; emit site must include literal context around the redaction`,
-          );
-        } else {
-          const missing = nonEmpty.find(s => !lineContent.includes(s));
-          if (missing !== undefined) {
-            reasons.push(
-              `verify: ${f.checkId} cites ${f.file}:${f.line} — line content doesn't include redacted-evidence segment (line=${JSON.stringify(lineContent.slice(0, 60))}, missing=${JSON.stringify(missing.slice(0, 60))})`,
-            );
-          }
-        }
-      } else if (!lineContent.includes(ev)) {
+      // Detectors redact secret values in evidence text so credentials
+      // don't leak into logs / diffs, so compare on the fragments either
+      // side of each marker rather than on the full string. The
+      // line-existence check above already gates that the cited position
+      // is real; this only relaxes the substring match, and every
+      // non-empty fragment must still be on the line.
+      //
+      // The marker vocabulary lives in src/types/redacted-evidence.ts and
+      // is a SHAPE, not a literal. It used to be the single literal
+      // `[REDACTED]`, which recognised one of the four marker families the
+      // tree emits — `'[REDACTED_GITHUB_TOKEN]'.includes('[REDACTED]')` is
+      // false — so any typed or lowercase marker failed this gate while
+      // citing its line correctly.
+      const problem = evidenceCitationProblem(ev, lineContent);
+      if (problem?.kind === 'pure-marker') {
+        reasons.push(
+          `verify: ${f.checkId} cites ${f.file}:${f.line} — evidence is a redaction marker with no surrounding content; emit site must include literal context around the redaction`,
+        );
+      } else if (problem?.kind === 'missing-segment') {
+        reasons.push(
+          `verify: ${f.checkId} cites ${f.file}:${f.line} — line content doesn't include redacted-evidence segment (line=${JSON.stringify(lineContent.slice(0, 60))}, missing=${JSON.stringify(problem.missing.slice(0, 60))})`,
+        );
+      } else if (problem?.kind === 'evidence-absent') {
         reasons.push(
           `verify: ${f.checkId} cites ${f.file}:${f.line} — line content doesn't include evidence (line=${JSON.stringify(lineContent.slice(0, 60))}, evidence=${JSON.stringify(ev.slice(0, 60))})`,
         );

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -290,7 +290,8 @@ import {
   UNREACHABLE_PREFIXES,
   type CategoryCoverage,
 } from './hardening/coverage-ledger';
-import type { ScanResult, SuppressionChannel } from './hardening/security-check';
+import type { ScanResult, SuppressionChannel, SecurityFindingDraft } from './hardening/security-check';
+import { emitFindings } from './hardening/finding-emit';
 import { compareFindingsByTier } from './ui/finding-tier';
 import {
   scoreLineLabel,
@@ -1572,7 +1573,28 @@ function displayUnifiedCheck(opts: UnifiedCheckDisplayOptions): void {
     medium = gatedIssues.filter(f => f.severity === 'medium').length;
     low = gatedIssues.filter(f => f.severity === 'low').length;
     verdictInput = gatedIssues as any;
-    failed = issues.map(f => ({
+    // `check`'s NanoMind re-map, on the TEXT path only.
+    //
+    // This emit does NOT cover `check --json`, and an earlier comment here said
+    // it did. `--json` returns above, before `displayUnifiedCheck` is ever
+    // called, so no line in this function is on the JSON channel. What actually
+    // covers `check` on both channels is upstream: `mergeFindings` builds every
+    // finding through `astFindingToSecurityFinding`, which emits, and `check`
+    // passes an EMPTY static set, so nothing reaches either channel unemitted.
+    //
+    // Stated this way because the previous wording named the one channel the
+    // code cannot reach, which is the same defect as the false depth-cap
+    // comment this release deletes: a comment that tells the next reader not to
+    // look is worse than no comment. The coverage above is also incidental —
+    // nothing here requires it — so it is pinned by a test rather than trusted
+    // (`__tests__/hardening/finding-emit.test.ts`, the `mergeFindings` block).
+    //
+    // KNOWN, ruled OUT of 0.32.0 and carried to the hardening unit: this re-map
+    // lists its fields by name and does not copy `redactionStatus` /
+    // `redactedShapes`, so re-emitting downgrades an honest `applied` to
+    // `clean`. Inert today — the field has no consumers and `failed` never
+    // reaches the JSON channel — but it is defect (1)'s false-clean class.
+    failed = emitFindings(issues.map(f => ({
       checkId: f.checkId || '',
       name: f.name || f.description || '',
       description: f.description || '',
@@ -1586,7 +1608,7 @@ function displayUnifiedCheck(opts: UnifiedCheckDisplayOptions): void {
       fix: f.fix,
       guidance: f.guidance,
       attackClass: f.attackClass,
-    }));
+    })));
     // Use the canonical scoring formula (exponential decay + 0.4x governance weight)
     //
     // #457 — `gatedIssues`, not `issues`. The counts, the verdict and the exit
@@ -4333,8 +4355,10 @@ async function handleSoulContribution(
   registryUrl?: string,
   format?: string,
 ): Promise<void> {
-  // Convert soul controls into SecurityFinding-shaped objects
-  const findings: SecurityFinding[] = [];
+  // Convert soul controls into SecurityFinding-shaped objects.
+  // A draft accumulator: these are emitted at the `handleContribution` call
+  // below, which publishes them to the Registry.
+  const findings: SecurityFindingDraft[] = [];
   for (const domain of result.domains) {
     if (domain.skippedByProfile || domain.skippedByTier) continue;
     for (const ctrl of domain.controls) {
@@ -4351,7 +4375,7 @@ async function handleSoulContribution(
     }
   }
 
-  await handleContribution(contributeFlag, targetDir, findings, durationMs, registryUrl, format);
+  await handleContribution(contributeFlag, targetDir, emitFindings(findings), durationMs, registryUrl, format);
 }
 
 program
@@ -4692,7 +4716,12 @@ Examples:
         // printed `CONFIG-004 (critical x2)` for a single occurrence.
         result.suppressed = scanner.lastSuppressed.length > 0 ? scanner.lastSuppressed : undefined;
         if (result.allFindings) {
-          result.allFindings = refiltered as typeof result.allFindings;
+          // No cast. `reapplyIgnoreFilters` is generic over the finding type and
+          // only marks and filters, so `refiltered` is still branded and assigns
+          // directly. A cast here would have compiled just as quietly while
+          // laundering the boundary guarantee at the one point downstream of it
+          // that rebuilds both channels.
+          result.allFindings = refiltered;
         }
         if (result.findings) {
           // Re-apply the same gates as the original filter:
@@ -4707,9 +4736,9 @@ Examples:
           // `countsAgainstScore` ran a few lines below, so the score was
           // recomputed from a list the unverified fix had been removed from.
           const projectType = result.projectType || 'library';
-          result.findings = refiltered.filter((f: any) =>
+          result.findings = refiltered.filter((f) =>
             scanner.isReportableFinding(f, projectType)
-          ) as typeof result.findings;
+          );
         }
         // Re-apply CLI --ignore list (reapplyIgnoreFilters only covers .hmaignore file rules)
         //
@@ -4734,7 +4763,7 @@ Examples:
                 .map((f: any) => ({ ...f, suppressed: true, suppressedBy: 'ignore-flag' })),
             ]);
           }
-          result.findings = (result.findings || []).filter((f: any) => !hit(f)) as typeof result.findings;
+          result.findings = (result.findings || []).filter((f: any) => !hit(f));
           if (result.allFindings) {
             result.allFindings = result.allFindings.filter((f: any) => !hit(f));
           }
@@ -5931,7 +5960,15 @@ Examples:
         const nmResult = await orchestrateNanoMind(targetDir, result.findings, { silent: !!options.json, projectType: result.projectType });
         // Re-apply .hmaignore filters and recalculate score after NanoMind merge
         const hRefiltered = await scanner.reapplyIgnoreFilters(nmResult.mergedFindings, targetDir, result.projectType || 'library');
-        result.findings = hRefiltered as typeof result.findings;
+        // `mergedFindings` is `SecurityFindingDraft[]`: NanoMind returns the
+        // findings it was given PLUS ones it created, and the created ones have
+        // never crossed the boundary. Casting the array into `RedactedFinding[]`
+        // published them unredacted while the brand said otherwise — which is
+        // the whole failure the brand exists to prevent. Emitting is correct
+        // rather than merely type-safe: re-emitting an already-emitted finding
+        // is a no-op on text, and `applied` is absorbing, so the ones that came
+        // from `result.findings` keep their honest status.
+        result.findings = emitFindings(hRefiltered);
         const hForScore = hRefiltered.filter((f: any) => countsAgainstScore(f));
         scanner.applyScore(result, hForScore);
       } catch { /* NanoMind unavailable */ }
@@ -6181,7 +6218,7 @@ Examples:
       try {
         const { orchestrateNanoMind } = await import('./nanomind-core/orchestrate.js');
         const nmResult = await orchestrateNanoMind(targetDir, findings, { silent: !!options.json });
-        mergedFindings = nmResult.mergedFindings as typeof findings;
+        mergedFindings = emitFindings(nmResult.mergedFindings);
       } catch { /* NanoMind unavailable */ }
 
       // Re-apply .hmaignore filtering after NanoMind merge (paths + check IDs)
@@ -11586,8 +11623,19 @@ function isAiToolingFile(filePath: string): boolean {
  * and build file findings. Mutates `result.findings` in place and
  * recalculates the score.
  */
+/**
+ * Takes `Pick<ScanResult, …>` and NOT a structural `{ findings: SecurityFinding[] }`.
+ *
+ * The structural version was the worst site in this class precisely because it
+ * had no cast to grep for: a `ScanResult` satisfies it by covariance, the
+ * parameter then re-binds `findings` to an UNBRANDED `SecurityFinding[]`, and
+ * the write-back laundered the array in silence. It is the last mutator before
+ * four `--json` payloads, so the brand was being erased one step before publish
+ * with nothing in the source to notice. Naming `ScanResult` keeps the element
+ * type branded through both the read and the write.
+ */
 function filterLocalOnlyFindings(
-  result: { findings: SecurityFinding[]; score: number; maxScore: number },
+  result: Pick<ScanResult, 'findings' | 'score' | 'maxScore'>,
   scanner: HardeningScanner,
 ): void {
   result.findings = result.findings.filter(f => {
@@ -11901,9 +11949,9 @@ async function checkGitHubRepo(
       const nmResult = await orchestrateNanoMind(repoDir, result.findings, { silent: true, nanomind: resolveNanomindFlag(options), findingVisible: (f) => scanner.findingAppliesTo(f, result.projectType || 'library') });
       const refiltered = await scanner.reapplyIgnoreFilters(nmResult.mergedFindings, repoDir, result.projectType || 'library');
       const projectType = result.projectType || 'library';
-      result.findings = refiltered.filter((f: any) =>
-        scanner.isReportableFinding(f, projectType)
-      ) as typeof result.findings;
+      result.findings = emitFindings(
+        refiltered.filter((f: any) => scanner.isReportableFinding(f, projectType)),
+      );
       scanner.applyScore(result, result.findings.filter((f: any) => countsAgainstScore(f)));
       analystFindings = nmResult.analystFindings;
       analystZeroState = nmResult.analystZeroState;
@@ -12235,9 +12283,9 @@ async function checkPyPiPackage(
       const nmResult = await orchestrateNanoMind(extractDir, result.findings, { silent: true, nanomind: resolveNanomindFlag(options), findingVisible: (f) => scanner.findingAppliesTo(f, result.projectType || 'library') });
       const refiltered = await scanner.reapplyIgnoreFilters(nmResult.mergedFindings, extractDir, result.projectType || 'library');
       const projectType = result.projectType || 'library';
-      result.findings = refiltered.filter((f: any) =>
-        scanner.isReportableFinding(f, projectType)
-      ) as typeof result.findings;
+      result.findings = emitFindings(
+        refiltered.filter((f: any) => scanner.isReportableFinding(f, projectType)),
+      );
       scanner.applyScore(result, result.findings.filter((f: any) => countsAgainstScore(f)));
       analystFindings = nmResult.analystFindings;
       analystZeroState = nmResult.analystZeroState;
@@ -12448,9 +12496,9 @@ async function checkRawUrl(
       const nmResult = await orchestrateNanoMind(scanDir, result.findings, { silent: true, nanomind: resolveNanomindFlag(options), findingVisible: (f) => scanner.findingAppliesTo(f, result.projectType || 'library') });
       const refiltered = await scanner.reapplyIgnoreFilters(nmResult.mergedFindings, scanDir, result.projectType || 'library');
       const projectType = result.projectType || 'library';
-      result.findings = refiltered.filter((f: any) =>
-        scanner.isReportableFinding(f, projectType)
-      ) as typeof result.findings;
+      result.findings = emitFindings(
+        refiltered.filter((f: any) => scanner.isReportableFinding(f, projectType)),
+      );
       scanner.applyScore(result, result.findings.filter((f: any) => countsAgainstScore(f)));
       analystFindings = nmResult.analystFindings;
       analystZeroState = nmResult.analystZeroState;
@@ -12632,9 +12680,9 @@ async function checkNpmPackage(
       const nmResult = await orchestrateNanoMind(packageDir, result.findings, { silent: true, nanomind: resolveNanomindFlag(options), findingVisible: (f) => scanner.findingAppliesTo(f, result.projectType || 'library') });
       const refiltered = await scanner.reapplyIgnoreFilters(nmResult.mergedFindings, packageDir, result.projectType || 'library');
       const projectType = result.projectType || 'library';
-      result.findings = refiltered.filter((f: any) =>
-        scanner.isReportableFinding(f, projectType)
-      ) as typeof result.findings;
+      result.findings = emitFindings(
+        refiltered.filter((f: any) => scanner.isReportableFinding(f, projectType)),
+      );
       scanner.applyScore(result, result.findings.filter((f: any) => countsAgainstScore(f)));
       analystFindings = nmResult.analystFindings;
       analystZeroState = nmResult.analystZeroState;

--- a/src/hardening/finding-emit.ts
+++ b/src/hardening/finding-emit.ts
@@ -1,0 +1,364 @@
+/**
+ * The credential redaction boundary.
+ *
+ * RIDER B1 (CA): the boundary is `SecurityFinding` CONSTRUCTION — the last
+ * construction before any channel, the first construction after every
+ * derivation. `ASTFinding` and `SemanticFinding` stay raw in process because
+ * line derivation reads them.
+ *
+ * It is at construction and not at serialization because `package.json` declares
+ * 13 subpath exports: a library consumer receives `SecurityFinding` OBJECTS that
+ * never touch a serializer, so a serialization boundary leaves the library
+ * surface leaking by construction.
+ *
+ * C1 — line derivation completes BEFORE any redaction of finding text. That
+ * ordering is structural here rather than asserted: `emitFinding` takes a draft
+ * whose `line` is already resolved and never consults finding text to locate
+ * anything, so there is no path on which redaction could run first.
+ */
+
+import type { Evidence, PositiveEvidence, AbsenceEvidence } from '../types/finding-evidence';
+import type { ShapeId } from '../types/credential-format';
+import type { SecurityFinding, SecurityFindingDraft } from './security-check';
+import { redactSecretsForReportReporting } from '../nanomind-core/security/defense-in-depth';
+
+/**
+ * Unforgeable witness that a finding passed the boundary.
+ *
+ * NOT exported, and that is the whole mechanism: a `unique symbol` declared in
+ * this module cannot be named by any other module, so no code outside this file
+ * can build a value of type `RedactedFinding`. `emitFinding` is therefore the
+ * only constructor, enforced by the compiler rather than by review.
+ */
+declare const REDACTION_WITNESS: unique symbol;
+
+/**
+ * A `SecurityFinding` that has passed the redaction boundary (C10).
+ *
+ * The brand and the two runtime fields are complementary, which is why D3 ships
+ * both: the brand catches an unwired site at COMPILE time and reaches the 13
+ * subpath exports, where a consumer holds an object and no JSON field reaches
+ * them at all; the fields catch at RUNTIME what a type cannot — a site that
+ * satisfies the type by casting, and the honest reporting of a finding that was
+ * never examined.
+ */
+export type RedactedFinding = SecurityFinding & {
+  readonly [REDACTION_WITNESS]: true;
+};
+
+/**
+ * The byte-carrying string fields of a finding.
+ *
+ * `rationale.plainEnglish` is handled separately below and is NOT optional
+ * despite being absent from the settlement brief's field list (§3.2). That
+ * omission is a hole, not a simplification: `finding-adapter.ts:87` assigns
+ * `finding.rationale` to `message` and `:98` assigns THE SAME STRING to
+ * `rationale.plainEnglish`, so redacting `message` alone leaves the identical
+ * bytes on a second field of the same object.
+ */
+const BYTE_CARRYING_FIELDS = [
+  'name',
+  'message',
+  'description',
+  'fix',
+  'manualFix',
+  'guidance',
+  'fixMessage',
+] as const satisfies readonly (keyof SecurityFindingDraft)[];
+
+/** Accumulates redaction outcomes across every field of one finding. */
+class RedactionPass {
+  private changed = false;
+  private readonly shapes = new Set<ShapeId>();
+
+  /** Redact one string; undefined passes through so optional fields stay optional. */
+  run<T extends string | undefined>(value: T): T {
+    if (value === undefined) return value;
+    const { text, shapes } = redactSecretsForReportReporting(value);
+    if (text !== value) this.changed = true;
+    for (const s of shapes) this.shapes.add(s);
+    return text as T;
+  }
+
+  /**
+   * Record that content was altered for safety without a rule having matched.
+   *
+   * The recursion backstop below uses this: it drops a subtree it declined to
+   * walk, and a dropped subtree must never be reported as `'clean'`.
+   */
+  markChanged(): void {
+    this.changed = true;
+  }
+
+  get status(): 'applied' | 'clean' {
+    return this.changed ? 'applied' : 'clean';
+  }
+
+  /** Sorted and deduped, per the frozen field contract. */
+  get resolvedShapes(): readonly ShapeId[] {
+    return [...this.shapes].sort();
+  }
+}
+
+/**
+ * A list sub-field as the walker will treat it: the value if it really is an
+ * array, otherwise empty.
+ *
+ * `?? []` is NOT sufficient here and that is the whole reason this exists. It
+ * guards `null` and `undefined` only, so a producer that writes a STRING (or a
+ * number, or a bare object) to `lines` or `expected` still reaches `.map`, and
+ * `.map is not a function` throws out of `redactEvidence` exactly as the
+ * missing-field crash did. A malformed evidence object must cost its own
+ * finding's evidence, never the whole scan.
+ */
+function asArray<T>(value: unknown): T[] {
+  return Array.isArray(value) ? (value as T[]) : [];
+}
+
+/** Walk the three `Evidence` variants, redacting every byte-carrying leaf. */
+function redactEvidence(evidence: Evidence, pass: RedactionPass): Evidence {
+  // Every sub-field read below is optional-chained, and that is not defensive
+  // habit. `Evidence` describes what a well-formed producer writes; it does not
+  // constrain what actually arrives, because `ScanOptions.semanticPass` is a
+  // PUBLIC hook and its output reaches here untyped at runtime. A malformed
+  // shape used to throw out of `redactEvidence`, and `scan()`'s return has no
+  // try/catch around it, so one bad evidence object aborted the entire scan —
+  // a crash introduced by the boundary, on input that was previously inert.
+  switch (evidence.kind) {
+    case 'positive':
+      return {
+        kind: 'positive',
+        lines: asArray<PositiveEvidence['lines'][number]>(evidence.lines).map(l => ({
+          n: l?.n,
+          content: pass.run(l?.content),
+          why: pass.run(l?.why),
+        })) as PositiveEvidence['lines'],
+      };
+    case 'absence':
+      return {
+        kind: 'absence',
+        observed: {
+          lines: asArray<AbsenceEvidence['observed']['lines'][number]>(evidence.observed?.lines).map(l => ({
+            n: l?.n,
+            content: pass.run(l?.content),
+          })) as AbsenceEvidence['observed']['lines'],
+          summary: pass.run(evidence.observed?.summary),
+        },
+        // `rationale` here is the constraint's rationale — prose the CHECK
+        // wrote about a missing defense, never bytes read out of the artifact.
+        // Redacted anyway: a rule that exempts a field by provenance is a rule
+        // an attacker can aim at, and the cost of redacting our own prose is a
+        // mangled token in text nobody templates a credential into.
+        expected: asArray<AbsenceEvidence['expected'][number]>(evidence.expected).map(e => ({
+          constraint: e?.constraint,
+          rationale: pass.run(e?.rationale),
+        })) as AbsenceEvidence['expected'],
+      };
+    case 'mixed':
+      return {
+        kind: 'mixed',
+        positive: {
+          lines: asArray<PositiveEvidence['lines'][number]>(evidence.positive?.lines).map(l => ({
+            n: l?.n,
+            content: pass.run(l?.content),
+            why: pass.run(l?.why),
+          })) as PositiveEvidence['lines'],
+        },
+        absence: {
+          observed: {
+            lines: asArray<AbsenceEvidence['observed']['lines'][number]>(evidence.absence?.observed?.lines).map(l => ({
+              n: l?.n,
+              content: pass.run(l?.content),
+            })) as AbsenceEvidence['observed']['lines'],
+            summary: pass.run(evidence.absence?.observed?.summary),
+          },
+          expected: asArray<AbsenceEvidence['expected'][number]>(evidence.absence?.expected).map(e => ({
+            constraint: e?.constraint,
+            rationale: pass.run(e?.rationale),
+          })) as AbsenceEvidence['expected'],
+        },
+      };
+    default:
+      // An unrecognised `kind` FAILS CLOSED.
+      //
+      // Returning `undefined` — which is what a `switch` with no `default` does
+      // — failed open in both directions at once: it silently DELETED the
+      // evidence, and because no rule had matched, the finding then reported
+      // `redactionStatus: 'clean'` over the deletion. Losing evidence and
+      // claiming cleanliness are each worse than the leak this boundary exists
+      // to close.
+      //
+      // `redactDetails` is the right fallback precisely because it assumes no
+      // shape: it rebuilds the object key by key, so the discriminant and every
+      // other field survive, and it redacts every string leaf at any depth. A
+      // variant added to `Evidence` later is therefore redacted from the day it
+      // exists rather than from the day someone remembers to add a case here.
+      return redactDetails(evidence, pass) as Evidence;
+  }
+}
+
+/**
+ * `details` is `Record<string, unknown>` — an open bag, so it cannot be walked
+ * by a field list. Every string leaf is redacted at any depth.
+ *
+ * Open-bag totality matters more here than anywhere else: `details.evidence` is
+ * one of the four measured JSON leak paths, and the next producer to put a
+ * credential in `details` will not think to add it to a list.
+ */
+/** A `{}`-shaped object: safe to rebuild key by key without losing structure. */
+function isPlainObject(v: unknown): v is Record<string, unknown> {
+  if (v === null || typeof v !== 'object') return false;
+  const proto = Object.getPrototypeOf(v);
+  return proto === Object.prototype || proto === null;
+}
+
+/**
+ * What replaces a container the walk declines to descend into.
+ *
+ * A placeholder rather than the value itself: returning the container verbatim
+ * is what made the previous depth cap a leak path, because every string inside
+ * it was published without ever being offered to the redactor.
+ */
+const CYCLE_PLACEHOLDER = '[CYCLE]';
+const UNWALKED_PLACEHOLDER = '[REDACTED_UNWALKED]';
+
+/**
+ * A depth no honest `details` bag reaches, so this never fires on real data.
+ *
+ * It is not the cycle guard — `ancestors` is. It is a stack backstop, and it
+ * exists because unbounded recursion inside `emitFinding` would throw a
+ * `RangeError` from `scan()`'s return, which is the same crash-the-whole-scan
+ * failure mode as the malformed-evidence defect two functions up.
+ */
+const MAX_DETAILS_DEPTH = 200;
+
+function redactDetails(
+  value: unknown,
+  pass: RedactionPass,
+  ancestors: WeakSet<object> = new WeakSet(),
+  depth = 0,
+): unknown {
+  // A string is redacted at ANY depth, and it is checked FIRST so that no
+  // guard below can return a string verbatim.
+  if (typeof value === 'string') return pass.run(value);
+
+  const isContainer = Array.isArray(value) || isPlainObject(value);
+  if (isContainer) {
+    const container = value as object;
+    // The real cycle guard: membership of the CURRENT PATH, not of everything
+    // ever seen. A visited-set would replace a legitimately shared sibling
+    // reference with a placeholder, which is silent data loss on a DAG; only an
+    // ancestor repeating is a cycle.
+    if (ancestors.has(container)) {
+      // No bytes are lost: the ancestor this points back at was already walked
+      // and every string under it was already offered to the redactor.
+      return CYCLE_PLACEHOLDER;
+    }
+    if (depth >= MAX_DETAILS_DEPTH) {
+      // Declining to walk is a modification, and the status must say so. This
+      // is the line that stops a deep bag from reporting `'clean'` over content
+      // the boundary never examined.
+      pass.markChanged();
+      return UNWALKED_PLACEHOLDER;
+    }
+
+    ancestors.add(container);
+    try {
+      if (Array.isArray(value)) {
+        return value.map(v => redactDetails(v, pass, ancestors, depth + 1));
+      }
+      const out: Record<string, unknown> = {};
+      for (const [k, v] of Object.entries(value as Record<string, unknown>)) {
+        out[k] = redactDetails(v, pass, ancestors, depth + 1);
+      }
+      return out;
+    } finally {
+      // Leaving the path. Without this the set would behave as a visited-set
+      // and collapse shared references, per the note above.
+      ancestors.delete(container);
+    }
+  }
+  // Non-plain objects (`Date`, `Map`, `Set`, class instances) are returned
+  // UNCHANGED rather than rebuilt. Rebuilding them from `Object.entries` is
+  // silent data loss — that yields `[]` for all three, so a `Date` in `details`
+  // would serialize as `{}` where it previously became an ISO string.
+  //
+  // Measured: nothing in the tree puts a non-plain object in `details` today, so
+  // this is a guard against a future producer, not a live path. If one is added
+  // and it can carry credential bytes, it needs handling HERE — passing through
+  // is safe only while the class carries no body text.
+  return value;
+}
+
+/**
+ * Run the redaction boundary over one draft and stamp the two always-present
+ * fields.
+ *
+ * Returns a NEW object; the draft is never mutated, so a caller holding the
+ * draft for its own bookkeeping does not observe redaction applied under it.
+ */
+export function emitFinding(draft: SecurityFindingDraft): RedactedFinding {
+  const pass = new RedactionPass();
+
+  // A value that has ALREADY crossed the boundary can arrive here: several
+  // producers are public exports (`scanAssembly` at `src/index.ts:47`) and must
+  // emit for their library consumers, and their output is then rebuilt by an
+  // internal caller further down.
+  //
+  // Redaction is idempotent on TEXT — a marker matches no rule — but NOT on the
+  // status: a second pass finds nothing to change and would conclude `'clean'`
+  // for a finding that really was redacted, downgrading an honest `'applied'`
+  // into a false assertion of cleanliness. Applied is therefore absorbing, and
+  // shapes accumulate across passes.
+  //
+  // Read off the runtime value rather than the type: `SecurityFindingDraft`
+  // omits these fields, but structural typing lets a full `SecurityFinding` be
+  // passed as one, so the type cannot see what is actually there.
+  const prior = draft as Partial<SecurityFinding>;
+  const priorApplied = prior.redactionStatus === 'applied';
+  const priorShapes: readonly ShapeId[] = prior.redactedShapes ?? [];
+
+  const emitted: Record<string, unknown> = { ...draft };
+  for (const field of BYTE_CARRYING_FIELDS) {
+    const value = draft[field];
+    if (typeof value === 'string') emitted[field] = pass.run(value);
+  }
+
+  if (draft.evidence !== undefined) {
+    emitted.evidence = redactEvidence(draft.evidence, pass);
+  }
+  if (draft.rationale !== undefined) {
+    emitted.rationale = { plainEnglish: pass.run(draft.rationale.plainEnglish) };
+  }
+  if (draft.details !== undefined) {
+    emitted.details = redactDetails(draft.details, pass) as Record<string, unknown>;
+  }
+
+  emitted.redactionStatus = priorApplied ? 'applied' : pass.status;
+  emitted.redactedShapes = [
+    ...new Set([...priorShapes, ...pass.resolvedShapes]),
+  ].sort();
+
+  // The one cast that produces the brand. It is confined to this line, which is
+  // why the symbol is not exported.
+  return emitted as unknown as RedactedFinding;
+}
+
+/** Array form. Same boundary, per element. */
+export function emitFindings(
+  drafts: readonly SecurityFindingDraft[],
+): RedactedFinding[] {
+  return drafts.map(emitFinding);
+}
+
+// A `reemitFinding` wrapper was written here and DELETED before it shipped: it
+// had zero production callers, and `emitFinding` already handles an
+// already-emitted input through its absorbing-applied merge, so the wrapper
+// added a second name for one behaviour and nothing else.
+//
+// The settlement brief §3.5 records the cost of keeping such a function:
+// `redactSecretsForNanoMind` is the documented "NanoMind has zero access to
+// secrets" boundary, has zero production call sites, and its presence is why the
+// daemon boundary was believed to exist for as long as it did. An exported
+// function with no callers is read as a guarantee. Rebuild sites call
+// `emitFinding` directly.

--- a/src/hardening/nemoclaw-scanner.ts
+++ b/src/hardening/nemoclaw-scanner.ts
@@ -12,7 +12,8 @@ import { statSync, readdirSync, readFileSync, existsSync } from 'fs';
 import * as path from 'path';
 import * as os from 'os';
 import { commandNaming } from '../ui/shell-quote';
-import type { SecurityFinding, Severity } from './security-check';
+import type { SecurityFinding, SecurityFindingDraft, Severity } from './security-check';
+import { emitFinding, type RedactedFinding } from './finding-emit';
 
 // ---------------------------------------------------------------------------
 // Constants
@@ -129,9 +130,11 @@ function finding(
   severity: Severity,
   passed: boolean,
   message: string,
-  extra?: Partial<SecurityFinding>,
-): SecurityFinding {
-  return {
+  extra?: Partial<SecurityFindingDraft>,
+): RedactedFinding {
+  // Route point 3 of the boundary: the single constructor every NemoClaw
+  // finding goes through, so emitting here covers all of them.
+  return emitFinding({
     checkId,
     name,
     description,
@@ -148,7 +151,7 @@ function finding(
     fix: extra?.fix,
     attackClass: extra?.attackClass,
     details: extra?.details,
-  };
+  });
 }
 
 // ---------------------------------------------------------------------------

--- a/src/hardening/scanner.ts
+++ b/src/hardening/scanner.ts
@@ -14,7 +14,8 @@ import * as fsSync from 'fs';
 import * as crypto from 'crypto';
 import * as path from 'path';
 import { execFile } from 'child_process';
-import type { ScanResult, SecurityFinding, Severity, ProjectType } from './security-check';
+import type { ScanResult, SecurityFinding, SecurityFindingDraft, Severity, ProjectType } from './security-check';
+import { emitFinding } from './finding-emit';
 import { StructuralAnalyzer, toSecurityFindings, LLMAnalyzer } from '../semantic';
 import { enrichWithTaxonomy } from './taxonomy';
 import { lineFromOffset } from '../types/text-position';
@@ -387,11 +388,15 @@ export interface ScanOptions {
    * contained: the semantic layer is an enhancement and must never take the
    * static scan down with it.
    */
+  // Drafts on both sides: the semantic pass runs INSIDE the scan, upstream of
+  // route point 4, so it neither receives nor returns emitted findings. Typing
+  // it on `SecurityFinding` would oblige a merge pass to invent the two
+  // redaction fields it is in no position to know.
   semanticPass?: (ctx: {
     targetDir: string;
-    findings: SecurityFinding[];
+    findings: SecurityFindingDraft[];
     projectType: ProjectType;
-  }) => Promise<{ findings?: SecurityFinding[] } | void>;
+  }) => Promise<{ findings?: SecurityFindingDraft[] } | void>;
 }
 
 // Patterns for detecting exposed credentials
@@ -1012,7 +1017,7 @@ export function calculateSecurityScore(findings: Array<{ passed?: boolean; fixed
  * finding can only lower `weightedSum`, so this is >= the headline score.
  */
 export function scoreExcludingOwnArchive(
-  findings: SecurityFinding[],
+  findings: SecurityFindingDraft[],
 ): number | undefined {
   if (!findings.some(f => f.inOwnArchive)) return undefined;
   const liveTree = findings.filter(f => !f.inOwnArchive);
@@ -1029,7 +1034,7 @@ export function scoreExcludingOwnArchive(
  * CHECK_PROJECT_TYPES map. Exported so CLI can filter findings after
  * NanoMind merge.
  */
-export function findingAppliesTo(finding: SecurityFinding, projectType: ProjectType): boolean {
+export function findingAppliesTo(finding: SecurityFindingDraft, projectType: ProjectType): boolean {
   // FIRST match in declaration order. A full check ID overrides the group it
   // sits in by being DECLARED BEFORE it — `check-project-types-order.test.ts`
   // holds that ordering, because nothing else does.
@@ -1080,7 +1085,7 @@ export function isReportableFinding(
   f: { passed?: boolean; fixed?: boolean; file?: string; checkId: string },
   projectType: ProjectType,
 ): boolean {
-  return retainForVerdict(f) && Boolean(f.file) && findingAppliesTo(f as SecurityFinding, projectType);
+  return retainForVerdict(f) && Boolean(f.file) && findingAppliesTo(f as SecurityFindingDraft, projectType);
 }
 
 /**
@@ -1099,9 +1104,9 @@ export function isReportableFinding(
  * composite) get a clean signal without dropping legitimate findings.
  */
 export function dropPathlessNoiseFloor(
-  findings: SecurityFinding[],
+  findings: SecurityFindingDraft[],
   projectType: ProjectType,
-): SecurityFinding[] {
+): SecurityFindingDraft[] {
   return findings.filter((f) => {
     if (f.passed || f.fixed) return true;
     if (f.file) return true;
@@ -1837,12 +1842,26 @@ export class HardeningScanner {
    * the defect this parameter exists to close, restored silently. Making it
    * required turns every un-migrated call site into a compile error instead.
    */
-  async reapplyIgnoreFilters(
-    findings: SecurityFinding[],
+  /**
+   * GENERIC over the finding type, deliberately. Every return is `findings`
+   * itself or a filter of it — this method marks and removes, and never
+   * constructs a finding — so whatever the caller passed in comes back out.
+   *
+   * Typing it on `SecurityFindingDraft` instead would force the CLI to cast at
+   * `cli.ts:4703`/`:4720`, where the post-merge report is re-derived into
+   * `ScanResult.findings`. That cast would launder the `RedactedFinding` brand
+   * at the one point downstream of the boundary that rebuilds both channels —
+   * exactly the "a site that satisfies the type by casting" case the runtime
+   * `redactionStatus` field exists to catch, except silent. Preserving the type
+   * parameter keeps the brand intact through the re-filter and makes the casts
+   * unnecessary rather than load-bearing.
+   */
+  async reapplyIgnoreFilters<T extends SecurityFindingDraft>(
+    findings: T[],
     targetDir: string,
     projectType: ProjectType,
     additionalIgnorePaths?: string[],
-  ): Promise<SecurityFinding[]> {
+  ): Promise<T[]> {
     const hmaIgnore = await this.loadHmaIgnore(targetDir);
     const allIgnoredPaths = [...hmaIgnore.paths, ...(additionalIgnorePaths || [])];
     const suppressedCheckPatterns = hmaIgnore.checkIds;
@@ -1863,8 +1882,8 @@ export class HardeningScanner {
     // path rule is a scope change and leaves the array, with the summary parked
     // on `lastOutOfScope` for the caller to disclose. Callers render with
     // `isDisplayed()`.
-    const pathExcluded: SecurityFinding[] = [];
-    const checkSuppressed: SecurityFinding[] = [];
+    const pathExcluded: T[] = [];
+    const checkSuppressed: T[] = [];
     for (const f of findings) {
       // Already out of scope from the scan pass. It must be re-collected, not
       // skipped: `nmResult.mergedFindings` is rebuilt from `allFindings`, which
@@ -1906,7 +1925,7 @@ export class HardeningScanner {
     // unreportable findings back into the returned array, and the one caller
     // that does not re-filter (`secure-openclaw`, `cli.ts`) would start listing
     // and scoring them — trading this defect for a new one on another path.
-    const reportable = (f: SecurityFinding) => isReportableFinding(f, projectType);
+    const reportable = (f: SecurityFindingDraft) => isReportableFinding(f, projectType);
     this.lastOutOfScope = summarizeSuppressed(pathExcluded.filter(reportable));
     this.lastSuppressed = summarizeSuppressed(checkSuppressed.filter(reportable));
     if (pathExcluded.length === 0 && checkSuppressed.length === 0) return findings;
@@ -1938,7 +1957,7 @@ export class HardeningScanner {
    * representative path and carry the rest of the evidence in
    * `details.files`, so reading either side alone loses paths.
    */
-  private coveredFilesOf(f: SecurityFinding): string[] {
+  private coveredFilesOf(f: SecurityFindingDraft): string[] {
     const listed = Array.isArray(f.details?.files) ? f.details.files : [];
     return [...new Set(
       [f.file, ...listed].filter(
@@ -1967,7 +1986,7 @@ export class HardeningScanner {
    *
    * Returns true to KEEP. May re-point `f.file` / `f.details.files` in place.
    */
-  private retainAfterPathSuppression(f: SecurityFinding, ignoredPaths: string[]): boolean {
+  private retainAfterPathSuppression(f: SecurityFindingDraft, ignoredPaths: string[]): boolean {
     // A coverage statement is not a finding ABOUT a path's contents, so a path
     // rule cannot scope it away (#438).
     //
@@ -2142,7 +2161,7 @@ export class HardeningScanner {
     const projectType = await this.detectProjectType(targetDir);
 
     // Run all checks
-    const findings: SecurityFinding[] = [];
+    const findings: SecurityFindingDraft[] = [];
 
     // Credential exposure checks
     const credFindings = await this.coverage.run('checkCredentialExposure', () => this.checkCredentialExposure(targetDir, shouldFix));
@@ -2468,7 +2487,7 @@ export class HardeningScanner {
             fixable: false,
             file: missed.path,
             fix: `Re-run the deep scan: ${this.cliName} secure ${shellQuote(targetDir)} --deep. If it repeats on the same file, the file's own content may be interfering with the analysis; the other layers' findings for it still stand.`,
-          } as SecurityFinding);
+          } as SecurityFindingDraft);
         }
       } catch {
         // LLM analysis failure is non-fatal — fall back to Layer 2 only
@@ -2903,7 +2922,7 @@ export class HardeningScanner {
         // SAME notion of "which paths does this finding speak for" that
         // verification does (#280) — the two disagreeing is what let one
         // ignored path delete a multi-file finding.
-        const coveredFiles = (f: SecurityFinding): string[] => this.coveredFilesOf(f);
+        const coveredFiles = (f: SecurityFindingDraft): string[] => this.coveredFilesOf(f);
 
         // Compare against the verify scan's UNFILTERED findings. Its
         // `findings` has already been through the user-facing filter below,
@@ -3059,11 +3078,11 @@ export class HardeningScanner {
         // spelled. (A NUL separator is the conventional choice and is what this
         // was first written with — it is also a raw control byte in source,
         // invisible in every diff, which `render-source-gate` rightly rejects.)
-        const alreadyHeld = new Map<string, SecurityFinding>();
+        const alreadyHeld = new Map<string, SecurityFindingDraft>();
         for (const f of findings) {
           if (f.file) alreadyHeld.set(`${f.checkId} ${f.file}`, f);
         }
-        const adopted: SecurityFinding[] = [];
+        const adopted: SecurityFindingDraft[] = [];
         for (const f of verifyResult.findings) {
           if (!f.file) continue;
           // Identity, not spelling (#317) — and only a proven `yes`. `unknown`
@@ -3152,7 +3171,7 @@ export class HardeningScanner {
     //
     // So: path exclusions leave the scored set and are reported as scope;
     // check-ID suppressions stay in it and are reported as suppression.
-    const pathExcluded: SecurityFinding[] = [];
+    const pathExcluded: SecurityFindingDraft[] = [];
     for (const f of filteredFindings) {
       if (ignoredChecks.has(f.checkId.toUpperCase())) {
         f.suppressed = true;
@@ -3219,7 +3238,7 @@ export class HardeningScanner {
     //    2 of them nominally critical. Nothing was found, so `clear` is not
     //    made false by them, and surfacing them by category would be a wall of
     //    FUD with no path forward. Counted, not named.
-    const survived = new Set<SecurityFinding>(filteredFindings);
+    const survived = new Set<SecurityFindingDraft>(filteredFindings);
     const suppressedFailures: Array<{
       checkId: string;
       name: string;
@@ -3270,7 +3289,7 @@ export class HardeningScanner {
     // separately on `outOfScope`.
     const scoredFindings = [
       ...filteredFindings,
-      ...(expandSuppressed(suppressed) as unknown as SecurityFinding[]),
+      ...(expandSuppressed(suppressed) as unknown as SecurityFindingDraft[]),
     ];
 
     // Calculate score (only on applicable findings, plus suppressed penalties)
@@ -3312,18 +3331,52 @@ export class HardeningScanner {
     const hasFixedFindings = filteredFindings.some((f) => f.fixed);
     const atomicFix = shouldFix ? !fixFailed && hasFixedFindings : undefined;
 
+    // Route point 4. Both returned arrays are filters of `findings`, so a draft
+    // that survives both used to be THE SAME OBJECT in each — `filteredFindings`
+    // is `findings.filter(...)` (:3122, :3204) and `dropPathlessNoiseFloor` is
+    // another filter over `findings`.
+    //
+    // Emitting each array independently would quietly end that. `emitFinding`
+    // returns a new object, so the two channels would hold separate copies and a
+    // post-scan mutation of `result.findings[i]` would stop reaching
+    // `result.allFindings` — `cli.ts:11630` demotes severity exactly that way.
+    // No consumer depends on it today (`eval` never reads `allFindings`, and the
+    // `secure` path re-derives both from one array at `cli.ts:4718`), so this is
+    // a latent hazard rather than a live defect — but it is one a future reader
+    // would have no way to see, and preserving identity costs a Map.
+    //
+    // It also halves the work: a finding in both channels is redacted once.
+    const emitted = new Map<SecurityFindingDraft, ReturnType<typeof emitFinding>>();
+    const emitOnce = (f: SecurityFindingDraft) => {
+      const seen = emitted.get(f);
+      if (seen) return seen;
+      const fresh = emitFinding(f);
+      emitted.set(f, fresh);
+      return fresh;
+    };
+
     return {
       timestamp: new Date(),
       platform,
       projectType,
-      findings: filteredFindings,
+      // Route point 4: the last construction before any channel. Everything
+      // above this line is a DRAFT — the 68 accumulators, the 65 check methods
+      // that fill them, and every helper that filters, scores or enriches them
+      // — and the two redaction fields do not exist until here. `scan()`'s
+      // return is the narrowest point that covers the 253 `scanner.ts` literals
+      // plus `assembly-scanner`, `external-scanner` and `nanomind-analyzer`.
+      findings: filteredFindings.map(emitOnce),
       // allFindings is consumed by benchmark, OASB-2 composite, and the
       // corpus release-smoke harness. Drop true noise-floor findings —
       // pathless failed findings whose check doesn't apply to this
       // project type (issue #131 / #130). Pathless findings whose check
       // DOES apply (a check that found real evidence but failed to
       // attribute a file) are preserved as legitimate detections.
-      allFindings: dropPathlessNoiseFloor(findings, projectType),
+      // `allFindings` is a SECOND channel, not a view of the first: benchmark,
+      // the OASB-2 composite and the corpus release-smoke harness read it, and
+      // two of the four measured JSON leak paths were under `$.allFindings[…]`.
+      // It emits independently for that reason.
+      allFindings: dropPathlessNoiseFloor(findings, projectType).map(emitOnce),
       score,
       rawScore,
       scoreClamped,
@@ -3611,7 +3664,7 @@ export class HardeningScanner {
    * separate copies of the same loop; the copies agreed by luck, and only one
    * of them would have been fixed (#421).
    */
-  findingAppliesTo(finding: SecurityFinding, projectType: ProjectType): boolean {
+  findingAppliesTo(finding: SecurityFindingDraft, projectType: ProjectType): boolean {
     return findingAppliesTo(finding, projectType);
   }
 
@@ -3622,15 +3675,15 @@ export class HardeningScanner {
    * `reapplyIgnoreFilters` had not, so the suppression accounting disagreed with
    * the display set about what a suppression could possibly withhold.
    */
-  isReportableFinding(finding: SecurityFinding, projectType: ProjectType): boolean {
+  isReportableFinding(finding: SecurityFindingDraft, projectType: ProjectType): boolean {
     return isReportableFinding(finding, projectType);
   }
 
   private async checkCredentialExposure(
     targetDir: string,
     autoFix: boolean
-  ): Promise<SecurityFinding[]> {
-    const findings: SecurityFinding[] = [];
+  ): Promise<SecurityFindingDraft[]> {
+    const findings: SecurityFindingDraft[] = [];
     const envVarsToAdd: Set<string> = new Set();
 
     // Credential patterns with their env var names (stricter to avoid false positives)
@@ -3852,8 +3905,8 @@ export class HardeningScanner {
   private async checkClaudeMd(
     targetDir: string,
     autoFix: boolean
-  ): Promise<SecurityFinding[]> {
-    const findings: SecurityFinding[] = [];
+  ): Promise<SecurityFindingDraft[]> {
+    const findings: SecurityFindingDraft[] = [];
     const claudeMdPath = path.join(targetDir, 'CLAUDE.md');
 
     try {
@@ -3901,8 +3954,8 @@ export class HardeningScanner {
   private async checkMcpConfig(
     targetDir: string,
     autoFix: boolean
-  ): Promise<SecurityFinding[]> {
-    const findings: SecurityFinding[] = [];
+  ): Promise<SecurityFindingDraft[]> {
+    const findings: SecurityFindingDraft[] = [];
     const mcpConfigPath = path.join(targetDir, 'mcp.json');
 
     try {
@@ -4671,8 +4724,8 @@ export class HardeningScanner {
   private async checkFilePermissions(
     targetDir: string,
     autoFix: boolean
-  ): Promise<SecurityFinding[]> {
-    const findings: SecurityFinding[] = [];
+  ): Promise<SecurityFindingDraft[]> {
+    const findings: SecurityFindingDraft[] = [];
 
     // Files that should have restricted permissions
     const sensitiveFiles = [
@@ -4762,8 +4815,8 @@ export class HardeningScanner {
   private async checkGitSecurity(
     targetDir: string,
     autoFix: boolean
-  ): Promise<SecurityFinding[]> {
-    const findings: SecurityFinding[] = [];
+  ): Promise<SecurityFindingDraft[]> {
+    const findings: SecurityFindingDraft[] = [];
 
     // Existence-aware severity (#250): a missing or incomplete .gitignore
     // is a LOW hardening advisory on its own; it becomes a HIGH exposure
@@ -4995,8 +5048,8 @@ dist/
   private async checkNetworkSecurity(
     targetDir: string,
     autoFix: boolean
-  ): Promise<SecurityFinding[]> {
-    const findings: SecurityFinding[] = [];
+  ): Promise<SecurityFindingDraft[]> {
+    const findings: SecurityFindingDraft[] = [];
     const mcpConfigPath = path.join(targetDir, 'mcp.json');
 
     let mcpConfig: Record<string, unknown> | null = null;
@@ -5076,8 +5129,8 @@ dist/
   private async checkMcpAdvanced(
     targetDir: string,
     autoFix: boolean
-  ): Promise<SecurityFinding[]> {
-    const findings: SecurityFinding[] = [];
+  ): Promise<SecurityFindingDraft[]> {
+    const findings: SecurityFindingDraft[] = [];
     const mcpConfigPath = path.join(targetDir, 'mcp.json');
 
     let mcpConfig: Record<string, unknown> | null = null;
@@ -5223,8 +5276,8 @@ dist/
   private async checkClaudeAdvanced(
     targetDir: string,
     autoFix: boolean
-  ): Promise<SecurityFinding[]> {
-    const findings: SecurityFinding[] = [];
+  ): Promise<SecurityFindingDraft[]> {
+    const findings: SecurityFindingDraft[] = [];
     const claudeSettingsPath = path.join(targetDir, '.claude', 'settings.json');
 
     // `.claude/settings.json`, parsed the way `detect` parses it (#363).
@@ -5343,8 +5396,8 @@ dist/
   private async checkCursorConfig(
     targetDir: string,
     autoFix: boolean
-  ): Promise<SecurityFinding[]> {
-    const findings: SecurityFinding[] = [];
+  ): Promise<SecurityFindingDraft[]> {
+    const findings: SecurityFindingDraft[] = [];
 
     // Check multiple Cursor config locations
     const cursorPaths = [
@@ -5386,8 +5439,8 @@ dist/
   private async checkVscodeConfig(
     targetDir: string,
     autoFix: boolean
-  ): Promise<SecurityFinding[]> {
-    const findings: SecurityFinding[] = [];
+  ): Promise<SecurityFindingDraft[]> {
+    const findings: SecurityFindingDraft[] = [];
     const vscodeMcpPath = path.join(targetDir, '.vscode', 'mcp.json');
 
     let vscodeConfig: Record<string, unknown> | null = null;
@@ -5925,8 +5978,8 @@ dist/
   private async checkCredentialsAdvanced(
     targetDir: string,
     autoFix: boolean
-  ): Promise<SecurityFinding[]> {
-    const findings: SecurityFinding[] = [];
+  ): Promise<SecurityFindingDraft[]> {
+    const findings: SecurityFindingDraft[] = [];
 
     // CRED-002: Check for private key files. Recursive (bounded) since
     // #250 — a key at certs/server.pem is exactly as committable as one
@@ -6049,8 +6102,8 @@ dist/
   private async checkPermissionsAdvanced(
     targetDir: string,
     autoFix: boolean
-  ): Promise<SecurityFinding[]> {
-    const findings: SecurityFinding[] = [];
+  ): Promise<SecurityFindingDraft[]> {
+    const findings: SecurityFindingDraft[] = [];
 
     // PERM-002: Check for executable config files
     const configFiles = ['config.json', 'mcp.json', 'settings.json', '.env'];
@@ -6118,8 +6171,8 @@ dist/
   private async checkEnvironmentSecurity(
     targetDir: string,
     autoFix: boolean
-  ): Promise<SecurityFinding[]> {
-    const findings: SecurityFinding[] = [];
+  ): Promise<SecurityFindingDraft[]> {
+    const findings: SecurityFindingDraft[] = [];
 
     // ENV-001: Check for development mode indicators
     let devModeEnabled = false;
@@ -6239,8 +6292,8 @@ dist/
   private async checkLoggingSecurity(
     targetDir: string,
     autoFix: boolean
-  ): Promise<SecurityFinding[]> {
-    const findings: SecurityFinding[] = [];
+  ): Promise<SecurityFindingDraft[]> {
+    const findings: SecurityFindingDraft[] = [];
 
     // LOG-001: Check for logging configuration
     let hasLoggingConfig = false;
@@ -6419,8 +6472,8 @@ dist/
   private async checkDependencySecurity(
     targetDir: string,
     autoFix: boolean
-  ): Promise<SecurityFinding[]> {
-    const findings: SecurityFinding[] = [];
+  ): Promise<SecurityFindingDraft[]> {
+    const findings: SecurityFindingDraft[] = [];
 
     // DEP-001: Check for package-lock.json
     let hasLockFile = false;
@@ -6562,8 +6615,8 @@ dist/
   private async checkAuthSecurity(
     targetDir: string,
     autoFix: boolean
-  ): Promise<SecurityFinding[]> {
-    const findings: SecurityFinding[] = [];
+  ): Promise<SecurityFindingDraft[]> {
+    const findings: SecurityFindingDraft[] = [];
 
     // AUTH-001: Check for auth configuration
     let hasAuthConfig = false;
@@ -6676,8 +6729,8 @@ dist/
   private async checkProcessSecurity(
     targetDir: string,
     autoFix: boolean
-  ): Promise<SecurityFinding[]> {
-    const findings: SecurityFinding[] = [];
+  ): Promise<SecurityFindingDraft[]> {
+    const findings: SecurityFindingDraft[] = [];
 
     // PROC-001: Check for Dockerfile security
     // Search common Dockerfile locations
@@ -6798,8 +6851,8 @@ dist/
   private async checkClaudeExtended(
     targetDir: string,
     autoFix: boolean
-  ): Promise<SecurityFinding[]> {
-    const findings: SecurityFinding[] = [];
+  ): Promise<SecurityFindingDraft[]> {
+    const findings: SecurityFindingDraft[] = [];
     const claudeSettingsPath = path.join(targetDir, '.claude', 'settings.json');
 
     let claudeSettings: Record<string, unknown> | null = null;
@@ -6899,8 +6952,8 @@ dist/
   private async checkMcpExtended(
     targetDir: string,
     autoFix: boolean
-  ): Promise<SecurityFinding[]> {
-    const findings: SecurityFinding[] = [];
+  ): Promise<SecurityFindingDraft[]> {
+    const findings: SecurityFindingDraft[] = [];
     const mcpConfigPath = path.join(targetDir, 'mcp.json');
 
     let mcpConfig: Record<string, unknown> | null = null;
@@ -7035,8 +7088,8 @@ dist/
   private async checkNetworkExtended(
     targetDir: string,
     autoFix: boolean
-  ): Promise<SecurityFinding[]> {
-    const findings: SecurityFinding[] = [];
+  ): Promise<SecurityFindingDraft[]> {
+    const findings: SecurityFindingDraft[] = [];
 
     // NET-003: Check for HTTPS enforcement
     let hasHttpsEnforcement = false;
@@ -7171,8 +7224,8 @@ dist/
   private async checkAPISecurity(
     targetDir: string,
     autoFix: boolean
-  ): Promise<SecurityFinding[]> {
-    const findings: SecurityFinding[] = [];
+  ): Promise<SecurityFindingDraft[]> {
+    const findings: SecurityFindingDraft[] = [];
 
     // API-001: Check for API versioning
     let hasApiVersioning = false;
@@ -7296,8 +7349,8 @@ dist/
   private async checkSecretManagement(
     targetDir: string,
     autoFix: boolean
-  ): Promise<SecurityFinding[]> {
-    const findings: SecurityFinding[] = [];
+  ): Promise<SecurityFindingDraft[]> {
+    const findings: SecurityFindingDraft[] = [];
 
     // SEC-001: Check for secret management tools
     let hasSecretManager = false;
@@ -7412,8 +7465,8 @@ dist/
   private async checkIOSecurity(
     targetDir: string,
     autoFix: boolean
-  ): Promise<SecurityFinding[]> {
-    const findings: SecurityFinding[] = [];
+  ): Promise<SecurityFindingDraft[]> {
+    const findings: SecurityFindingDraft[] = [];
 
     // IO-001: Check for file upload handling
     let hasFileUpload = false;
@@ -7548,8 +7601,8 @@ dist/
   private async checkPromptSecurity(
     targetDir: string,
     autoFix: boolean
-  ): Promise<SecurityFinding[]> {
-    const findings: SecurityFinding[] = [];
+  ): Promise<SecurityFindingDraft[]> {
+    const findings: SecurityFindingDraft[] = [];
 
     // PROMPT-001: Check for system prompt boundary markers
     let hasPromptBoundaries = false;
@@ -7665,8 +7718,8 @@ dist/
   private async checkInputValidation(
     targetDir: string,
     autoFix: boolean
-  ): Promise<SecurityFinding[]> {
-    const findings: SecurityFinding[] = [];
+  ): Promise<SecurityFindingDraft[]> {
+    const findings: SecurityFindingDraft[] = [];
 
     // INJ-001: Check for input validation in MCP handlers
     let hasInputValidation = false;
@@ -7833,8 +7886,8 @@ dist/
   private async checkRateLimiting(
     targetDir: string,
     autoFix: boolean
-  ): Promise<SecurityFinding[]> {
-    const findings: SecurityFinding[] = [];
+  ): Promise<SecurityFindingDraft[]> {
+    const findings: SecurityFindingDraft[] = [];
 
     // RATE-001: Check for rate limiting configuration
     let hasRateLimiting = false;
@@ -7980,8 +8033,8 @@ dist/
   private async checkSessionSecurity(
     targetDir: string,
     autoFix: boolean
-  ): Promise<SecurityFinding[]> {
-    const findings: SecurityFinding[] = [];
+  ): Promise<SecurityFindingDraft[]> {
+    const findings: SecurityFindingDraft[] = [];
 
     // SESSION-001: Check for secure session configuration
     let hasSecureSessions = false;
@@ -8123,8 +8176,8 @@ dist/
   private async checkEncryption(
     targetDir: string,
     autoFix: boolean
-  ): Promise<SecurityFinding[]> {
-    const findings: SecurityFinding[] = [];
+  ): Promise<SecurityFindingDraft[]> {
+    const findings: SecurityFindingDraft[] = [];
 
     // ENCRYPT-001: Check for encryption at rest
     let hasEncryption = false;
@@ -8279,8 +8332,8 @@ dist/
   private async checkAuditTrail(
     targetDir: string,
     autoFix: boolean
-  ): Promise<SecurityFinding[]> {
-    const findings: SecurityFinding[] = [];
+  ): Promise<SecurityFindingDraft[]> {
+    const findings: SecurityFindingDraft[] = [];
 
     // AUDIT-001: Check for audit logging
     let hasAuditLogging = false;
@@ -8421,8 +8474,8 @@ dist/
   private async checkSandboxing(
     targetDir: string,
     autoFix: boolean
-  ): Promise<SecurityFinding[]> {
-    const findings: SecurityFinding[] = [];
+  ): Promise<SecurityFindingDraft[]> {
+    const findings: SecurityFindingDraft[] = [];
 
     // SANDBOX-001: Check for Docker/container usage
     let hasContainerization = false;
@@ -8533,8 +8586,8 @@ dist/
   private async checkToolBoundaries(
     targetDir: string,
     autoFix: boolean
-  ): Promise<SecurityFinding[]> {
-    const findings: SecurityFinding[] = [];
+  ): Promise<SecurityFindingDraft[]> {
+    const findings: SecurityFindingDraft[] = [];
     const mcpConfigPath = path.join(targetDir, 'mcp.json');
 
     let mcpConfig: Record<string, unknown> | null = null;
@@ -8649,7 +8702,7 @@ dist/
     return findings;
   }
 
-  calculateScore(findings: SecurityFinding[]): {
+  calculateScore(findings: SecurityFindingDraft[]): {
     score: number;
     maxScore: number;
   } {
@@ -8675,7 +8728,7 @@ dist/
       scoreClamped?: boolean;
       scoreExcludingOwnArchive?: number;
     },
-    findings: SecurityFinding[],
+    findings: SecurityFindingDraft[],
   ): void {
     const { score: rawScore } = this.calculateScore(findings);
     const { score, clamped } = clampScoreToVerdictBand(rawScore, findings);
@@ -9793,8 +9846,8 @@ dist/
   private async checkOpenclawSkills(
     targetDir: string,
     autoFix: boolean
-  ): Promise<SecurityFinding[]> {
-    const findings: SecurityFinding[] = [];
+  ): Promise<SecurityFindingDraft[]> {
+    const findings: SecurityFindingDraft[] = [];
     const skillFiles = await this.findSkillFiles(targetDir);
 
     for (const skillFile of skillFiles) {
@@ -10604,8 +10657,8 @@ dist/
   private async checkOpenclawHeartbeat(
     targetDir: string,
     autoFix: boolean
-  ): Promise<SecurityFinding[]> {
-    const findings: SecurityFinding[] = [];
+  ): Promise<SecurityFindingDraft[]> {
+    const findings: SecurityFindingDraft[] = [];
     const heartbeatFiles = await this.findHeartbeatFiles(targetDir);
 
     for (const heartbeatFile of heartbeatFiles) {
@@ -10835,8 +10888,8 @@ dist/
   private async checkOpenclawGateway(
     targetDir: string,
     autoFix: boolean
-  ): Promise<SecurityFinding[]> {
-    const findings: SecurityFinding[] = [];
+  ): Promise<SecurityFindingDraft[]> {
+    const findings: SecurityFindingDraft[] = [];
     const configFiles = await this.findGatewayConfigFiles(targetDir);
 
     for (const configFile of configFiles) {
@@ -11356,8 +11409,8 @@ dist/
   private async checkOpenclawConfig(
     targetDir: string,
     autoFix: boolean
-  ): Promise<SecurityFinding[]> {
-    const findings: SecurityFinding[] = [];
+  ): Promise<SecurityFindingDraft[]> {
+    const findings: SecurityFindingDraft[] = [];
 
     // CONFIG-001: Session File Exposure
     const sessionPatterns = [
@@ -11733,8 +11786,8 @@ dist/
   private async checkOpenclawSupplyChain(
     targetDir: string,
     autoFix: boolean
-  ): Promise<SecurityFinding[]> {
-    const findings: SecurityFinding[] = [];
+  ): Promise<SecurityFindingDraft[]> {
+    const findings: SecurityFindingDraft[] = [];
     const skillFiles = await this.findSkillFiles(targetDir);
 
     // Known malicious skill patterns from ClawHavoc campaign
@@ -11989,8 +12042,8 @@ dist/
   private async checkOpenclawCVE(
     targetDir: string,
     _autoFix: boolean
-  ): Promise<SecurityFinding[]> {
-    const findings: SecurityFinding[] = [];
+  ): Promise<SecurityFindingDraft[]> {
+    const findings: SecurityFindingDraft[] = [];
 
     // CVE-001: Vulnerable OpenClaw Version
     const pkgJsonPath = path.join(targetDir, 'package.json');
@@ -12254,8 +12307,8 @@ dist/
    * Check for memory/context poisoning risks
    * Detects patterns that could allow attackers to poison agent memory or conversation context
    */
-  private async checkMemoryPoisoning(targetDir: string, _autoFix: boolean): Promise<SecurityFinding[]> {
-    const findings: SecurityFinding[] = [];
+  private async checkMemoryPoisoning(targetDir: string, _autoFix: boolean): Promise<SecurityFindingDraft[]> {
+    const findings: SecurityFindingDraft[] = [];
 
     // MEM-001: Unvalidated memory persistence
     // Check for memory/context files that accept external input without validation
@@ -12422,8 +12475,8 @@ dist/
    * Check for RAG (Retrieval-Augmented Generation) poisoning risks
    * Detects patterns that could allow attackers to inject malicious content into RAG pipelines
    */
-  private async checkRAGPoisoning(targetDir: string, _autoFix: boolean): Promise<SecurityFinding[]> {
-    const findings: SecurityFinding[] = [];
+  private async checkRAGPoisoning(targetDir: string, _autoFix: boolean): Promise<SecurityFindingDraft[]> {
+    const findings: SecurityFindingDraft[] = [];
 
     // RAG-001: Unvalidated retrieval sources
     const ragConfigFiles = ['rag.json', 'retrieval.json', 'vector-store.json', 'embeddings.json'];
@@ -12597,8 +12650,8 @@ dist/
    * Check for agent identity spoofing risks
    * Detects missing or weak agent identity verification
    */
-  private async checkAgentIdentity(targetDir: string, _autoFix: boolean): Promise<SecurityFinding[]> {
-    const findings: SecurityFinding[] = [];
+  private async checkAgentIdentity(targetDir: string, _autoFix: boolean): Promise<SecurityFindingDraft[]> {
+    const findings: SecurityFindingDraft[] = [];
 
     // AIM-001: No agent identity declaration
     const identityFiles = ['agent-card.json', '.well-known/agent-card.json', 'agent.json', '.well-known/agent.json', 'aim.json', '.well-known/aim.json'];
@@ -12697,8 +12750,8 @@ dist/
    * Check for agent DNA/behavioral fingerprint forgery risks
    * Detects integrity issues with agent behavioral profiles
    */
-  private async checkAgentDNA(targetDir: string, _autoFix: boolean): Promise<SecurityFinding[]> {
-    const findings: SecurityFinding[] = [];
+  private async checkAgentDNA(targetDir: string, _autoFix: boolean): Promise<SecurityFindingDraft[]> {
+    const findings: SecurityFindingDraft[] = [];
 
     // DNA-001: No behavioral fingerprint
     const dnaFiles = ['agent-dna.json', '.well-known/agent-dna.json', '.agent-dna', 'behavioral-profile.json'];
@@ -12825,8 +12878,8 @@ dist/
   /**
    * Check for skill-based memory manipulation risks
    */
-  private async checkSkillMemory(targetDir: string, _autoFix: boolean): Promise<SecurityFinding[]> {
-    const findings: SecurityFinding[] = [];
+  private async checkSkillMemory(targetDir: string, _autoFix: boolean): Promise<SecurityFindingDraft[]> {
+    const findings: SecurityFindingDraft[] = [];
 
     // SKILL-MEM-001: Skills with memory write access
     // Check SKILL.md for memory manipulation patterns
@@ -12898,8 +12951,8 @@ dist/
   private async checkUnicodeSteganography(
     targetDir: string,
     _autoFix: boolean
-  ): Promise<SecurityFinding[]> {
-    const findings: SecurityFinding[] = [];
+  ): Promise<SecurityFindingDraft[]> {
+    const findings: SecurityFindingDraft[] = [];
     // Scan expanded file types beyond JS/TS (configs, docs, and Python are attack surfaces too)
     const stegoExtensions = ['.ts', '.js', '.mjs', '.cjs', '.tsx', '.jsx', '.py', '.md', '.txt', '.yaml', '.yml', '.json', '.toml'];
     const sourceFiles = await this.walkDirectory(targetDir, stegoExtensions);
@@ -13389,8 +13442,8 @@ dist/
   private async checkNemoClawPatterns(
     targetDir: string,
     _shouldFix: boolean,
-  ): Promise<SecurityFinding[]> {
-    const findings: SecurityFinding[] = [];
+  ): Promise<SecurityFindingDraft[]> {
+    const findings: SecurityFindingDraft[] = [];
 
     // Collect source files by extension (max depth 5, skips node_modules/.git/dist/build)
     const shFiles = await this.walkDirectory(targetDir, ['.sh'], 0, 5);
@@ -14082,8 +14135,8 @@ dist/
   private async checkLLMExposure(
     targetDir: string,
     autoFix: boolean
-  ): Promise<SecurityFinding[]> {
-    const findings: SecurityFinding[] = [];
+  ): Promise<SecurityFindingDraft[]> {
+    const findings: SecurityFindingDraft[] = [];
 
     // Patterns for LLM server configs that indicate exposure risk
     const llmConfigFiles = [
@@ -14194,8 +14247,8 @@ dist/
   private async checkAIToolExposure(
     targetDir: string,
     autoFix: boolean
-  ): Promise<SecurityFinding[]> {
-    const findings: SecurityFinding[] = [];
+  ): Promise<SecurityFindingDraft[]> {
+    const findings: SecurityFindingDraft[] = [];
 
     // Fix transforms for AI tool patterns
     const AI_TOOL_FIXES: Record<string, Array<{ match: RegExp; replace: string }>> = {
@@ -14363,8 +14416,8 @@ dist/
   private async checkA2AExposure(
     targetDir: string,
     _autoFix: boolean
-  ): Promise<SecurityFinding[]> {
-    const findings: SecurityFinding[] = [];
+  ): Promise<SecurityFindingDraft[]> {
+    const findings: SecurityFindingDraft[] = [];
 
     // Check for .well-known/agent.json (A2A discovery file)
     const wellKnownPaths = [
@@ -14449,8 +14502,8 @@ dist/
   private async checkMCPDiscovery(
     targetDir: string,
     _autoFix: boolean
-  ): Promise<SecurityFinding[]> {
-    const findings: SecurityFinding[] = [];
+  ): Promise<SecurityFindingDraft[]> {
+    const findings: SecurityFindingDraft[] = [];
 
     const mcpDiscoveryPaths = [
       path.join(targetDir, '.well-known', 'mcp'),
@@ -14501,8 +14554,8 @@ dist/
   private async checkWebServedCredentials(
     targetDir: string,
     autoFix: boolean
-  ): Promise<SecurityFinding[]> {
-    const findings: SecurityFinding[] = [];
+  ): Promise<SecurityFindingDraft[]> {
+    const findings: SecurityFindingDraft[] = [];
 
     // Unambiguous web-served directories — static assets published to a
     // public web server.
@@ -14717,8 +14770,8 @@ dist/
   private async checkCodeInjection(
     targetDir: string,
     _autoFix: boolean
-  ): Promise<SecurityFinding[]> {
-    const findings: SecurityFinding[] = [];
+  ): Promise<SecurityFindingDraft[]> {
+    const findings: SecurityFindingDraft[] = [];
     const files = await this.walkDirectory(targetDir, ['.ts', '.js', '.mjs'], 0, 2);
 
     // Match exec( or execSync( followed by a backtick (template literal)
@@ -14767,8 +14820,8 @@ dist/
   private async checkInstallScripts(
     targetDir: string,
     _autoFix: boolean
-  ): Promise<SecurityFinding[]> {
-    const findings: SecurityFinding[] = [];
+  ): Promise<SecurityFindingDraft[]> {
+    const findings: SecurityFindingDraft[] = [];
     const files = await this.walkDirectory(targetDir, ['.sh'], 0, 2);
 
     const pattern = /\b(curl|wget)\b[^|]*\|\s*(ba)?sh\b/g;
@@ -14815,8 +14868,8 @@ dist/
   private async checkCLICredentialPassthrough(
     targetDir: string,
     _autoFix: boolean
-  ): Promise<SecurityFinding[]> {
-    const findings: SecurityFinding[] = [];
+  ): Promise<SecurityFindingDraft[]> {
+    const findings: SecurityFindingDraft[] = [];
     const files = await this.walkDirectory(targetDir, ['.ts', '.js', '.mjs'], 0, 2);
 
     const pattern = /--(token|password|api[_-]?key|secret|auth)\s*[=\s]\s*[`$"']\s*\$?\{?|["']--(token|password|api[_-]?key|secret|auth)["']/g;
@@ -14868,8 +14921,8 @@ dist/
   private async checkIntegrityBypass(
     targetDir: string,
     _autoFix: boolean
-  ): Promise<SecurityFinding[]> {
-    const findings: SecurityFinding[] = [];
+  ): Promise<SecurityFindingDraft[]> {
+    const findings: SecurityFindingDraft[] = [];
     const files = await this.walkDirectory(targetDir, ['.ts', '.js', '.mjs'], 0, 2);
 
     const pattern = /if\s*\(\s*(digest|hash|checksum|signature|integrity)\s*&&/g;
@@ -14916,8 +14969,8 @@ dist/
   private async checkTOCTOU(
     targetDir: string,
     _autoFix: boolean
-  ): Promise<SecurityFinding[]> {
-    const findings: SecurityFinding[] = [];
+  ): Promise<SecurityFindingDraft[]> {
+    const findings: SecurityFindingDraft[] = [];
     const files = await this.walkDirectory(targetDir, ['.ts', '.js', '.mjs'], 0, 2);
 
     for (const file of files.slice(0, 100)) {
@@ -15021,8 +15074,8 @@ dist/
   private async checkTmpPaths(
     targetDir: string,
     _autoFix: boolean
-  ): Promise<SecurityFinding[]> {
-    const findings: SecurityFinding[] = [];
+  ): Promise<SecurityFindingDraft[]> {
+    const findings: SecurityFindingDraft[] = [];
     const files = await this.walkDirectory(targetDir, ['.sh'], 0, 2);
 
     const pattern = /(>|>>)\s*\/tmp\/|(-o)\s+\/tmp\/|\s\/tmp\/\S+/g;
@@ -15073,8 +15126,8 @@ dist/
   private async checkDockerInjection(
     targetDir: string,
     _autoFix: boolean
-  ): Promise<SecurityFinding[]> {
-    const findings: SecurityFinding[] = [];
+  ): Promise<SecurityFindingDraft[]> {
+    const findings: SecurityFindingDraft[] = [];
     const files = await this.walkDirectory(targetDir, ['.sh'], 0, 2);
 
     const pattern = /docker\s+exec\b.*?(\$\{?\w+\}?)/g;
@@ -15122,8 +15175,8 @@ dist/
   private async checkEnvLeak(
     targetDir: string,
     _autoFix: boolean
-  ): Promise<SecurityFinding[]> {
-    const findings: SecurityFinding[] = [];
+  ): Promise<SecurityFindingDraft[]> {
+    const findings: SecurityFindingDraft[] = [];
     const files = await this.walkDirectory(targetDir, ['.ts', '.js', '.mjs'], 0, 2);
 
     const spreadPattern = /env:\s*\{\s*\.\.\.process\.env/g;
@@ -15177,8 +15230,8 @@ dist/
   private async checkSandboxMessaging(
     targetDir: string,
     _autoFix: boolean
-  ): Promise<SecurityFinding[]> {
-    const findings: SecurityFinding[] = [];
+  ): Promise<SecurityFindingDraft[]> {
+    const findings: SecurityFindingDraft[] = [];
 
     // Scan YAML/JSON files in policies/ and config/ directories
     const policyDirs = ['policies', 'config', '.openclaw'];
@@ -15245,8 +15298,8 @@ dist/
   private async checkWebExposedFiles(
     targetDir: string,
     _autoFix: boolean
-  ): Promise<SecurityFinding[]> {
-    const findings: SecurityFinding[] = [];
+  ): Promise<SecurityFindingDraft[]> {
+    const findings: SecurityFindingDraft[] = [];
 
     const webDirs = ['public', 'static', 'dist', 'build', 'out', 'www'];
     // Track seen real paths to avoid duplicates on case-insensitive filesystems
@@ -15370,8 +15423,8 @@ dist/
   private async checkSoulOverride(
     targetDir: string,
     _autoFix: boolean
-  ): Promise<SecurityFinding[]> {
-    const findings: SecurityFinding[] = [];
+  ): Promise<SecurityFindingDraft[]> {
+    const findings: SecurityFindingDraft[] = [];
 
     // Path 1: Look for system-prompt files that load both soul and skill content
     const promptFiles = await this.walkDirectory(targetDir, ['.ts', '.js', '.mjs'], 0, 2);
@@ -15514,8 +15567,8 @@ dist/
    * Scans SOUL.md files for missing constraints, escape clauses, bypass instructions,
    * contradictory privacy claims, or stacked unverifiable compliance assertions.
    */
-  private async checkSoulGovernanceGaps(targetDir: string): Promise<SecurityFinding[]> {
-    const findings: SecurityFinding[] = [];
+  private async checkSoulGovernanceGaps(targetDir: string): Promise<SecurityFindingDraft[]> {
+    const findings: SecurityFindingDraft[] = [];
     const soulFiles = await this.findFilesMatching(targetDir, ['SOUL.md']);
 
     for (const soulFile of soulFiles) {
@@ -15744,8 +15797,8 @@ dist/
   private async checkMemoryStoreSanitization(
     targetDir: string,
     _autoFix: boolean
-  ): Promise<SecurityFinding[]> {
-    const findings: SecurityFinding[] = [];
+  ): Promise<SecurityFindingDraft[]> {
+    const findings: SecurityFindingDraft[] = [];
     const files = await this.walkDirectory(targetDir, ['.ts', '.js', '.mjs'], 0, 2);
 
     // Look for store/save/persist calls with text/content parameter (method or function)
@@ -15853,8 +15906,8 @@ dist/
   private async checkAgentCredentialProtection(
     targetDir: string,
     _autoFix: boolean
-  ): Promise<SecurityFinding[]> {
-    const findings: SecurityFinding[] = [];
+  ): Promise<SecurityFindingDraft[]> {
+    const findings: SecurityFindingDraft[] = [];
 
     // System prompt files to check
     const promptFileNames = ['SOUL.md', 'CLAUDE.md', 'system-prompt.md', 'system-prompt.txt'];
@@ -15922,7 +15975,7 @@ dist/
   private async checkContextLifecycle(
     targetDir: string,
     options: ScanOptions,
-  ): Promise<SecurityFinding[]> {
+  ): Promise<SecurityFindingDraft[]> {
     try {
       const result = await scanAssembly({
         targetDir,

--- a/src/hardening/security-check.ts
+++ b/src/hardening/security-check.ts
@@ -3,6 +3,10 @@
  */
 
 import type { Evidence, Rationale, ConceptId } from '../types/finding-evidence';
+import type { ShapeId } from '../types/credential-format';
+// Type-only, and therefore erased: `finding-emit` imports types from here, so a
+// value import would be a runtime cycle. This one is not.
+import type { RedactedFinding } from './finding-emit';
 
 export type Severity = 'critical' | 'high' | 'medium' | 'low';
 
@@ -141,7 +145,63 @@ export interface SecurityFinding {
    * (not the heuristic fallback). See `NanoMindIntentSignal`.
    */
   nanomindIntent?: NanoMindIntentSignal;
+  /**
+   * Always present. Whether this finding's byte-carrying fields passed the
+   * redaction boundary (`emitFinding`), and what the boundary concluded.
+   *
+   * `'unverified'` is the INITIALIZER, not a fallback: a construction path that
+   * never reached the redactor emits an explicit unknown, never a claim of
+   * cleanliness. An unwired site is therefore visible in the output rather than
+   * silently asserting it is clean — this workspace's rule for degraded state.
+   *
+   * `[ABDEL]` 2026-08-13 (D3). Field name, type and the always-present rule are
+   * FROZEN, as is the closed three-member union.
+   */
+  redactionStatus: 'applied' | 'clean' | 'unverified';
+  /**
+   * Always present. Registry shape ids the redactor resolved FROM THE VALUE.
+   *
+   * `[]` unless `'applied'` — and `'applied'` with `[]` is valid and honest,
+   * because a key-name or context heuristic resolves no shape (C9). Sorted and
+   * deduped.
+   *
+   * `ShapeId`'s MEMBERSHIP is deliberately open (22 today; GAP-8 grows it).
+   * `readonly ShapeId[]` here, `string[]` in the published schema — consumers
+   * MUST tolerate an id they have not seen. Do not publish this as a
+   * string-literal union: that freezes the vocabulary by accident and makes
+   * every future credential shape a breaking change.
+   *
+   * Forbidden on this pair, now and after the freeze: `redactionCount`, byte
+   * offsets, any length / `totalChars` / `byteLength` / character count, any
+   * preserved prefix or suffix, any hash or fingerprint of the body, salted or
+   * not. The predicate: a redaction field may carry CLASSIFICATION, never a
+   * MEASUREMENT OF THE BODY.
+   */
+  redactedShapes: readonly ShapeId[];
 }
+
+/**
+ * What a PRODUCER writes: every field of a finding except the two the
+ * redaction boundary stamps.
+ *
+ * A detector cannot write `redactionStatus` or `redactedShapes`, because a
+ * detector is not in a position to know them — only `emitFinding`
+ * (`src/hardening/finding-emit.ts`) is. Producer-side accumulators, the private
+ * check methods that fill them, and every hand-written adapter therefore carry
+ * `SecurityFindingDraft[]`; the two redaction fields appear exactly when a value
+ * crosses the boundary and not one line earlier.
+ *
+ * This is the type that makes the boundary provable rather than asserted. The
+ * settlement brief's claim that four route points cover every construction site
+ * was an unverified premise (CA rejected it as such): with the two fields
+ * REQUIRED on `SecurityFinding`, the compiler enumerates the real set, and it
+ * found three producers the four-point route set did not name
+ * (`skill-capability-validator.ts:167`, `cli.ts:4341`, `cli.ts:1575`).
+ */
+export type SecurityFindingDraft = Omit<
+  SecurityFinding,
+  'redactionStatus' | 'redactedShapes'
+>;
 
 /**
  * Per-artifact advisory classification from the NanoMind non-generative
@@ -169,10 +229,19 @@ export interface ScanResult {
   platform: string;
   /** Detected project type */
   projectType: ProjectType;
-  /** Filtered findings (failed checks with file paths) - for CLI display */
-  findings: SecurityFinding[];
-  /** All findings including passed checks - for benchmark evaluation */
-  allFindings?: SecurityFinding[];
+  /**
+   * Filtered findings (failed checks with file paths) - for CLI display.
+   *
+   * `RedactedFinding`, not `SecurityFinding`: this is what makes C10's brand
+   * load-bearing rather than decorative. A `ScanResult` cannot be built from
+   * findings that did not cross `emitFinding`, because no other module can
+   * produce the brand — so a future channel that assembles its own result is a
+   * COMPILE error rather than a silent leak.
+   */
+  findings: RedactedFinding[];
+  /** All findings including passed checks - for benchmark evaluation. Branded
+   *  for the same reason: it is a second published channel, not a view. */
+  allFindings?: RedactedFinding[];
   /**
    * Composite score as rendered and published. Clamped out of the "good"
    * band whenever the scan's own verdict is fail-direction (>=1 critical or

--- a/src/hardening/skill-capability-validator.ts
+++ b/src/hardening/skill-capability-validator.ts
@@ -6,7 +6,7 @@
  * undeclared capabilities.
  */
 
-import type { SecurityFinding } from './security-check';
+import type { SecurityFindingDraft } from './security-check';
 
 export interface SkillDeclaredCapabilities {
   capabilities: string[];
@@ -156,8 +156,8 @@ export function validateCapabilities(
   declared: SkillDeclaredCapabilities,
   inferred: InferredCapability[],
   filePath?: string
-): SecurityFinding[] {
-  const findings: SecurityFinding[] = [];
+): SecurityFindingDraft[] {
+  const findings: SecurityFindingDraft[] = [];
 
   for (const inf of inferred) {
     if (isCapabilityDeclared(inf.capability, declared)) {

--- a/src/hardening/taxonomy.ts
+++ b/src/hardening/taxonomy.ts
@@ -4,7 +4,7 @@
  * These identifiers match the attack_classes table in the OpenA2A Registry.
  */
 
-import type { SecurityFinding } from './security-check';
+import type { SecurityFindingDraft } from './security-check';
 
 /** Maps HMA check ID prefixes and exact IDs to attack class identifiers */
 const TAXONOMY_MAP: Record<string, string> = {
@@ -611,7 +611,7 @@ export function getCheckCounts(): CheckCounts {
  * `CRED-EXPOSURE`) are left untouched — inline values take precedence
  * over the table lookup.
  */
-export function enrichWithTaxonomy(findings: SecurityFinding[]): void {
+export function enrichWithTaxonomy(findings: SecurityFindingDraft[]): void {
   for (const finding of findings) {
     if (finding.attackClass) continue;
     const attackClass = getAttackClass(finding.checkId);

--- a/src/lifecycle/assembly-scanner.ts
+++ b/src/lifecycle/assembly-scanner.ts
@@ -24,11 +24,15 @@
 import { fs } from '../hardening/tracked-fs';
 import * as path from 'path';
 import type {
-  SecurityFinding,
+  SecurityFindingDraft,
   AssemblyComponent,
   AssemblyInteraction,
   LifecycleScanResult,
 } from '../hardening/security-check';
+// `scanAssembly` is a PUBLIC export (`src/index.ts:47`), so its findings reach
+// library consumers as objects that never touch a serializer. It emits here
+// rather than relying on the scanner's boundary downstream.
+import { emitFindings, type RedactedFinding } from '../hardening/finding-emit';
 
 /** Patterns that indicate prompt injection when found in assembled context */
 const INJECTION_PATTERNS: { pattern: RegExp; name: string; severity: 'critical' | 'high' | 'medium' }[] = [
@@ -210,8 +214,8 @@ function assemblePrompt(components: AssemblyComponent[]): { assembled: string; c
 function scanAssembledPrompt(
   assembled: string,
   components: AssemblyComponent[],
-): { findings: SecurityFinding[]; interactions: AssemblyInteraction[] } {
-  const findings: SecurityFinding[] = [];
+): { findings: SecurityFindingDraft[]; interactions: AssemblyInteraction[] } {
+  const findings: SecurityFindingDraft[] = [];
   const interactions: AssemblyInteraction[] = [];
 
   // 1. Scan full assembled prompt for injection patterns
@@ -434,7 +438,7 @@ function scanAssembledPrompt(
  * Runs the full Stage 1 assembly scan.
  */
 export async function scanAssembly(options: AssemblyScanOptions): Promise<{
-  findings: SecurityFinding[];
+  findings: RedactedFinding[];
   components: AssemblyComponent[];
   interactions: AssemblyInteraction[];
   assembledPrompt: string;
@@ -536,7 +540,7 @@ export async function scanAssembly(options: AssemblyScanOptions): Promise<{
 
   if (onProgress) onProgress(`Assembly scan complete: ${findings.length} findings from ${components.length} components`);
 
-  return { findings, components, interactions, assembledPrompt: assembled, tokenEstimate };
+  return { findings: emitFindings(findings), components, interactions, assembledPrompt: assembled, tokenEstimate };
 }
 
 /**

--- a/src/nanomind-core/analyzers/credential-analyzer.ts
+++ b/src/nanomind-core/analyzers/credential-analyzer.ts
@@ -864,9 +864,14 @@ function maskCredentialValue(value: string): string {
     const remaining = Math.max(0, value.length - prefix.length);
     return `${prefix}${'*'.repeat(Math.min(remaining, 16))}`;
   }
-  // Unknown shape — show first 8 chars then asterisks. Cap so the
-  // masked output never exceeds 24 chars regardless of input length.
-  return `${value.slice(0, 8)}${'*'.repeat(Math.min(Math.max(value.length - 8, 0), 16))}`;
+  // Unknown shape — mask ENTIRELY. The vendor-prefix branch above is safe because a
+  // vendor prefix is a constant: it is identical for every key of that vendor and so
+  // says nothing about this one, so it is classification, which PC-6' permits. When no
+  // prefix matches there is no constant to keep, and `value.slice(0, 8)` was therefore
+  // 8 characters of live secret body — the exact leak this file's docstring forbids, and
+  // one the boundary cannot clean up downstream because a truncated credential no longer
+  // matches the redactor's full-length shapes. Cap the mask so output stays bounded.
+  return '*'.repeat(Math.min(Math.max(value.length, 1), 24));
 }
 
 /**

--- a/src/nanomind-core/compiler/semantic-compiler.ts
+++ b/src/nanomind-core/compiler/semantic-compiler.ts
@@ -1312,7 +1312,7 @@ const CANONICAL_CREDENTIAL_PATTERNS: Array<{ label: string; regex: RegExp }> = [
   // admits `-` and `_`, so `glpat-` plus any hyphenated identifier of 20+
   // characters matches, and no cheap predicate separates the two: an entropy
   // lookahead (`(?=[a-z_-]*[A-Z0-9])`) still passed
-  // `glpat-shared-linux-docker-runner-1` and `glpat-XXXXXXXXXXXXXXXXXXXX` —
+  // a hyphenated GitLab runner slug and a drawn-blank GitLab token placeholder —
   // GitLab's own docs placeholder — while introducing a QUADRATIC scan on
   // attacker-supplied file content (measured 0ms -> 651ms at 60 KB,
   // 1ms -> 40s at 480 KB, against a 10 MB file cap). A denial of service in a
@@ -1454,7 +1454,12 @@ function scanCanonicalCredentialFormats(content: string): CanonicalCredentialHit
 
       hits.push({
         label,
-        evidence: `${label}: ${matched.slice(0, 16)}...`,
+        // Classification only. A truncated credential is still credential bytes, and it
+        // is bytes the boundary cannot remove: `redactSecretsForReportReporting` matches
+        // full-length shapes, so `matched.slice(0, 16)` passes through untouched AND is
+        // stamped `redactionStatus: 'clean'`. `label` already carries everything the user
+        // acts on (which vendor), and `file`/`line` carry where.
+        evidence: `${label}: [REDACTED]`,
       });
     }
   }
@@ -1493,7 +1498,9 @@ function scanCanonicalCredentialFormats(content: string): CanonicalCredentialHit
 
       hits.push({
         label,
-        evidence: `${label}: ${value.slice(0, 8)}...`,
+        // Same rule as the canonical arm above. This is a SEPARATE producer with its own
+        // truncation width, so fixing only the canonical one leaves the class open.
+        evidence: `${label}: [REDACTED]`,
       });
     }
   }

--- a/src/nanomind-core/orchestrate.ts
+++ b/src/nanomind-core/orchestrate.ts
@@ -14,7 +14,7 @@
  * Defense-in-depth: static findings can NEVER be suppressed, only upgraded.
  */
 
-import type { SecurityFinding, ProjectType } from '../hardening/security-check.js';
+import type { SecurityFinding, SecurityFindingDraft, ProjectType } from '../hardening/security-check.js';
 import type { NanoMindScanResult, ArtifactSummary, CoverageCandidate, SemanticFamilyCoverage } from './scanner-bridge.js';
 import { ANALYZER_FAMILY_COUNT } from './analyzers/family-coverage.js';
 import type { AnalystResponse, ArtifactCoverageVerdict } from './inference/security-analyst.js';
@@ -42,11 +42,11 @@ export interface OrchestrationOptions {
    * .well-known/mcp.json filtered for projectType=library while still
    * suppressing the sweep). Absent = all findings count (legacy behavior).
    */
-  findingVisible?: (finding: SecurityFinding) => boolean;
+  findingVisible?: (finding: SecurityFindingDraft) => boolean;
 }
 
 export interface OrchestrationResult {
-  mergedFindings: SecurityFinding[];
+  mergedFindings: SecurityFindingDraft[];
   nanomindUsed: boolean;
   compiledArtifacts: number;
   /**
@@ -150,7 +150,7 @@ export function sweepIndicatesDaemonError(stats: CoverageSweepStats): boolean {
  */
 export async function orchestrateNanoMind(
   targetDir: string,
-  existingFindings: SecurityFinding[],
+  existingFindings: SecurityFindingDraft[],
   options: OrchestrationOptions = {},
 ): Promise<OrchestrationResult> {
   const { staticOnly = false, ci = false, silent = false, nanomind = false } = options;
@@ -383,7 +383,7 @@ export async function orchestrateNanoMind(
  * and high/critical severity findings.
  */
 async function runAnalystOnFindings(
-  findings: SecurityFinding[],
+  findings: SecurityFindingDraft[],
   runInference: typeof import('./inference/security-analyst.js').runAnalystInference,
 ): Promise<AnalystResponse[]> {
   const results: AnalystResponse[] = [];
@@ -506,10 +506,10 @@ export interface CoverageSweepOutcome {
 export async function runCoverageSweep(
   targetDir: string,
   candidates: CoverageCandidate[],
-  mergedFindings: SecurityFinding[],
+  mergedFindings: SecurityFindingDraft[],
   classify: (content: string) => Promise<ArtifactCoverageVerdict | null>,
   silent = false,
-  findingVisible?: (finding: SecurityFinding) => boolean,
+  findingVisible?: (finding: SecurityFindingDraft) => boolean,
 ): Promise<CoverageSweepOutcome> {
   // Files already carrying a high/critical structural ATTACK finding are
   // covered by the per-finding analyst stage; the sweep targets the misses.

--- a/src/nanomind-core/scanner-bridge.ts
+++ b/src/nanomind-core/scanner-bridge.ts
@@ -46,7 +46,8 @@ const { readFile, readdir, stat } = trackedFs;
 import { readFileSync } from 'node:fs';
 import { join, relative, extname, basename, isAbsolute } from 'node:path';
 
-import type { SecurityFinding, Severity, ProjectType, NanoMindIntentSignal } from '../hardening/security-check.js';
+import type { SecurityFinding, SecurityFindingDraft, Severity, ProjectType, NanoMindIntentSignal } from '../hardening/security-check.js';
+import { emitFinding, type RedactedFinding } from '../hardening/finding-emit.js';
 import type { SecurityAST, CompilationResult } from './types.js';
 import type { ASTFinding } from './analyzers/capability-analyzer.js';
 import type { IntegrityStatus } from './security/integrity-verifier.js';
@@ -220,7 +221,7 @@ export interface SemanticFamilyCoverage {
 }
 
 export interface NanoMindScanResult {
-  mergedFindings: SecurityFinding[];
+  mergedFindings: SecurityFindingDraft[];
   astFindings: ASTFinding[];
   integrityStatus: IntegrityStatus;
   compiledArtifacts: number;
@@ -255,7 +256,7 @@ export interface NanoMindScanResult {
  */
 export async function runNanoMindScan(
   targetDir: string,
-  existingFindings: SecurityFinding[],
+  existingFindings: SecurityFindingDraft[],
   projectType?: ProjectType,
 ): Promise<NanoMindScanResult> {
   // Step 1: Integrity check before anything else
@@ -594,9 +595,9 @@ export function intentSignalFromCompilation(
  * an empty map returns the input array unchanged.
  */
 export function annotateFindingsWithIntent(
-  findings: SecurityFinding[],
+  findings: SecurityFindingDraft[],
   intentByPath: Map<string, NanoMindIntentSignal>,
-): SecurityFinding[] {
+): SecurityFindingDraft[] {
   if (intentByPath.size === 0) return findings;
   return findings.map(f => {
     const intent = f.file ? intentByPath.get(f.file) : undefined;
@@ -1013,12 +1014,12 @@ function findingMatchKey(file: string | undefined, attackClass: string | undefin
  * hand (tests, in-memory merges) omit it and get the previous behaviour.
  */
 export function mergeFindings(
-  staticFindings: SecurityFinding[],
+  staticFindings: SecurityFindingDraft[],
   astFindings: ASTFinding[],
   readArtifact?: (file: string) => string | undefined,
-): SecurityFinding[] {
+): SecurityFindingDraft[] {
   // Clone static findings so we don't mutate the originals
-  const merged: SecurityFinding[] = staticFindings.map(f => ({ ...f }));
+  const merged: SecurityFindingDraft[] = staticFindings.map(f => ({ ...f }));
 
   // Index static findings by match key for O(1) lookup
   const staticIndex = new Map<string, number[]>();
@@ -1086,11 +1087,17 @@ export function mergeFindings(
 function astFindingToSecurityFinding(
   ast: ASTFinding,
   readArtifact?: (file: string) => string | undefined,
-): SecurityFinding {
+): RedactedFinding {
   const needsLine = ast.line === undefined && !!ast.file;
   const raw = needsLine && readArtifact && ast.file ? readArtifact(ast.file) : undefined;
   const line = resolveFindingLine({ file: ast.file, line: ast.line, evidence: ast.evidence }, raw);
-  return {
+  // Route point 2, and the one C1 is about: `resolveFindingLine` above reads the
+  // RAW artifact and the raw `ast.evidence`, and it has already returned by the
+  // time `emitFinding` runs. Line derivation completing before redaction is
+  // therefore a property of the control flow here, not a convention a later
+  // edit could quietly invert — there is no path on which the redacted text is
+  // what gets located.
+  return emitFinding({
     checkId: ast.checkId,
     name: ast.name,
     description: ast.description,
@@ -1110,7 +1117,7 @@ function astFindingToSecurityFinding(
       evidence: ast.evidence,
       instanceCount: (ast as ASTFinding & { instanceCount?: number }).instanceCount ?? 1,
     },
-  };
+  });
 }
 
 /**

--- a/src/nanomind-core/security/defense-in-depth.ts
+++ b/src/nanomind-core/security/defense-in-depth.ts
@@ -16,6 +16,7 @@
  */
 
 import type { SecurityAST, IntentClass } from '../types.js';
+import type { ShapeId } from '../../types/credential-format.js';
 
 // ============================================================================
 // Rule 1: NanoMind can UPGRADE but NEVER SUPPRESS
@@ -137,98 +138,126 @@ export function requireBenignConsensus(
 // ============================================================================
 
 /**
+ * One redaction rule: the pattern, what replaces it, and — the reason this
+ * table exists — WHICH registry shape a match proves.
+ *
+ * `redactedShapes` (C9) may carry only ids the redactor resolved FROM THE
+ * VALUE, and a marker cannot supply that: `CREDENTIAL_REDACTION_MARKERS` is
+ * many-to-one (all five GitHub shapes share `[REDACTED_GITHUB_TOKEN]`), so
+ * recovering ids from redacted text would publish five candidates where one
+ * matched. The RULES are 1:1 with shape ids, so the id is recorded where it is
+ * actually known — at the match — rather than reconstructed afterwards.
+ *
+ * `replacement` rather than a bare marker because the AWS-secret rule preserves
+ * its name anchor via `$1`.
+ */
+interface CredentialRedactionRule {
+  readonly id: ShapeId;
+  readonly pattern: RegExp;
+  readonly replacement: string;
+}
+
+/**
+ * The rules, in the order they must run. Order and pattern bodies are carried
+ * over verbatim from the sequential `.replace()` chain this table replaced;
+ * `redaction-rule-table-parity.test.ts` pins that the folded output is
+ * byte-identical to the chain's on every fixture, so the table is a
+ * refactoring and not a behaviour change.
+ *
+ * Two registry shapes are deliberately ABSENT and must stay absent in this
+ * release: `entropy-blob` and `jwt`. Adding `entropy-blob` is the measured S4
+ * stop condition — its class `[A-Za-z0-9+=_]{40,}` swallows a git SHA-40, a
+ * SHA-256 `contentHash`, an npm `sha512-` integrity value and a base64 data-URI
+ * body, and HMA's own reports carry `contentHash` values. Closing those two is
+ * GAP-8, which is held out of this release deliberately.
+ */
+const CREDENTIAL_REDACTION_RULES: readonly CredentialRedactionRule[] = [
+  // Order matters here in a way it does not in the detector: `sk-proj-` and
+  // `sk-ant-api` must be replaced BEFORE the generic `sk-` rule, or a project
+  // key would be reported under the legacy label. The legacy rule's
+  // alphanumeric-only class already excludes both, and the ordering makes that
+  // independent of the class staying that way.
+  { id: 'anthropic-key', pattern: /sk-ant-api\d{2}-[a-zA-Z0-9_-]{20,}/g, replacement: '[REDACTED_ANTHROPIC_KEY]' },
+  { id: 'openai-project-key', pattern: /sk-proj-[a-zA-Z0-9_-]{20,}/g, replacement: '[REDACTED_OPENAI_KEY]' },
+  { id: 'openai-key', pattern: /sk-[a-zA-Z0-9]{48,}/g, replacement: '[REDACTED_OPENAI_KEY]' },
+  { id: 'aws-access-key-id', pattern: /AKIA[0-9A-Z]{16}/g, replacement: '[REDACTED_AWS_KEY]' },
+  { id: 'github-pat', pattern: /ghp_[a-zA-Z0-9]{36}/g, replacement: '[REDACTED_GITHUB_TOKEN]' },
+  { id: 'github-oauth', pattern: /gho_[a-zA-Z0-9]{36}/g, replacement: '[REDACTED_GITHUB_TOKEN]' },
+  { id: 'github-server', pattern: /ghs_[a-zA-Z0-9]{36}/g, replacement: '[REDACTED_GITHUB_TOKEN]' },
+  { id: 'github-user', pattern: /ghu_[a-zA-Z0-9]{36}/g, replacement: '[REDACTED_GITHUB_TOKEN]' },
+  { id: 'github-fine-grained', pattern: /github_pat_[a-zA-Z0-9_]{60,}/g, replacement: '[REDACTED_GITHUB_TOKEN]' },
+  { id: 'gitlab-pat', pattern: /glpat-[a-zA-Z0-9_-]{20,}/g, replacement: '[REDACTED_GITLAB_TOKEN]' },
+  { id: 'huggingface-token', pattern: /hf_[a-zA-Z0-9]{34,}/g, replacement: '[REDACTED_HUGGINGFACE_TOKEN]' },
+  { id: 'npm-token', pattern: /npm_[a-zA-Z0-9]{36}/g, replacement: '[REDACTED_NPM_TOKEN]' },
+  { id: 'stripe-live', pattern: /sk_live_[0-9a-zA-Z]{24,}/g, replacement: '[REDACTED_STRIPE_KEY]' },
+  { id: 'stripe-test', pattern: /sk_test_[0-9a-zA-Z]{24,}/g, replacement: '[REDACTED_STRIPE_KEY]' },
+  { id: 'sendgrid-key', pattern: /SG\.[a-zA-Z0-9_-]{22}\.[a-zA-Z0-9_-]{43}/g, replacement: '[REDACTED_SENDGRID_KEY]' },
+  { id: 'google-api-key', pattern: /AIza[0-9A-Za-z_-]{35}/g, replacement: '[REDACTED_GOOGLE_KEY]' },
+  { id: 'slack-token', pattern: /xox[baprs]-[a-zA-Z0-9-]{10,}/g, replacement: '[REDACTED_SLACK_TOKEN]' },
+  // AWS secret access key. The name anchor MIRRORS the detector's deliberately,
+  // and the value class is intentionally WIDER than the detector's (`=`
+  // padding, `{40,}` rather than exactly 40): over-redaction here costs a
+  // mangled token, under-redaction leaks a live secret. `$1` preserves the
+  // matched name anchor so only the value is removed.
+  {
+    id: 'aws-secret-access-key',
+    pattern: /((?:aws.{0,16}?(?:secret|private).{0,16}?key|secret[_\s.-]?access[_\s.-]?key)["'\s]*[:=]+>?\s*["']?)([A-Za-z0-9/+=]{40,})/gi,
+    replacement: '$1[REDACTED_AWS_SECRET]',
+  },
+  // The header alone is enough: the detector fires on `-----BEGIN … KEY-----`
+  // without requiring the closing marker, and a truncated or single-line block
+  // would otherwise stay verbatim.
+  { id: 'pem-private-key', pattern: /-----BEGIN [A-Z ]+ KEY-----[\s\S]*?-----END [A-Z ]+ KEY-----/g, replacement: '[REDACTED_PRIVATE_KEY]' },
+  { id: 'connection-string', pattern: /(?:postgres|mysql|mongodb|redis):\/\/[^\s'"]+/gi, replacement: '[REDACTED_CONNECTION_STRING]' },
+];
+
+/**
+ * Shape-anchored redaction that also reports WHICH shapes it resolved from the
+ * value. `shapes` is sorted and deduped, and it is empty exactly when nothing
+ * shape-anchored matched.
+ *
+ * This is the only function that can answer C9 honestly, because it is the only
+ * point at which the matched rule — and therefore the shape id — is still in
+ * hand.
+ */
+export function redactCredentialShapesReporting(content: string): {
+  text: string;
+  shapes: ShapeId[];
+} {
+  let text = content;
+  const shapes = new Set<ShapeId>();
+
+  for (const rule of CREDENTIAL_REDACTION_RULES) {
+    // `pattern` carries /g, so `replace` is a full scan; testing separately
+    // would advance `lastIndex` on a shared literal. Compare instead.
+    const before = text;
+    text = text.replace(rule.pattern, rule.replacement);
+    if (text !== before) shapes.add(rule.id);
+  }
+
+  return { text, shapes: [...shapes].sort() };
+}
+
+/**
  * Strip ALL credential-like content before sending to NanoMind.
  * This goes beyond the input sanitizer (which strips meta-instructions).
  * This strips actual secrets so NanoMind never sees real credentials.
  *
  * Even if the daemon is compromised, it cannot exfiltrate credentials
  * because it never received them.
- */
-/**
- * Redact only values that carry a recognizable CREDENTIAL SHAPE — a vendor
- * prefix, a key block, a connection string. Every rule here is anchored to a
- * shape, so it cannot destroy ordinary prose.
+ *
+ * Redacts only values that carry a recognizable CREDENTIAL SHAPE — a vendor
+ * prefix, a key block, a connection string. Every rule is anchored to a shape,
+ * so it cannot destroy ordinary prose.
  *
  * Shared by both boundaries below so the shape list cannot drift between them.
  * A shape the compiler's detectors can report MUST appear here; see
  * `pinned-credential-shapes.test.ts`, which iterates BOTH detector lists.
  */
 export function redactCredentialShapes(content: string): string {
-  let redacted = content;
-
-  // API keys.
-  //
-  // The invariant is COVERAGE, not equality: this list must redact every shape
-  // `CANONICAL_CREDENTIAL_PATTERNS` in the semantic compiler can DETECT, and it
-  // may redact more. A shape detected but not redacted is the worst of both —
-  // the scanner proves the secret is real, then forwards it to the daemon —
-  // whereas redacting something that was not a credential costs only a mangled
-  // token in an advisory prompt. `pinned-credential-shapes.test.ts` asserts
-  // that direction. (`glpat-` is deliberately here and NOT in the detector.)
-  //
-  // These rules are deliberately NOT left-anchored, unlike the detector's.
-  // Anchoring is an FP control, and the two sides want opposite defaults: a
-  // false positive here is a mangled token, a false negative is a leaked
-  // secret. Anchoring also broke adjacent tokens — `ghp_<36>ghp_<36>` redacted
-  // the first and left the second verbatim, because the replacement consumed
-  // the boundary the next match needed.
-  //
-  // Order matters here in a way it does not in the detector: `sk-proj-` and
-  // `sk-ant-api` must be replaced BEFORE the generic `sk-` rule, or a project
-  // key would be reported under the legacy label. The legacy rule's
-  // alphanumeric-only class already excludes both, and the ordering makes that
-  // independent of the class staying that way.
-  redacted = redacted.replace(/sk-ant-api\d{2}-[a-zA-Z0-9_-]{20,}/g, '[REDACTED_ANTHROPIC_KEY]');
-  redacted = redacted.replace(/sk-proj-[a-zA-Z0-9_-]{20,}/g, '[REDACTED_OPENAI_KEY]');
-  redacted = redacted.replace(/sk-[a-zA-Z0-9]{48,}/g, '[REDACTED_OPENAI_KEY]');
-  redacted = redacted.replace(/AKIA[0-9A-Z]{16}/g, '[REDACTED_AWS_KEY]');
-  redacted = redacted.replace(/ghp_[a-zA-Z0-9]{36}/g, '[REDACTED_GITHUB_TOKEN]');
-  redacted = redacted.replace(/gho_[a-zA-Z0-9]{36}/g, '[REDACTED_GITHUB_TOKEN]');
-  redacted = redacted.replace(/ghs_[a-zA-Z0-9]{36}/g, '[REDACTED_GITHUB_TOKEN]');
-  redacted = redacted.replace(/ghu_[a-zA-Z0-9]{36}/g, '[REDACTED_GITHUB_TOKEN]');
-  redacted = redacted.replace(/github_pat_[a-zA-Z0-9_]{60,}/g, '[REDACTED_GITHUB_TOKEN]');
-  redacted = redacted.replace(/glpat-[a-zA-Z0-9_-]{20,}/g, '[REDACTED_GITLAB_TOKEN]');
-  redacted = redacted.replace(/hf_[a-zA-Z0-9]{34,}/g, '[REDACTED_HUGGINGFACE_TOKEN]');
-  redacted = redacted.replace(/npm_[a-zA-Z0-9]{36}/g, '[REDACTED_NPM_TOKEN]');
-  redacted = redacted.replace(/sk_live_[0-9a-zA-Z]{24,}/g, '[REDACTED_STRIPE_KEY]');
-  redacted = redacted.replace(/sk_test_[0-9a-zA-Z]{24,}/g, '[REDACTED_STRIPE_KEY]');
-  redacted = redacted.replace(/SG\.[a-zA-Z0-9_-]{22}\.[a-zA-Z0-9_-]{43}/g, '[REDACTED_SENDGRID_KEY]');
-  redacted = redacted.replace(/AIza[0-9A-Za-z_-]{35}/g, '[REDACTED_GOOGLE_KEY]');
-  redacted = redacted.replace(/xox[baprs]-[a-zA-Z0-9-]{10,}/g, '[REDACTED_SLACK_TOKEN]');
-
-  // AWS secret access key. The compiler's SECOND detector list
-  // (`NAME_GATED_CREDENTIAL_PATTERNS`) reports this shape, so the coverage
-  // invariant requires it here — its absence left a detected 40-character
-  // secret rendering 33 characters into text, JSON, HTML and SARIF.
-  //
-  // The name anchor below MIRRORS the detector's anchor deliberately, and the
-  // first attempt at this rule shows why that is not optional: it matched only
-  // a literal `aws_secret_access_key`, while the detector also fires on
-  // `secretAccessKey`, `awsSecretKey` and `secret_access_key`. All three were
-  // detected and left verbatim, leaking the FULL 40 characters whenever the
-  // value was unquoted — a narrower redactor than detector is the same drift
-  // this rule exists to close, just one level down.
-  //
-  // The value class is intentionally WIDER than the detector's (`=` padding,
-  // `{40,}` rather than exactly 40): over-redaction here costs a mangled
-  // token, under-redaction leaks a live secret. Quotes stay optional because
-  // the detector makes them optional; the generic name-gated rule below
-  // requires quotes and therefore cannot cover the bare form.
-  redacted = redacted.replace(
-    /((?:aws.{0,16}?(?:secret|private).{0,16}?key|secret[_\s.-]?access[_\s.-]?key)["'\s]*[:=]+>?\s*["']?)([A-Za-z0-9/+=]{40,})/gi,
-    '$1[REDACTED_AWS_SECRET]',
-  );
-
-  // Private key blocks. The header alone is enough: the detector fires on
-  // `-----BEGIN … KEY-----` without requiring the closing marker, and a
-  // truncated or single-line block would otherwise stay verbatim.
-  redacted = redacted.replace(/-----BEGIN [A-Z ]+ KEY-----[\s\S]*?-----END [A-Z ]+ KEY-----/g, '[REDACTED_PRIVATE_KEY]');
-
-  // Connection strings
-  redacted = redacted.replace(/(?:postgres|mysql|mongodb|redis):\/\/[^\s'"]+/gi, '[REDACTED_CONNECTION_STRING]');
-
-  return redacted;
+  return redactCredentialShapesReporting(content).text;
 }
+
 
 /**
  * Daemon boundary. Shapes, plus an aggressive name-gated rule that redacts ANY
@@ -267,10 +296,29 @@ export function redactSecretsForNanoMind(content: string): string {
  * "hunter2xyz"` redacted while leaving prose intact.
  */
 export function redactSecretsForReport(content: string): string {
-  return redactCredentialShapes(content).replace(
+  return redactSecretsForReportReporting(content).text;
+}
+
+/**
+ * The report boundary, reporting which shapes it resolved FROM THE VALUE.
+ *
+ * The name-gated rule below contributes NO shape ids, and that is C9 stated as
+ * code rather than as a convention: it fires on an IDENTIFIER
+ * (`password`/`secret`/`token`/`key`) without ever inspecting what the value
+ * is, so it cannot know which shape it removed — it cannot even know it removed
+ * a credential. A finding redacted only by this rule is honestly
+ * `redactionStatus: 'applied'` with `redactedShapes: []`.
+ */
+export function redactSecretsForReportReporting(content: string): {
+  text: string;
+  shapes: ShapeId[];
+} {
+  const shapePass = redactCredentialShapesReporting(content);
+  const text = shapePass.text.replace(
     /(?:password|secret|token|key)\s*[=:]\s*['"]([^'"\s]{8,})['"]/gi,
     (match) => `${match.split(/[=:]/)[0]}=[REDACTED]`,
   );
+  return { text, shapes: shapePass.shapes };
 }
 
 // ============================================================================

--- a/src/semantic/structural/credential-context.ts
+++ b/src/semantic/structural/credential-context.ts
@@ -37,12 +37,25 @@ const URL_CREDENTIAL_PATTERN =
 
 /**
  * Classify a secret by its key name and value.
- * Returns { type, masked } where type is a human-readable label and
- * masked shows the first 5 chars of the value followed by ****.
+ * Returns { type, masked } where type is a human-readable label and masked is a
+ * fixed marker carrying NO characters of the value.
+ *
+ * `masked` deliberately does not preview the value. It once returned the first 5
+ * characters, which reached `description` and could not be removed downstream: the
+ * reporting boundary matches full-length credential shapes, so a 5-character prefix
+ * is invisible to it and rides out stamped `redactionStatus: 'clean'`. Do not
+ * reintroduce a preview here -- `type` is what identifies the credential to the user,
+ * and `__tests__/hardening/credential-preview-truncation.test.ts` fails if any
+ * character of the value reaches the finding.
  */
 function classifySecret(key: string, value: string): { type: string; masked: string } {
   const v = value.trim().replace(/^["']|["']$/g, '');
-  const preview = v.length > 5 ? v.slice(0, 5) + '****' : '****';
+  // Classification only — never a prefix of the value. `v.slice(0, 5) + '****'` put 5 raw
+  // characters into `description`, and the boundary could not remove them: its patterns
+  // match full-length credentials, so a 5-character preview is invisible to it and rides
+  // out stamped `redactionStatus: 'clean'`. The `type` returned alongside is what tells
+  // the user which credential this is.
+  const preview = '[REDACTED]';
 
   // Value-based classification (most reliable)
   if (/^sk-ant-/.test(v)) return { type: 'Anthropic API key', masked: preview };
@@ -447,7 +460,10 @@ function detectUrlPasswords(file: AnalysisFile): SemanticFinding[] {
       if (isPlaceholderUrlPassword(password)) continue;
       if (isVisualFiller(password, MIN_DRAWN_ONLY_CORE_CHARS)) continue;
 
-      const urlPwMasked = password.length > 5 ? password.slice(0, 5) + '****' : '****';
+      // Classification only. The line below already redacts every occurrence of `password`
+      // out of `safeContent`; this parenthetical was the one place the same secret's first
+      // 5 characters still reached `description`.
+      const urlPwMasked = '[REDACTED]';
       // Redact every occurrence of the raw password from the line before placing it
       // into structured evidence. Split-on-`:pw@` only catches the URL slot, but
       // the same secret can appear in comments, sibling assignments, or doc strings

--- a/src/types/credential-format.ts
+++ b/src/types/credential-format.ts
@@ -62,15 +62,565 @@
  */
 const JWT_PREFIX = 'eyJ';
 
+/* ------------------------------------------------------------------ *
+ * The credential shape registry
+ * ------------------------------------------------------------------ */
+
+/**
+ * The surfaces a credential shape can reach.
+ *
+ * These are the four places in the tree that decide, independently, whether a
+ * run of bytes is a credential. They are named here so that a shape's ABSENCE
+ * from one of them is data rather than an accident nobody can see:
+ *
+ *   - `format-scan`        this module's `findCredentialFormatMatch` /
+ *                          `hasCredentialFormat` — vendor alternation, JWT scan
+ *                          and the entropy fallback.
+ *   - `vendor-alternation` membership in `VENDOR_PREFIX_ALTERNATIVES`, i.e. the
+ *                          regex alternation the format scan and its callers
+ *                          compose.
+ *   - `ast-canonical`      `CANONICAL_CREDENTIAL_PATTERNS` and
+ *                          `NAME_GATED_CREDENTIAL_PATTERNS` in
+ *                          `nanomind-core/compiler/semantic-compiler.ts`.
+ *   - `nanomind-redaction` `redactCredentialShapes` in
+ *                          `nanomind-core/security/defense-in-depth.ts`.
+ *
+ * Every membership recorded below was read off those three files, not inferred.
+ */
+export type Surface =
+  | 'format-scan'
+  | 'vendor-alternation'
+  | 'ast-canonical'
+  | 'nanomind-redaction';
+
+/** Every shape this tree can detect or redact, by id. */
+export type ShapeId =
+  | 'anthropic-key'
+  | 'openai-project-key'
+  | 'openai-key'
+  | 'stripe-live'
+  | 'stripe-test'
+  | 'github-pat'
+  | 'github-oauth'
+  | 'github-server'
+  | 'github-user'
+  | 'github-fine-grained'
+  | 'huggingface-token'
+  | 'gitlab-pat'
+  | 'npm-token'
+  | 'aws-access-key-id'
+  | 'google-api-key'
+  | 'slack-token'
+  | 'sendgrid-key'
+  | 'jwt'
+  | 'entropy-blob'
+  | 'pem-private-key'
+  | 'aws-secret-access-key'
+  | 'connection-string';
+
+/**
+ * A credential body: either one run of a character class, or fixed-width
+ * segments joined by a separator (SendGrid, and nothing else today).
+ *
+ * `min`/`max` are the DETECTOR's floor and ceiling, deliberately — see
+ * `shapeAlternation`.
+ */
+export type ShapeBody =
+  | { readonly kind: 'run'; readonly class: string; readonly min: number; readonly max?: number }
+  | {
+      readonly kind: 'segments';
+      readonly separator: string;
+      readonly segments: readonly { readonly class: string; readonly length: number }[];
+    };
+
+interface ShapeCommon {
+  readonly id: ShapeId;
+  /** Display only. NEVER enumerate by this — see `slack-token`. */
+  readonly label: string;
+  /**
+   * Literal substrings that identify a hand-written COPY of this shape in
+   * source. One entry per spelling: `SG.` and `SG\.` are the same shape written
+   * two ways and a single-spelling guard sees only one of them.
+   */
+  readonly guards: readonly string[];
+  readonly surfaces: ReadonlySet<Surface>;
+  /**
+   * The measured reason this shape does not reach every surface. REQUIRED
+   * whenever `surfaces` is not the full set — enforced at load, below.
+   */
+  readonly rationale?: string;
+}
+
+/** A shape identified by a vendor-issued prefix. */
+export interface VendorShape extends ShapeCommon {
+  readonly kind: 'vendor';
+  /**
+   * The recognisable head, as regex source, carrying NO quantifier: `ghp_`,
+   * `sk-ant-api[0-9]`, `xox[abprs]-`. Unquantified classes are part of the head
+   * because they are part of what makes the token recognisable.
+   */
+  readonly head: string;
+  readonly body: ShapeBody;
+}
+
+/** A shape with no vendor prefix: self-describing, or gated by a key name. */
+export interface StructuralShape extends ShapeCommon {
+  readonly kind: 'structural';
+  /**
+   * Full regex source, or the empty string for a shape matched by a scan rather
+   * than by a regex (the JWT).
+   */
+  readonly source: string;
+  /** The key-name regex a name-gated shape requires before it will fire. */
+  readonly nameGate?: string;
+}
+
+export type CredentialShape = VendorShape | StructuralShape;
+
+const ALL_SURFACES: readonly Surface[] = [
+  'format-scan',
+  'vendor-alternation',
+  'ast-canonical',
+  'nanomind-redaction',
+];
+
+const EVERY_SURFACE: ReadonlySet<Surface> = new Set(ALL_SURFACES);
+
+/**
+ * Why five shapes are missing from `ast-canonical`, in one place because it is
+ * ONE reason and repeating it per shape would read as five findings.
+ *
+ * It is NOT a measured exclusion, and saying so is the point. The canonical
+ * list is short by process, not by judgement: a first draft added eight shapes
+ * at once, two adversarial rounds measured a false-positive class on ordinary
+ * identifiers plus a quadratic scan introduced while trying to bound it, and
+ * the rest are being re-added ONE AT A TIME on `fix/credential-fp-siblings`
+ * (#352/#353). The history is written down at
+ * `__tests__/nanomind-core/pinned-credential-shapes.test.ts:9-14`.
+ *
+ * So for each shape carrying this string: nobody has measured its false-
+ * positive cost, and nobody has decided it should be absent. It is an
+ * UNDECLARED GAP with a known cause, which is a different thing from a
+ * deliberate exclusion like `gitlab-pat`'s, and a reader has to be able to tell
+ * them apart. Closing them is the widening step, and it is separately gated.
+ *
+ * Note what the gap actually costs, because it is not "the shape is unknown":
+ * `credential-analyzer.ts:116-121` wires the shared matcher as a GATE
+ * (`if (!credLocation) return findings;`) and never as a producer, so these
+ * shapes are matched by the vocabulary and then dropped rather than never seen.
+ */
+const NOT_YET_RE_ADDED_TO_CANONICAL =
+  'UNDECLARED GAP, not a measured exclusion: absent from CANONICAL_CREDENTIAL_PATTERNS ' +
+  '(semantic-compiler.ts:1279-1330) only because that list is being re-populated one shape at a ' +
+  'time on fix/credential-fp-siblings (#352/#353) after a first draft of eight measured an FP ' +
+  'class and a quadratic scan — see __tests__/nanomind-core/pinned-credential-shapes.test.ts:9-14. ' +
+  'No FP measurement exists for this shape. Contrast gitlab-pat, whose absence IS measured.';
+
+/**
+ * ONE floor per shape, and it is the DETECTOR's.
+ *
+ * The reason is measured. `defense-in-depth` hand-wrote its own body counts —
+ * `ghp_…{36}`, `github_pat_…{60,}`, `hf_…{34,}`, `npm_…{36}`, `sk_live_…{24,}`
+ * — while this module's detector uses `{20,}`. Every gap between the two is a
+ * band in which a token is DETECTED and then NOT redacted: the scanner proves
+ * the secret is real and forwards it verbatim. Deriving a redactor quantifier
+ * from `body.min` closes that band mechanically. Nothing derives from it yet —
+ * this registry is data first — but the floor lives in exactly one place now,
+ * so the adoption cannot re-create the drift it removes.
+ */
+export const CREDENTIAL_SHAPES: readonly CredentialShape[] = [
+  {
+    kind: 'vendor',
+    id: 'anthropic-key',
+    label: 'Anthropic API key',
+    head: 'sk-ant-api[0-9]',
+    body: { kind: 'run', class: '[a-zA-Z0-9_-]', min: 16 },
+    guards: ['sk-ant'],
+    surfaces: EVERY_SURFACE,
+  },
+  {
+    kind: 'vendor',
+    id: 'openai-project-key',
+    label: 'OpenAI project key',
+    head: 'sk-proj-',
+    body: { kind: 'run', class: '[a-zA-Z0-9_-]', min: 16 },
+    guards: ['sk-proj'],
+    surfaces: EVERY_SURFACE,
+  },
+  {
+    kind: 'vendor',
+    id: 'openai-key',
+    label: 'OpenAI legacy key',
+    head: 'sk-',
+    body: { kind: 'run', class: '[a-zA-Z0-9_-]', min: 20 },
+    // `sk-` on its own matches `task-`, `risk-` and `disk-` and would make the
+    // enumeration guard useless. The two spellings a copy actually takes are a
+    // character class (`sk-[a-zA-Z0-9…`) and an alternation branch (`sk-|…`).
+    guards: ['sk-[', 'sk-|'],
+    surfaces: EVERY_SURFACE,
+  },
+  {
+    kind: 'vendor',
+    id: 'stripe-live',
+    label: 'Stripe live key',
+    head: 'sk_live_',
+    body: { kind: 'run', class: '[a-zA-Z0-9]', min: 20 },
+    guards: ['sk_live_'],
+    surfaces: EVERY_SURFACE,
+  },
+  {
+    kind: 'vendor',
+    id: 'stripe-test',
+    label: 'Stripe test key',
+    head: 'sk_test_',
+    body: { kind: 'run', class: '[a-zA-Z0-9]', min: 20 },
+    guards: ['sk_test_'],
+    surfaces: new Set<Surface>(['format-scan', 'vendor-alternation', 'nanomind-redaction']),
+    rationale: NOT_YET_RE_ADDED_TO_CANONICAL,
+  },
+  {
+    kind: 'vendor',
+    id: 'github-pat',
+    label: 'GitHub personal access token',
+    head: 'ghp_',
+    body: { kind: 'run', class: '[a-zA-Z0-9]', min: 20 },
+    guards: ['ghp_'],
+    surfaces: EVERY_SURFACE,
+  },
+  {
+    kind: 'vendor',
+    id: 'github-oauth',
+    label: 'GitHub OAuth token',
+    head: 'gho_',
+    body: { kind: 'run', class: '[a-zA-Z0-9]', min: 20 },
+    guards: ['gho_'],
+    surfaces: EVERY_SURFACE,
+  },
+  {
+    kind: 'vendor',
+    id: 'github-server',
+    label: 'GitHub app token',
+    head: 'ghs_',
+    body: { kind: 'run', class: '[a-zA-Z0-9]', min: 20 },
+    guards: ['ghs_'],
+    surfaces: EVERY_SURFACE,
+  },
+  {
+    kind: 'vendor',
+    id: 'github-user',
+    label: 'GitHub user-to-server token',
+    head: 'ghu_',
+    body: { kind: 'run', class: '[a-zA-Z0-9]', min: 20 },
+    guards: ['ghu_'],
+    surfaces: new Set<Surface>(['format-scan', 'vendor-alternation', 'nanomind-redaction']),
+    rationale: NOT_YET_RE_ADDED_TO_CANONICAL,
+  },
+  {
+    kind: 'vendor',
+    id: 'github-fine-grained',
+    label: 'GitHub fine-grained token',
+    head: 'github_pat_',
+    body: { kind: 'run', class: '[a-zA-Z0-9_]', min: 20 },
+    guards: ['github_pat_'],
+    surfaces: new Set<Surface>(['format-scan', 'vendor-alternation', 'nanomind-redaction']),
+    rationale: NOT_YET_RE_ADDED_TO_CANONICAL,
+  },
+  {
+    kind: 'vendor',
+    id: 'huggingface-token',
+    label: 'Hugging Face token',
+    head: 'hf_',
+    body: { kind: 'run', class: '[a-zA-Z0-9]', min: 20 },
+    guards: ['hf_'],
+    surfaces: new Set<Surface>(['format-scan', 'vendor-alternation', 'nanomind-redaction']),
+    rationale: NOT_YET_RE_ADDED_TO_CANONICAL,
+  },
+  {
+    kind: 'vendor',
+    id: 'gitlab-pat',
+    label: 'GitLab personal access token',
+    head: 'glpat-',
+    body: { kind: 'run', class: '[a-zA-Z0-9_-]', min: 20 },
+    guards: ['glpat-'],
+    surfaces: new Set<Surface>(['format-scan', 'vendor-alternation', 'nanomind-redaction']),
+    rationale:
+      'DELIBERATELY excluded from CANONICAL_CREDENTIAL_PATTERNS and the exclusion is measured ' +
+      '(semantic-compiler.ts:1310-1324): the body class admits `-` and `_`, so `glpat-` plus any ' +
+      'hyphenated identifier matches, and the entropy lookahead tried to separate them went ' +
+      'QUADRATIC on attacker-supplied content — 0ms -> 651ms at 60 KB, 1ms -> 40s at 480 KB — ' +
+      'while still passing `glpat-' + 'shared-linux-docker-runner-1`. Do not flatten this into the ' +
+      'canonical list without a bounded pattern AND a ReDoS measurement.',
+  },
+  {
+    kind: 'vendor',
+    id: 'npm-token',
+    label: 'npm access token',
+    head: 'npm_',
+    body: { kind: 'run', class: '[a-zA-Z0-9]', min: 20 },
+    guards: ['npm_'],
+    surfaces: new Set<Surface>(['format-scan', 'vendor-alternation', 'nanomind-redaction']),
+    rationale: NOT_YET_RE_ADDED_TO_CANONICAL,
+  },
+  {
+    kind: 'vendor',
+    id: 'aws-access-key-id',
+    label: 'AWS access key ID',
+    head: 'AKIA',
+    body: { kind: 'run', class: '[0-9A-Z]', min: 16, max: 16 },
+    guards: ['AKIA'],
+    surfaces: EVERY_SURFACE,
+  },
+  {
+    kind: 'vendor',
+    id: 'google-api-key',
+    label: 'Google API key',
+    head: 'AIza',
+    body: { kind: 'run', class: '[0-9A-Za-z_-]', min: 35, max: 35 },
+    guards: ['AIza'],
+    surfaces: EVERY_SURFACE,
+  },
+  {
+    kind: 'vendor',
+    id: 'slack-token',
+    label: 'Slack token',
+    // The class is part of the head on purpose: `xoxb-`, `xoxp-`, `xoxa-`,
+    // `xoxr-` and `xoxs-` are five distinct token types that this tree reports
+    // under the SINGLE label "Slack bot token". That is why enumeration is by
+    // pattern and never by label — narrowing this to `xoxb-` is invisible to
+    // any label-set assertion.
+    head: 'xox[abprs]-',
+    body: { kind: 'run', class: '[0-9A-Za-z-]', min: 10 },
+    guards: ['xox'],
+    surfaces: EVERY_SURFACE,
+  },
+  {
+    kind: 'vendor',
+    id: 'sendgrid-key',
+    label: 'SendGrid API key',
+    head: 'SG\\.',
+    // FIXED widths, and they are load-bearing. Written as `SG\.<16,>\.<16,>`
+    // this matched any dotted identifier with two long segments, so
+    // `MSG.INCIDENT_ESCALATION_QUEUE.HIGH_PRIORITY_ROUTE` was positively
+    // identified as a credential on a benign taxonomy document. A real SendGrid
+    // secret is 43 characters and clears the 40-character blob fallback on its
+    // own; this shape is what NAMES it. Do not relax the widths.
+    body: {
+      kind: 'segments',
+      separator: '\\.',
+      segments: [
+        { class: '[A-Za-z0-9_-]', length: 22 },
+        { class: '[A-Za-z0-9_-]', length: 43 },
+      ],
+    },
+    guards: ['SG.', 'SG\\.'],
+    surfaces: new Set<Surface>(['format-scan', 'vendor-alternation', 'nanomind-redaction']),
+    rationale:
+      'Absent from CANONICAL_CREDENTIAL_PATTERNS: semantic-compiler.ts:1325-1329 carries the ' +
+      'explanatory comment for this shape but no entry beneath it, so the comment reads as ' +
+      'coverage that is not there.',
+  },
+  {
+    kind: 'structural',
+    id: 'jwt',
+    label: 'JSON Web Token',
+    // Matched by a linear scan, not by a regex alternative. Expressing the JWT
+    // as an alternative is what made every consumer either quadratic or
+    // truncating, so `findJwtMatch` owns it and there is no source here.
+    source: '',
+    guards: ['eyJ'],
+    surfaces: new Set<Surface>(['format-scan']),
+    rationale:
+      'Detected only by this module (findJwtMatch, and the JWT_PREFIX entry in ' +
+      'VENDOR_PREFIX_MATCHERS). It is NOT in CANONICAL_CREDENTIAL_PATTERNS and it is NOT in ' +
+      'redactCredentialShapes — defense-in-depth.ts:181-231 has no eyJ rule at all. ' +
+      'A JWT reaching redactCredentialShapes today is passed through verbatim.',
+  },
+  {
+    kind: 'structural',
+    id: 'entropy-blob',
+    label: 'High-entropy secret',
+    source: '\\b[A-Za-z0-9+=_]{40,}\\b',
+    guards: ['[A-Za-z0-9+=_]{40,}'],
+    surfaces: new Set<Surface>(['format-scan']),
+    rationale:
+      'The anonymous fallback (credential-format.ts:873 ENTROPY_BLOB_ALTERNATIVE), gated by ' +
+      'isCredibleEntropyBlob at credential-format.ts:995. Deliberately confined to this module: ' +
+      'it has no vendor name to report, so promoting it to the redactor or to ' +
+      'CANONICAL_CREDENTIAL_PATTERNS (semantic-compiler.ts:1279-1330) is an FP question nobody ' +
+      'has measured.',
+  },
+  {
+    kind: 'structural',
+    id: 'pem-private-key',
+    label: 'PEM private key',
+    source: '-----BEGIN (?:RSA |EC |DSA |OPENSSH |ENCRYPTED |PRIVATE)[A-Z ]*KEY-----',
+    guards: ['-----BEGIN'],
+    surfaces: new Set<Surface>(['ast-canonical', 'nanomind-redaction']),
+    rationale:
+      'Not a vendor prefix and not part of this module: detected by ' +
+      'CANONICAL_CREDENTIAL_PATTERNS (semantic-compiler.ts:1330) and redacted by ' +
+      'defense-in-depth.ts:227. Listed here because a shape absent from the registry cannot be ' +
+      'guarded against being copied a fourth time.',
+  },
+  {
+    kind: 'structural',
+    id: 'aws-secret-access-key',
+    label: 'AWS secret access key',
+    source: '[A-Za-z0-9/+=]{40,}',
+    nameGate: '(?:aws.{0,16}?(?:secret|private).{0,16}?key|secret[_\\s.-]?access[_\\s.-]?key)',
+    guards: ['secret_access_key', 'secret[_\\s.-]?access'],
+    surfaces: new Set<Surface>(['ast-canonical', 'nanomind-redaction']),
+    rationale:
+      'Name-gated: a bare 40-character blob is a git SHA as often as a secret, so it fires only ' +
+      'when the assignment target names it. Lives in NAME_GATED_CREDENTIAL_PATTERNS ' +
+      '(semantic-compiler.ts:1350-1364), not the canonical list, and has no vendor prefix, so it ' +
+      'is on neither of this module`s surfaces.',
+  },
+  {
+    kind: 'structural',
+    id: 'connection-string',
+    label: 'Connection string with embedded credentials',
+    source: '(?:postgres|mysql|mongodb|redis)://[^\\s\'"]+',
+    guards: ['postgres://', 'mongodb://'],
+    surfaces: new Set<Surface>(['nanomind-redaction']),
+    rationale:
+      'Redacted by defense-in-depth but detected by neither this module nor the canonical list. ' +
+      'Note the scheme sets already disagree: the redactor covers 4 schemes while ' +
+      'credential-context.ts:35 URL_CREDENTIAL_PATTERN covers 10 (adding postgresql, amqp, ' +
+      'rabbitmq, ftp, sftp, http, https), so six schemes are located and never redacted here.',
+  },
+];
+
+/**
+ * Compose a shape's alternation source from its own parts.
+ *
+ * THE RECORD STORES A BARE ALTERNATION AND EACH ROLE COMPOSES ITS OWN ANCHOR.
+ * The detector left-anchors (`anchoredVendorAlternation`); the redactor is
+ * deliberately unanchored, with a written reason — anchoring broke
+ * `ghp_<36>ghp_<36>`, redacting the first and leaving the second, because the
+ * replacement consumed the boundary the next match needed. Storing an anchored
+ * regex would force one of the two roles to be wrong.
+ */
+export function shapeAlternation(shape: CredentialShape): string {
+  if (shape.kind === 'structural') return shape.source;
+  const { body } = shape;
+  if (body.kind === 'segments') {
+    return (
+      shape.head +
+      body.segments.map(s => `${s.class}{${s.length}}`).join(body.separator)
+    );
+  }
+  const quantifier =
+    body.max === undefined
+      ? `{${body.min},}`
+      : body.max === body.min
+        ? `{${body.min}}`
+        : `{${body.min},${body.max}}`;
+  return `${shape.head}${body.class}${quantifier}`;
+}
+
+/**
+ * The marker each shape redacts to.
+ *
+ * A `Record<ShapeId, string>` rather than a field on the shape, so that the
+ * TYPE is what forces totality: adding a member to `ShapeId` without adding a
+ * marker is a compile error, before any test runs. The load-time check below is
+ * the second layer, for the JavaScript consumer the type never reaches.
+ *
+ * A shape cannot become detectable without becoming redactable in the same
+ * edit. That is the whole mechanism: `defense-in-depth` used to carry sixteen
+ * hand-written vendor rules with their own body counts, and a `ghp_` token with
+ * a 44-character body had its first 36 characters consumed by the labelled rule
+ * and shipped the remaining 8 verbatim to stdout, `--json`, SARIF and HTML.
+ */
+export const CREDENTIAL_REDACTION_MARKERS: Readonly<Record<ShapeId, string>> = {
+  'anthropic-key': '[REDACTED_ANTHROPIC_KEY]',
+  'openai-project-key': '[REDACTED_OPENAI_KEY]',
+  'openai-key': '[REDACTED_OPENAI_KEY]',
+  'stripe-live': '[REDACTED_STRIPE_KEY]',
+  'stripe-test': '[REDACTED_STRIPE_KEY]',
+  'github-pat': '[REDACTED_GITHUB_TOKEN]',
+  'github-oauth': '[REDACTED_GITHUB_TOKEN]',
+  'github-server': '[REDACTED_GITHUB_TOKEN]',
+  'github-user': '[REDACTED_GITHUB_TOKEN]',
+  'github-fine-grained': '[REDACTED_GITHUB_TOKEN]',
+  'huggingface-token': '[REDACTED_HUGGINGFACE_TOKEN]',
+  'gitlab-pat': '[REDACTED_GITLAB_TOKEN]',
+  'npm-token': '[REDACTED_NPM_TOKEN]',
+  'aws-access-key-id': '[REDACTED_AWS_KEY]',
+  'google-api-key': '[REDACTED_GOOGLE_KEY]',
+  'slack-token': '[REDACTED_SLACK_TOKEN]',
+  'sendgrid-key': '[REDACTED_SENDGRID_KEY]',
+  jwt: '[REDACTED_JWT]',
+  'entropy-blob': '[REDACTED_SECRET]',
+  'pem-private-key': '[REDACTED_PRIVATE_KEY]',
+  'aws-secret-access-key': '[REDACTED_AWS_SECRET]',
+  'connection-string': '[REDACTED_CONNECTION_STRING]',
+};
+
+/**
+ * Load-time totality, in both directions, plus the rationale rule.
+ *
+ * Runs at module initialisation so a registry that cannot satisfy its own
+ * contract fails loudly at import rather than silently at the first redaction.
+ */
+(function assertRegistryTotality(): void {
+  const ids = new Set<ShapeId>();
+  for (const shape of CREDENTIAL_SHAPES) {
+    if (ids.has(shape.id)) {
+      throw new Error(`credential-format: duplicate shape id ${shape.id}`);
+    }
+    ids.add(shape.id);
+    if (CREDENTIAL_REDACTION_MARKERS[shape.id] === undefined) {
+      throw new Error(
+        `credential-format: no redaction marker for shape ${shape.id}. Add one to ` +
+          'CREDENTIAL_REDACTION_MARKERS — a detectable shape must be nameable when it is redacted.',
+      );
+    }
+    if (shape.guards.length === 0) {
+      throw new Error(
+        `credential-format: shape ${shape.id} has no enumeration guard. A shape with no guard ` +
+          'literal can be copied into another file without the enumeration test seeing it.',
+      );
+    }
+    const total = ALL_SURFACES.every(s => shape.surfaces.has(s));
+    if (!total && (shape.rationale === undefined || shape.rationale.length === 0)) {
+      throw new Error(
+        `credential-format: shape ${shape.id} reaches only ` +
+          `${[...shape.surfaces].join(', ')} and carries no rationale. A surface a shape does ` +
+          'not reach is either a measured decision or a defect, and the record has to say which.',
+      );
+    }
+  }
+  for (const id of Object.keys(CREDENTIAL_REDACTION_MARKERS) as ShapeId[]) {
+    if (!ids.has(id)) {
+      throw new Error(
+        `credential-format: orphan redaction marker for ${id} — no such shape in ` +
+          'CREDENTIAL_SHAPES. Markers and shapes are one vocabulary, not two.',
+      );
+    }
+  }
+})();
+
+/** Every shape that reaches `surface`, in registry order. */
+export function shapesFor(surface: Surface): readonly CredentialShape[] {
+  return CREDENTIAL_SHAPES.filter(s => s.surfaces.has(surface));
+}
+
 /**
  * Vendor-prefixed credential shapes, in one place.
  *
- * This is the single source of truth. The credential analyzer's
- * `hasVendorPrefixCredential` content gate and `maskCredentialValue` both build
- * from this same array; keeping separate hand-maintained lists meant a token
- * could be "vendor-known" to one gate and anonymous to another, which is how
- * `hf_`, `ghs_`, `ghu_`, `glpat-` and `npm_` ended up subject to the entropy
- * fallback in one code path and exempt in the next.
+ * DERIVED from `CREDENTIAL_SHAPES` — this array used to be the source of truth
+ * and is now a VIEW of it, byte-identical to the literal it replaced
+ * (`__tests__/types/credential-shape-registry.test.ts` pins every entry against
+ * a hand-written expectation). Keeping separate hand-maintained lists meant a
+ * token could be "vendor-known" to one gate and anonymous to another, which is
+ * how `hf_`, `ghs_`, `ghu_`, `glpat-` and `npm_` ended up subject to the
+ * entropy fallback in one code path and exempt in the next.
+ *
+ * Order is registry order and it is load-bearing: `sk-ant-api…` and `sk-proj-…`
+ * must be tested before the generic `sk-…`, or a project key is reported under
+ * the legacy label.
  *
  * The JWT is deliberately NOT here — it is the one shape whose segments are
  * unbounded, and expressing it as a regex alternative is what made every
@@ -81,37 +631,67 @@ const JWT_PREFIX = 'eyJ';
  * Alternatives are NOT anchored here. See `anchoredVendorAlternation` for who
  * anchors and who deliberately does not.
  */
-export const VENDOR_PREFIX_ALTERNATIVES = [
-  'sk-ant-api[0-9][a-zA-Z0-9_-]{16,}',
-  'sk-proj-[a-zA-Z0-9_-]{16,}',
-  'sk-[a-zA-Z0-9_-]{20,}',
-  'sk_live_[a-zA-Z0-9]{20,}',
-  'sk_test_[a-zA-Z0-9]{20,}',
-  'ghp_[a-zA-Z0-9]{20,}',
-  'gho_[a-zA-Z0-9]{20,}',
-  'ghs_[a-zA-Z0-9]{20,}',
-  'ghu_[a-zA-Z0-9]{20,}',
-  'github_pat_[a-zA-Z0-9_]{20,}',
-  'hf_[a-zA-Z0-9]{20,}',
-  'glpat-[a-zA-Z0-9_-]{20,}',
-  'npm_[a-zA-Z0-9]{20,}',
-  'AKIA[0-9A-Z]{16}',
-  'AIza[0-9A-Za-z_-]{35}',
-  'xox[abprs]-[0-9A-Za-z-]{10,}',
-  // SendGrid keys are `SG.<22-char key id>.<43-char secret>`, both segments at
-  // FIXED lengths. Written as `SG\.<16,>\.<16,>` this matched any dotted
-  // identifier with two long segments, so
-  // `MSG.INCIDENT_ESCALATION_QUEUE.HIGH_PRIORITY_ROUTE` was positively
-  // identified as a credential on a benign taxonomy document — the very
-  // false-positive class this module exists to remove, re-created one gate
-  // over. `origin/main` has no `SG.` at all and is clean on it.
-  //
-  // The fixed lengths are what separate a key from a namespace, and they do it
-  // in the UNANCHORED veto too, which is where the anchor could not reach. A
-  // real SendGrid secret is 43 characters, so it also clears the 40-character
-  // blob fallback on its own; this alternative is what names it.
-  'SG\\.[A-Za-z0-9_-]{22}\\.[A-Za-z0-9_-]{43}',
+export const VENDOR_PREFIX_ALTERNATIVES = shapesFor('vendor-alternation').map(shapeAlternation);
+
+/**
+ * Key names that mark a value as a credential when the value itself has no
+ * recognisable shape.
+ *
+ * The union of the four vocabularies that encode this list today, each of which
+ * was read to build it:
+ *
+ *   - `scanner/detect.ts:496`               api[_-]?key, secret, token, password
+ *   - `scanner/permission-vocabulary.ts:415` + apikey, passwd, pwd, authorization
+ *   - `nanomind-core/security/defense-in-depth.ts:270` password, secret, token, key
+ *   - `semantic/structural/credential-context.ts:29` the 20-name list
+ *
+ * WARNING FOR THE ADOPTION STEP: this union is WIDER than three of the four
+ * consumers, and `key` alone (from defense-in-depth) is the widest member of
+ * all. Adopting this list at a narrow site widens what that site reports, which
+ * is a detection change and not a refactor. `keyNamesFor` records which sites
+ * carry which name so that widening is a measured decision rather than a
+ * side effect.
+ */
+export const CREDENTIAL_KEY_NAMES: readonly string[] = [
+  'api_key',
+  'apikey',
+  'secret',
+  'token',
+  'password',
+  'passwd',
+  'pwd',
+  'authorization',
+  'auth',
+  'credential',
+  'key',
+  'access_key',
+  'private_key',
+  'client_secret',
+  'signing_key',
+  'encryption_key',
+  'master_key',
+  'jwt_secret',
+  'session_secret',
+  'db_password',
+  'database_password',
 ];
+
+/**
+ * The separator between a credential key name and its value, in one place.
+ *
+ * `\s*` `[:=]` `\s*` `["']?` and NOTHING ELSE. Every optional atom added
+ * between the two `\s*` runs makes the pair ambiguous and the match quadratic:
+ * a `(?:bearer|basic|token)?` group added here took `detect` from 0.25s to 51s
+ * on a 200 KB config, reachable through `secure`, which has no size cap in
+ * front of it. An opaque bearer token is a KNOWN GAP, not something to close by
+ * stepping over the scheme word.
+ *
+ * Returns a fresh RegExp each call: a shared `g`-flagged instance carries
+ * `lastIndex` between callers.
+ */
+export function keyNameDelimiterPattern(): RegExp {
+  return /\s*[:=]\s*["']?/;
+}
 
 /**
  * Left anchor for a vendor prefix: the prefix must not be glued to the tail of

--- a/src/types/redacted-evidence.ts
+++ b/src/types/redacted-evidence.ts
@@ -1,0 +1,97 @@
+/**
+ * Reading a finding's evidence text when part of it has been redacted.
+ *
+ * A finding cites `file:line`, and the citation is only trustworthy if the
+ * evidence it carries actually appears at that position. That check is what
+ * catches "wrong line" regressions, and it is a substring comparison — which
+ * stops working the moment a redactor replaces credential bytes inside the
+ * evidence with a marker, because the marker is not in the file.
+ *
+ * The pre-publish corpus gate already had a carve-out for this, and the
+ * carve-out was keyed on ONE literal spelling, `[REDACTED]`. Measured: `src`
+ * emits four families of marker —
+ *
+ *   - typed, uppercase: `[REDACTED_GITHUB_TOKEN]`, `[REDACTED_AWS_SECRET]`, …
+ *     (the shape registry's `CREDENTIAL_REDACTION_MARKERS`, plus
+ *     `[REDACTED_META_INSTRUCTION]` from the prompt redactor)
+ *   - bare: `[REDACTED]` (`semantic/structural/credential-context.ts:456`,
+ *     `nanomind-core/security/defense-in-depth.ts:270-274`)
+ *   - lowercase: `[redacted]` and `[redacted-jwt]`
+ *     (`scanner/permission-vocabulary.ts:415-421`)
+ *
+ * — and the literal check recognised exactly one of them:
+ * `'[REDACTED_GITHUB_TOKEN]'.includes('[REDACTED]')` is `false`. So every
+ * redactor except the bare one would have turned the gate red on a finding
+ * that was citing its line correctly.
+ *
+ * The answer is a rule per spelling, expressed as a SHAPE rather than a list,
+ * so that adding a marker to the registry does not require editing a second
+ * table here. `credential-shape-registry.test.ts` asserts every registry marker
+ * is recognised by this pattern, which is the link that keeps the two honest.
+ *
+ * What this module deliberately does NOT do is decide whether a marker is a
+ * REGISTERED one. An unregistered marker is a registry defect and the registry
+ * has its own totality check for it; giving the citation gate a second job
+ * would couple two failures that need separate messages.
+ */
+
+/**
+ * Every marker spelling, as a pattern.
+ *
+ * Returns a fresh RegExp: a shared `g`-flagged instance carries `lastIndex`
+ * between callers, so the second call over the same text starts in the middle
+ * of it.
+ */
+export function redactionMarkerPattern(): RegExp {
+  return /\[REDACTED(?:_[A-Z]+)*\]|\[redacted(?:-[a-z]+)*\]/g;
+}
+
+/** True when `text` is a redaction marker and nothing else. */
+export function isRedactionMarker(text: string): boolean {
+  return new RegExp(`^(?:${redactionMarkerPattern().source})$`).test(text.trim());
+}
+
+/** The literal fragments of `text` either side of every marker in it. */
+export function splitOnRedactionMarkers(text: string): string[] {
+  return text.split(redactionMarkerPattern());
+}
+
+/** True when `text` carries at least one redaction marker. */
+export function containsRedactionMarker(text: string): boolean {
+  return redactionMarkerPattern().test(text);
+}
+
+export type EvidenceCitationProblem =
+  /** The evidence is nothing but markers — there is no context left to verify. */
+  | { readonly kind: 'pure-marker' }
+  /** A literal fragment around a marker is not on the cited line. */
+  | { readonly kind: 'missing-segment'; readonly missing: string }
+  /** Un-redacted evidence that is simply not on the cited line. */
+  | { readonly kind: 'evidence-absent' };
+
+/**
+ * Why `evidence` fails to corroborate `lineContent`, or `undefined` if it does.
+ *
+ * Redaction relaxes the comparison, it does not remove it: EVERY non-empty
+ * fragment either side of a marker must still appear on the cited line. A
+ * finding whose evidence reduces to a bare marker is a defect at the emit site
+ * — it has redacted the context along with the secret and left nothing that
+ * could ever be checked — so that is reported rather than waved through.
+ */
+export function evidenceCitationProblem(
+  evidence: string,
+  lineContent: string,
+): EvidenceCitationProblem | undefined {
+  const ev = evidence.trim();
+  if (ev === '') return undefined;
+
+  if (!containsRedactionMarker(ev)) {
+    return lineContent.includes(ev) ? undefined : { kind: 'evidence-absent' };
+  }
+
+  const nonEmpty = splitOnRedactionMarkers(ev).filter(s => s !== '');
+  if (nonEmpty.length === 0) return { kind: 'pure-marker' };
+
+  const missing = nonEmpty.find(s => !lineContent.includes(s));
+  return missing === undefined ? undefined : { kind: 'missing-segment', missing };
+}


### PR DESCRIPTION
0.32.0 was tagged and published from `release/0.32.0`, and the branch was never merged back.
`main` therefore still carries the code GHSA-ccp3-g7fv-9cqr describes: a build of `b0c0e72`
puts twelve characters of a credential body into `secure --json` output where the published
0.32.0 puts none, on identical detection — both arms score 69 and report 57 credential
findings, so the difference is the redaction boundary and not one side failing to look.

Left unmerged, the next release cut from `main` would have reintroduced the advisory.

| build | credential body chars in `secure --json` | score | credential findings |
|---|---|---|---|
| `main` @ `b0c0e72` | 12 | 69 | 57 |
| published 0.32.0 | 0 | 69 | 57 |
| this branch | **0** | 69 | 57 |

**Conflict resolution.** `src/hardening/scanner.ts` only, six structurally identical hunks:
#533 replaced hand-written JS extension arrays with `JS_FAMILY_EXTENSIONS` while 0.32.0
changed the same signatures to `SecurityFindingDraft`. Each hunk takes both. Neither side is
droppable: #533's test fails if any `walkDirectory` call enumerates the family by hand, and
0.32.0's emitter contract needs the draft type. The resolution introduces zero lines that are
not verbatim from one of the two parents.

**One test baseline moved.** The credential vocabulary guard's frozen count for `scanner.ts`
goes 95 -> 96 (total 301 -> 302). The 96th occurrence is not code: #533's doc comment names its
fixture (`sk-ant-api03` in prose), and the counter is deliberately blind to comment-vs-code so
it cannot be evaded. Confirmed as the only delta by counting each shape on both parents and
attributing it with `git log -S`; the raised baseline still fails on a 97th literal.

**Changelog.** Carries the 0.32.0 section onto `main` (which previously jumped 0.31.0 to
0.30.0), adds #535 to the known-issues list it belonged in, and corrects the entry date to the
day the release actually published.

One binary now holds both fixes: a `.mjs` carrying `eval()` and an AWS-shaped key gets the
`.mjs` statically scanned (#533) and leaks no part of the key (0.32.0).

Full suite 281 files / 4115 tests green; `tsc` clean.
