### PR TITLE
Bump @opena2a/aim-sdk to 1.2.0 so the ARP re-export delivers opt-in telemetry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,35 @@
 
 All notable changes to HackMyAgent are documented in this file.
 
+## [Unreleased]
+
+### The ARP re-export now delivers opt-in telemetry
+
+`hackmyagent/arp` is a thin re-export of `@opena2a/aim-sdk/arp` (#249), so the pin in
+package.json decides the runtime-protection behaviour this package delivers. The pin read
+`1.0.2`, which predates the aim-sdk release that made ARP structural-signature telemetry
+opt-in (`1.2.0`, GHSA-r2hq-x5w4-5v63) — so the module delivered here still started that
+channel by default and read neither the documented `OPENA2A_TELEMETRY=off` opt-out nor the
+explicit opt-in.
+
+Measured through the re-export on a clean `HOME`, before and after the bump:
+
+| probe | pinned 1.0.2 | pinned 1.2.0 |
+|---|---|---|
+| default posture | on | **off** |
+| `OPENA2A_TELEMETRY=off` honored | no | **yes** |
+| opt-out beats an explicit opt-in | no | **yes** |
+
+Scope, measured rather than assumed: no hackmyagent scan command constructs
+`AgentRuntimeProtection`, so `secure` / `check` / `scan` users were never emitting. The
+change reaches consumers who start the runtime themselves — importers of `hackmyagent/arp`,
+the `hackmyagent/oasb` harness adapter (which constructs it), and the `arp-guard` shim,
+which floats on this package.
+
+`__tests__/arp/delivered-telemetry-posture.test.ts` pins the delivered property in a
+scrubbed-env, fresh-`HOME` child process, so a future pin change cannot regress the posture
+silently — the test fails on the behaviour, whatever version string carries it.
+
 ## [0.32.0] - 2026-08-20
 
 ### Finding evidence carries a classification, not a prefix of the matched value

--- a/__tests__/arp/delivered-telemetry-posture.test.ts
+++ b/__tests__/arp/delivered-telemetry-posture.test.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect } from 'vitest';
+import { execFileSync } from 'child_process';
+import { mkdtempSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+
+/**
+ * `hackmyagent/arp` is a thin re-export of `@opena2a/aim-sdk/arp` (src/arp/index.ts,
+ * #249), so the runtime-protection behaviour hackmyagent DELIVERS — including whether
+ * the structural-signature telemetry channel is on by default — is decided entirely by
+ * the aim-sdk version the pin in package.json resolves to. aim-sdk 1.2.0 made that
+ * channel opt-in and honors the documented `OPENA2A_TELEMETRY=off` opt-out
+ * (GHSA-r2hq-x5w4-5v63); earlier versions were default-on and read neither.
+ *
+ * These tests pin the PROPERTY, not the version number: they probe the installed
+ * dependency the way a consumer's process would, and fail if a future pin change
+ * regresses the delivered posture — whatever version string it carries.
+ *
+ * Probes run in a child process with a scrubbed env and a fresh empty HOME, for two
+ * reasons learned the hard way:
+ * - `~/.opena2a/telemetry-optout` on a developer machine makes every posture read
+ *   `false`, silently inverting the measurement. A fresh HOME removes it.
+ * - Inherited `OPENA2A_TELEMETRY*` / `AIM_TELEMETRY` / `ARP_TELEMETRY_DISABLED` vars
+ *   in the runner's env would leak into the probe. Passing an explicit env object
+ *   scrubs them.
+ */
+const repoRoot = join(__dirname, '..', '..');
+
+function probePosture(extraEnv: Record<string, string> = {}): string {
+  const cleanHome = mkdtempSync(join(tmpdir(), 'arp-posture-'));
+  return execFileSync(
+    process.execPath,
+    ['-e', "process.stdout.write(String(require('@opena2a/aim-sdk/arp').signatureTelemetryEnabled()))"],
+    {
+      cwd: repoRoot,
+      env: { HOME: cleanHome, PATH: process.env.PATH ?? '', ...extraEnv },
+      encoding: 'utf8',
+    },
+  );
+}
+
+describe('the telemetry posture hackmyagent delivers through its arp re-export', () => {
+  it('is OFF by default on a clean machine', () => {
+    expect(probePosture()).toBe('false');
+  });
+
+  it('honors the documented opt-out spelling, OPENA2A_TELEMETRY=off', () => {
+    expect(probePosture({ OPENA2A_TELEMETRY: 'off' })).toBe('false');
+  });
+
+  it('turns on only under an explicit opt-in — and the probe can see "true", so the two tests above are not vacuous', () => {
+    // Non-vacuity control: a probe that failed to load the module would throw, but a
+    // probe reading the wrong state could report 'false' forever. This asserts the
+    // discriminating direction: the same probe, given the opt-in, reads 'true'.
+    expect(probePosture({ AIM_TELEMETRY: '1' })).toBe('true');
+  });
+
+  it('and an opt-out beats the opt-in when both are set', () => {
+    expect(probePosture({ AIM_TELEMETRY: '1', OPENA2A_TELEMETRY: 'off' })).toBe('false');
+  });
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@noble/ed25519": "^2.3.0",
         "@noble/post-quantum": "^0.2.1",
         "@opena2a/aim-core": "^0.1.2",
-        "@opena2a/aim-sdk": "1.0.2",
+        "@opena2a/aim-sdk": "1.2.0",
         "@opena2a/check-core": "0.3.0",
         "@opena2a/cli-ui": "0.5.2",
         "@opena2a/contribute": "^0.1.0",
@@ -640,16 +640,16 @@
       }
     },
     "node_modules/@opena2a/aim-sdk": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@opena2a/aim-sdk/-/aim-sdk-1.0.2.tgz",
-      "integrity": "sha512-COAqsyscdMdygQYQYZrQm4zfeN/PxIIHdkq9XrgqceH6JfY2qrUpbA0F1nfjUCEUGpjSODdPcOnDPlXgSNMLqg==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@opena2a/aim-sdk/-/aim-sdk-1.2.0.tgz",
+      "integrity": "sha512-B7JFi93qzxHPzywQjB77RbdYH3aRGBaWLUfHJWt2c6sZ6Zvqd4dtBJqLSty6kENnOJmk6fJZj+zQ4cuekg7BTQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@noble/ed25519": "^2.1.0",
         "@noble/post-quantum": "^0.2.1",
         "@opena2a/atx-verify": "0.3.0",
         "fastify-plugin": "^6.0.0",
-        "js-yaml": "^4.1.1"
+        "js-yaml": "^4.3.1"
       },
       "engines": {
         "node": ">=18.0.0"

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "@noble/ed25519": "^2.3.0",
     "@noble/post-quantum": "^0.2.1",
     "@opena2a/aim-core": "^0.1.2",
-    "@opena2a/aim-sdk": "1.0.2",
+    "@opena2a/aim-sdk": "1.2.0",
     "@opena2a/check-core": "0.3.0",
     "@opena2a/cli-ui": "0.5.2",
     "@opena2a/contribute": "^0.1.0",


### PR DESCRIPTION
`hackmyagent/arp` is a thin re-export of `@opena2a/aim-sdk/arp` (#249), so the exact pin in package.json decides the runtime-protection behaviour this package delivers. The pin read `1.0.2`, which predates aim-sdk 1.2.0's change making ARP structural-signature telemetry opt-in (GHSA-r2hq-x5w4-5v63) and honoring the documented `OPENA2A_TELEMETRY=off` opt-out spelling.

## Measured through the re-export, clean `HOME`, scrubbed env

| probe | pinned 1.0.2 | pinned 1.2.0 |
|---|---|---|
| default posture | on | **off** |
| `OPENA2A_TELEMETRY=off` honored | no | **yes** |
| opt-out beats an explicit opt-in | no | **yes** |

## Scope, measured rather than assumed

No hackmyagent scan command constructs `AgentRuntimeProtection` — `secure` / `check` / `scan` users were never emitting. The change reaches consumers who start the runtime themselves: importers of `hackmyagent/arp`, the `hackmyagent/oasb` harness adapter (which constructs it), and the `arp-guard` shim, which floats on this package via `hackmyagent >=0.11.0`.

## The test pins the property, not the version

`__tests__/arp/delivered-telemetry-posture.test.ts` probes the installed dependency in a child process with a scrubbed env and fresh `HOME` (a developer-machine `~/.opena2a/telemetry-optout` otherwise inverts the reading). Red-proof against the pinned 1.0.2: 3 of 4 fail exactly as the defect predicts; 4 of 4 green after the bump. A future pin change that regresses the delivered posture fails the suite whatever version string it carries.

Lockfile churn is exactly one entry (`node_modules/@opena2a/aim-sdk`). Full suite against the bumped dependency: 4122 passed, 0 failed. Build + self-scan clean.

Note for the next release cut: this changes delivered behaviour for `hackmyagent/arp` / `hackmyagent/oasb` / `arp-guard` consumers — the CHANGELOG entry under `[Unreleased]` should ship with whichever version goes out next.