### PR TITLE
Sweep the provenance abort across every publish catch, and say what it does

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,15 +42,20 @@ fact modified.
 - **Every channel that publishes findings now reads the stamp before a byte leaves.** The
   JSON stdout chokepoint, the `--output` file arms, the SARIF/HTML/ASFF/ASP report
   generators, the registry publish builders, and the MCP tool payloads all assert that every
-  finding-shaped value carries redaction provenance. A finding without it aborts the scan
-  with an error naming the channel and check — never the finding's text. There is
-  deliberately no flag to soften this: a finding without provenance was constructed outside
-  the redaction boundary and its text may carry an unredacted credential. Channels that
+  finding-shaped value carries redaction provenance. A finding without it is never
+  published, and raises an error naming the channel and check — never the finding's text.
+  On most channels that ends the scan; the registry publish paths and the MCP handler
+  catch it so a network failure cannot kill a local scan, and both surface the error
+  rather than swallowing it. There is deliberately no flag to soften this: a finding
+  without provenance was constructed outside the redaction boundary and its text may carry
+  an unredacted credential. Channels that
   serialize other result types — `attack`, `wild`, `eval`, `scan-soul` — are outside this
   contract and unchanged.
-- **Rebuilds go through `reemitFinding`**, whose parameter types make dropping or
-  downgrading the two stamps unrepresentable. The `check` re-map is fixed, and a repo guard
-  now rejects casts into the branded finding types anywhere outside the boundary module.
+- **Rebuilds go through `reemitFinding`**, which refuses to drop or downgrade the two
+  stamps: its parameter types stop a literal override bag from naming them, and because
+  that check does not extend to a widened variable, the body discards both keys at runtime
+  as well. The `check` re-map is fixed, and a repo guard now rejects casts into the branded
+  finding types anywhere outside the boundary module.
 - **Both analyst advisory channels are redacted structurally.** Per-finding analyst output
   previously rested on the fact that its prompts are built from already-redacted finding
   text. Coverage-sweep escalations had no such property at all: that pass hands the model the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,9 +44,11 @@ fact modified.
   generators, the registry publish builders, and the MCP tool payloads all assert that every
   finding-shaped value carries redaction provenance. A finding without it is never
   published, and raises an error naming the channel and check — never the finding's text.
-  On most channels that ends the scan; the registry publish paths and the MCP handler
-  catch it so a network failure cannot kill a local scan, and both surface the error
-  rather than swallowing it. There is deliberately no flag to soften this: a finding
+  On most channels that ends the scan. The registry publish paths and the MCP handler
+  wrap their calls so a network failure cannot kill a local scan; they re-raise this
+  error rather than reporting it as a publish failure, which does end the run — so
+  `secure --json --publish` now exits without emitting a document where it previously
+  emitted one carrying `publish.error`. There is deliberately no flag to soften this: a finding
   without provenance was constructed outside the redaction boundary and its text may carry
   an unredacted credential. Channels that
   serialize other result types — `attack`, `wild`, `eval`, `scan-soul` — are outside this

--- a/__tests__/hardening/provenance-abort-survives-catches.test.ts
+++ b/__tests__/hardening/provenance-abort-survives-catches.test.ts
@@ -3,16 +3,27 @@
  * failures.
  *
  * Found by adversarial review 2026-08-21 on the MERGED change: the first fix
- * added a rethrow to ONE catch — the one the review reported — and left five
- * sibling `publishScanResults` catches swallowing. That is the reported-surface
- * fix rather than the class fix. No byte ever leaked (the read runs before the
- * request), but the signal that a laundering path exists died in five places.
+ * added a rethrow to ONE catch — the one the review reported — and left eight
+ * sibling catches catching it. That is the reported-surface fix rather than the
+ * class fix.
+ *
+ * No byte ever leaked (the read runs before the request), and — stated
+ * precisely, because an earlier version of this comment did not — the message
+ * was not lost either: those catches print it or put it on `publishStatus`.
+ * They MISLABELLED it, rendering an internal laundering defect as a network
+ * failure and then continuing. That is what this fix corrects.
  *
  * Two layers here, because a text pin alone proves nothing about behaviour and
  * a behaviour test alone cannot see a NEW catch someone adds tomorrow:
  *   1. `rethrowIfRedactionProvenance` is exercised directly.
