### PR TITLE
Give the redaction boundary its reader, and a rebuild that cannot drop the stamp

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,20 +12,24 @@ text path rebuilt findings field-by-field, dropping both stamps so a second emit
 an honest `applied` to `clean` — a false cleanliness claim over text the boundary had in
 fact modified.
 
-- **Every publish channel now reads the stamp before a byte leaves.** The JSON stdout
-  chokepoint, the `--output` file arms, the SARIF/HTML/ASFF/ASP report generators, the
-  registry publish builders, and the MCP tool payloads all assert that every finding-shaped
-  value carries redaction provenance. A finding without it aborts the scan with an error
-  naming the channel and check — never the finding's text. There is deliberately no flag to
-  soften this: a finding without provenance was constructed outside the redaction boundary
-  and its text may carry an unredacted credential.
+- **Every channel that publishes findings now reads the stamp before a byte leaves.** The
+  JSON stdout chokepoint, the `--output` file arms, the SARIF/HTML/ASFF/ASP report
+  generators, the registry publish builders, and the MCP tool payloads all assert that every
+  finding-shaped value carries redaction provenance. A finding without it aborts the scan
+  with an error naming the channel and check — never the finding's text. There is
+  deliberately no flag to soften this: a finding without provenance was constructed outside
+  the redaction boundary and its text may carry an unredacted credential. Channels that
+  serialize other result types — `attack`, `wild`, `eval`, `scan-soul` — are outside this
+  contract and unchanged.
 - **Rebuilds go through `reemitFinding`**, whose parameter types make dropping or
   downgrading the two stamps unrepresentable. The `check` re-map is fixed, and a repo guard
   now rejects casts into the branded finding types anywhere outside the boundary module.
-- **The analyst advisory channel is redacted structurally.** Its safety previously rested on
-  the fact that analyst prompts are built from already-redacted finding text; every analyst
-  response now passes through the same open-bag redaction walk as finding `details`, so an
-  upstream change cannot silently turn it into a leak path.
+- **Both analyst advisory channels are redacted structurally.** Per-finding analyst output
+  previously rested on the fact that its prompts are built from already-redacted finding
+  text. Coverage-sweep escalations had no such property at all: that pass hands the model the
+  raw artifact file, so its narrative could quote a credential it read, and those rows carry
+  no `passed` field so the boundary reader exempts them by shape. Both now pass through the
+  same open-bag redaction walk as finding `details`.
 - No output changes on healthy scans: scores, finding counts, and every measured JSON
   payload are byte-identical before and after, and the new read fires on zero healthy
   objects across all measured channels.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,34 @@
 
 All notable changes to HackMyAgent are documented in this file.
 
+## [Unreleased]
+
+### The redaction boundary gained its reader, and rebuilds can no longer drop the stamp
+
+0.32.0 stamped every emitted finding with `redactionStatus` and `redactedShapes`, but the
+stamp was write-only: nothing read it at any publish boundary, and one re-map on the `check`
+text path rebuilt findings field-by-field, dropping both stamps so a second emit downgraded
+an honest `applied` to `clean` — a false cleanliness claim over text the boundary had in
+fact modified.
+
+- **Every publish channel now reads the stamp before a byte leaves.** The JSON stdout
+  chokepoint, the `--output` file arms, the SARIF/HTML/ASFF/ASP report generators, the
+  registry publish builders, and the MCP tool payloads all assert that every finding-shaped
+  value carries redaction provenance. A finding without it aborts the scan with an error
+  naming the channel and check — never the finding's text. There is deliberately no flag to
+  soften this: a finding without provenance was constructed outside the redaction boundary
+  and its text may carry an unredacted credential.
+- **Rebuilds go through `reemitFinding`**, whose parameter types make dropping or
+  downgrading the two stamps unrepresentable. The `check` re-map is fixed, and a repo guard
+  now rejects casts into the branded finding types anywhere outside the boundary module.
+- **The analyst advisory channel is redacted structurally.** Its safety previously rested on
+  the fact that analyst prompts are built from already-redacted finding text; every analyst
+  response now passes through the same open-bag redaction walk as finding `details`, so an
+  upstream change cannot silently turn it into a leak path.
+- No output changes on healthy scans: scores, finding counts, and every measured JSON
+  payload are byte-identical before and after, and the new read fires on zero healthy
+  objects across all measured channels.
+
 ## [0.32.0] - 2026-08-20
 
 ### Finding evidence carries a classification, not a prefix of the matched value

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,9 +30,9 @@ fact modified.
   raw artifact file, so its narrative could quote a credential it read, and those rows carry
   no `passed` field so the boundary reader exempts them by shape. Both now pass through the
   same open-bag redaction walk as finding `details`.
-- No output changes on healthy scans: scores, finding counts, and every measured JSON
-  payload are byte-identical before and after, and the new read fires on zero healthy
-  objects across all measured channels.
+- No output changes on healthy scans: across every measured JSON payload the only field
+  that differs before and after is the scan's own `timestamp` — scores, finding counts and
+  every finding byte are unchanged — and the new read fires on zero healthy objects.
 
 ## [0.32.0] - 2026-08-20
 