- *   2. The count of its call sites in `cli.ts` is pinned, so a sixth publish
- *      catch fails this test until its author classifies it.
+ *   2. The count of its call sites in `cli.ts` is pinned, so a NEW catch around
+ *      a publish boundary fails this test until its author classifies it.
+ *
+ * Both layers are weaker than they look, and saying so is cheaper than being
+ * caught by it: the positional check only knows the `publishErr` spelling, and
+ * the count pin is a substring count that a comment can satisfy. A catch with
+ * a different variable name passes both while swallowing. What actually holds
+ * this class is the reader's own tests plus these pins forcing a look.
  */
 import { describe, it, expect } from 'vitest';
 import { readFileSync } from 'node:fs';
@@ -63,6 +74,6 @@ describe('every swallowing catch around a publish boundary calls the helper', ()
     expect(
       calls,
       'cli.ts gained or lost a rethrowIfRedactionProvenance call — a new catch around a publish boundary must call it, then update this pin',
-    ).toBe(6);
+    ).toBe(9);
   });
 });

--- a/__tests__/hardening/provenance-abort-survives-catches.test.ts
+++ b/__tests__/hardening/provenance-abort-survives-catches.test.ts
@@ -1,0 +1,68 @@
+/**
+ * The provenance abort must survive the catches that exist to swallow network
+ * failures.
+ *
+ * Found by adversarial review 2026-08-21 on the MERGED change: the first fix
+ * added a rethrow to ONE catch — the one the review reported — and left five
+ * sibling `publishScanResults` catches swallowing. That is the reported-surface
+ * fix rather than the class fix. No byte ever leaked (the read runs before the
+ * request), but the signal that a laundering path exists died in five places.
+ *
+ * Two layers here, because a text pin alone proves nothing about behaviour and
+ * a behaviour test alone cannot see a NEW catch someone adds tomorrow:
+ *   1. `rethrowIfRedactionProvenance` is exercised directly.
+ *   2. The count of its call sites in `cli.ts` is pinned, so a sixth publish
+ *      catch fails this test until its author classifies it.
+ */
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import {
+  rethrowIfRedactionProvenance,
+  RedactionProvenanceError,
+} from '../../src/hardening/finding-emit';
+
+const CLI = join(__dirname, '..', '..', 'src', 'cli.ts');
+
+describe('rethrowIfRedactionProvenance', () => {
+  // RED-PROOF: make the helper a no-op — this case goes red.
+  it('rethrows a provenance failure', () => {
+    const err = new RedactionProvenanceError('registry-publish', 'CRED-001', 'with no redactionStatus');
+    expect(() => rethrowIfRedactionProvenance(err)).toThrow(RedactionProvenanceError);
+  });
+
+  // RED-PROOF: make the helper rethrow unconditionally — this case goes red,
+  // and with it the whole reason the publish catches exist (a network failure
+  // must not kill a local scan).
+  it('lets an ordinary network error pass, so the catch can still swallow it', () => {
+    expect(() => rethrowIfRedactionProvenance(new Error('ECONNREFUSED'))).not.toThrow();
+    expect(() => rethrowIfRedactionProvenance('socket hang up')).not.toThrow();
+    expect(() => rethrowIfRedactionProvenance(undefined)).not.toThrow();
+  });
+});
+
+describe('every swallowing catch around a publish boundary calls the helper', () => {
+  const src = readFileSync(CLI, 'utf8');
+
+  it('the publish-path catches are all guarded', () => {
+    // Each `catch (publishErr: unknown) {` must be followed immediately by the
+    // helper. Checked positionally rather than by a global count, so moving a
+    // call elsewhere in the file cannot satisfy this.
+    const catches = [...src.matchAll(/\} catch \(publishErr: unknown\) \{\n([^\n]*)\n/g)];
+    expect(catches.length, 'no publish catches found — the pattern moved and this test is vacuous').toBeGreaterThan(0);
+    const unguarded = catches
+      .map((m, i) => ({ i, next: m[1].trim() }))
+      .filter(({ next }) => !next.startsWith('rethrowIfRedactionProvenance(publishErr)'));
+    expect(unguarded, 'a publish catch would swallow the provenance abort').toEqual([]);
+  });
+
+  it('the count of guarded catches is pinned', () => {
+    // Blunt on purpose, like the JSON.stringify tripwire: it does not prove
+    // coverage, it forces the author of a NEW publish catch to classify it.
+    const calls = (src.match(/rethrowIfRedactionProvenance\(/g) ?? []).length;
+    expect(
+      calls,
+      'cli.ts gained or lost a rethrowIfRedactionProvenance call — a new catch around a publish boundary must call it, then update this pin',
+    ).toBe(6);
+  });
+});

--- a/__tests__/hardening/redaction-provenance-reader.test.ts
+++ b/__tests__/hardening/redaction-provenance-reader.test.ts
@@ -192,6 +192,40 @@ describe('assertRedactionProvenance — the publish-boundary read', () => {
     );
   });
 
+  // RED-PROOF: narrow the predicate's last clause back to
+  // `(message || description)` — this case goes red.
+  //
+  // `toASSF` renders `f.message || f.name || f.checkId` over a local finding
+  // type whose `message` is OPTIONAL and which declares no `description`, so a
+  // message-less finding would ship its `name` — a byte-carrying field — while
+  // a two-field predicate skipped it unexamined (adversarial review
+  // 2026-08-21). The predicate now derives from BYTE_CARRYING_FIELDS.
+  it('catches a laundered finding whose only body text is name', () => {
+    const nameOnly = {
+      checkId: 'TEST-NAMEONLY-001',
+      severity: 'high',
+      passed: false,
+      name: 'a finding whose bytes live only in name',
+    };
+    expect(() => assertRedactionProvenance([nameOnly], 'asff')).toThrow(
+      RedactionProvenanceError,
+    );
+  });
+
+  it('catches a laundered finding whose only body text is guidance', () => {
+    // The same property for a field neither the old predicate nor the asff
+    // case named — the point of deriving from the redactor's own list.
+    const guidanceOnly = {
+      checkId: 'TEST-GUIDANCEONLY-001',
+      severity: 'high',
+      passed: false,
+      guidance: 'remediation prose that could quote an artifact',
+    };
+    expect(() => assertRedactionProvenance([guidanceOnly], 'test-channel')).toThrow(
+      RedactionProvenanceError,
+    );
+  });
+
   it('zero-fire control: an honestly emitted finding passes', () => {
     const payload = { findings: emitFindings([draft(), draft({ message: `x ${GH}` })]) };
     expect(() => assertRedactionProvenance(payload, 'test-channel')).not.toThrow();

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -291,7 +291,7 @@ import {
   type CategoryCoverage,
 } from './hardening/coverage-ledger';
 import type { ScanResult, SuppressionChannel, SecurityFindingDraft } from './hardening/security-check';
-import { emitFindings, reemitFinding, assertRedactionProvenance, RedactionProvenanceError } from './hardening/finding-emit';
+import { emitFindings, reemitFinding, assertRedactionProvenance, rethrowIfRedactionProvenance } from './hardening/finding-emit';
 import { buildJsonStdoutDocument } from './output/json-stdout';
 import { compareFindingsByTier } from './ui/finding-tier';
 import {
@@ -5134,6 +5134,7 @@ Examples:
               publishStatus = { success: false, error: 'Could not determine package name' };
             }
           } catch (publishErr: unknown) {
+            rethrowIfRedactionProvenance(publishErr);
             const msg = publishErr instanceof Error ? publishErr.message : 'unknown error';
             publishStatus = { success: false, error: msg };
           }
@@ -5536,7 +5537,7 @@ Examples:
           // but silenced the only signal that a laundering defect exists
           // (adversarial review 2026-08-21, F2). An internal invariant is not
           // a registry error; it propagates.
-          if (_reportErr instanceof RedactionProvenanceError) throw _reportErr;
+          rethrowIfRedactionProvenance(_reportErr);
         }
       }
 
@@ -5597,6 +5598,7 @@ Examples:
             }
           }
         } catch (publishErr: unknown) {
+          rethrowIfRedactionProvenance(publishErr);
           const msg = publishErr instanceof Error ? publishErr.message : 'unknown error';
           console.error(`\nFailed to publish to registry: ${msg}`);
           console.error('Scan results are still available locally.');
@@ -7110,6 +7112,7 @@ Examples:
             console.log();
           }
         } catch (publishErr: unknown) {
+          rethrowIfRedactionProvenance(publishErr);
           const msg = publishErr instanceof Error ? publishErr.message : 'unknown error';
           console.error(`\nFailed to publish to registry: ${msg}`);
           console.error('Scan results are still available locally.');
@@ -8931,6 +8934,7 @@ Examples:
               publishStatus = { success: false, error: 'Could not determine package name' };
             }
           } catch (publishErr: unknown) {
+            rethrowIfRedactionProvenance(publishErr);
             const msg = publishErr instanceof Error ? publishErr.message : 'unknown error';
             publishStatus = { success: false, error: msg };
           }