--- a/__tests__/hardening/analyst-escalation-redaction.test.ts
+++ b/__tests__/hardening/analyst-escalation-redaction.test.ts
@@ -1,0 +1,80 @@
+/**
+ * The coverage-sweep escalation channel's redaction.
+ *
+ * This is the STRONGER half of the analyst advisory channel and the one that
+ * was left prose-guarded when the per-finding half was closed (adversarial
+ * review 2026-08-21, F3): `runAnalystOnFindings` builds its prompt from
+ * already-redacted finding text, but the sweep hands the model the RAW
+ * artifact file, so the model's own narrative can quote a credential it read.
+ * Those rows ride `secure --json` and every `check --json` path, and they
+ * carry no `passed` field, so the publish-boundary reader exempts them by
+ * shape — nothing else would catch them.
+ *
+ * Proven by injection through the real `runCoverageSweep` with a stubbed
+ * classifier, not by grep.
+ */
+import { describe, it, expect } from 'vitest';
+import { mkdtemp, writeFile, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { runCoverageSweep } from '../../src/nanomind-core/orchestrate';
+import type { CoverageCandidate } from '../../src/nanomind-core/scanner-bridge';
+import type { ArtifactCoverageVerdict } from '../../src/nanomind-core/inference/security-analyst';
+
+/** Synthesised at runtime — never a literal in the source tree. */
+const GH = `ghp_${'a'.repeat(36)}`;
+const GH_MARK = '[REDACTED_GITHUB_TOKEN]';
+
+/** A verdict that routes to `attack`: known class + high severity. */
+function quotingVerdict(text: string): ArtifactCoverageVerdict {
+  return {
+    attackClass: 'credential_abuse',
+    classification: 'malicious',
+    severity: 'high',
+    confidence: 0.9,
+    source: 'nlm',
+    analysis: text,
+    modelVersion: 'stub-1',
+  } as ArtifactCoverageVerdict;
+}
+
+async function sweepWith(verdict: ArtifactCoverageVerdict) {
+  const dir = await mkdtemp(join(tmpdir(), 'hma-sweep-'));
+  try {
+    await writeFile(join(dir, 'SKILL.md'), 'irrelevant — the stub classifier decides the verdict\n');
+    const candidates: CoverageCandidate[] = [
+      { path: 'SKILL.md', artifactType: 'skill' } as CoverageCandidate,
+    ];
+    return await runCoverageSweep(dir, candidates, [], async () => verdict, true);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+}
+
+describe('coverage-sweep escalations are redacted before they can reach a channel', () => {
+  // RED-PROOF: remove the `redactOpenBagForPublish` wrap around the
+  // `escalations.push({...})` call in orchestrate.ts — this case goes red with
+  // the raw canary present in `summary`.
+  it('a model narrative quoting a credential ships the marker, not the bytes', async () => {
+    expect(GH.length, 'canary must clear the ghp_ 36-char pattern gate').toBe(40);
+    const outcome = await sweepWith(quotingVerdict(`the file contains ${GH} in plain text`));
+    expect(
+      outcome.escalations.length,
+      'the stub must actually escalate or this test is vacuous',
+    ).toBe(1);
+    const text = JSON.stringify(outcome.escalations);
+    expect(text).not.toContain(GH);
+    expect(text).toContain(GH_MARK);
+  });
+
+  it('control: a benign narrative survives unchanged, including its scalar fields', async () => {
+    const outcome = await sweepWith(quotingVerdict('the skill declares broad filesystem access'));
+    expect(outcome.escalations.length).toBe(1);
+    const row = outcome.escalations[0];
+    expect(row.summary).toBe('the skill declares broad filesystem access');
+    expect(row.attackClass).toBe('credential_abuse');
+    expect(row.routed).toBe('attack');
+    expect(row.file).toBe('SKILL.md');
+    expect(row.policy).toBe('abstention-gated');
+  });
+});

--- a/__tests__/hardening/analyst-findings-redaction.test.ts
+++ b/__tests__/hardening/analyst-findings-redaction.test.ts
@@ -1,0 +1,73 @@
+/**
+ * The analyst advisory channel's open-bag redaction — [CHIEF-CISO] 2026-08-21.
+ *
+ * `analystFindings` rides the secure/check JSON channels raw and is not
+ * finding-shaped, so the publish-boundary reader does not see it. Its safety
+ * used to rest on a prose invariant ("the analyst's input is already-redacted
+ * finding text") that one upstream edit could break silently. The
+ * `redactOpenBagForPublish` call at the push site in `runAnalystOnFindings`
+ * makes it structural; this file proves the WIRING by injection through the
+ * real function with a stubbed inference backend — not by grep, which dead
+ * code satisfies.
+ */
+import { describe, it, expect } from 'vitest';
+import { emitFinding } from '../../src/hardening/finding-emit';
+import type { SecurityFinding, SecurityFindingDraft } from '../../src/hardening/security-check';
+import { runAnalystOnFindingsForTest } from '../../src/nanomind-core/orchestrate';
+
+/** Synthesised at runtime — never a literal in the source tree. */
+const GH = `ghp_${'a'.repeat(36)}`;
+const GH_MARK = '[REDACTED_GITHUB_TOKEN]';
+
+function emitted(over: Record<string, unknown> = {}): SecurityFinding {
+  return emitFinding({
+    checkId: 'TEST-ANALYST-001',
+    name: 'analyst channel test finding',
+    description: 'exercises the analyst advisory channel',
+    category: 'credentials',
+    severity: 'critical',
+    passed: false,
+    message: 'analyst channel test message',
+    fixable: false,
+    file: 'x.ts',
+    ...over,
+  } as unknown as SecurityFindingDraft);
+}
+
+describe('analyst advisory channel: the open-bag redaction is wired, not prose', () => {
+  // RED-PROOF: remove the `redactOpenBagForPublish` call at the push site in
+  // `runAnalystOnFindings` (orchestrate.ts) — this case goes red with the raw
+  // canary present in the response bag.
+  it('a credential-bearing analyst response is redacted before it can reach a channel', async () => {
+    expect(GH.length, 'canary must clear the ghp_ 36-char pattern gate').toBe(40);
+    const stubInference = (async () => ({
+      taskType: 'threatAnalysis',
+      result: { analysis: `exposed token ${GH}`, nested: [{ note: `again ${GH}` }] },
+      confidence: 0.9,
+      modelVersion: 'stub',
+      durationMs: 1,
+      backend: 'stub',
+    })) as never;
+    const out = await runAnalystOnFindingsForTest([emitted()], stubInference);
+    expect(out.length, 'stub inference must produce a response or this test is vacuous').toBe(1);
+    const text = JSON.stringify(out);
+    expect(text).not.toContain(GH);
+    expect(text).toContain(GH_MARK);
+  });
+
+  it('control: a benign analyst response passes through with its scalar fields intact', async () => {
+    const stubInference = (async () => ({
+      taskType: 'checkExplanation',
+      result: { analysis: 'benign prose only' },
+      confidence: 0.5,
+      modelVersion: 'stub',
+      durationMs: 1,
+      backend: 'stub',
+    })) as never;
+    const out = await runAnalystOnFindingsForTest([emitted()], stubInference);
+    expect(out.length).toBe(1);
+    expect(out[0].confidence).toBe(0.5);
+    expect(out[0].taskType).toBe('checkExplanation');
+    expect((out[0].result as { analysis: string }).analysis).toBe('benign prose only');
+  });
+});

--- a/__tests__/hardening/finding-cast-launder-guard.test.ts
+++ b/__tests__/hardening/finding-cast-launder-guard.test.ts
@@ -1,0 +1,73 @@
+/**
+ * CI guard for defect (9)'s laundering casts, extended per [CHIEF-CA]
+ * 2026-08-21 (unit 2): no production file may cast a value INTO
+ * `SecurityFinding` or `RedactedFinding` — the brand's one sanctioned cast
+ * lives in `finding-emit.ts`, and every other spelling is a boundary bypass
+ * the compiler cannot see.
+ *
+ * Scope is `src/` excluding `*.test.ts`: test files legitimately fabricate
+ * finding-shaped fixtures (the pre-existing factories in
+ * `src/registry/publish.test.ts` et al.), and the type system is not what a
+ * test exercises. `as SecurityFindingDraft` is allowed everywhere — a draft
+ * carries no guarantee to launder.
+ *
+ * This is a line-anchored text guard, with the known limits of one: it cannot
+ * see a cast split across renames or an `as any` two-step. It exists as a
+ * tripwire that forces classification, not as proof of absence — the runtime
+ * reader (`assertRedactionProvenance`) is the layer that catches what text
+ * cannot.
+ */
+import { describe, it, expect } from 'vitest';
+import { readdirSync, readFileSync, statSync } from 'node:fs';
+import { join } from 'node:path';
+
+const SRC_ROOT = join(__dirname, '..', '..', 'src');
+
+/** The one file allowed to produce the brand (its single `as unknown as
+ * RedactedFinding` at the end of `emitFinding`). */
+const SANCTIONED = new Set(['hardening/finding-emit.ts']);
+
+// `\b` after the type name: `SecurityFindingDraft` has no word boundary
+// between "Finding" and "Draft", so draft casts do not match.
+const LAUNDER_CAST = /\bas\s+(?:unknown\s+as\s+)?(?:SecurityFinding|RedactedFinding)\b(?:\[\])?/;
+
+function walk(dir: string, out: string[] = []): string[] {
+  for (const entry of readdirSync(dir)) {
+    const full = join(dir, entry);
+    if (statSync(full).isDirectory()) walk(full, out);
+    else if (full.endsWith('.ts') && !full.endsWith('.test.ts')) out.push(full);
+  }
+  return out;
+}
+
+describe('finding cast-launder guard', () => {
+  it('no production file casts into SecurityFinding or RedactedFinding', () => {
+    const offenders: string[] = [];
+    for (const file of walk(SRC_ROOT)) {
+      const rel = file.slice(SRC_ROOT.length + 1);
+      if (SANCTIONED.has(rel)) continue;
+      const lines = readFileSync(file, 'utf8').split('\n');
+      lines.forEach((line, i) => {
+        if (LAUNDER_CAST.test(line)) offenders.push(`${rel}:${i + 1}: ${line.trim()}`);
+      });
+    }
+    expect(offenders, 'launder casts found — route these through emitFinding/reemitFinding').toEqual([]);
+  });
+
+  it('positive control: the guard pattern actually matches a launder spelling', () => {
+    // A regex that rots matches nothing and the empty-offenders assertion
+    // above becomes vacuous. Pin the pattern against the spellings it exists
+    // to catch, and against the draft spelling it must NOT catch.
+    expect(LAUNDER_CAST.test('const f = bag as SecurityFinding;')).toBe(true);
+    expect(LAUNDER_CAST.test('const f = bag as unknown as RedactedFinding;')).toBe(true);
+    expect(LAUNDER_CAST.test('const f = bags as SecurityFinding[];')).toBe(true);
+    expect(LAUNDER_CAST.test('const d = bag as SecurityFindingDraft;')).toBe(false);
+  });
+
+  it('positive control: the sanctioned file really contains the one brand cast', () => {
+    // If finding-emit.ts is renamed or the cast moves, the exemption silently
+    // exempts nothing — surface that instead of passing by accident.
+    const content = readFileSync(join(SRC_ROOT, 'hardening', 'finding-emit.ts'), 'utf8');
+    expect(LAUNDER_CAST.test(content)).toBe(true);
+  });
+});

--- a/__tests__/hardening/redaction-provenance-boundaries.test.ts
+++ b/__tests__/hardening/redaction-provenance-boundaries.test.ts
@@ -1,0 +1,119 @@
+/**
+ * Per-boundary injection proofs — [CHIEF-CISO] 2026-08-21 condition (ii):
+ * every publish boundary's provenance read is proven by runtime injection
+ * through the REAL channel builder, never by grep. A grep guard is satisfied
+ * by dead code; an injection is not.
+ *
+ * Each case sends a laundered finding (emitted, then stripped of the two
+ * redaction fields — the exact shape any named-field rebuild produces)
+ * through one importable builder and asserts `RedactionProvenanceError`.
+ * Each builder also gets a healthy-pass control so the throw cases cannot be
+ * satisfied by a builder that always throws.
+ *
+ * NOT provable here (recorded, not hidden): the SARIF/HTML/ASP/benchmark
+ * generators and the two `secure-json` / `benchmark-composite-json` inline
+ * asserts live inside `cli.ts`, which exports nothing and cannot be imported
+ * without executing the CLI. Their reads are the same `assertRedactionProvenance`
+ * proven here and in the reader's own suite; their WIRING is exercised by the
+ * healthy zero-fire e2e runs (corpus smoke + walkthrough) and pinned by the
+ * stringify tripwire below.
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  emitFinding,
+  RedactionProvenanceError,
+} from '../../src/hardening/finding-emit';
+import type { SecurityFinding, SecurityFindingDraft } from '../../src/hardening/security-check';
+import { buildJsonStdoutDocument } from '../../src/output/json-stdout';
+import { buildPublishPayload } from '../../src/registry/publish';
+import { buildScanReport, buildCommunityReport } from '../../src/registry/client';
+import { toASSF } from '../../src/output/asff';
+import { buildScanToolText, buildDeepScanLayer1 } from '../../src/mcp-server';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+function emitted(over: Record<string, unknown> = {}): SecurityFinding {
+  return emitFinding({
+    checkId: 'TEST-BOUNDARY-001',
+    name: 'boundary test finding',
+    description: 'exercises a publish boundary',
+    category: 'credentials',
+    severity: 'high',
+    passed: false,
+    message: 'boundary test message',
+    fixable: false,
+    ...over,
+  } as unknown as SecurityFindingDraft);
+}
+
+/** The launder every named-field rebuild produces. */
+function laundered(): SecurityFinding {
+  const { redactionStatus: _s, redactedShapes: _h, ...rest } = emitted() as SecurityFinding &
+    Record<string, unknown>;
+  return rest as unknown as SecurityFinding;
+}
+
+describe('per-boundary injection: each real builder throws on a laundered finding', () => {
+  it('json-stdout chokepoint (buildJsonStdoutDocument)', () => {
+    expect(() => buildJsonStdoutDocument({ findings: [laundered()] }, '0.0.0-test')).toThrow(
+      RedactionProvenanceError,
+    );
+    const doc = buildJsonStdoutDocument({ findings: [emitted()] }, '0.0.0-test');
+    expect(JSON.parse(doc).hackmyagentVersion, 'healthy control must still stamp').toBe('0.0.0-test');
+  });
+
+  it('registry publish payload (buildPublishPayload)', () => {
+    expect(() =>
+      buildPublishPayload({ packageName: 'x', hardeningFindings: [laundered()] } as never, '0.0.0'),
+    ).toThrow(RedactionProvenanceError);
+    expect(() =>
+      buildPublishPayload({ packageName: 'x', hardeningFindings: [emitted()] } as never, '0.0.0'),
+    ).not.toThrow();
+  });
+
+  it('registry scan report (buildScanReport)', () => {
+    expect(() => buildScanReport('v1', [laundered()])).toThrow(RedactionProvenanceError);
+    expect(() => buildScanReport('v1', [emitted()])).not.toThrow();
+  });
+
+  it('registry community report (buildCommunityReport)', () => {
+    expect(() => buildCommunityReport('pkg', [laundered()])).toThrow(RedactionProvenanceError);
+    expect(() => buildCommunityReport('pkg', [emitted()])).not.toThrow();
+  });
+
+  it('ASFF output (toASSF)', () => {
+    expect(() => toASSF([laundered()])).toThrow(RedactionProvenanceError);
+    expect(() => toASSF([emitted()])).not.toThrow();
+  });
+
+  it('MCP scan text (buildScanToolText)', () => {
+    expect(() =>
+      buildScanToolText({ score: 50, maxScore: 100, findings: [laundered()] }),
+    ).toThrow(RedactionProvenanceError);
+    expect(() =>
+      buildScanToolText({ score: 50, maxScore: 100, findings: [emitted()] }),
+    ).not.toThrow();
+  });
+
+  it('MCP deep-scan payload (buildDeepScanLayer1)', () => {
+    expect(() => buildDeepScanLayer1([laundered()])).toThrow(RedactionProvenanceError);
+    expect(() => buildDeepScanLayer1([emitted()])).not.toThrow();
+  });
+});
+
+describe('cli.ts JSON-serialization tripwire', () => {
+  // [CHIEF-CA] D2: a new `JSON.stringify` site in cli.ts is a potential new
+  // publish channel that silently misses the boundary read. This pin is
+  // BLUNT on purpose — it forces the author of a new site to classify it
+  // (route through writeJsonStdout, add an assert, or record why neither),
+  // then update the count. It does not prove coverage; the injections above
+  // and the healthy e2e runs do that for the known set.
+  it('the number of JSON.stringify sites in cli.ts is accounted for', () => {
+    const cli = readFileSync(join(__dirname, '..', '..', 'src', 'cli.ts'), 'utf8');
+    const count = (cli.match(/JSON\.stringify\(/g) ?? []).length;
+    expect(
+      count,
+      'cli.ts gained or lost a JSON.stringify site — classify it against the publish-boundary read (unit 2) before updating this pin',
+    ).toBe(18);
+  });
+});

--- a/__tests__/hardening/redaction-provenance-reader.test.ts
+++ b/__tests__/hardening/redaction-provenance-reader.test.ts
@@ -89,6 +89,28 @@ describe('reemitFinding — the sanctioned rebuild preserves provenance', () => 
     expect(JSON.stringify(second)).not.toContain(AWS);
   });
 
+  // RED-PROOF: delete the runtime destructure of `redactionStatus` /
+  // `redactedShapes` from `reemitFinding` — this case goes red.
+  //
+  // The `Omit` on the override parameter is not sufficient on its own:
+  // TypeScript's excess-property check applies to LITERAL bags, so a widened
+  // variable carrying `redactionStatus: 'clean'` typechecks, reaches the
+  // spread, and downgrades a prior 'applied' — defect (13) reintroduced
+  // through the sanctioned helper, and invisible to the publish reader
+  // because 'clean' is a valid publish status. Found by adversarial review
+  // 2026-08-21 (F1), which built exactly this bag and compiled it.
+  it('a widened override bag cannot smuggle a status downgrade', () => {
+    const first = appliedFinding();
+    const smuggle: Record<string, unknown> = {
+      passed: false,
+      redactionStatus: 'clean',
+      redactedShapes: [],
+    };
+    const second = reemitFinding(first, smuggle);
+    expect(second.redactionStatus, 'the prior applied must survive a hostile override bag').toBe('applied');
+    expect(second.redactedShapes).toContain('github-pat');
+  });
+
   // MECHANISM CONTROL, not a defect pin — this is defect (13) itself, measured,
   // so the preserving cases above are provably non-vacuous. It passes on every
   // tree because it exercises the hazard, not the fix: `emitFinding` cannot

--- a/__tests__/hardening/redaction-provenance-reader.test.ts
+++ b/__tests__/hardening/redaction-provenance-reader.test.ts
@@ -1,0 +1,231 @@
+/**
+ * Unit 2 of the redaction-boundary hardening: defects (10) + (13).
+ *
+ * (10) `redactionStatus` was a write-only guarantee — nothing read it at any
+ * publish boundary. `assertRedactionProvenance` is the read; these tests prove
+ * it throws on a laundered finding and fires on ZERO healthy objects.
+ *
+ * (13) a named-field rebuild drops the two redaction fields and re-emits, so an
+ * honest `'applied'` is downgraded to `'clean'` — invisible to grep because a
+ * stripped draft is indistinguishable from a fresh one. `reemitFinding` is the
+ * sanctioned rebuild; its parameter types make the drop unrepresentable.
+ *
+ * RED-PROOF. Each block names the exact implementation property whose reversion
+ * turns it red. The dropping-rebuild case below is a MECHANISM CONTROL, not a
+ * defect pin: it measures the hazard the helper exists to prevent, so the
+ * green elsewhere is non-vacuous. Canaries are synthesised at runtime — never
+ * a literal in the source tree (the idiom finding-emit.test.ts:35-39 uses).
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  emitFinding,
+  emitFindings,
+  reemitFinding,
+  assertRedactionProvenance,
+  RedactionProvenanceError,
+  redactOpenBagForPublish,
+} from '../../src/hardening/finding-emit';
+import type { SecurityFinding, SecurityFindingDraft } from '../../src/hardening/security-check';
+
+/** Synthesised at runtime — never a literal in the source tree. */
+const GH = `ghp_${'a'.repeat(36)}`;
+const AWS = `AKIA${'B'.repeat(16)}`;
+const GH_MARK = '[REDACTED_GITHUB_TOKEN]';
+
+function draft(over: Record<string, unknown> = {}): SecurityFindingDraft {
+  return {
+    checkId: 'TEST-READER-001',
+    name: 'reader test finding',
+    description: 'a finding used to exercise the publish-boundary reader',
+    category: 'credentials',
+    severity: 'high',
+    passed: false,
+    message: 'reader test message',
+    fixable: false,
+    ...over,
+  } as unknown as SecurityFindingDraft;
+}
+
+/** An emitted finding carrying an honest 'applied' — the precondition most
+ * cases below rest on, asserted once so no case is vacuous. */
+function appliedFinding(): SecurityFinding {
+  const f = emitFinding(draft({ message: `token ${GH}` }));
+  expect(f.redactionStatus, 'precondition: canary must be detected').toBe('applied');
+  expect(f.redactedShapes, 'precondition: shape must resolve').toContain('github-pat');
+  expect(JSON.stringify(f), 'precondition: emit must strip the bytes').not.toContain(GH);
+  return f;
+}
+
+/** The launder: strip the two fields off an emitted finding, the way any
+ * named-field rebuild does. Enumerates every OTHER field on purpose. */
+function stripped(f: SecurityFinding): Record<string, unknown> {
+  const { redactionStatus: _s, redactedShapes: _h, ...rest } = f as SecurityFinding &
+    Record<string, unknown>;
+  return rest;
+}
+
+describe('reemitFinding — the sanctioned rebuild preserves provenance', () => {
+  // RED-PROOF: finding-emit.ts `reemitFinding` — replace `{ ...prior, ...overrides }`
+  // with a named-field enumeration of the draft fields. This case then reads
+  // 'clean' and goes red.
+  it('preserves an honest applied through a normalizing rebuild', () => {
+    const first = appliedFinding();
+    const second = reemitFinding(first, {
+      checkId: first.checkId || '',
+      name: first.name || first.description || '',
+      message: first.message || first.description || '',
+    });
+    expect(second.redactionStatus).toBe('applied');
+    expect(second.redactedShapes).toContain('github-pat');
+  });
+
+  it('accumulates shapes when an override introduces new credential bytes', () => {
+    const first = appliedFinding();
+    const second = reemitFinding(first, { description: `and also ${AWS}` });
+    expect(second.redactionStatus).toBe('applied');
+    expect(second.redactedShapes).toEqual(
+      expect.arrayContaining(['github-pat', 'aws-access-key-id']),
+    );
+    expect(JSON.stringify(second)).not.toContain(AWS);
+  });
+
+  // MECHANISM CONTROL, not a defect pin — this is defect (13) itself, measured,
+  // so the preserving cases above are provably non-vacuous. It passes on every
+  // tree because it exercises the hazard, not the fix: `emitFinding` cannot
+  // distinguish a stripped rebuild from a fresh draft. That is WHY rebuilds
+  // must go through `reemitFinding`; nothing weaker is testable.
+  it('control: a named-field rebuild that drops the two fields downgrades applied to clean', () => {
+    const first = appliedFinding();
+    const relaundered = emitFindings([stripped(first) as unknown as SecurityFindingDraft])[0];
+    expect(relaundered.redactionStatus, 'the defect-13 mechanism must be live for these tests to mean anything').toBe('clean');
+    expect(relaundered.redactedShapes).toEqual([]);
+  });
+});
+
+describe('assertRedactionProvenance — the publish-boundary read', () => {
+  // RED-PROOF: finding-emit.ts `assertRedactionProvenance` — delete the
+  // `status !== 'applied' && status !== 'clean'` throw. Every case in this
+  // block except the zero-fire controls goes red.
+  it('throws on a stripped finding at the top level of a payload', () => {
+    const laundered = stripped(appliedFinding());
+    expect(() => assertRedactionProvenance([laundered], 'test-channel')).toThrow(
+      RedactionProvenanceError,
+    );
+  });
+
+  it('throws on a stripped finding nested inside objects and arrays', () => {
+    const laundered = stripped(appliedFinding());
+    const payload = { report: { sections: [{ items: [{ wrapped: laundered }] }] } };
+    expect(() => assertRedactionProvenance(payload, 'test-channel')).toThrow(
+      RedactionProvenanceError,
+    );
+  });
+
+  // RED-PROOF: reintroduce a depth cap that `continue`s on deep containers —
+  // this case goes red. The walk must have NO silent skip (defect (1)'s class).
+  it('throws on a stripped finding buried 500 containers deep', () => {
+    const laundered = stripped(appliedFinding());
+    let payload: unknown = laundered;
+    for (let i = 0; i < 500; i++) payload = { deeper: [payload] };
+    expect(() => assertRedactionProvenance(payload, 'test-channel')).toThrow(
+      RedactionProvenanceError,
+    );
+  });
+
+  it('names the channel and checkId, and carries none of the finding text', () => {
+    const laundered = stripped(
+      emitFinding(draft({ message: `token ${GH}`, description: `desc ${GH}` })),
+    );
+    // The launder keeps the redacted text; simulate the worst case — a finding
+    // whose bytes were NEVER redacted — by planting the canary directly.
+    laundered.message = `raw ${GH}`;
+    let thrown: unknown;
+    try {
+      assertRedactionProvenance({ findings: [laundered] }, 'registry-publish');
+    } catch (e) {
+      thrown = e;
+    }
+    expect(thrown).toBeInstanceOf(RedactionProvenanceError);
+    const err = thrown as RedactionProvenanceError;
+    expect(err.message).toContain('registry-publish');
+    expect(err.message).toContain('TEST-READER-001');
+    expect(err.message, 'the error must not republish the bytes it exists to contain').not.toContain(GH);
+  });
+
+  // RED-PROOF: allow 'unverified' through the status check — goes red.
+  // [CHIEF-CISO] 2026-08-21: 'unverified' may exist in process, it may never
+  // cross a publish boundary.
+  it("throws on redactionStatus 'unverified' at a publish boundary", () => {
+    const f = { ...appliedFinding(), redactionStatus: 'unverified' };
+    expect(() => assertRedactionProvenance([f], 'test-channel')).toThrow(
+      RedactionProvenanceError,
+    );
+  });
+
+  // RED-PROOF: delete the `Array.isArray(value.redactedShapes)` throw — goes red.
+  it('throws when redactedShapes is missing even with a valid status', () => {
+    const f: Record<string, unknown> = { ...stripped(appliedFinding()), redactionStatus: 'clean' };
+    expect(() => assertRedactionProvenance([f], 'test-channel')).toThrow(
+      RedactionProvenanceError,
+    );
+  });
+
+  it('zero-fire control: an honestly emitted finding passes', () => {
+    const payload = { findings: emitFindings([draft(), draft({ message: `x ${GH}` })]) };
+    expect(() => assertRedactionProvenance(payload, 'test-channel')).not.toThrow();
+  });
+
+  // The exemption mechanism is the SHAPE predicate, never a site allowlist
+  // ([CHIEF-CISO] condition). The pair below are complementary on purpose: the
+  // same row, with and without the fields that make it finding-shaped. If the
+  // predicate drifts, one of the two goes red — the filters must negate.
+  it('exempts an identity-only projection row (no passed, no body text) by shape', () => {
+    const identityRow = { checkId: 'PROC-001', name: 'Container User', category: 'process', severity: 'high' };
+    expect(() => assertRedactionProvenance({ coverage: { suppressedFailures: [identityRow] } }, 'test-channel')).not.toThrow();
+  });
+
+  it('revokes the exemption the moment the same row grows passed + body text', () => {
+    const grownRow = {
+      checkId: 'PROC-001', name: 'Container User', category: 'process', severity: 'high',
+      passed: false, message: 'now it carries bytes',
+    };
+    expect(() => assertRedactionProvenance({ coverage: { suppressedFailures: [grownRow] } }, 'test-channel')).toThrow(
+      RedactionProvenanceError,
+    );
+  });
+
+  // RED-PROOF: remove the `seen` cycle guard — this case hangs instead of
+  // passing, and vitest's timeout turns it red.
+  it('a cycle elsewhere in the payload does not stop the walk from reaching a launder', () => {
+    const laundered = stripped(appliedFinding());
+    const cyclic: Record<string, unknown> = { a: 1 };
+    cyclic.self = cyclic;
+    const payload = { first: cyclic, second: [laundered] };
+    expect(() => assertRedactionProvenance(payload, 'test-channel')).toThrow(
+      RedactionProvenanceError,
+    );
+  });
+});
+
+describe('redactOpenBagForPublish — the analyst advisory channel', () => {
+  // RED-PROOF: make redactOpenBagForPublish return its input — both cases red.
+  it('strips credential bytes from string leaves at any depth', () => {
+    expect(GH.length, 'canary must clear the ghp_ 36-char pattern gate').toBe(4 + 36);
+    const bag = {
+      taskType: 'threatAnalysis',
+      result: { analysis: `the token ${GH} is exposed`, nested: [{ note: `also ${GH}` }] },
+      confidence: 0.9,
+    };
+    const out = redactOpenBagForPublish(bag) as typeof bag;
+    const text = JSON.stringify(out);
+    expect(text).not.toContain(GH);
+    expect(text).toContain(GH_MARK);
+    expect(out.confidence, 'non-string leaves must survive unchanged').toBe(0.9);
+    expect(out.taskType).toBe('threatAnalysis');
+  });
+
+  it('control: a bag with no credential bytes passes through byte-identical', () => {
+    const bag = { taskType: 'checkExplanation', result: { analysis: 'benign prose only' }, confidence: 0.5 };
+    expect(redactOpenBagForPublish(bag)).toEqual(bag);
+  });
+});

--- a/__tests__/mcp/mcp-server-unverified-fix.test.ts
+++ b/__tests__/mcp/mcp-server-unverified-fix.test.ts
@@ -17,11 +17,13 @@
  */
 import { describe, it, expect } from 'vitest';
 import { buildScanToolText, buildDeepScanLayer1 } from '../../src/mcp-server';
+import { emitFinding } from '../../src/hardening/finding-emit';
+import type { SecurityFindingDraft } from '../../src/hardening/security-check';
 import { countsAgainstScore } from '../../src/ui/verdict-band';
 import type { SecurityFinding } from '../../src/index';
 
 /** A CRITICAL whose fix was applied and then DISPROVED by the verification pass. */
-const disprovedFix = {
+const disprovedFix = emitFinding({
   checkId: 'CRED-001',
   name: 'Hardcoded Secret',
   category: 'credentials',
@@ -35,10 +37,10 @@ const disprovedFix = {
   passed: true,
   fixed: true,
   fixVerified: false,
-} as unknown as SecurityFinding;
+} as unknown as SecurityFindingDraft) as SecurityFinding;
 
 /** An ordinary genuinely-passing check. */
-const cleanPass = {
+const cleanPass = emitFinding({
   checkId: 'GIT-001',
   name: 'Gitignore present',
   category: 'git',
@@ -46,7 +48,7 @@ const cleanPass = {
   message: '.gitignore covers secrets',
   fixable: false,
   passed: true,
-} as unknown as SecurityFinding;
+} as unknown as SecurityFindingDraft) as SecurityFinding;
 
 describe('#285 MCP scan tool reports a disproved fix', () => {
   it('pins the premise: the naive predicate and the real one disagree on this finding', () => {

--- a/__tests__/registry/unverified-fix-must-count.test.ts
+++ b/__tests__/registry/unverified-fix-must-count.test.ts
@@ -34,9 +34,16 @@ import { toASSF } from '../../src/output/asff';
 import { reportRemediation, reportFindings } from '../../src/registry/remediation';
 import { countsAgainstScore } from '../../src/ui/verdict-band';
 import type { SecurityFinding } from '../../src/hardening';
+import { emitFinding } from '../../src/hardening/finding-emit';
+import type { SecurityFindingDraft } from '../../src/hardening/security-check';
 
 /** The PERM-001 shape: the fix ran, the verification pass disproved it. */
-const UNVERIFIED_FIX: SecurityFinding = {
+// Emitted through the real boundary (unit 2): the builders under test now
+// read redaction provenance on their inputs, and a fixture that fabricates
+// the type without the stamps is exactly the launder the read exists to
+// catch. These fixtures carry no credential bytes, so emission stamps
+// 'clean' and leaves every byte the assertions read unchanged.
+const UNVERIFIED_FIX: SecurityFinding = emitFinding({
   checkId: 'PERM-001',
   name: 'World-readable credential file',
   description: '.env is readable by every user on the host',
@@ -48,7 +55,7 @@ const UNVERIFIED_FIX: SecurityFinding = {
   fixed: true,
   fixVerified: false,
   file: '.env',
-};
+} as SecurityFindingDraft);
 
 /**
  * The same two shapes in a category that reaches a package page.
@@ -56,7 +63,12 @@ const UNVERIFIED_FIX: SecurityFinding = {
  * (`permissions` among them) because they say nothing about the published
  * package, so the PERM-001 fixture cannot exercise that consumer.
  */
-const UNVERIFIED_FIX_PUBLIC: SecurityFinding = {
+// Emitted through the real boundary (unit 2): the builders under test now
+// read redaction provenance on their inputs, and a fixture that fabricates
+// the type without the stamps is exactly the launder the read exists to
+// catch. These fixtures carry no credential bytes, so emission stamps
+// 'clean' and leaves every byte the assertions read unchanged.
+const UNVERIFIED_FIX_PUBLIC: SecurityFinding = emitFinding({
   checkId: 'CRED-001',
   name: 'Hardcoded credential',
   description: 'A credential is committed in source',
@@ -68,23 +80,33 @@ const UNVERIFIED_FIX_PUBLIC: SecurityFinding = {
   fixed: true,
   fixVerified: false,
   file: 'config.js',
-};
+} as SecurityFindingDraft);
 
-const VERIFIED_FIX_PUBLIC: SecurityFinding = {
+// Emitted through the real boundary (unit 2): the builders under test now
+// read redaction provenance on their inputs, and a fixture that fabricates
+// the type without the stamps is exactly the launder the read exists to
+// catch. These fixtures carry no credential bytes, so emission stamps
+// 'clean' and leaves every byte the assertions read unchanged.
+const VERIFIED_FIX_PUBLIC: SecurityFinding = emitFinding({
   ...UNVERIFIED_FIX_PUBLIC,
   checkId: 'CRED-002',
   fixVerified: true,
-};
+} as SecurityFindingDraft);
 
 /** Same shape, but the fix demonstrably landed. */
-const VERIFIED_FIX: SecurityFinding = {
+// Emitted through the real boundary (unit 2): the builders under test now
+// read redaction provenance on their inputs, and a fixture that fabricates
+// the type without the stamps is exactly the launder the read exists to
+// catch. These fixtures carry no credential bytes, so emission stamps
+// 'clean' and leaves every byte the assertions read unchanged.
+const VERIFIED_FIX: SecurityFinding = emitFinding({
   ...UNVERIFIED_FIX,
   checkId: 'PERM-002',
   name: 'World-readable key file',
   description: 'id_rsa is readable by every user on the host',
   fixVerified: true,
   file: 'id_rsa',
-};
+} as SecurityFindingDraft);
 
 afterEach(() => vi.restoreAllMocks());
 

--- a/__tests__/ui/clamp-scope.test.ts
+++ b/__tests__/ui/clamp-scope.test.ts
@@ -22,6 +22,7 @@
 //   never displayed.
 
 import { describe, it, expect } from 'vitest';
+import { emitFindings } from '../../src/hardening/finding-emit';
 import { readFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { calculateSecurityScore } from '../../src/hardening';
@@ -154,9 +155,11 @@ describe('H-7: no published surface computes a composite without the clamp', () 
       packageName: 'p',
       packageType: 'npm',
       packageVersion: '1.0.0',
-      hardeningFindings: [
-        { checkId: 'X-1', name: 'x', severity: 'high', passed: false, category: 'other', message: '' },
-      ],
+      // Emitted through the real boundary (unit 2): buildPublishPayload now
+      // reads redaction provenance on its input.
+      hardeningFindings: emitFindings([
+        { checkId: 'X-1', name: 'x', severity: 'high', passed: false, category: 'other', message: '' } as never,
+      ]),
     } as any, '0.0.0-test');
 
     // Non-vacuity: the input must actually land in the good band pre-clamp,

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -291,7 +291,7 @@ import {
   type CategoryCoverage,
 } from './hardening/coverage-ledger';
 import type { ScanResult, SuppressionChannel, SecurityFindingDraft } from './hardening/security-check';
-import { emitFindings, reemitFinding, assertRedactionProvenance } from './hardening/finding-emit';
+import { emitFindings, reemitFinding, assertRedactionProvenance, RedactionProvenanceError } from './hardening/finding-emit';
 import { buildJsonStdoutDocument } from './output/json-stdout';
 import { compareFindingsByTier } from './ui/finding-tier';
 import {
@@ -5530,7 +5530,13 @@ Examples:
             }
           }
         } catch (_reportErr: any) {
-          // Silently ignore registry errors - they are not relevant to local scan results
+          // Silently ignore NETWORK/registry errors - they are not relevant to
+          // local scan results. The provenance read is the one exception: this
+          // catch was swallowing its abort, which kept the bytes off the wire
+          // but silenced the only signal that a laundering defect exists
+          // (adversarial review 2026-08-21, F2). An internal invariant is not
+          // a registry error; it propagates.
+          if (_reportErr instanceof RedactionProvenanceError) throw _reportErr;
         }
       }
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -291,7 +291,8 @@ import {
   type CategoryCoverage,
 } from './hardening/coverage-ledger';
 import type { ScanResult, SuppressionChannel, SecurityFindingDraft } from './hardening/security-check';
-import { emitFindings } from './hardening/finding-emit';
+import { emitFindings, reemitFinding, assertRedactionProvenance } from './hardening/finding-emit';
+import { buildJsonStdoutDocument } from './output/json-stdout';
 import { compareFindingsByTier } from './ui/finding-tier';
 import {
   scoreLineLabel,
@@ -358,21 +359,12 @@ function writeLargeStdout(text: string): void {
 }
 
 function writeJsonStdout(data: unknown): void {
-  // Stamp the producing version on every JSON surface (#202). A finding
-  // pasted into a bug report or archived in CI otherwise carries no record
-  // of which build emitted it. Injected centrally rather than at each call
-  // site so no surface can be missed or drift.
-  //
-  // Only plain objects are stamped: arrays and scalars would change shape.
-  // An existing `hackmyagentVersion` is never overwritten, so a payload that
-  // deliberately reports a different version keeps it. Corpus goldens store a
-  // distilled projection (score / severities / checkIds), not raw JSON, so
-  // this does not churn them on a version bump.
-  const stamped =
-    data && typeof data === 'object' && !Array.isArray(data)
-      ? { hackmyagentVersion: VERSION, ...(data as Record<string, unknown>) }
-      : data;
-  writeLargeStdout(JSON.stringify(stamped, null, 2) + '\n');
+  // Version stamping (#202) and the publish-boundary provenance read (unit 2)
+  // both live in `buildJsonStdoutDocument` — extracted so the chokepoint is
+  // importable and its read is provable by injection rather than by grep.
+  // ~32 JSON surfaces flow through here; a finding-shaped value without
+  // redaction provenance THROWS before a byte is written.
+  writeLargeStdout(buildJsonStdoutDocument(data, VERSION));
 }
 
 // The version-footer command set and its gate moved to
@@ -803,7 +795,15 @@ Examples:
             // same terms as `secure`. Two paths rendering the same compile
             // count must not disagree about how much of the suite read it.
             semanticFamilyCoverage: nmResult.semanticFamilyCoverage,
-            findings: issues as any[],
+            // Emitted at the bag boundary so the bag's `SecurityFinding[]`
+            // type is earned, not cast. Runtime no-op on this path — every
+            // element already crossed the boundary inside `mergeFindings`
+            // with the empty static set, and applied is absorbing — but the
+            // type witness this restores is what lets the re-map downstream
+            // use `reemitFinding` without a launder. Roadmap item (11)
+            // rejected an emit near here when the value became `as any[]`
+            // one line later; that premise is what this change removes.
+            findings: emitFindings(issues),
           },
           artifactSummaries: nmResult.artifactSummaries,
           suppressed: skillSuppressed.length > 0 ? skillSuppressed : undefined,
@@ -1099,7 +1099,15 @@ interface UnifiedCheckDisplayOptions {
      * than assert a coverage claim built from nothing.
      */
     semanticFamilyCoverage?: SemanticFamilyCoverage;
-    findings: Array<{ severity: string; checkId?: string; description?: string; name?: string; message?: string; fix?: string; guidance?: string; file?: string; line?: number; passed?: boolean; attackClass?: string; category?: string }>;
+    /**
+     * `SecurityFinding[]`, not an inline bag — `[CHIEF-CA]` 2026-08-21. The
+     * previous hand-listed bag type was a TYPE-level named-field rebuild: it
+     * admitted values without the two redaction fields, which is exactly how
+     * the defect-(13) re-map downstream of it typechecked. With the canonical
+     * type here, the compiler enumerates the producers, and the re-map can go
+     * through `reemitFinding` without a cast.
+     */
+    findings: SecurityFinding[];
   };
   /** Per-artifact summaries for the Observations block. Skill/MCP/SOUL/A2A
    *  detected and compiled by the semantic compiler. Shape mirrors
@@ -1589,26 +1597,27 @@ function displayUnifiedCheck(opts: UnifiedCheckDisplayOptions): void {
     // nothing here requires it — so it is pinned by a test rather than trusted
     // (`__tests__/hardening/finding-emit.test.ts`, the `mergeFindings` block).
     //
-    // KNOWN, ruled OUT of 0.32.0 and carried to the hardening unit: this re-map
-    // lists its fields by name and does not copy `redactionStatus` /
-    // `redactedShapes`, so re-emitting downgrades an honest `applied` to
-    // `clean`. Inert today — the field has no consumers and `failed` never
-    // reaches the JSON channel — but it is defect (1)'s false-clean class.
-    failed = emitFindings(issues.map(f => ({
+    // Defect (13) of the hardening unit, FIXED here: the previous re-map
+    // listed 13 fields by name and copied neither `redactionStatus` nor
+    // `redactedShapes`, so re-emitting downgraded an honest `applied` to
+    // `clean` — a false cleanliness claim, invisible to grep because a
+    // stripped draft is indistinguishable from a fresh one. `reemitFinding`
+    // spreads the prior finding, so the two fields ride through and the
+    // absorbing-applied merge honours them; its `Omit`-typed overrides make
+    // reintroducing the drop unrepresentable. The normalizations below are
+    // the old re-map's, unchanged; fields it used to drop (evidence,
+    // rationale, details) now ride along, which is additive on this text
+    // path. `severity` needs no cast now that the bag carries the canonical
+    // type.
+    failed = issues.map(f => reemitFinding(f, {
       checkId: f.checkId || '',
       name: f.name || f.description || '',
       description: f.description || '',
       category: f.category || '',
-      severity: f.severity as Severity,
       passed: false,
       message: f.message || f.description || '',
       fixable: false,
-      file: f.file,
-      line: f.line,
-      fix: f.fix,
-      guidance: f.guidance,
-      attackClass: f.attackClass,
-    })));
+    }));
     // Use the canonical scoring formula (exponential decay + 0.4x governance weight)
     //
     // #457 — `gatedIssues`, not `issues`. The counts, the verdict and the exit
@@ -3036,6 +3045,7 @@ function generateBenchmarkReport(
 
 // SARIF 2.1.0 output for GitHub Security tab and IDE integration
 function generateSarifOutput(benchmarkResult: BenchmarkResult, findings: SecurityFinding[], targetDir: string): string {
+  assertRedactionProvenance(findings, 'sarif-benchmark');
   const rules: Array<{
     id: string;
     name: string;
@@ -3134,6 +3144,7 @@ function generateSarifOutput(benchmarkResult: BenchmarkResult, findings: Securit
 
 // HTML report for shareable compliance documentation
 function generateHtmlReport(result: BenchmarkResult): string {
+  assertRedactionProvenance(result, 'html-benchmark');
   const ratingColor = {
     'Certified': '#22c55e',
     'Compliant': '#22c55e',
@@ -3850,6 +3861,7 @@ function escapeHtml(str: string): string {
 
 // SARIF output for non-benchmark secure scans
 function generateScanSarif(findings: SecurityFinding[], targetDir: string): string {
+  assertRedactionProvenance(findings, 'sarif-scan');
   const issues = findings.filter(f => countsAgainstScore(f));
   const rules = issues.map(f => ({
     id: f.checkId,
@@ -3901,6 +3913,7 @@ function generateScanSarif(findings: SecurityFinding[], targetDir: string): stri
 
 // HTML report for non-benchmark secure scans
 function generateScanHtmlReport(scanResult: { findings: SecurityFinding[]; score: number; maxScore: number; projectType: string }, targetDir: string): string {
+  assertRedactionProvenance(scanResult.findings, 'html-scan');
   const issues = scanResult.findings.filter(f => countsAgainstScore(f));
   // Verified fixes only, so "Auto-Fixed" and "issues" stay disjoint and the
   // header arithmetic adds up. A fix the verification pass could not confirm
@@ -4016,6 +4029,7 @@ function generateScanHtmlReport(scanResult: { findings: SecurityFinding[]; score
 
 // Agent Security Profile (ASP) - our differentiator format
 function generateAspOutput(benchmarkResult: BenchmarkResult, scanResult: { findings: SecurityFinding[]; projectType: string }, targetDir: string): string {
+  assertRedactionProvenance(scanResult.findings, 'asp');
   const fs = require('fs');
   const path = require('path');
 
@@ -4941,7 +4955,7 @@ Examples:
         const compositeScore = Math.round((infraScore + govScore) / 2);
 
         if (format === 'json') {
-          const jsonOutput = JSON.stringify({
+          const compositePayload = {
             benchmark: 'OASB',
             infraScore,
             govScore,
@@ -4949,7 +4963,11 @@ Examples:
             conformance: govResult.conformance,
             infraResult,
             govResult,
-          }, null, 2);
+          };
+          // This arm bypasses writeJsonStdout (writeFileSync(1, ...) below),
+          // so it carries its own boundary read.
+          assertRedactionProvenance(compositePayload, 'benchmark-composite-json');
+          const jsonOutput = JSON.stringify(compositePayload, null, 2);
           if (options.output) {
             require('fs').writeFileSync(options.output, jsonOutput);
             console.error(`Report written to ${options.output}`);
@@ -5186,6 +5204,10 @@ Examples:
           ...(nmResult.coverageSweep ? { coverageSweep: nmResult.coverageSweep } : {}),
         };
         const jsonOutput = publishStatus ? { ...jsonBase, publish: publishStatus } : jsonBase;
+        // The --output arm below bypasses writeJsonStdout, so the boundary
+        // read runs here, covering both arms (the stdout arm re-reads inside
+        // buildJsonStdoutDocument — a read is idempotent).
+        assertRedactionProvenance(jsonOutput, 'secure-json');
         if (options.output) {
           require('fs').writeFileSync(options.output, JSON.stringify(jsonOutput, null, 2) + '\n');
           console.error(`Report written to ${options.output}`);
@@ -11391,6 +11413,7 @@ async function publishToRegistry(
   name: string,
   result: { score: number; maxScore: number; projectType: string; findings: SecurityFinding[] },
 ): Promise<boolean> {
+  assertRedactionProvenance(result.findings, 'registry-publish-scan');
   try {
     const { RegistryClient } = await import('@opena2a/registry-client');
     const client = new RegistryClient({

--- a/src/hardening/finding-emit.ts
+++ b/src/hardening/finding-emit.ts
@@ -351,14 +351,162 @@ export function emitFindings(
   return drafts.map(emitFinding);
 }
 
-// A `reemitFinding` wrapper was written here and DELETED before it shipped: it
-// had zero production callers, and `emitFinding` already handles an
-// already-emitted input through its absorbing-applied merge, so the wrapper
-// added a second name for one behaviour and nothing else.
-//
-// The settlement brief §3.5 records the cost of keeping such a function:
-// `redactSecretsForNanoMind` is the documented "NanoMind has zero access to
-// secrets" boundary, has zero production call sites, and its presence is why the
-// daemon boundary was believed to exist for as long as it did. An exported
-// function with no callers is read as a guarantee. Rebuild sites call
-// `emitFinding` directly.
+/**
+ * Re-emit an already-emitted finding with normalizing overrides, without the
+ * rebuild being able to drop or downgrade the two redaction fields.
+ *
+ * The parameter types are the mechanism, not documentation of it. `prior` is a
+ * full `SecurityFinding`, on which both redaction fields are REQUIRED — a
+ * stripped bag does not typecheck. `overrides` is `Omit`-typed so handing in a
+ * `redactionStatus` or `redactedShapes` override is unrepresentable — the only
+ * source for those fields is the prior value, which the absorbing-applied merge
+ * in `emitFinding` then honours.
+ *
+ * HISTORY, kept because a reversed rationale left implicit is a hazard: a
+ * `reemitFinding` wrapper was written here once before and DELETED before it
+ * shipped — that version was a zero-caller alias with `emitFinding`'s own
+ * signature, and an exported function with no callers is read as a guarantee
+ * (the settlement brief §3.5 records `redactSecretsForNanoMind` as the cost of
+ * keeping one). This version differs on both counts: it has a production
+ * caller (the `check` text-path re-map in `cli.ts`), and its narrower types ARE
+ * the guarantee — defect (13) of the hardening unit was a named-field rebuild
+ * at that call site downgrading an honest `'applied'` to `'clean'`, invisible
+ * to grep because a stripped draft is indistinguishable from a fresh one.
+ *
+ * LIMIT, stated: nothing forces a future rebuild site through this function. A
+ * hand-enumerated rebuild fed to `emitFinding` still typechecks and still
+ * downgrades. This narrows the class; `assertRedactionProvenance` below and
+ * the publish-boundary tests are the runtime residue-catcher for launders, and
+ * the value-level downgrade remains catchable only at its call site.
+ */
+export function reemitFinding(
+  prior: SecurityFinding,
+  overrides?: Partial<Omit<SecurityFinding, 'redactionStatus' | 'redactedShapes'>>,
+): RedactedFinding {
+  return emitFinding({ ...prior, ...overrides } as SecurityFindingDraft);
+}
+
+// Compile-time pin for the property the `Omit` buys (tsc does not check
+// `__tests__/`, so this lives here where the build enforces it): the override
+// bag must not admit either redaction field.
+type _OverrideBag = NonNullable<Parameters<typeof reemitFinding>[1]>;
+type _OverridesCannotCarryStatus = 'redactionStatus' extends keyof _OverrideBag ? never : true;
+type _OverridesCannotCarryShapes = 'redactedShapes' extends keyof _OverrideBag ? never : true;
+const _overridesCannotCarryStatus: _OverridesCannotCarryStatus = true;
+const _overridesCannotCarryShapes: _OverridesCannotCarryShapes = true;
+void _overridesCannotCarryStatus;
+void _overridesCannotCarryShapes;
+
+/**
+ * Thrown by `assertRedactionProvenance` when a finding-shaped value reaches a
+ * publish boundary without redaction provenance. Carries NO byte-carrying
+ * content — the whole point is that the value's text may hold an unredacted
+ * credential, so the error names the channel, the checkId and the offending
+ * field, never the finding's text.
+ */
+export class RedactionProvenanceError extends Error {
+  constructor(
+    public readonly channel: string,
+    public readonly checkId: string,
+    public readonly defect: string,
+  ) {
+    super(
+      `hackmyagent internal defect: finding "${checkId}" reached publish channel ` +
+      `"${channel}" ${defect}. This finding was constructed outside the redaction ` +
+      `boundary and its text may contain unredacted credentials, so the scan was ` +
+      `aborted rather than published. Please report this at ` +
+      `https://github.com/opena2a-org/hackmyagent/issues`,
+    );
+    this.name = 'RedactionProvenanceError';
+  }
+}
+
+/** The reader's shape predicate: what counts as a finding at a boundary. */
+function isFindingShaped(v: Record<string, unknown>): boolean {
+  // The four-part predicate is the exemption mechanism — identity-only
+  // projections (`coverage.suppressedFailures`, `summarizeSuppressed` rows)
+  // carry no `passed` and no body text, so they are exempt BY SHAPE. Never
+  // exempt a site by allowlist: a shape exemption is earned by carrying no
+  // bytes, and adding a body-text field to a projection revokes it.
+  return (
+    typeof v.checkId === 'string' &&
+    typeof v.severity === 'string' &&
+    typeof v.passed === 'boolean' &&
+    (typeof v.message === 'string' || typeof v.description === 'string')
+  );
+}
+
+/**
+ * The publish-boundary reader (defect (10) of the hardening unit): the runtime
+ * read that the `redactionStatus` contract promised and nothing implemented.
+ *
+ * Walks a payload about to leave the process and THROWS if any finding-shaped
+ * value lacks redaction provenance: `redactionStatus` missing or outside
+ * {'applied','clean'}, or `redactedShapes` not an array. `'unverified'` is
+ * REJECTED at publish by `[CHIEF-CISO]` ruling (2026-08-21): it may exist on a
+ * value in process, it may never cross a publish boundary.
+ *
+ * Fail-mode is ABORT, uniformly — no CI/production fork, and deliberately no
+ * flag or env var to soften it (that would be a gate bypass). A laundered
+ * finding's text may carry unredacted credentials; publishing it in any
+ * annotated form is fail-open for a tool whose users chose it for exactly this
+ * guarantee. Untrusted-INPUT malformation is handled upstream by `emitFinding`
+ * per finding; this reader fires only on our own unwired producer, where a
+ * crash is the honest state and the only signal that reaches the defect.
+ *
+ * The walk is iterative (no recursion depth to overflow), cycle-safe, and has
+ * NO depth cap — a walker that silently skips containers re-enacts defect (1),
+ * publishing content nothing examined. Read-only on the healthy path.
+ */
+export function assertRedactionProvenance(payload: unknown, channel: string): void {
+  const seen = new WeakSet<object>();
+  const stack: unknown[] = [payload];
+  while (stack.length > 0) {
+    const value = stack.pop();
+    if (Array.isArray(value)) {
+      if (seen.has(value)) continue;
+      seen.add(value);
+      for (const item of value) stack.push(item);
+      continue;
+    }
+    if (isPlainObject(value)) {
+      if (seen.has(value)) continue;
+      seen.add(value);
+      if (isFindingShaped(value)) {
+        const checkId = String(value.checkId);
+        const status = value.redactionStatus;
+        if (status !== 'applied' && status !== 'clean') {
+          throw new RedactionProvenanceError(
+            channel,
+            checkId,
+            status === undefined
+              ? 'with no redactionStatus'
+              : `with redactionStatus ${JSON.stringify(status)}`,
+          );
+        }
+        if (!Array.isArray(value.redactedShapes)) {
+          throw new RedactionProvenanceError(channel, checkId, 'with no redactedShapes array');
+        }
+      }
+      for (const v of Object.values(value)) stack.push(v);
+    }
+    // Strings, numbers, non-plain objects: nothing to read. A non-plain
+    // container (Map/Set/class instance) serializes as `{}` on every JSON
+    // channel, so it cannot carry finding text onto the wire.
+  }
+}
+
+/**
+ * Redact an untyped bag that is about to ride a publish channel OUTSIDE any
+ * `SecurityFinding` (the analyst advisory channel is the production caller).
+ *
+ * `[CHIEF-CISO]` 2026-08-21: the analyst channel's "input is already redacted"
+ * property was prose-only — one upstream edit away from a silent leak path.
+ * This walk makes it structural: every string leaf at any depth is offered to
+ * the redactor, exactly as `details` is inside `emitFinding`. The pass's
+ * status/shapes are deliberately discarded — the bag is not a finding and has
+ * no provenance fields; the guarantee bought here is byte-level only.
+ */
+export function redactOpenBagForPublish(value: unknown): unknown {
+  return redactDetails(value, new RedactionPass());
+}

--- a/src/hardening/finding-emit.ts
+++ b/src/hardening/finding-emit.ts
@@ -355,12 +355,14 @@ export function emitFindings(
  * Re-emit an already-emitted finding with normalizing overrides, without the
  * rebuild being able to drop or downgrade the two redaction fields.
  *
- * The parameter types are the mechanism, not documentation of it. `prior` is a
- * full `SecurityFinding`, on which both redaction fields are REQUIRED — a
- * stripped bag does not typecheck. `overrides` is `Omit`-typed so handing in a
- * `redactionStatus` or `redactedShapes` override is unrepresentable — the only
- * source for those fields is the prior value, which the absorbing-applied merge
- * in `emitFinding` then honours.
+ * The parameter types are the first mechanism: `prior` is a full
+ * `SecurityFinding`, on which both redaction fields are REQUIRED — a stripped
+ * bag does not typecheck — and `overrides` is `Omit`-typed so a LITERAL
+ * override bag cannot name either redaction field. The type alone is NOT
+ * sufficient (excess-property checks do not apply to widened variables), so
+ * the body also discards the two keys at runtime; the only source for them is
+ * the prior value, which the absorbing-applied merge in `emitFinding` then
+ * honours.
  *
  * HISTORY, kept because a reversed rationale left implicit is a hazard: a
  * `reemitFinding` wrapper was written here once before and DELETED before it
@@ -383,7 +385,14 @@ export function reemitFinding(
   prior: SecurityFinding,
   overrides?: Partial<Omit<SecurityFinding, 'redactionStatus' | 'redactedShapes'>>,
 ): RedactedFinding {
-  return emitFinding({ ...prior, ...overrides } as SecurityFindingDraft);
+  // The `Omit` guards LITERAL override bags only — TypeScript's excess-property
+  // check does not apply to a widened variable, so a bag that happens to carry
+  // `redactionStatus: 'clean'` typechecks, reaches the spread, and downgrades a
+  // prior `'applied'` (adversarial review 2026-08-21, F1). Discard the two keys
+  // at runtime so the only source for them is `prior`, whatever the caller holds.
+  const { redactionStatus: _smuggledStatus, redactedShapes: _smuggledShapes, ...safeOverrides } =
+    (overrides ?? {}) as Record<string, unknown>;
+  return emitFinding({ ...prior, ...safeOverrides } as SecurityFindingDraft);
 }
 
 // Compile-time pin for the property the `Omit` buys (tsc does not check
@@ -490,9 +499,14 @@ export function assertRedactionProvenance(payload: unknown, channel: string): vo
       }
       for (const v of Object.values(value)) stack.push(v);
     }
-    // Strings, numbers, non-plain objects: nothing to read. A non-plain
-    // container (Map/Set/class instance) serializes as `{}` on every JSON
-    // channel, so it cannot carry finding text onto the wire.
+    // Strings, numbers, non-plain objects: nothing to read. KNOWN RESIDUE
+    // (adversarial review 2026-08-21, F5): a non-plain container is skipped
+    // here, and while a bare Map/Set serializes as `{}`, an object with a
+    // `toJSON()` serializes FULLY — so a producer that put finding text
+    // behind `toJSON` would cross this reader unexamined. No producer in the
+    // tree constructs such a value on any findings channel today (analyst
+    // responses are JSON-parsed daemon output; `Date` fields carry no text);
+    // if one appears, it needs handling HERE before it ships.
   }
 }
 

--- a/src/hardening/security-check.ts
+++ b/src/hardening/security-check.ts
@@ -149,10 +149,16 @@ export interface SecurityFinding {
    * Always present. Whether this finding's byte-carrying fields passed the
    * redaction boundary (`emitFinding`), and what the boundary concluded.
    *
-   * `'unverified'` is the INITIALIZER, not a fallback: a construction path that
-   * never reached the redactor emits an explicit unknown, never a claim of
-   * cleanliness. An unwired site is therefore visible in the output rather than
-   * silently asserting it is clean — this workspace's rule for degraded state.
+   * `'unverified'` is the DEGRADED value, not an initializer: no construction
+   * path sets it — every construction emits. It is what a publish boundary
+   * would stamp on a finding-shaped value carrying no redaction provenance IF
+   * its fail-mode were not abort — an explicit unknown, never a claim of
+   * cleanliness. Under the shipped fail-mode (`[CHIEF-CISO]` 2026-08-21,
+   * abort, uniformly) it has no producer, and `assertRedactionProvenance`
+   * REJECTS it at every publish boundary: it may exist on a value in process,
+   * it may never cross a channel. (`[CHIEF-CA]` 2026-08-21 corrected the
+   * earlier "INITIALIZER" wording here, which described semantics nothing
+   * implemented — the reader is the implementation now.)
    *
    * `[ABDEL]` 2026-08-13 (D3). Field name, type and the always-present rule are
    * FROZEN, as is the closed three-member union.

--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -32,6 +32,7 @@ import {
   buildDeepScanResult,
 } from './semantic';
 import { citationTarget } from './ui/shell-quote';
+import { assertRedactionProvenance } from './hardening/finding-emit';
 import { getCheckCounts } from './hardening/taxonomy';
 import { countsAgainstScore } from './ui/verdict-band';
 import {
@@ -149,6 +150,7 @@ export function buildScanToolText(result: {
   findings: SecurityFinding[];
   semanticAnalysis?: { layer2Findings: number };
 }): string {
+  assertRedactionProvenance(result.findings, 'mcp-scan-text');
   const issues = result.findings.filter((f) => countsAgainstScore(f));
   const fixed = result.findings.filter((f) => f.fixed);
 
@@ -179,6 +181,7 @@ export function buildDeepScanLayer1(findings: SecurityFinding[]): Array<{
   file?: string;
   message: string;
 }> {
+  assertRedactionProvenance(findings, 'mcp-deep-scan');
   return findings
     .filter((f) => countsAgainstScore(f))
     .map((f) => ({

--- a/src/nanomind-core/orchestrate.ts
+++ b/src/nanomind-core/orchestrate.ts
@@ -599,7 +599,15 @@ export async function runCoverageSweep(
     const combined = combineVerdict(false, routed, 'abstention-gated');
     if (combined.escalate && (routed === 'attack' || routed === 'abstain')) {
       const severity = oneLine(verdict.severity);
-      escalations.push({
+      // The sweep is the STRONGER half of the analyst channel: unlike
+      // `runAnalystOnFindings`, whose prompt is built from already-redacted
+      // finding text, `classify` above read the RAW artifact file — so the
+      // model's own text can quote a credential it saw (adversarial review
+      // 2026-08-21, F3). Every field that carries model text goes through the
+      // open-bag walk before the escalation can reach a JSON channel;
+      // `sanitizeAnalystString`/`oneLine` strip control characters only and
+      // are not a redactor.
+      escalations.push(redactOpenBagForPublish({
         file: candidate.path,
         artifactType: candidate.artifactType,
         routed,
@@ -609,7 +617,7 @@ export async function runCoverageSweep(
         summary: oneLine(verdict.analysis).slice(0, 600),
         modelVersion: verdict.modelVersion,
         policy: 'abstention-gated',
-      });
+      }) as AnalystEscalation);
     }
   }
 

--- a/src/nanomind-core/orchestrate.ts
+++ b/src/nanomind-core/orchestrate.ts
@@ -20,6 +20,7 @@ import { ANALYZER_FAMILY_COUNT } from './analyzers/family-coverage.js';
 import type { AnalystResponse, ArtifactCoverageVerdict } from './inference/security-analyst.js';
 import { routeAnalystVerdict, combineVerdict } from './analyst-coverage.js';
 import { countsAgainstScore } from '../ui/verdict-band';
+import { redactOpenBagForPublish } from '../hardening/finding-emit';
 
 export type { ArtifactSummary } from './scanner-bridge.js';
 
@@ -386,6 +387,10 @@ async function runAnalystOnFindings(
   findings: SecurityFindingDraft[],
   runInference: typeof import('./inference/security-analyst.js').runAnalystInference,
 ): Promise<AnalystResponse[]> {
+  // Exported below as `runAnalystOnFindingsForTest` so the open-bag redaction
+  // wiring (the `redactOpenBagForPublish` call at the push site) is provable
+  // by injection through THIS function with a stubbed `runInference`, not by
+  // grep — a text guard is satisfied by dead code; an injection is not.
   const results: AnalystResponse[] = [];
   const failed = findings.filter(f => countsAgainstScore(f));
 
@@ -448,12 +453,20 @@ async function runAnalystOnFindings(
     });
 
     if (response) {
-      results.push(response);
+      // [CHIEF-CISO] 2026-08-21: the analyst response rides the secure/check
+      // JSON channels raw, and "its input was already redacted" was a
+      // prose-only invariant one upstream edit could break silently. The
+      // open-bag walk makes it structural: every string leaf at any depth is
+      // offered to the redactor before the bag can reach a channel.
+      results.push(redactOpenBagForPublish(response) as AnalystResponse);
     }
   }
 
   return results;
 }
+
+/** Test-only alias — see the comment inside `runAnalystOnFindings`. */
+export const runAnalystOnFindingsForTest = runAnalystOnFindings;
 
 // ============================================================================
 // Coverage sweep (Phase A P1 — CDS-023/024, abstention-gated)

--- a/src/output/asff.ts
+++ b/src/output/asff.ts
@@ -13,6 +13,7 @@
 
 import { VERSION } from '../index.js';
 import { countsAgainstScore } from '../ui/verdict-band';
+import { assertRedactionProvenance } from '../hardening/finding-emit';
 
 export interface SecurityFinding {
   checkId: string;
@@ -85,6 +86,7 @@ export function toASSF(
     targetDir?: string;
   } = {},
 ): string {
+  assertRedactionProvenance(findings, 'asff');
   const accountId = options.awsAccountId || process.env.AWS_ACCOUNT_ID || '000000000000';
   const region = options.awsRegion || process.env.AWS_REGION || 'us-east-1';
   const targetDir = options.targetDir || process.cwd();

--- a/src/output/json-stdout.ts
+++ b/src/output/json-stdout.ts
@@ -1,0 +1,30 @@
+/**
+ * The JSON-stdout document builder: version stamp + the publish-boundary read.
+ *
+ * Extracted from `cli.ts` (unit 2 of the redaction-boundary hardening) so the
+ * chokepoint is IMPORTABLE — `[CHIEF-CISO]` 2026-08-21 requires every publish
+ * boundary's read to be proven by runtime injection through the real builder,
+ * and a function buried in the CLI entrypoint cannot be injected without
+ * spawning. `cli.ts`'s `writeJsonStdout` delegates here; ~32 JSON surfaces
+ * flow through this one function.
+ */
+import { assertRedactionProvenance } from '../hardening/finding-emit';
+
+/**
+ * Assert redaction provenance over the payload, stamp the producing version,
+ * and serialize. Throws `RedactionProvenanceError` (never writes) if any
+ * finding-shaped value in the payload lacks provenance.
+ *
+ * Version stamping semantics preserved from the original `writeJsonStdout`
+ * (#202): only plain objects are stamped — arrays and scalars would change
+ * shape — and an existing `hackmyagentVersion` is never overwritten, so a
+ * payload that deliberately reports a different version keeps it.
+ */
+export function buildJsonStdoutDocument(data: unknown, version: string): string {
+  assertRedactionProvenance(data, 'json-stdout');
+  const stamped =
+    data && typeof data === 'object' && !Array.isArray(data)
+      ? { hackmyagentVersion: version, ...(data as Record<string, unknown>) }
+      : data;
+  return JSON.stringify(stamped, null, 2) + '\n';
+}

--- a/src/registry/client.ts
+++ b/src/registry/client.ts
@@ -7,6 +7,7 @@
 
 import { createHash } from 'crypto';
 import type { SecurityFinding, Severity } from '../hardening';
+import { assertRedactionProvenance } from '../hardening/finding-emit';
 import type { AttackReport } from '../attack';
 import { countsAgainstScore } from '../ui/verdict-band';
 
@@ -484,6 +485,7 @@ export function buildScanReport(
   versionId: string,
   findings: SecurityFinding[],
 ): ScanReportPayload {
+  assertRedactionProvenance(findings, 'registry-scan-report');
   const failed = findings.filter(f => countsAgainstScore(f));
 
   const counts = countBySeverity(failed);
@@ -587,6 +589,7 @@ export function buildCommunityReport(
   findings: SecurityFinding[],
   options?: { packageType?: string; version?: string },
 ): CommunityScanPayload {
+  assertRedactionProvenance(findings, 'registry-community-report');
   const failed = findings.filter(f => countsAgainstScore(f));
   // Only send package-relevant findings to registry — local dev hygiene
   // checks (git, permissions, env, IDE config) don't belong on a package page

--- a/src/registry/publish.test.ts
+++ b/src/registry/publish.test.ts
@@ -16,6 +16,7 @@ import {
   type PublishResult,
 } from './publish';
 import type { SecurityFinding } from '../hardening';
+import { emitFinding } from '../hardening/finding-emit';
 import type { AttackReport } from '../attack';
 import type { SoulScanResult } from '../soul';
 import type { BenchmarkResult } from '../benchmarks';
@@ -76,7 +77,7 @@ function makeHardeningFindings(): SecurityFinding[] {
       fixed: false,
       fix: 'Restrict permissions',
     },
-  ] as SecurityFinding[];
+  ].map(f => emitFinding(f as never)) as SecurityFinding[];
 }
 
 function makeAttackReport(): AttackReport {
@@ -371,7 +372,7 @@ describe('buildPublishPayload', () => {
         passed: true,
         fixed: false,
       },
-    ] as SecurityFinding[];
+    ].map(f => emitFinding(f as never)) as SecurityFinding[];
 
     const data: PublishScanData = {
       packageName: '@test/clean',
@@ -395,7 +396,7 @@ describe('buildPublishPayload', () => {
         passed: false,
         fixed: false,
       },
-    ] as SecurityFinding[];
+    ].map(f => emitFinding(f as never)) as SecurityFinding[];
 
     const data: PublishScanData = {
       packageName: '@test/warn',

--- a/src/registry/publish.ts
+++ b/src/registry/publish.ts
@@ -12,6 +12,7 @@ import { createHash } from 'crypto';
 import { readdirSync, statSync, readFileSync } from 'fs';
 import { join, relative } from 'path';
 import type { SecurityFinding, Severity } from '../hardening';
+import { assertRedactionProvenance } from '../hardening/finding-emit';
 import { calculateSecurityScore } from '../hardening';
 import { clampScoreToVerdictBand, countsAgainstScore } from '../ui/verdict-band';
 import type { AttackReport } from '../attack';
@@ -166,6 +167,11 @@ export function signPayload(payload: string, privateKeyPem: string): string | nu
  * Combines results from hardening, attack, SOUL, and OASB scans into a single payload.
  */
 export function buildPublishPayload(data: PublishScanData, toolVersion: string): UnifiedPublishPayload {
+  // Publish-boundary read (unit 2): every finding leaving for the Registry
+  // must carry redaction provenance. The payload built below projects the
+  // fields away (wire-schema carry is a separate unit), so the read runs on
+  // the INPUT, where the provenance still exists to be read.
+  assertRedactionProvenance(data, 'registry-publish');
   const scanTimestamp = new Date().toISOString();
   const findings: UnifiedFinding[] = [];
 

--- a/src/semantic/integration/finding-adapter.ts
+++ b/src/semantic/integration/finding-adapter.ts
@@ -13,12 +13,20 @@ import type { Evidence, Rationale, ConceptId } from '../../types/finding-evidenc
 import { resolveFindingLine } from '../../types/finding-location';
 
 /**
- * SecurityFinding shape duplicated here to avoid a circular dependency —
- * the semantic engine has zero runtime dependencies.
+ * PRE-EMIT finding shape duplicated here so the semantic engine keeps zero
+ * runtime dependencies (the import below is type-only and erased at compile).
  *
- * Keep this interface in sync with the canonical `SecurityFinding` in
- * `src/hardening/security-check.ts`. Drift here causes silently-stripped
- * fields when SemanticFinding → SecurityFinding conversion happens.
+ * This interface mirrors `SecurityFindingDraft`, NOT the full
+ * `SecurityFinding` — deliberately. This adapter's outputs are drafts: they
+ * have not crossed the redaction boundary yet (they are emitted downstream at
+ * the scanner's route points), so they must NOT carry `redactionStatus` /
+ * `redactedShapes` — a detector is not in a position to know them. The
+ * compile-time assertion after the interface makes drift a build error in
+ * both directions the old "keep in sync" comment could not enforce: a field
+ * added here that the canonical draft lacks, or a type that widens past it.
+ * The exported NAME stays `SecurityFinding` because it is public on the `.`
+ * and `./semantic` subpaths and renaming a published type is a breaking
+ * change (`[CHIEF-CA]` 2026-08-21).
  */
 export interface SecurityFinding {
   checkId: string;
@@ -39,6 +47,22 @@ export interface SecurityFinding {
   rationale?: Rationale;
   concept?: ConceptId;
 }
+
+// Drift assertions against the canonical draft (type-only import — erased at
+// compile, so the zero-runtime-dependency property of this module holds).
+// (1) Every key here must exist on `SecurityFindingDraft`, so a field the
+// canonical type drops (or never had) is a build error here, not a silently
+// stripped field at conversion. (2) A value of this shape must be assignable
+// to the canonical draft, so a type widened past the canonical one fails.
+// The canonical draft may grow fields this mirror lacks — that is additive
+// and safe; the hazard this pins is the mirror inventing or widening.
+import type { SecurityFindingDraft as _CanonicalDraft } from '../../hardening/security-check';
+type _AdapterKeysExistOnDraft =
+  Exclude<keyof SecurityFinding, keyof _CanonicalDraft> extends never ? true : never;
+const _adapterKeysExistOnDraft: _AdapterKeysExistOnDraft = true;
+void _adapterKeysExistOnDraft;
+const _adapterAssignableToDraft = (f: SecurityFinding): _CanonicalDraft => f;
+void _adapterAssignableToDraft;
 
 const CATEGORY_LABELS: Record<string, string> = {
   credential: 'Credential Protection',


### PR DESCRIPTION
## The redaction boundary gets its reader, and rebuilds can no longer drop the stamp

0.32.0 stamped every emitted finding with `redactionStatus` + `redactedShapes`, but the stamp
was write-only: no publish boundary read it, `'unverified'` had no producer, and one re-map on
the `check` text path rebuilt findings field-by-field, dropping both stamps — so a second emit
downgraded an honest `applied` to `clean`, a false cleanliness claim invisible to grep because
a stripped draft is indistinguishable from a fresh one. These are defects (10) and (13) of the
hardening unit, coupled deliberately: landing a reader is exactly what would have made the
false-clean stamp live, so they ship together or not at all.

### What changed

- **`assertRedactionProvenance(payload, channel)`** — the publish-boundary read. Wired into
  the JSON stdout chokepoint (extracted to an importable builder so its read is provable by
  injection), the `--output` file arms, the SARIF/HTML/ASFF/ASP generators, the registry
  publish builders, and the MCP tool payloads. A finding-shaped value without provenance
  aborts the scan with an error naming the channel and checkId — never the finding's text.
  There is deliberately no flag to soften this: a finding without provenance was constructed
  outside the redaction boundary and its text may carry an unredacted credential.
- **`reemitFinding(prior, overrides)`** — the sanctioned rebuild. `prior` must be a full
  `SecurityFinding` (both stamps required, a stripped bag does not typecheck) and `overrides`
  is `Omit`-typed, so dropping or downgrading the stamps is unrepresentable. The `check`
  re-map now uses it, and the inline bag type it flowed through carries the canonical finding
  type so the compiler enumerates producers.
- **The analyst advisory channel is redacted structurally.** Its safety rested on prose
  ("analyst prompts are built from already-redacted text"); every analyst response now passes
  through the same open-bag redaction walk as finding `details`.
- **A cast guard** rejects casts into the branded finding types anywhere outside the boundary
  module, and the semantic adapter's duplicated finding shape is pinned to the canonical
  draft by compile-time assertions instead of a keep-in-sync comment.

### Verification

- The pre-fix downgrade was reproduced on this tree before the fix: first emit
  `applied ["aws-access-key-id"]`, re-map, second emit `clean []`. The spread-based rebuild
  preserves `applied` — that measurement is now the mechanism-control test.
- Every importable channel builder is proven by runtime injection with a laundered finding,
  plus a healthy control (a builder that always throws cannot satisfy the pair).
- 11/11 targeted mutations killed, each by its named test: the helper dropping the stamps,
  the reader's three throw conditions, a reintroduced silent walk cap, the open-bag walk
  returning its input, the analyst wiring removed, per-builder read removal, and the two
  fixes from the review below.
- Healthy output is unchanged: across every measured JSON payload
  (`secure`/`check`/`scan-soul`/`benchmark`/`fix-all`/`check-metadata`) the only differing
  field is the scan's own `timestamp` — 333 + 40 finding-shaped objects, every score and
  count identical — and the read fires on zero healthy objects. `attack`/`wild`/`eval`/
  `scan-soul` serialize non-finding types outside this contract and are deliberately unwired.
- Full suite green (287 files, 4149 tests); corpus release-smoke 12/12 with goldens
  byte-identical.

### What an independent review changed

An adversarial review of this branch against its base found no critical or high
regressions and three mediums, all fixed here — and two of them were defects in this
change's own claims rather than in its code:

- The re-emit helper's `Omit` only guards literal override bags; a widened variable
  carrying `redactionStatus: 'clean'` typechecked and downgraded a prior `applied`,
  reintroducing the defect the helper exists to prevent, through the sanctioned path and
  past the reader (`clean` is a legal publish value). Now discarded at runtime.
- "Aborts uniformly" was false on the auto-contribute path, where a pre-existing catch
  that ignores registry network errors also swallowed the provenance abort. The bytes
  stayed off the wire but the signal died; it now propagates.
- The analyst channel was only half closed. Coverage-sweep escalations hand the model the
  raw artifact file and ship its narrative, and carry no `passed` field so this change's
  own reader exempts them by shape. Now redacted, proven by injection through the real
  sweep with a stubbed classifier.

Two lows are recorded rather than fixed: a theoretical reader abort if the Registry ever
returned a finding-shaped row without provenance in `check --no-scan --json`, and the
reader's blind spot for objects with a custom `toJSON` (no producer builds one on a
findings channel today; the residue is documented at the skip site).

Carrying the two stamps onto the registry/SARIF wire schemas (today they are projected away
at payload build; the read runs on the builders' inputs) is deliberately out of scope and
tracked separately.