@@ -9363,6 +9367,7 @@ Examples:
             }
           }
         } catch (publishErr: unknown) {
+          rethrowIfRedactionProvenance(publishErr);
           const msg = publishErr instanceof Error ? publishErr.message : 'unknown error';
           process.stderr.write(`Failed to publish to registry: ${msg}\n`);
           process.stderr.write('Scan results are still available locally.\n');

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -12099,6 +12099,7 @@ async function checkGitHubRepo(
     // /tmp/hma-check-gh-* directories orphaned, which eventually ENOSPC'd the
     // scanner container. See `finally { await rm(tempDir, ...) }` below.
   } catch (err: unknown) {
+    rethrowIfRedactionProvenance(err);
     const message = err instanceof Error ? err.message : String(err);
     if (message.includes('128') || message.includes('not found') || message.includes('Repository not found')) {
       const errorHint = `Verify the URL: https://github.com/${displayName}`;
@@ -12611,6 +12612,7 @@ async function checkRawUrl(
 
     // Exit code settled above, before the `--json` branch.
   } catch (err: unknown) {
+    rethrowIfRedactionProvenance(err);
     const message = err instanceof Error ? err.message : String(err);
     if (message.includes('128') || message.includes('not found') || message.includes('Repository not found')) {
       console.error(`Error: Could not clone repository from "${escapeForDisplay(String(url))}".`);
@@ -12824,6 +12826,7 @@ async function checkNpmPackage(
 
     // Exit code settled above, before the `--json` branch.
   } catch (err: unknown) {
+    rethrowIfRedactionProvenance(err);
     const message = err instanceof Error ? err.message : String(err);
     // Clean npm error messages
     if (message.includes('404') || message.includes('Not Found')) {

--- a/src/hardening/finding-emit.ts
+++ b/src/hardening/finding-emit.ts
@@ -422,26 +422,52 @@ export class RedactionProvenanceError extends Error {
     super(
       `hackmyagent internal defect: finding "${checkId}" reached publish channel ` +
       `"${channel}" ${defect}. This finding was constructed outside the redaction ` +
-      `boundary and its text may contain unredacted credentials, so the scan was ` +
-      `aborted rather than published. Please report this at ` +
+      `boundary and its text may contain unredacted credentials, so it was NOT ` +
+      `published. Please report this at ` +
       `https://github.com/opena2a-org/hackmyagent/issues`,
     );
     this.name = 'RedactionProvenanceError';
   }
 }
 
+/**
+ * Re-throw a redaction-provenance failure out of a catch that exists to
+ * swallow something else.
+ *
+ * Every registry publish path wraps its call in `try/catch` because a network
+ * failure must not kill a local scan — correct, and it also swallowed the
+ * provenance abort, which is the one error in there that is OUR defect rather
+ * than the network's. Bytes stay off the wire either way (the read runs before
+ * the request), but the signal that a laundering path exists died in the catch.
+ *
+ * Call this FIRST in any catch that wraps a publish boundary. An internal
+ * invariant is not a registry error.
+ */
+export function rethrowIfRedactionProvenance(err: unknown): void {
+  if (err instanceof RedactionProvenanceError) throw err;
+}
+
 /** The reader's shape predicate: what counts as a finding at a boundary. */
 function isFindingShaped(v: Record<string, unknown>): boolean {
-  // The four-part predicate is the exemption mechanism — identity-only
-  // projections (`coverage.suppressedFailures`, `summarizeSuppressed` rows)
-  // carry no `passed` and no body text, so they are exempt BY SHAPE. Never
-  // exempt a site by allowlist: a shape exemption is earned by carrying no
-  // bytes, and adding a body-text field to a projection revokes it.
+  // The predicate is the exemption mechanism — identity-only projections
+  // (`coverage.suppressedFailures`, `summarizeSuppressed` rows) carry no
+  // `passed`, so they are exempt BY SHAPE. Never exempt a site by allowlist: a
+  // shape exemption is earned by what the value carries, and a projection that
+  // grows a byte-carrying field revokes its own exemption automatically.
+  //
+  // The last clause reads `BYTE_CARRYING_FIELDS` rather than naming `message`
+  // and `description`: those two were an under-count. `toASSF` renders
+  // `f.message || f.name || f.checkId` over a local finding type whose
+  // `message` is OPTIONAL and which has no `description` at all, so a
+  // message-less finding would have shipped its `name` — a byte-carrying field
+  // — while failing a two-field predicate and being skipped unexamined
+  // (adversarial review 2026-08-21). Deriving the clause from the same list the
+  // redactor walks means a field added there is covered here the day it exists.
   return (
     typeof v.checkId === 'string' &&
     typeof v.severity === 'string' &&
     typeof v.passed === 'boolean' &&
-    (typeof v.message === 'string' || typeof v.description === 'string')
+    BYTE_CARRYING_FIELDS.some(f => typeof v[f] === 'string')
   );
 }
 
@@ -455,13 +481,21 @@ function isFindingShaped(v: Record<string, unknown>): boolean {
  * REJECTED at publish by `[CHIEF-CISO]` ruling (2026-08-21): it may exist on a
  * value in process, it may never cross a publish boundary.
  *
- * Fail-mode is ABORT, uniformly — no CI/production fork, and deliberately no
- * flag or env var to soften it (that would be a gate bypass). A laundered
- * finding's text may carry unredacted credentials; publishing it in any
- * annotated form is fail-open for a tool whose users chose it for exactly this
- * guarantee. Untrusted-INPUT malformation is handled upstream by `emitFinding`
- * per finding; this reader fires only on our own unwired producer, where a
- * crash is the honest state and the only signal that reaches the defect.
+ * Fail-mode is THROW, in every environment — no CI/production fork, and
+ * deliberately no flag or env var to soften it (that would be a gate bypass).
+ * A laundered finding's text may carry unredacted credentials; publishing it in
+ * any annotated form is fail-open for a tool whose users chose it for exactly
+ * this guarantee. Untrusted-INPUT malformation is handled upstream by
+ * `emitFinding` per finding; this reader fires only on our own unwired
+ * producer.
+ *
+ * A throw is not always an abort, and the difference is a caller's, not this
+ * function's. Registry publish paths and the MCP handler wrap their calls in
+ * `try/catch` so a network failure cannot kill a local scan; those catches call
+ * `rethrowIfRedactionProvenance` (publish) or surface the message as a tool
+ * error (MCP), so the SIGNAL always survives even where the process does not
+ * abort. What is invariant everywhere is that the bytes never leave: this read
+ * runs before the write or the request.
  *
  * The walk is iterative (no recursion depth to overflow), cycle-safe, and has
  * NO depth cap — a walker that silently skips containers re-enacts defect (1),

--- a/src/hardening/finding-emit.ts
+++ b/src/hardening/finding-emit.ts
@@ -435,10 +435,17 @@ export class RedactionProvenanceError extends Error {
  * swallow something else.
  *
  * Every registry publish path wraps its call in `try/catch` because a network
- * failure must not kill a local scan — correct, and it also swallowed the
+ * failure must not kill a local scan — correct, and it also caught the
  * provenance abort, which is the one error in there that is OUR defect rather
- * than the network's. Bytes stay off the wire either way (the read runs before
- * the request), but the signal that a laundering path exists died in the catch.
+ * than the network's.
+ *
+ * Precisely what went wrong is worth stating, because a first version of this
+ * comment overstated it: the message was NOT lost. Those catches print
+ * "Failed to publish to registry: <msg>" or put it on `publishStatus.error`,
+ * so the text reached the user. What they did was MISLABEL it — an internal
+ * laundering defect rendered as a network failure, on a path that then
+ * continues and exits normally. A reader who sees "failed to publish" checks
+ * their connectivity, not their code.
  *
  * Call this FIRST in any catch that wraps a publish boundary. An internal
  * invariant is not a registry error.

--- a/src/hardening/security-check.ts
+++ b/src/hardening/security-check.ts
@@ -152,9 +152,9 @@ export interface SecurityFinding {
    * `'unverified'` is the DEGRADED value, not an initializer: no construction
    * path sets it — every construction emits. It is what a publish boundary
    * would stamp on a finding-shaped value carrying no redaction provenance IF
-   * its fail-mode were not abort — an explicit unknown, never a claim of
-   * cleanliness. Under the shipped fail-mode (`[CHIEF-CISO]` 2026-08-21,
-   * abort, uniformly) it has no producer, and `assertRedactionProvenance`
+   * its fail-mode were not to throw — an explicit unknown, never a claim of
+   * cleanliness. Under the shipped fail-mode (`[CHIEF-CISO]` 2026-08-21, throw
+   * in every environment) it has no producer, and `assertRedactionProvenance`
    * REJECTS it at every publish boundary: it may exist on a value in process,
    * it may never cross a channel. (`[CHIEF-CA]` 2026-08-21 corrected the
    * earlier "INITIALIZER" wording here, which described semantics nothing


### PR DESCRIPTION
## Sweep the provenance abort across every publish catch, and say what it does

A review of the merged boundary work (#551) found that one of its fixes had closed the
reported surface and left the class open, and that three of its claims were still wider
than the code. All four are fixed here.

### The class fix

The provenance abort was rethrown from one catch; **eight sibling catches still caught
it** — five around `publishScanResults`, and three more in `checkGitHubRepo`,
`checkRawUrl` and `checkNpmPackage` that a first pass missed because it swept the
`publishErr` spelling and those catch `err`.

Stated precisely, because a first version of this description was not: no byte ever
leaked (the read runs before the request) and the message was not lost either — those
catches print it or put it on `publishStatus.error`. They **mislabelled** it, rendering an
internal laundering defect as a network failure and then continuing. Three of them carry
comments asserting that every branch is "a clone that did not happen", which stops being
true once the repo has been cloned, scanned and reported.

All nine now call `rethrowIfRedactionProvenance`, a named helper rather than a repeated
`instanceof`, so the intent is legible at each site. Two tests hold the class: the helper
is exercised in both directions (a provenance failure propagates; an ordinary network
error still passes, so the catch can do the job it exists for), and the publish catches
are checked **positionally** with their count pinned, so a new one fails until its author
classifies it — with both limits of that approach written into the test itself.

### The predicate under-counted

The reader asked for `message || description`. `toASSF` renders the first of `message`,
`name` or `checkId` that is set, over a local finding type whose `message` is optional and
which declares no `description` — so a message-less finding would have shipped its `name`,
a byte-carrying field, while failing the predicate and being skipped unexamined.

The predicate now derives from `BYTE_CARRYING_FIELDS`, the same list the redactor walks,
so a field added there is covered here the day it exists rather than the day someone
remembers.

### Four claims corrected to match the code

- **"ABORT, uniformly"** was still unqualified in the docblock and still false on those
  paths — and a sibling copy of the same sentence in `security-check.ts` survived the first
  correction, so the tree briefly carried two comments disagreeing about the fail-mode.
  A throw is not always an abort, and whether it becomes one belongs to the caller.
  What is invariant is that the bytes never leave; the docblock now says that, and names
  where the signal survives without the process dying.
- **The error text** claimed *"the scan was aborted rather than published"* on paths where
  the scan continues. It now says the finding was not published, which is true everywhere.
- **The changelog** credited the rebuild guarantee to the parameter types alone — exactly
  what the widened-bag defect disproved. It now describes both halves.

### Verification

- 4/4 targeted mutations killed, each by its named test: the helper made a no-op, the
  helper made unconditional, one publish catch stripped of its guard, and the predicate
  narrowed back. Mutants were restored from pristine file copies, not `git checkout`.
- **The widening fires on nothing healthy, measured rather than reasoned.** `expandSuppressed`
  produces `{checkId, name, severity, passed}` stubs that the old predicate missed and the
  new one matches, so the suppression paths that produce them were exercised directly:
  `--ignore` flags and an `.hmaignore` file, on both `secure --json` and `check --json`,
  plus the `sarif`, `html` and `asff` formats. Zero fires in all of them, and the JSON
  payloads are identical to before the widening.
- Full suite green (289 files, 4159 tests); corpus release-smoke 12/12.

**Recorded residue**: those suppressed-summary stubs carry text that is already redacted
(they are projected from emitted findings) but carry no stamp, so if a future change ever
routed them onto a channel the reader would throw on safe bytes. They are score-only today
and reach no channel. The fix, if that changes, is to emit them rather than to loosen the
predicate.

### Why this stops here

Three consecutive review rounds have each found a defect inside the previous round's fix,
and every one was the same class — a sentence asserting more than the code does, in a
docblock, a test header, or this changelog. That is the documented signal to cut back to
the minimum fix rather than run a fourth round, so the remaining findings are filed as
#552 and #553 rather than grown into this branch. The new test's own limits are written
into it for the same reason.
