### PR TITLE
Acceptance run for the chunked review gate — do not merge

### DIFF
--- a/test-fixtures/gate-acceptance/artifact-index.ts
+++ b/test-fixtures/gate-acceptance/artifact-index.ts
@@ -1,0 +1,1500 @@
+// Acceptance corpus for the pull request review gate.
+//
+// This file is synthetic and is not part of the shipped package. It
+// exists so that one pull request is large enough to exercise two
+// limits at once: the diff API's 20,000-changed-line ceiling, and the
+// review request budget above which the gate splits a change into
+// batches. This pull request is opened to exercise them and closed
+// again; it is not merged.
+
+export interface artifactIndexEntry {
+  readonly key: string;
+  readonly slot: number;
+  readonly active: boolean;
+}
+
+export interface artifactIndexState {
+  readonly entries: ReadonlyArray<artifactIndexEntry>;
+  readonly total: number;
+}
+
+/** Collect one entry for the artifact-index stage. */
+export function collectEntry000(
+  entries: ReadonlyArray<artifactIndexEntry>,
+  slot: number,
+): artifactIndexEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Resolve one entry for the artifact-index stage. */
+export function resolveEntry001(
+  entries: ReadonlyArray<artifactIndexEntry>,
+  slot: number,
+): artifactIndexEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Merge one entry for the artifact-index stage. */
+export function mergeEntry002(
+  entries: ReadonlyArray<artifactIndexEntry>,
+  slot: number,
+): artifactIndexEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Filter one entry for the artifact-index stage. */
+export function filterEntry003(
+  entries: ReadonlyArray<artifactIndexEntry>,
+  slot: number,
+): artifactIndexEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Reduce one entry for the artifact-index stage. */
+export function reduceEntry004(
+  entries: ReadonlyArray<artifactIndexEntry>,
+  slot: number,
+): artifactIndexEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Expand one entry for the artifact-index stage. */
+export function expandEntry005(
+  entries: ReadonlyArray<artifactIndexEntry>,
+  slot: number,
+): artifactIndexEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Normalise one entry for the artifact-index stage. */
+export function normaliseEntry006(
+  entries: ReadonlyArray<artifactIndexEntry>,
+  slot: number,
+): artifactIndexEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Compare one entry for the artifact-index stage. */
+export function compareEntry007(
+  entries: ReadonlyArray<artifactIndexEntry>,
+  slot: number,
+): artifactIndexEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Select one entry for the artifact-index stage. */
+export function selectEntry008(
+  entries: ReadonlyArray<artifactIndexEntry>,
+  slot: number,
+): artifactIndexEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Record one entry for the artifact-index stage. */
+export function recordEntry009(
+  entries: ReadonlyArray<artifactIndexEntry>,
+  slot: number,
+): artifactIndexEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Collect one record for the artifact-index stage. */
+export function collectRecord010(
+  entries: ReadonlyArray<artifactIndexEntry>,
+  slot: number,
+): artifactIndexEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Resolve one record for the artifact-index stage. */
+export function resolveRecord011(
+  entries: ReadonlyArray<artifactIndexEntry>,
+  slot: number,
+): artifactIndexEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Merge one record for the artifact-index stage. */
+export function mergeRecord012(
+  entries: ReadonlyArray<artifactIndexEntry>,
+  slot: number,
+): artifactIndexEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Filter one record for the artifact-index stage. */
+export function filterRecord013(
+  entries: ReadonlyArray<artifactIndexEntry>,
+  slot: number,
+): artifactIndexEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Reduce one record for the artifact-index stage. */
+export function reduceRecord014(
+  entries: ReadonlyArray<artifactIndexEntry>,
+  slot: number,
+): artifactIndexEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Expand one record for the artifact-index stage. */
+export function expandRecord015(
+  entries: ReadonlyArray<artifactIndexEntry>,
+  slot: number,
+): artifactIndexEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Normalise one record for the artifact-index stage. */
+export function normaliseRecord016(
+  entries: ReadonlyArray<artifactIndexEntry>,
+  slot: number,
+): artifactIndexEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Compare one record for the artifact-index stage. */
+export function compareRecord017(
+  entries: ReadonlyArray<artifactIndexEntry>,
+  slot: number,
+): artifactIndexEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Select one record for the artifact-index stage. */
+export function selectRecord018(
+  entries: ReadonlyArray<artifactIndexEntry>,
+  slot: number,
+): artifactIndexEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Record one record for the artifact-index stage. */
+export function recordRecord019(
+  entries: ReadonlyArray<artifactIndexEntry>,
+  slot: number,
+): artifactIndexEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Collect one bucket for the artifact-index stage. */
+export function collectBucket020(
+  entries: ReadonlyArray<artifactIndexEntry>,
+  slot: number,
+): artifactIndexEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Resolve one bucket for the artifact-index stage. */
+export function resolveBucket021(
+  entries: ReadonlyArray<artifactIndexEntry>,
+  slot: number,
+): artifactIndexEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Merge one bucket for the artifact-index stage. */
+export function mergeBucket022(
+  entries: ReadonlyArray<artifactIndexEntry>,
+  slot: number,
+): artifactIndexEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Filter one bucket for the artifact-index stage. */
+export function filterBucket023(
+  entries: ReadonlyArray<artifactIndexEntry>,
+  slot: number,
+): artifactIndexEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Reduce one bucket for the artifact-index stage. */
+export function reduceBucket024(
+  entries: ReadonlyArray<artifactIndexEntry>,
+  slot: number,
+): artifactIndexEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Expand one bucket for the artifact-index stage. */
+export function expandBucket025(
+  entries: ReadonlyArray<artifactIndexEntry>,
+  slot: number,
+): artifactIndexEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Normalise one bucket for the artifact-index stage. */
+export function normaliseBucket026(
+  entries: ReadonlyArray<artifactIndexEntry>,
+  slot: number,
+): artifactIndexEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Compare one bucket for the artifact-index stage. */
+export function compareBucket027(
+  entries: ReadonlyArray<artifactIndexEntry>,
+  slot: number,
+): artifactIndexEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Select one bucket for the artifact-index stage. */
+export function selectBucket028(
+  entries: ReadonlyArray<artifactIndexEntry>,
+  slot: number,
+): artifactIndexEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Record one bucket for the artifact-index stage. */
+export function recordBucket029(
+  entries: ReadonlyArray<artifactIndexEntry>,
+  slot: number,
+): artifactIndexEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Collect one segment for the artifact-index stage. */
+export function collectSegment030(
+  entries: ReadonlyArray<artifactIndexEntry>,
+  slot: number,
+): artifactIndexEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Resolve one segment for the artifact-index stage. */
+export function resolveSegment031(
+  entries: ReadonlyArray<artifactIndexEntry>,
+  slot: number,
+): artifactIndexEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Merge one segment for the artifact-index stage. */
+export function mergeSegment032(
+  entries: ReadonlyArray<artifactIndexEntry>,
+  slot: number,
+): artifactIndexEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Filter one segment for the artifact-index stage. */
+export function filterSegment033(
+  entries: ReadonlyArray<artifactIndexEntry>,
+  slot: number,
+): artifactIndexEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Reduce one segment for the artifact-index stage. */
+export function reduceSegment034(
+  entries: ReadonlyArray<artifactIndexEntry>,
+  slot: number,
+): artifactIndexEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Expand one segment for the artifact-index stage. */
+export function expandSegment035(
+  entries: ReadonlyArray<artifactIndexEntry>,
+  slot: number,
+): artifactIndexEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Normalise one segment for the artifact-index stage. */
+export function normaliseSegment036(
+  entries: ReadonlyArray<artifactIndexEntry>,
+  slot: number,
+): artifactIndexEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Compare one segment for the artifact-index stage. */
+export function compareSegment037(
+  entries: ReadonlyArray<artifactIndexEntry>,
+  slot: number,
+): artifactIndexEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Select one segment for the artifact-index stage. */
+export function selectSegment038(
+  entries: ReadonlyArray<artifactIndexEntry>,
+  slot: number,
+): artifactIndexEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Record one segment for the artifact-index stage. */
+export function recordSegment039(
+  entries: ReadonlyArray<artifactIndexEntry>,
+  slot: number,
+): artifactIndexEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Collect one window for the artifact-index stage. */
+export function collectWindow040(
+  entries: ReadonlyArray<artifactIndexEntry>,
+  slot: number,
+): artifactIndexEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Resolve one window for the artifact-index stage. */
+export function resolveWindow041(
+  entries: ReadonlyArray<artifactIndexEntry>,
+  slot: number,
+): artifactIndexEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Merge one window for the artifact-index stage. */
+export function mergeWindow042(
+  entries: ReadonlyArray<artifactIndexEntry>,
+  slot: number,
+): artifactIndexEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Filter one window for the artifact-index stage. */
+export function filterWindow043(
+  entries: ReadonlyArray<artifactIndexEntry>,
+  slot: number,
+): artifactIndexEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Reduce one window for the artifact-index stage. */
+export function reduceWindow044(
+  entries: ReadonlyArray<artifactIndexEntry>,
+  slot: number,
+): artifactIndexEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Expand one window for the artifact-index stage. */
+export function expandWindow045(
+  entries: ReadonlyArray<artifactIndexEntry>,
+  slot: number,
+): artifactIndexEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Normalise one window for the artifact-index stage. */
+export function normaliseWindow046(
+  entries: ReadonlyArray<artifactIndexEntry>,
+  slot: number,
+): artifactIndexEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Compare one window for the artifact-index stage. */
+export function compareWindow047(
+  entries: ReadonlyArray<artifactIndexEntry>,
+  slot: number,
+): artifactIndexEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Select one window for the artifact-index stage. */
+export function selectWindow048(
+  entries: ReadonlyArray<artifactIndexEntry>,
+  slot: number,
+): artifactIndexEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Record one window for the artifact-index stage. */
+export function recordWindow049(
+  entries: ReadonlyArray<artifactIndexEntry>,
+  slot: number,
+): artifactIndexEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Collect one marker for the artifact-index stage. */
+export function collectMarker050(
+  entries: ReadonlyArray<artifactIndexEntry>,
+  slot: number,
+): artifactIndexEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Resolve one marker for the artifact-index stage. */
+export function resolveMarker051(
+  entries: ReadonlyArray<artifactIndexEntry>,
+  slot: number,
+): artifactIndexEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Merge one marker for the artifact-index stage. */
+export function mergeMarker052(
+  entries: ReadonlyArray<artifactIndexEntry>,
+  slot: number,
+): artifactIndexEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Filter one marker for the artifact-index stage. */
+export function filterMarker053(
+  entries: ReadonlyArray<artifactIndexEntry>,
+  slot: number,
+): artifactIndexEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Reduce one marker for the artifact-index stage. */
+export function reduceMarker054(
+  entries: ReadonlyArray<artifactIndexEntry>,
+  slot: number,
+): artifactIndexEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Expand one marker for the artifact-index stage. */
+export function expandMarker055(
+  entries: ReadonlyArray<artifactIndexEntry>,
+  slot: number,
+): artifactIndexEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Normalise one marker for the artifact-index stage. */
+export function normaliseMarker056(
+  entries: ReadonlyArray<artifactIndexEntry>,
+  slot: number,
+): artifactIndexEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Compare one marker for the artifact-index stage. */
+export function compareMarker057(
+  entries: ReadonlyArray<artifactIndexEntry>,
+  slot: number,
+): artifactIndexEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Select one marker for the artifact-index stage. */
+export function selectMarker058(
+  entries: ReadonlyArray<artifactIndexEntry>,
+  slot: number,
+): artifactIndexEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Record one marker for the artifact-index stage. */
+export function recordMarker059(
+  entries: ReadonlyArray<artifactIndexEntry>,
+  slot: number,
+): artifactIndexEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Collect one handle for the artifact-index stage. */
+export function collectHandle060(
+  entries: ReadonlyArray<artifactIndexEntry>,
+  slot: number,
+): artifactIndexEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Resolve one handle for the artifact-index stage. */
+export function resolveHandle061(
+  entries: ReadonlyArray<artifactIndexEntry>,
+  slot: number,
+): artifactIndexEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Merge one handle for the artifact-index stage. */
+export function mergeHandle062(
+  entries: ReadonlyArray<artifactIndexEntry>,
+  slot: number,
+): artifactIndexEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Filter one handle for the artifact-index stage. */
+export function filterHandle063(
+  entries: ReadonlyArray<artifactIndexEntry>,
+  slot: number,
+): artifactIndexEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Reduce one handle for the artifact-index stage. */
+export function reduceHandle064(
+  entries: ReadonlyArray<artifactIndexEntry>,
+  slot: number,
+): artifactIndexEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Expand one handle for the artifact-index stage. */
+export function expandHandle065(
+  entries: ReadonlyArray<artifactIndexEntry>,
+  slot: number,
+): artifactIndexEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Normalise one handle for the artifact-index stage. */
+export function normaliseHandle066(
+  entries: ReadonlyArray<artifactIndexEntry>,
+  slot: number,
+): artifactIndexEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Compare one handle for the artifact-index stage. */
+export function compareHandle067(
+  entries: ReadonlyArray<artifactIndexEntry>,
+  slot: number,
+): artifactIndexEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Select one handle for the artifact-index stage. */
+export function selectHandle068(
+  entries: ReadonlyArray<artifactIndexEntry>,
+  slot: number,
+): artifactIndexEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Record one handle for the artifact-index stage. */
+export function recordHandle069(
+  entries: ReadonlyArray<artifactIndexEntry>,
+  slot: number,
+): artifactIndexEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Collect one cursor for the artifact-index stage. */
+export function collectCursor070(
+  entries: ReadonlyArray<artifactIndexEntry>,
+  slot: number,
+): artifactIndexEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Resolve one cursor for the artifact-index stage. */
+export function resolveCursor071(
+  entries: ReadonlyArray<artifactIndexEntry>,
+  slot: number,
+): artifactIndexEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Merge one cursor for the artifact-index stage. */
+export function mergeCursor072(
+  entries: ReadonlyArray<artifactIndexEntry>,
+  slot: number,
+): artifactIndexEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Filter one cursor for the artifact-index stage. */
+export function filterCursor073(
+  entries: ReadonlyArray<artifactIndexEntry>,
+  slot: number,
+): artifactIndexEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+

--- a/test-fixtures/gate-acceptance/budget-meter.ts
+++ b/test-fixtures/gate-acceptance/budget-meter.ts
@@ -1,0 +1,1500 @@
+// Acceptance corpus for the pull request review gate.
+//
+// This file is synthetic and is not part of the shipped package. It
+// exists so that one pull request is large enough to exercise two
+// limits at once: the diff API's 20,000-changed-line ceiling, and the
+// review request budget above which the gate splits a change into
+// batches. This pull request is opened to exercise them and closed
+// again; it is not merged.
+
+export interface budgetMeterEntry {
+  readonly key: string;
+  readonly slot: number;
+  readonly active: boolean;
+}
+
+export interface budgetMeterState {
+  readonly entries: ReadonlyArray<budgetMeterEntry>;
+  readonly total: number;
+}
+
+/** Collect one entry for the budget-meter stage. */
+export function collectEntry000(
+  entries: ReadonlyArray<budgetMeterEntry>,
+  slot: number,
+): budgetMeterEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Resolve one entry for the budget-meter stage. */
+export function resolveEntry001(
+  entries: ReadonlyArray<budgetMeterEntry>,
+  slot: number,
+): budgetMeterEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Merge one entry for the budget-meter stage. */
+export function mergeEntry002(
+  entries: ReadonlyArray<budgetMeterEntry>,
+  slot: number,
+): budgetMeterEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Filter one entry for the budget-meter stage. */
+export function filterEntry003(
+  entries: ReadonlyArray<budgetMeterEntry>,
+  slot: number,
+): budgetMeterEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Reduce one entry for the budget-meter stage. */
+export function reduceEntry004(
+  entries: ReadonlyArray<budgetMeterEntry>,
+  slot: number,
+): budgetMeterEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Expand one entry for the budget-meter stage. */
+export function expandEntry005(
+  entries: ReadonlyArray<budgetMeterEntry>,
+  slot: number,
+): budgetMeterEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Normalise one entry for the budget-meter stage. */
+export function normaliseEntry006(
+  entries: ReadonlyArray<budgetMeterEntry>,
+  slot: number,
+): budgetMeterEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Compare one entry for the budget-meter stage. */
+export function compareEntry007(
+  entries: ReadonlyArray<budgetMeterEntry>,
+  slot: number,
+): budgetMeterEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Select one entry for the budget-meter stage. */
+export function selectEntry008(
+  entries: ReadonlyArray<budgetMeterEntry>,
+  slot: number,
+): budgetMeterEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Record one entry for the budget-meter stage. */
+export function recordEntry009(
+  entries: ReadonlyArray<budgetMeterEntry>,
+  slot: number,
+): budgetMeterEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Collect one record for the budget-meter stage. */
+export function collectRecord010(
+  entries: ReadonlyArray<budgetMeterEntry>,
+  slot: number,
+): budgetMeterEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Resolve one record for the budget-meter stage. */
+export function resolveRecord011(
+  entries: ReadonlyArray<budgetMeterEntry>,
+  slot: number,
+): budgetMeterEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Merge one record for the budget-meter stage. */
+export function mergeRecord012(
+  entries: ReadonlyArray<budgetMeterEntry>,
+  slot: number,
+): budgetMeterEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Filter one record for the budget-meter stage. */
+export function filterRecord013(
+  entries: ReadonlyArray<budgetMeterEntry>,
+  slot: number,
+): budgetMeterEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Reduce one record for the budget-meter stage. */
+export function reduceRecord014(
+  entries: ReadonlyArray<budgetMeterEntry>,
+  slot: number,
+): budgetMeterEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Expand one record for the budget-meter stage. */
+export function expandRecord015(
+  entries: ReadonlyArray<budgetMeterEntry>,
+  slot: number,
+): budgetMeterEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Normalise one record for the budget-meter stage. */
+export function normaliseRecord016(
+  entries: ReadonlyArray<budgetMeterEntry>,
+  slot: number,
+): budgetMeterEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Compare one record for the budget-meter stage. */
+export function compareRecord017(
+  entries: ReadonlyArray<budgetMeterEntry>,
+  slot: number,
+): budgetMeterEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Select one record for the budget-meter stage. */
+export function selectRecord018(
+  entries: ReadonlyArray<budgetMeterEntry>,
+  slot: number,
+): budgetMeterEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Record one record for the budget-meter stage. */
+export function recordRecord019(
+  entries: ReadonlyArray<budgetMeterEntry>,
+  slot: number,
+): budgetMeterEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Collect one bucket for the budget-meter stage. */
+export function collectBucket020(
+  entries: ReadonlyArray<budgetMeterEntry>,
+  slot: number,
+): budgetMeterEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Resolve one bucket for the budget-meter stage. */
+export function resolveBucket021(
+  entries: ReadonlyArray<budgetMeterEntry>,
+  slot: number,
+): budgetMeterEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Merge one bucket for the budget-meter stage. */
+export function mergeBucket022(
+  entries: ReadonlyArray<budgetMeterEntry>,
+  slot: number,
+): budgetMeterEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Filter one bucket for the budget-meter stage. */
+export function filterBucket023(
+  entries: ReadonlyArray<budgetMeterEntry>,
+  slot: number,
+): budgetMeterEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Reduce one bucket for the budget-meter stage. */
+export function reduceBucket024(
+  entries: ReadonlyArray<budgetMeterEntry>,
+  slot: number,
+): budgetMeterEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Expand one bucket for the budget-meter stage. */
+export function expandBucket025(
+  entries: ReadonlyArray<budgetMeterEntry>,
+  slot: number,
+): budgetMeterEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Normalise one bucket for the budget-meter stage. */
+export function normaliseBucket026(
+  entries: ReadonlyArray<budgetMeterEntry>,
+  slot: number,
+): budgetMeterEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Compare one bucket for the budget-meter stage. */
+export function compareBucket027(
+  entries: ReadonlyArray<budgetMeterEntry>,
+  slot: number,
+): budgetMeterEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Select one bucket for the budget-meter stage. */
+export function selectBucket028(
+  entries: ReadonlyArray<budgetMeterEntry>,
+  slot: number,
+): budgetMeterEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Record one bucket for the budget-meter stage. */
+export function recordBucket029(
+  entries: ReadonlyArray<budgetMeterEntry>,
+  slot: number,
+): budgetMeterEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Collect one segment for the budget-meter stage. */
+export function collectSegment030(
+  entries: ReadonlyArray<budgetMeterEntry>,
+  slot: number,
+): budgetMeterEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Resolve one segment for the budget-meter stage. */
+export function resolveSegment031(
+  entries: ReadonlyArray<budgetMeterEntry>,
+  slot: number,
+): budgetMeterEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Merge one segment for the budget-meter stage. */
+export function mergeSegment032(
+  entries: ReadonlyArray<budgetMeterEntry>,
+  slot: number,
+): budgetMeterEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Filter one segment for the budget-meter stage. */
+export function filterSegment033(
+  entries: ReadonlyArray<budgetMeterEntry>,
+  slot: number,
+): budgetMeterEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Reduce one segment for the budget-meter stage. */
+export function reduceSegment034(
+  entries: ReadonlyArray<budgetMeterEntry>,
+  slot: number,
+): budgetMeterEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Expand one segment for the budget-meter stage. */
+export function expandSegment035(
+  entries: ReadonlyArray<budgetMeterEntry>,
+  slot: number,
+): budgetMeterEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Normalise one segment for the budget-meter stage. */
+export function normaliseSegment036(
+  entries: ReadonlyArray<budgetMeterEntry>,
+  slot: number,
+): budgetMeterEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Compare one segment for the budget-meter stage. */
+export function compareSegment037(
+  entries: ReadonlyArray<budgetMeterEntry>,
+  slot: number,
+): budgetMeterEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Select one segment for the budget-meter stage. */
+export function selectSegment038(
+  entries: ReadonlyArray<budgetMeterEntry>,
+  slot: number,
+): budgetMeterEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Record one segment for the budget-meter stage. */
+export function recordSegment039(
+  entries: ReadonlyArray<budgetMeterEntry>,
+  slot: number,
+): budgetMeterEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Collect one window for the budget-meter stage. */
+export function collectWindow040(
+  entries: ReadonlyArray<budgetMeterEntry>,
+  slot: number,
+): budgetMeterEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Resolve one window for the budget-meter stage. */
+export function resolveWindow041(
+  entries: ReadonlyArray<budgetMeterEntry>,
+  slot: number,
+): budgetMeterEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Merge one window for the budget-meter stage. */
+export function mergeWindow042(
+  entries: ReadonlyArray<budgetMeterEntry>,
+  slot: number,
+): budgetMeterEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Filter one window for the budget-meter stage. */
+export function filterWindow043(
+  entries: ReadonlyArray<budgetMeterEntry>,
+  slot: number,
+): budgetMeterEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Reduce one window for the budget-meter stage. */
+export function reduceWindow044(
+  entries: ReadonlyArray<budgetMeterEntry>,
+  slot: number,
+): budgetMeterEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Expand one window for the budget-meter stage. */
+export function expandWindow045(
+  entries: ReadonlyArray<budgetMeterEntry>,
+  slot: number,
+): budgetMeterEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Normalise one window for the budget-meter stage. */
+export function normaliseWindow046(
+  entries: ReadonlyArray<budgetMeterEntry>,
+  slot: number,
+): budgetMeterEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Compare one window for the budget-meter stage. */
+export function compareWindow047(
+  entries: ReadonlyArray<budgetMeterEntry>,
+  slot: number,
+): budgetMeterEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Select one window for the budget-meter stage. */
+export function selectWindow048(
+  entries: ReadonlyArray<budgetMeterEntry>,
+  slot: number,
+): budgetMeterEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Record one window for the budget-meter stage. */
+export function recordWindow049(
+  entries: ReadonlyArray<budgetMeterEntry>,
+  slot: number,
+): budgetMeterEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Collect one marker for the budget-meter stage. */
+export function collectMarker050(
+  entries: ReadonlyArray<budgetMeterEntry>,
+  slot: number,
+): budgetMeterEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Resolve one marker for the budget-meter stage. */
+export function resolveMarker051(
+  entries: ReadonlyArray<budgetMeterEntry>,
+  slot: number,
+): budgetMeterEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Merge one marker for the budget-meter stage. */
+export function mergeMarker052(
+  entries: ReadonlyArray<budgetMeterEntry>,
+  slot: number,
+): budgetMeterEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Filter one marker for the budget-meter stage. */
+export function filterMarker053(
+  entries: ReadonlyArray<budgetMeterEntry>,
+  slot: number,
+): budgetMeterEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Reduce one marker for the budget-meter stage. */
+export function reduceMarker054(
+  entries: ReadonlyArray<budgetMeterEntry>,
+  slot: number,
+): budgetMeterEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Expand one marker for the budget-meter stage. */
+export function expandMarker055(
+  entries: ReadonlyArray<budgetMeterEntry>,
+  slot: number,
+): budgetMeterEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Normalise one marker for the budget-meter stage. */
+export function normaliseMarker056(
+  entries: ReadonlyArray<budgetMeterEntry>,
+  slot: number,
+): budgetMeterEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Compare one marker for the budget-meter stage. */
+export function compareMarker057(
+  entries: ReadonlyArray<budgetMeterEntry>,
+  slot: number,
+): budgetMeterEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Select one marker for the budget-meter stage. */
+export function selectMarker058(
+  entries: ReadonlyArray<budgetMeterEntry>,
+  slot: number,
+): budgetMeterEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Record one marker for the budget-meter stage. */
+export function recordMarker059(
+  entries: ReadonlyArray<budgetMeterEntry>,
+  slot: number,
+): budgetMeterEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Collect one handle for the budget-meter stage. */
+export function collectHandle060(
+  entries: ReadonlyArray<budgetMeterEntry>,
+  slot: number,
+): budgetMeterEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Resolve one handle for the budget-meter stage. */
+export function resolveHandle061(
+  entries: ReadonlyArray<budgetMeterEntry>,
+  slot: number,
+): budgetMeterEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Merge one handle for the budget-meter stage. */
+export function mergeHandle062(
+  entries: ReadonlyArray<budgetMeterEntry>,
+  slot: number,
+): budgetMeterEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Filter one handle for the budget-meter stage. */
+export function filterHandle063(
+  entries: ReadonlyArray<budgetMeterEntry>,
+  slot: number,
+): budgetMeterEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Reduce one handle for the budget-meter stage. */
+export function reduceHandle064(
+  entries: ReadonlyArray<budgetMeterEntry>,
+  slot: number,
+): budgetMeterEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Expand one handle for the budget-meter stage. */
+export function expandHandle065(
+  entries: ReadonlyArray<budgetMeterEntry>,
+  slot: number,
+): budgetMeterEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Normalise one handle for the budget-meter stage. */
+export function normaliseHandle066(
+  entries: ReadonlyArray<budgetMeterEntry>,
+  slot: number,
+): budgetMeterEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Compare one handle for the budget-meter stage. */
+export function compareHandle067(
+  entries: ReadonlyArray<budgetMeterEntry>,
+  slot: number,
+): budgetMeterEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Select one handle for the budget-meter stage. */
+export function selectHandle068(
+  entries: ReadonlyArray<budgetMeterEntry>,
+  slot: number,
+): budgetMeterEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Record one handle for the budget-meter stage. */
+export function recordHandle069(
+  entries: ReadonlyArray<budgetMeterEntry>,
+  slot: number,
+): budgetMeterEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Collect one cursor for the budget-meter stage. */
+export function collectCursor070(
+  entries: ReadonlyArray<budgetMeterEntry>,
+  slot: number,
+): budgetMeterEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Resolve one cursor for the budget-meter stage. */
+export function resolveCursor071(
+  entries: ReadonlyArray<budgetMeterEntry>,
+  slot: number,
+): budgetMeterEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Merge one cursor for the budget-meter stage. */
+export function mergeCursor072(
+  entries: ReadonlyArray<budgetMeterEntry>,
+  slot: number,
+): budgetMeterEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Filter one cursor for the budget-meter stage. */
+export function filterCursor073(
+  entries: ReadonlyArray<budgetMeterEntry>,
+  slot: number,
+): budgetMeterEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+

--- a/test-fixtures/gate-acceptance/cache-keys.ts
+++ b/test-fixtures/gate-acceptance/cache-keys.ts
@@ -1,0 +1,1500 @@
+// Acceptance corpus for the pull request review gate.
+//
+// This file is synthetic and is not part of the shipped package. It
+// exists so that one pull request is large enough to exercise two
+// limits at once: the diff API's 20,000-changed-line ceiling, and the
+// review request budget above which the gate splits a change into
+// batches. This pull request is opened to exercise them and closed
+// again; it is not merged.
+
+export interface cacheKeysEntry {
+  readonly key: string;
+  readonly slot: number;
+  readonly active: boolean;
+}
+
+export interface cacheKeysState {
+  readonly entries: ReadonlyArray<cacheKeysEntry>;
+  readonly total: number;
+}
+
+/** Collect one entry for the cache-keys stage. */
+export function collectEntry000(
+  entries: ReadonlyArray<cacheKeysEntry>,
+  slot: number,
+): cacheKeysEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Resolve one entry for the cache-keys stage. */
+export function resolveEntry001(
+  entries: ReadonlyArray<cacheKeysEntry>,
+  slot: number,
+): cacheKeysEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Merge one entry for the cache-keys stage. */
+export function mergeEntry002(
+  entries: ReadonlyArray<cacheKeysEntry>,
+  slot: number,
+): cacheKeysEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Filter one entry for the cache-keys stage. */
+export function filterEntry003(
+  entries: ReadonlyArray<cacheKeysEntry>,
+  slot: number,
+): cacheKeysEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Reduce one entry for the cache-keys stage. */
+export function reduceEntry004(
+  entries: ReadonlyArray<cacheKeysEntry>,
+  slot: number,
+): cacheKeysEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Expand one entry for the cache-keys stage. */
+export function expandEntry005(
+  entries: ReadonlyArray<cacheKeysEntry>,
+  slot: number,
+): cacheKeysEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Normalise one entry for the cache-keys stage. */
+export function normaliseEntry006(
+  entries: ReadonlyArray<cacheKeysEntry>,
+  slot: number,
+): cacheKeysEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Compare one entry for the cache-keys stage. */
+export function compareEntry007(
+  entries: ReadonlyArray<cacheKeysEntry>,
+  slot: number,
+): cacheKeysEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Select one entry for the cache-keys stage. */
+export function selectEntry008(
+  entries: ReadonlyArray<cacheKeysEntry>,
+  slot: number,
+): cacheKeysEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Record one entry for the cache-keys stage. */
+export function recordEntry009(
+  entries: ReadonlyArray<cacheKeysEntry>,
+  slot: number,
+): cacheKeysEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Collect one record for the cache-keys stage. */
+export function collectRecord010(
+  entries: ReadonlyArray<cacheKeysEntry>,
+  slot: number,
+): cacheKeysEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Resolve one record for the cache-keys stage. */
+export function resolveRecord011(
+  entries: ReadonlyArray<cacheKeysEntry>,
+  slot: number,
+): cacheKeysEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Merge one record for the cache-keys stage. */
+export function mergeRecord012(
+  entries: ReadonlyArray<cacheKeysEntry>,
+  slot: number,
+): cacheKeysEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Filter one record for the cache-keys stage. */
+export function filterRecord013(
+  entries: ReadonlyArray<cacheKeysEntry>,
+  slot: number,
+): cacheKeysEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Reduce one record for the cache-keys stage. */
+export function reduceRecord014(
+  entries: ReadonlyArray<cacheKeysEntry>,
+  slot: number,
+): cacheKeysEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Expand one record for the cache-keys stage. */
+export function expandRecord015(
+  entries: ReadonlyArray<cacheKeysEntry>,
+  slot: number,
+): cacheKeysEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Normalise one record for the cache-keys stage. */
+export function normaliseRecord016(
+  entries: ReadonlyArray<cacheKeysEntry>,
+  slot: number,
+): cacheKeysEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Compare one record for the cache-keys stage. */
+export function compareRecord017(
+  entries: ReadonlyArray<cacheKeysEntry>,
+  slot: number,
+): cacheKeysEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Select one record for the cache-keys stage. */
+export function selectRecord018(
+  entries: ReadonlyArray<cacheKeysEntry>,
+  slot: number,
+): cacheKeysEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Record one record for the cache-keys stage. */
+export function recordRecord019(
+  entries: ReadonlyArray<cacheKeysEntry>,
+  slot: number,
+): cacheKeysEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Collect one bucket for the cache-keys stage. */
+export function collectBucket020(
+  entries: ReadonlyArray<cacheKeysEntry>,
+  slot: number,
+): cacheKeysEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Resolve one bucket for the cache-keys stage. */
+export function resolveBucket021(
+  entries: ReadonlyArray<cacheKeysEntry>,
+  slot: number,
+): cacheKeysEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Merge one bucket for the cache-keys stage. */
+export function mergeBucket022(
+  entries: ReadonlyArray<cacheKeysEntry>,
+  slot: number,
+): cacheKeysEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Filter one bucket for the cache-keys stage. */
+export function filterBucket023(
+  entries: ReadonlyArray<cacheKeysEntry>,
+  slot: number,
+): cacheKeysEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Reduce one bucket for the cache-keys stage. */
+export function reduceBucket024(
+  entries: ReadonlyArray<cacheKeysEntry>,
+  slot: number,
+): cacheKeysEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Expand one bucket for the cache-keys stage. */
+export function expandBucket025(
+  entries: ReadonlyArray<cacheKeysEntry>,
+  slot: number,
+): cacheKeysEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Normalise one bucket for the cache-keys stage. */
+export function normaliseBucket026(
+  entries: ReadonlyArray<cacheKeysEntry>,
+  slot: number,
+): cacheKeysEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Compare one bucket for the cache-keys stage. */
+export function compareBucket027(
+  entries: ReadonlyArray<cacheKeysEntry>,
+  slot: number,
+): cacheKeysEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Select one bucket for the cache-keys stage. */
+export function selectBucket028(
+  entries: ReadonlyArray<cacheKeysEntry>,
+  slot: number,
+): cacheKeysEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Record one bucket for the cache-keys stage. */
+export function recordBucket029(
+  entries: ReadonlyArray<cacheKeysEntry>,
+  slot: number,
+): cacheKeysEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Collect one segment for the cache-keys stage. */
+export function collectSegment030(
+  entries: ReadonlyArray<cacheKeysEntry>,
+  slot: number,
+): cacheKeysEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Resolve one segment for the cache-keys stage. */
+export function resolveSegment031(
+  entries: ReadonlyArray<cacheKeysEntry>,
+  slot: number,
+): cacheKeysEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Merge one segment for the cache-keys stage. */
+export function mergeSegment032(
+  entries: ReadonlyArray<cacheKeysEntry>,
+  slot: number,
+): cacheKeysEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Filter one segment for the cache-keys stage. */
+export function filterSegment033(
+  entries: ReadonlyArray<cacheKeysEntry>,
+  slot: number,
+): cacheKeysEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Reduce one segment for the cache-keys stage. */
+export function reduceSegment034(
+  entries: ReadonlyArray<cacheKeysEntry>,
+  slot: number,
+): cacheKeysEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Expand one segment for the cache-keys stage. */
+export function expandSegment035(
+  entries: ReadonlyArray<cacheKeysEntry>,
+  slot: number,
+): cacheKeysEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Normalise one segment for the cache-keys stage. */
+export function normaliseSegment036(
+  entries: ReadonlyArray<cacheKeysEntry>,
+  slot: number,
+): cacheKeysEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Compare one segment for the cache-keys stage. */
+export function compareSegment037(
+  entries: ReadonlyArray<cacheKeysEntry>,
+  slot: number,
+): cacheKeysEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Select one segment for the cache-keys stage. */
+export function selectSegment038(
+  entries: ReadonlyArray<cacheKeysEntry>,
+  slot: number,
+): cacheKeysEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Record one segment for the cache-keys stage. */
+export function recordSegment039(
+  entries: ReadonlyArray<cacheKeysEntry>,
+  slot: number,
+): cacheKeysEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Collect one window for the cache-keys stage. */
+export function collectWindow040(
+  entries: ReadonlyArray<cacheKeysEntry>,
+  slot: number,
+): cacheKeysEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Resolve one window for the cache-keys stage. */
+export function resolveWindow041(
+  entries: ReadonlyArray<cacheKeysEntry>,
+  slot: number,
+): cacheKeysEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Merge one window for the cache-keys stage. */
+export function mergeWindow042(
+  entries: ReadonlyArray<cacheKeysEntry>,
+  slot: number,
+): cacheKeysEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Filter one window for the cache-keys stage. */
+export function filterWindow043(
+  entries: ReadonlyArray<cacheKeysEntry>,
+  slot: number,
+): cacheKeysEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Reduce one window for the cache-keys stage. */
+export function reduceWindow044(
+  entries: ReadonlyArray<cacheKeysEntry>,
+  slot: number,
+): cacheKeysEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Expand one window for the cache-keys stage. */
+export function expandWindow045(
+  entries: ReadonlyArray<cacheKeysEntry>,
+  slot: number,
+): cacheKeysEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Normalise one window for the cache-keys stage. */
+export function normaliseWindow046(
+  entries: ReadonlyArray<cacheKeysEntry>,
+  slot: number,
+): cacheKeysEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Compare one window for the cache-keys stage. */
+export function compareWindow047(
+  entries: ReadonlyArray<cacheKeysEntry>,
+  slot: number,
+): cacheKeysEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Select one window for the cache-keys stage. */
+export function selectWindow048(
+  entries: ReadonlyArray<cacheKeysEntry>,
+  slot: number,
+): cacheKeysEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Record one window for the cache-keys stage. */
+export function recordWindow049(
+  entries: ReadonlyArray<cacheKeysEntry>,
+  slot: number,
+): cacheKeysEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Collect one marker for the cache-keys stage. */
+export function collectMarker050(
+  entries: ReadonlyArray<cacheKeysEntry>,
+  slot: number,
+): cacheKeysEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Resolve one marker for the cache-keys stage. */
+export function resolveMarker051(
+  entries: ReadonlyArray<cacheKeysEntry>,
+  slot: number,
+): cacheKeysEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Merge one marker for the cache-keys stage. */
+export function mergeMarker052(
+  entries: ReadonlyArray<cacheKeysEntry>,
+  slot: number,
+): cacheKeysEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Filter one marker for the cache-keys stage. */
+export function filterMarker053(
+  entries: ReadonlyArray<cacheKeysEntry>,
+  slot: number,
+): cacheKeysEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Reduce one marker for the cache-keys stage. */
+export function reduceMarker054(
+  entries: ReadonlyArray<cacheKeysEntry>,
+  slot: number,
+): cacheKeysEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Expand one marker for the cache-keys stage. */
+export function expandMarker055(
+  entries: ReadonlyArray<cacheKeysEntry>,
+  slot: number,
+): cacheKeysEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Normalise one marker for the cache-keys stage. */
+export function normaliseMarker056(
+  entries: ReadonlyArray<cacheKeysEntry>,
+  slot: number,
+): cacheKeysEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Compare one marker for the cache-keys stage. */
+export function compareMarker057(
+  entries: ReadonlyArray<cacheKeysEntry>,
+  slot: number,
+): cacheKeysEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Select one marker for the cache-keys stage. */
+export function selectMarker058(
+  entries: ReadonlyArray<cacheKeysEntry>,
+  slot: number,
+): cacheKeysEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Record one marker for the cache-keys stage. */
+export function recordMarker059(
+  entries: ReadonlyArray<cacheKeysEntry>,
+  slot: number,
+): cacheKeysEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Collect one handle for the cache-keys stage. */
+export function collectHandle060(
+  entries: ReadonlyArray<cacheKeysEntry>,
+  slot: number,
+): cacheKeysEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Resolve one handle for the cache-keys stage. */
+export function resolveHandle061(
+  entries: ReadonlyArray<cacheKeysEntry>,
+  slot: number,
+): cacheKeysEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Merge one handle for the cache-keys stage. */
+export function mergeHandle062(
+  entries: ReadonlyArray<cacheKeysEntry>,
+  slot: number,
+): cacheKeysEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Filter one handle for the cache-keys stage. */
+export function filterHandle063(
+  entries: ReadonlyArray<cacheKeysEntry>,
+  slot: number,
+): cacheKeysEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Reduce one handle for the cache-keys stage. */
+export function reduceHandle064(
+  entries: ReadonlyArray<cacheKeysEntry>,
+  slot: number,
+): cacheKeysEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Expand one handle for the cache-keys stage. */
+export function expandHandle065(
+  entries: ReadonlyArray<cacheKeysEntry>,
+  slot: number,
+): cacheKeysEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Normalise one handle for the cache-keys stage. */
+export function normaliseHandle066(
+  entries: ReadonlyArray<cacheKeysEntry>,
+  slot: number,
+): cacheKeysEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Compare one handle for the cache-keys stage. */
+export function compareHandle067(
+  entries: ReadonlyArray<cacheKeysEntry>,
+  slot: number,
+): cacheKeysEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Select one handle for the cache-keys stage. */
+export function selectHandle068(
+  entries: ReadonlyArray<cacheKeysEntry>,
+  slot: number,
+): cacheKeysEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Record one handle for the cache-keys stage. */
+export function recordHandle069(
+  entries: ReadonlyArray<cacheKeysEntry>,
+  slot: number,
+): cacheKeysEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Collect one cursor for the cache-keys stage. */
+export function collectCursor070(
+  entries: ReadonlyArray<cacheKeysEntry>,
+  slot: number,
+): cacheKeysEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Resolve one cursor for the cache-keys stage. */
+export function resolveCursor071(
+  entries: ReadonlyArray<cacheKeysEntry>,
+  slot: number,
+): cacheKeysEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Merge one cursor for the cache-keys stage. */
+export function mergeCursor072(
+  entries: ReadonlyArray<cacheKeysEntry>,
+  slot: number,
+): cacheKeysEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Filter one cursor for the cache-keys stage. */
+export function filterCursor073(
+  entries: ReadonlyArray<cacheKeysEntry>,
+  slot: number,
+): cacheKeysEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+

--- a/test-fixtures/gate-acceptance/chunk-walker.ts
+++ b/test-fixtures/gate-acceptance/chunk-walker.ts
@@ -1,0 +1,1500 @@
+// Acceptance corpus for the pull request review gate.
+//
+// This file is synthetic and is not part of the shipped package. It
+// exists so that one pull request is large enough to exercise two
+// limits at once: the diff API's 20,000-changed-line ceiling, and the
+// review request budget above which the gate splits a change into
+// batches. This pull request is opened to exercise them and closed
+// again; it is not merged.
+
+export interface chunkWalkerEntry {
+  readonly key: string;
+  readonly slot: number;
+  readonly active: boolean;
+}
+
+export interface chunkWalkerState {
+  readonly entries: ReadonlyArray<chunkWalkerEntry>;
+  readonly total: number;
+}
+
+/** Collect one entry for the chunk-walker stage. */
+export function collectEntry000(
+  entries: ReadonlyArray<chunkWalkerEntry>,
+  slot: number,
+): chunkWalkerEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Resolve one entry for the chunk-walker stage. */
+export function resolveEntry001(
+  entries: ReadonlyArray<chunkWalkerEntry>,
+  slot: number,
+): chunkWalkerEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Merge one entry for the chunk-walker stage. */
+export function mergeEntry002(
+  entries: ReadonlyArray<chunkWalkerEntry>,
+  slot: number,
+): chunkWalkerEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Filter one entry for the chunk-walker stage. */
+export function filterEntry003(
+  entries: ReadonlyArray<chunkWalkerEntry>,
+  slot: number,
+): chunkWalkerEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Reduce one entry for the chunk-walker stage. */
+export function reduceEntry004(
+  entries: ReadonlyArray<chunkWalkerEntry>,
+  slot: number,
+): chunkWalkerEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Expand one entry for the chunk-walker stage. */
+export function expandEntry005(
+  entries: ReadonlyArray<chunkWalkerEntry>,
+  slot: number,
+): chunkWalkerEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Normalise one entry for the chunk-walker stage. */
+export function normaliseEntry006(
+  entries: ReadonlyArray<chunkWalkerEntry>,
+  slot: number,
+): chunkWalkerEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Compare one entry for the chunk-walker stage. */
+export function compareEntry007(
+  entries: ReadonlyArray<chunkWalkerEntry>,
+  slot: number,
+): chunkWalkerEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Select one entry for the chunk-walker stage. */
+export function selectEntry008(
+  entries: ReadonlyArray<chunkWalkerEntry>,
+  slot: number,
+): chunkWalkerEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Record one entry for the chunk-walker stage. */
+export function recordEntry009(
+  entries: ReadonlyArray<chunkWalkerEntry>,
+  slot: number,
+): chunkWalkerEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Collect one record for the chunk-walker stage. */
+export function collectRecord010(
+  entries: ReadonlyArray<chunkWalkerEntry>,
+  slot: number,
+): chunkWalkerEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Resolve one record for the chunk-walker stage. */
+export function resolveRecord011(
+  entries: ReadonlyArray<chunkWalkerEntry>,
+  slot: number,
+): chunkWalkerEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Merge one record for the chunk-walker stage. */
+export function mergeRecord012(
+  entries: ReadonlyArray<chunkWalkerEntry>,
+  slot: number,
+): chunkWalkerEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Filter one record for the chunk-walker stage. */
+export function filterRecord013(
+  entries: ReadonlyArray<chunkWalkerEntry>,
+  slot: number,
+): chunkWalkerEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Reduce one record for the chunk-walker stage. */
+export function reduceRecord014(
+  entries: ReadonlyArray<chunkWalkerEntry>,
+  slot: number,
+): chunkWalkerEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Expand one record for the chunk-walker stage. */
+export function expandRecord015(
+  entries: ReadonlyArray<chunkWalkerEntry>,
+  slot: number,
+): chunkWalkerEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Normalise one record for the chunk-walker stage. */
+export function normaliseRecord016(
+  entries: ReadonlyArray<chunkWalkerEntry>,
+  slot: number,
+): chunkWalkerEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Compare one record for the chunk-walker stage. */
+export function compareRecord017(
+  entries: ReadonlyArray<chunkWalkerEntry>,
+  slot: number,
+): chunkWalkerEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Select one record for the chunk-walker stage. */
+export function selectRecord018(
+  entries: ReadonlyArray<chunkWalkerEntry>,
+  slot: number,
+): chunkWalkerEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Record one record for the chunk-walker stage. */
+export function recordRecord019(
+  entries: ReadonlyArray<chunkWalkerEntry>,
+  slot: number,
+): chunkWalkerEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Collect one bucket for the chunk-walker stage. */
+export function collectBucket020(
+  entries: ReadonlyArray<chunkWalkerEntry>,
+  slot: number,
+): chunkWalkerEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Resolve one bucket for the chunk-walker stage. */
+export function resolveBucket021(
+  entries: ReadonlyArray<chunkWalkerEntry>,
+  slot: number,
+): chunkWalkerEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Merge one bucket for the chunk-walker stage. */
+export function mergeBucket022(
+  entries: ReadonlyArray<chunkWalkerEntry>,
+  slot: number,
+): chunkWalkerEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Filter one bucket for the chunk-walker stage. */
+export function filterBucket023(
+  entries: ReadonlyArray<chunkWalkerEntry>,
+  slot: number,
+): chunkWalkerEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Reduce one bucket for the chunk-walker stage. */
+export function reduceBucket024(
+  entries: ReadonlyArray<chunkWalkerEntry>,
+  slot: number,
+): chunkWalkerEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Expand one bucket for the chunk-walker stage. */
+export function expandBucket025(
+  entries: ReadonlyArray<chunkWalkerEntry>,
+  slot: number,
+): chunkWalkerEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Normalise one bucket for the chunk-walker stage. */
+export function normaliseBucket026(
+  entries: ReadonlyArray<chunkWalkerEntry>,
+  slot: number,
+): chunkWalkerEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Compare one bucket for the chunk-walker stage. */
+export function compareBucket027(
+  entries: ReadonlyArray<chunkWalkerEntry>,
+  slot: number,
+): chunkWalkerEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Select one bucket for the chunk-walker stage. */
+export function selectBucket028(
+  entries: ReadonlyArray<chunkWalkerEntry>,
+  slot: number,
+): chunkWalkerEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Record one bucket for the chunk-walker stage. */
+export function recordBucket029(
+  entries: ReadonlyArray<chunkWalkerEntry>,
+  slot: number,
+): chunkWalkerEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Collect one segment for the chunk-walker stage. */
+export function collectSegment030(
+  entries: ReadonlyArray<chunkWalkerEntry>,
+  slot: number,
+): chunkWalkerEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Resolve one segment for the chunk-walker stage. */
+export function resolveSegment031(
+  entries: ReadonlyArray<chunkWalkerEntry>,
+  slot: number,
+): chunkWalkerEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Merge one segment for the chunk-walker stage. */
+export function mergeSegment032(
+  entries: ReadonlyArray<chunkWalkerEntry>,
+  slot: number,
+): chunkWalkerEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Filter one segment for the chunk-walker stage. */
+export function filterSegment033(
+  entries: ReadonlyArray<chunkWalkerEntry>,
+  slot: number,
+): chunkWalkerEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Reduce one segment for the chunk-walker stage. */
+export function reduceSegment034(
+  entries: ReadonlyArray<chunkWalkerEntry>,
+  slot: number,
+): chunkWalkerEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Expand one segment for the chunk-walker stage. */
+export function expandSegment035(
+  entries: ReadonlyArray<chunkWalkerEntry>,
+  slot: number,
+): chunkWalkerEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Normalise one segment for the chunk-walker stage. */
+export function normaliseSegment036(
+  entries: ReadonlyArray<chunkWalkerEntry>,
+  slot: number,
+): chunkWalkerEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Compare one segment for the chunk-walker stage. */
+export function compareSegment037(
+  entries: ReadonlyArray<chunkWalkerEntry>,
+  slot: number,
+): chunkWalkerEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Select one segment for the chunk-walker stage. */
+export function selectSegment038(
+  entries: ReadonlyArray<chunkWalkerEntry>,
+  slot: number,
+): chunkWalkerEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Record one segment for the chunk-walker stage. */
+export function recordSegment039(
+  entries: ReadonlyArray<chunkWalkerEntry>,
+  slot: number,
+): chunkWalkerEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Collect one window for the chunk-walker stage. */
+export function collectWindow040(
+  entries: ReadonlyArray<chunkWalkerEntry>,
+  slot: number,
+): chunkWalkerEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Resolve one window for the chunk-walker stage. */
+export function resolveWindow041(
+  entries: ReadonlyArray<chunkWalkerEntry>,
+  slot: number,
+): chunkWalkerEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Merge one window for the chunk-walker stage. */
+export function mergeWindow042(
+  entries: ReadonlyArray<chunkWalkerEntry>,
+  slot: number,
+): chunkWalkerEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Filter one window for the chunk-walker stage. */
+export function filterWindow043(
+  entries: ReadonlyArray<chunkWalkerEntry>,
+  slot: number,
+): chunkWalkerEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Reduce one window for the chunk-walker stage. */
+export function reduceWindow044(
+  entries: ReadonlyArray<chunkWalkerEntry>,
+  slot: number,
+): chunkWalkerEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Expand one window for the chunk-walker stage. */
+export function expandWindow045(
+  entries: ReadonlyArray<chunkWalkerEntry>,
+  slot: number,
+): chunkWalkerEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Normalise one window for the chunk-walker stage. */
+export function normaliseWindow046(
+  entries: ReadonlyArray<chunkWalkerEntry>,
+  slot: number,
+): chunkWalkerEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Compare one window for the chunk-walker stage. */
+export function compareWindow047(
+  entries: ReadonlyArray<chunkWalkerEntry>,
+  slot: number,
+): chunkWalkerEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Select one window for the chunk-walker stage. */
+export function selectWindow048(
+  entries: ReadonlyArray<chunkWalkerEntry>,
+  slot: number,
+): chunkWalkerEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Record one window for the chunk-walker stage. */
+export function recordWindow049(
+  entries: ReadonlyArray<chunkWalkerEntry>,
+  slot: number,
+): chunkWalkerEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Collect one marker for the chunk-walker stage. */
+export function collectMarker050(
+  entries: ReadonlyArray<chunkWalkerEntry>,
+  slot: number,
+): chunkWalkerEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Resolve one marker for the chunk-walker stage. */
+export function resolveMarker051(
+  entries: ReadonlyArray<chunkWalkerEntry>,
+  slot: number,
+): chunkWalkerEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Merge one marker for the chunk-walker stage. */
+export function mergeMarker052(
+  entries: ReadonlyArray<chunkWalkerEntry>,
+  slot: number,
+): chunkWalkerEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Filter one marker for the chunk-walker stage. */
+export function filterMarker053(
+  entries: ReadonlyArray<chunkWalkerEntry>,
+  slot: number,
+): chunkWalkerEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Reduce one marker for the chunk-walker stage. */
+export function reduceMarker054(
+  entries: ReadonlyArray<chunkWalkerEntry>,
+  slot: number,
+): chunkWalkerEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Expand one marker for the chunk-walker stage. */
+export function expandMarker055(
+  entries: ReadonlyArray<chunkWalkerEntry>,
+  slot: number,
+): chunkWalkerEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Normalise one marker for the chunk-walker stage. */
+export function normaliseMarker056(
+  entries: ReadonlyArray<chunkWalkerEntry>,
+  slot: number,
+): chunkWalkerEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Compare one marker for the chunk-walker stage. */
+export function compareMarker057(
+  entries: ReadonlyArray<chunkWalkerEntry>,
+  slot: number,
+): chunkWalkerEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Select one marker for the chunk-walker stage. */
+export function selectMarker058(
+  entries: ReadonlyArray<chunkWalkerEntry>,
+  slot: number,
+): chunkWalkerEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Record one marker for the chunk-walker stage. */
+export function recordMarker059(
+  entries: ReadonlyArray<chunkWalkerEntry>,
+  slot: number,
+): chunkWalkerEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Collect one handle for the chunk-walker stage. */
+export function collectHandle060(
+  entries: ReadonlyArray<chunkWalkerEntry>,
+  slot: number,
+): chunkWalkerEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Resolve one handle for the chunk-walker stage. */
+export function resolveHandle061(
+  entries: ReadonlyArray<chunkWalkerEntry>,
+  slot: number,
+): chunkWalkerEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Merge one handle for the chunk-walker stage. */
+export function mergeHandle062(
+  entries: ReadonlyArray<chunkWalkerEntry>,
+  slot: number,
+): chunkWalkerEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Filter one handle for the chunk-walker stage. */
+export function filterHandle063(
+  entries: ReadonlyArray<chunkWalkerEntry>,
+  slot: number,
+): chunkWalkerEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Reduce one handle for the chunk-walker stage. */
+export function reduceHandle064(
+  entries: ReadonlyArray<chunkWalkerEntry>,
+  slot: number,
+): chunkWalkerEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Expand one handle for the chunk-walker stage. */
+export function expandHandle065(
+  entries: ReadonlyArray<chunkWalkerEntry>,
+  slot: number,
+): chunkWalkerEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Normalise one handle for the chunk-walker stage. */
+export function normaliseHandle066(
+  entries: ReadonlyArray<chunkWalkerEntry>,
+  slot: number,
+): chunkWalkerEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Compare one handle for the chunk-walker stage. */
+export function compareHandle067(
+  entries: ReadonlyArray<chunkWalkerEntry>,
+  slot: number,
+): chunkWalkerEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Select one handle for the chunk-walker stage. */
+export function selectHandle068(
+  entries: ReadonlyArray<chunkWalkerEntry>,
+  slot: number,
+): chunkWalkerEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Record one handle for the chunk-walker stage. */
+export function recordHandle069(
+  entries: ReadonlyArray<chunkWalkerEntry>,
+  slot: number,
+): chunkWalkerEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Collect one cursor for the chunk-walker stage. */
+export function collectCursor070(
+  entries: ReadonlyArray<chunkWalkerEntry>,
+  slot: number,
+): chunkWalkerEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Resolve one cursor for the chunk-walker stage. */
+export function resolveCursor071(
+  entries: ReadonlyArray<chunkWalkerEntry>,
+  slot: number,
+): chunkWalkerEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Merge one cursor for the chunk-walker stage. */
+export function mergeCursor072(
+  entries: ReadonlyArray<chunkWalkerEntry>,
+  slot: number,
+): chunkWalkerEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Filter one cursor for the chunk-walker stage. */
+export function filterCursor073(
+  entries: ReadonlyArray<chunkWalkerEntry>,
+  slot: number,
+): chunkWalkerEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+

--- a/test-fixtures/gate-acceptance/column-map.ts
+++ b/test-fixtures/gate-acceptance/column-map.ts
@@ -1,0 +1,1500 @@
+// Acceptance corpus for the pull request review gate.
+//
+// This file is synthetic and is not part of the shipped package. It
+// exists so that one pull request is large enough to exercise two
+// limits at once: the diff API's 20,000-changed-line ceiling, and the
+// review request budget above which the gate splits a change into
+// batches. This pull request is opened to exercise them and closed
+// again; it is not merged.
+
+export interface columnMapEntry {
+  readonly key: string;
+  readonly slot: number;
+  readonly active: boolean;
+}
+
+export interface columnMapState {
+  readonly entries: ReadonlyArray<columnMapEntry>;
+  readonly total: number;
+}
+
+/** Collect one entry for the column-map stage. */
+export function collectEntry000(
+  entries: ReadonlyArray<columnMapEntry>,
+  slot: number,
+): columnMapEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Resolve one entry for the column-map stage. */
+export function resolveEntry001(
+  entries: ReadonlyArray<columnMapEntry>,
+  slot: number,
+): columnMapEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Merge one entry for the column-map stage. */
+export function mergeEntry002(
+  entries: ReadonlyArray<columnMapEntry>,
+  slot: number,
+): columnMapEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Filter one entry for the column-map stage. */
+export function filterEntry003(
+  entries: ReadonlyArray<columnMapEntry>,
+  slot: number,
+): columnMapEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Reduce one entry for the column-map stage. */
+export function reduceEntry004(
+  entries: ReadonlyArray<columnMapEntry>,
+  slot: number,
+): columnMapEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Expand one entry for the column-map stage. */
+export function expandEntry005(
+  entries: ReadonlyArray<columnMapEntry>,
+  slot: number,
+): columnMapEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Normalise one entry for the column-map stage. */
+export function normaliseEntry006(
+  entries: ReadonlyArray<columnMapEntry>,
+  slot: number,
+): columnMapEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Compare one entry for the column-map stage. */
+export function compareEntry007(
+  entries: ReadonlyArray<columnMapEntry>,
+  slot: number,
+): columnMapEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Select one entry for the column-map stage. */
+export function selectEntry008(
+  entries: ReadonlyArray<columnMapEntry>,
+  slot: number,
+): columnMapEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Record one entry for the column-map stage. */
+export function recordEntry009(
+  entries: ReadonlyArray<columnMapEntry>,
+  slot: number,
+): columnMapEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Collect one record for the column-map stage. */
+export function collectRecord010(
+  entries: ReadonlyArray<columnMapEntry>,
+  slot: number,
+): columnMapEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Resolve one record for the column-map stage. */
+export function resolveRecord011(
+  entries: ReadonlyArray<columnMapEntry>,
+  slot: number,
+): columnMapEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Merge one record for the column-map stage. */
+export function mergeRecord012(
+  entries: ReadonlyArray<columnMapEntry>,
+  slot: number,
+): columnMapEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Filter one record for the column-map stage. */
+export function filterRecord013(
+  entries: ReadonlyArray<columnMapEntry>,
+  slot: number,
+): columnMapEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Reduce one record for the column-map stage. */
+export function reduceRecord014(
+  entries: ReadonlyArray<columnMapEntry>,
+  slot: number,
+): columnMapEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Expand one record for the column-map stage. */
+export function expandRecord015(
+  entries: ReadonlyArray<columnMapEntry>,
+  slot: number,
+): columnMapEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Normalise one record for the column-map stage. */
+export function normaliseRecord016(
+  entries: ReadonlyArray<columnMapEntry>,
+  slot: number,
+): columnMapEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Compare one record for the column-map stage. */
+export function compareRecord017(
+  entries: ReadonlyArray<columnMapEntry>,
+  slot: number,
+): columnMapEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Select one record for the column-map stage. */
+export function selectRecord018(
+  entries: ReadonlyArray<columnMapEntry>,
+  slot: number,
+): columnMapEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Record one record for the column-map stage. */
+export function recordRecord019(
+  entries: ReadonlyArray<columnMapEntry>,
+  slot: number,
+): columnMapEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Collect one bucket for the column-map stage. */
+export function collectBucket020(
+  entries: ReadonlyArray<columnMapEntry>,
+  slot: number,
+): columnMapEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Resolve one bucket for the column-map stage. */
+export function resolveBucket021(
+  entries: ReadonlyArray<columnMapEntry>,
+  slot: number,
+): columnMapEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Merge one bucket for the column-map stage. */
+export function mergeBucket022(
+  entries: ReadonlyArray<columnMapEntry>,
+  slot: number,
+): columnMapEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Filter one bucket for the column-map stage. */
+export function filterBucket023(
+  entries: ReadonlyArray<columnMapEntry>,
+  slot: number,
+): columnMapEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Reduce one bucket for the column-map stage. */
+export function reduceBucket024(
+  entries: ReadonlyArray<columnMapEntry>,
+  slot: number,
+): columnMapEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Expand one bucket for the column-map stage. */
+export function expandBucket025(
+  entries: ReadonlyArray<columnMapEntry>,
+  slot: number,
+): columnMapEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Normalise one bucket for the column-map stage. */
+export function normaliseBucket026(
+  entries: ReadonlyArray<columnMapEntry>,
+  slot: number,
+): columnMapEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Compare one bucket for the column-map stage. */
+export function compareBucket027(
+  entries: ReadonlyArray<columnMapEntry>,
+  slot: number,
+): columnMapEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Select one bucket for the column-map stage. */
+export function selectBucket028(
+  entries: ReadonlyArray<columnMapEntry>,
+  slot: number,
+): columnMapEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Record one bucket for the column-map stage. */
+export function recordBucket029(
+  entries: ReadonlyArray<columnMapEntry>,
+  slot: number,
+): columnMapEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Collect one segment for the column-map stage. */
+export function collectSegment030(
+  entries: ReadonlyArray<columnMapEntry>,
+  slot: number,
+): columnMapEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Resolve one segment for the column-map stage. */
+export function resolveSegment031(
+  entries: ReadonlyArray<columnMapEntry>,
+  slot: number,
+): columnMapEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Merge one segment for the column-map stage. */
+export function mergeSegment032(
+  entries: ReadonlyArray<columnMapEntry>,
+  slot: number,
+): columnMapEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Filter one segment for the column-map stage. */
+export function filterSegment033(
+  entries: ReadonlyArray<columnMapEntry>,
+  slot: number,
+): columnMapEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Reduce one segment for the column-map stage. */
+export function reduceSegment034(
+  entries: ReadonlyArray<columnMapEntry>,
+  slot: number,
+): columnMapEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Expand one segment for the column-map stage. */
+export function expandSegment035(
+  entries: ReadonlyArray<columnMapEntry>,
+  slot: number,
+): columnMapEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Normalise one segment for the column-map stage. */
+export function normaliseSegment036(
+  entries: ReadonlyArray<columnMapEntry>,
+  slot: number,
+): columnMapEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Compare one segment for the column-map stage. */
+export function compareSegment037(
+  entries: ReadonlyArray<columnMapEntry>,
+  slot: number,
+): columnMapEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Select one segment for the column-map stage. */
+export function selectSegment038(
+  entries: ReadonlyArray<columnMapEntry>,
+  slot: number,
+): columnMapEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Record one segment for the column-map stage. */
+export function recordSegment039(
+  entries: ReadonlyArray<columnMapEntry>,
+  slot: number,
+): columnMapEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Collect one window for the column-map stage. */
+export function collectWindow040(
+  entries: ReadonlyArray<columnMapEntry>,
+  slot: number,
+): columnMapEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Resolve one window for the column-map stage. */
+export function resolveWindow041(
+  entries: ReadonlyArray<columnMapEntry>,
+  slot: number,
+): columnMapEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Merge one window for the column-map stage. */
+export function mergeWindow042(
+  entries: ReadonlyArray<columnMapEntry>,
+  slot: number,
+): columnMapEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Filter one window for the column-map stage. */
+export function filterWindow043(
+  entries: ReadonlyArray<columnMapEntry>,
+  slot: number,
+): columnMapEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Reduce one window for the column-map stage. */
+export function reduceWindow044(
+  entries: ReadonlyArray<columnMapEntry>,
+  slot: number,
+): columnMapEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Expand one window for the column-map stage. */
+export function expandWindow045(
+  entries: ReadonlyArray<columnMapEntry>,
+  slot: number,
+): columnMapEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Normalise one window for the column-map stage. */
+export function normaliseWindow046(
+  entries: ReadonlyArray<columnMapEntry>,
+  slot: number,
+): columnMapEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Compare one window for the column-map stage. */
+export function compareWindow047(
+  entries: ReadonlyArray<columnMapEntry>,
+  slot: number,
+): columnMapEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Select one window for the column-map stage. */
+export function selectWindow048(
+  entries: ReadonlyArray<columnMapEntry>,
+  slot: number,
+): columnMapEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Record one window for the column-map stage. */
+export function recordWindow049(
+  entries: ReadonlyArray<columnMapEntry>,
+  slot: number,
+): columnMapEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Collect one marker for the column-map stage. */
+export function collectMarker050(
+  entries: ReadonlyArray<columnMapEntry>,
+  slot: number,
+): columnMapEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Resolve one marker for the column-map stage. */
+export function resolveMarker051(
+  entries: ReadonlyArray<columnMapEntry>,
+  slot: number,
+): columnMapEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Merge one marker for the column-map stage. */
+export function mergeMarker052(
+  entries: ReadonlyArray<columnMapEntry>,
+  slot: number,
+): columnMapEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Filter one marker for the column-map stage. */
+export function filterMarker053(
+  entries: ReadonlyArray<columnMapEntry>,
+  slot: number,
+): columnMapEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Reduce one marker for the column-map stage. */
+export function reduceMarker054(
+  entries: ReadonlyArray<columnMapEntry>,
+  slot: number,
+): columnMapEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Expand one marker for the column-map stage. */
+export function expandMarker055(
+  entries: ReadonlyArray<columnMapEntry>,
+  slot: number,
+): columnMapEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Normalise one marker for the column-map stage. */
+export function normaliseMarker056(
+  entries: ReadonlyArray<columnMapEntry>,
+  slot: number,
+): columnMapEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Compare one marker for the column-map stage. */
+export function compareMarker057(
+  entries: ReadonlyArray<columnMapEntry>,
+  slot: number,
+): columnMapEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Select one marker for the column-map stage. */
+export function selectMarker058(
+  entries: ReadonlyArray<columnMapEntry>,
+  slot: number,
+): columnMapEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Record one marker for the column-map stage. */
+export function recordMarker059(
+  entries: ReadonlyArray<columnMapEntry>,
+  slot: number,
+): columnMapEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Collect one handle for the column-map stage. */
+export function collectHandle060(
+  entries: ReadonlyArray<columnMapEntry>,
+  slot: number,
+): columnMapEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Resolve one handle for the column-map stage. */
+export function resolveHandle061(
+  entries: ReadonlyArray<columnMapEntry>,
+  slot: number,
+): columnMapEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Merge one handle for the column-map stage. */
+export function mergeHandle062(
+  entries: ReadonlyArray<columnMapEntry>,
+  slot: number,
+): columnMapEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Filter one handle for the column-map stage. */
+export function filterHandle063(
+  entries: ReadonlyArray<columnMapEntry>,
+  slot: number,
+): columnMapEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Reduce one handle for the column-map stage. */
+export function reduceHandle064(
+  entries: ReadonlyArray<columnMapEntry>,
+  slot: number,
+): columnMapEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Expand one handle for the column-map stage. */
+export function expandHandle065(
+  entries: ReadonlyArray<columnMapEntry>,
+  slot: number,
+): columnMapEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Normalise one handle for the column-map stage. */
+export function normaliseHandle066(
+  entries: ReadonlyArray<columnMapEntry>,
+  slot: number,
+): columnMapEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Compare one handle for the column-map stage. */
+export function compareHandle067(
+  entries: ReadonlyArray<columnMapEntry>,
+  slot: number,
+): columnMapEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Select one handle for the column-map stage. */
+export function selectHandle068(
+  entries: ReadonlyArray<columnMapEntry>,
+  slot: number,
+): columnMapEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Record one handle for the column-map stage. */
+export function recordHandle069(
+  entries: ReadonlyArray<columnMapEntry>,
+  slot: number,
+): columnMapEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Collect one cursor for the column-map stage. */
+export function collectCursor070(
+  entries: ReadonlyArray<columnMapEntry>,
+  slot: number,
+): columnMapEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Resolve one cursor for the column-map stage. */
+export function resolveCursor071(
+  entries: ReadonlyArray<columnMapEntry>,
+  slot: number,
+): columnMapEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Merge one cursor for the column-map stage. */
+export function mergeCursor072(
+  entries: ReadonlyArray<columnMapEntry>,
+  slot: number,
+): columnMapEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Filter one cursor for the column-map stage. */
+export function filterCursor073(
+  entries: ReadonlyArray<columnMapEntry>,
+  slot: number,
+): columnMapEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+

--- a/test-fixtures/gate-acceptance/config-merge.ts
+++ b/test-fixtures/gate-acceptance/config-merge.ts
@@ -1,0 +1,1500 @@
+// Acceptance corpus for the pull request review gate.
+//
+// This file is synthetic and is not part of the shipped package. It
+// exists so that one pull request is large enough to exercise two
+// limits at once: the diff API's 20,000-changed-line ceiling, and the
+// review request budget above which the gate splits a change into
+// batches. This pull request is opened to exercise them and closed
+// again; it is not merged.
+
+export interface configMergeEntry {
+  readonly key: string;
+  readonly slot: number;
+  readonly active: boolean;
+}
+
+export interface configMergeState {
+  readonly entries: ReadonlyArray<configMergeEntry>;
+  readonly total: number;
+}
+
+/** Collect one entry for the config-merge stage. */
+export function collectEntry000(
+  entries: ReadonlyArray<configMergeEntry>,
+  slot: number,
+): configMergeEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Resolve one entry for the config-merge stage. */
+export function resolveEntry001(
+  entries: ReadonlyArray<configMergeEntry>,
+  slot: number,
+): configMergeEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Merge one entry for the config-merge stage. */
+export function mergeEntry002(
+  entries: ReadonlyArray<configMergeEntry>,
+  slot: number,
+): configMergeEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Filter one entry for the config-merge stage. */
+export function filterEntry003(
+  entries: ReadonlyArray<configMergeEntry>,
+  slot: number,
+): configMergeEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Reduce one entry for the config-merge stage. */
+export function reduceEntry004(
+  entries: ReadonlyArray<configMergeEntry>,
+  slot: number,
+): configMergeEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Expand one entry for the config-merge stage. */
+export function expandEntry005(
+  entries: ReadonlyArray<configMergeEntry>,
+  slot: number,
+): configMergeEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Normalise one entry for the config-merge stage. */
+export function normaliseEntry006(
+  entries: ReadonlyArray<configMergeEntry>,
+  slot: number,
+): configMergeEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Compare one entry for the config-merge stage. */
+export function compareEntry007(
+  entries: ReadonlyArray<configMergeEntry>,
+  slot: number,
+): configMergeEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Select one entry for the config-merge stage. */
+export function selectEntry008(
+  entries: ReadonlyArray<configMergeEntry>,
+  slot: number,
+): configMergeEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Record one entry for the config-merge stage. */
+export function recordEntry009(
+  entries: ReadonlyArray<configMergeEntry>,
+  slot: number,
+): configMergeEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Collect one record for the config-merge stage. */
+export function collectRecord010(
+  entries: ReadonlyArray<configMergeEntry>,
+  slot: number,
+): configMergeEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Resolve one record for the config-merge stage. */
+export function resolveRecord011(
+  entries: ReadonlyArray<configMergeEntry>,
+  slot: number,
+): configMergeEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Merge one record for the config-merge stage. */
+export function mergeRecord012(
+  entries: ReadonlyArray<configMergeEntry>,
+  slot: number,
+): configMergeEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Filter one record for the config-merge stage. */
+export function filterRecord013(
+  entries: ReadonlyArray<configMergeEntry>,
+  slot: number,
+): configMergeEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Reduce one record for the config-merge stage. */
+export function reduceRecord014(
+  entries: ReadonlyArray<configMergeEntry>,
+  slot: number,
+): configMergeEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Expand one record for the config-merge stage. */
+export function expandRecord015(
+  entries: ReadonlyArray<configMergeEntry>,
+  slot: number,
+): configMergeEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Normalise one record for the config-merge stage. */
+export function normaliseRecord016(
+  entries: ReadonlyArray<configMergeEntry>,
+  slot: number,
+): configMergeEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Compare one record for the config-merge stage. */
+export function compareRecord017(
+  entries: ReadonlyArray<configMergeEntry>,
+  slot: number,
+): configMergeEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Select one record for the config-merge stage. */
+export function selectRecord018(
+  entries: ReadonlyArray<configMergeEntry>,
+  slot: number,
+): configMergeEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Record one record for the config-merge stage. */
+export function recordRecord019(
+  entries: ReadonlyArray<configMergeEntry>,
+  slot: number,
+): configMergeEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Collect one bucket for the config-merge stage. */
+export function collectBucket020(
+  entries: ReadonlyArray<configMergeEntry>,
+  slot: number,
+): configMergeEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Resolve one bucket for the config-merge stage. */
+export function resolveBucket021(
+  entries: ReadonlyArray<configMergeEntry>,
+  slot: number,
+): configMergeEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Merge one bucket for the config-merge stage. */
+export function mergeBucket022(
+  entries: ReadonlyArray<configMergeEntry>,
+  slot: number,
+): configMergeEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Filter one bucket for the config-merge stage. */
+export function filterBucket023(
+  entries: ReadonlyArray<configMergeEntry>,
+  slot: number,
+): configMergeEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Reduce one bucket for the config-merge stage. */
+export function reduceBucket024(
+  entries: ReadonlyArray<configMergeEntry>,
+  slot: number,
+): configMergeEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Expand one bucket for the config-merge stage. */
+export function expandBucket025(
+  entries: ReadonlyArray<configMergeEntry>,
+  slot: number,
+): configMergeEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Normalise one bucket for the config-merge stage. */
+export function normaliseBucket026(
+  entries: ReadonlyArray<configMergeEntry>,
+  slot: number,
+): configMergeEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Compare one bucket for the config-merge stage. */
+export function compareBucket027(
+  entries: ReadonlyArray<configMergeEntry>,
+  slot: number,
+): configMergeEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Select one bucket for the config-merge stage. */
+export function selectBucket028(
+  entries: ReadonlyArray<configMergeEntry>,
+  slot: number,
+): configMergeEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Record one bucket for the config-merge stage. */
+export function recordBucket029(
+  entries: ReadonlyArray<configMergeEntry>,
+  slot: number,
+): configMergeEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Collect one segment for the config-merge stage. */
+export function collectSegment030(
+  entries: ReadonlyArray<configMergeEntry>,
+  slot: number,
+): configMergeEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Resolve one segment for the config-merge stage. */
+export function resolveSegment031(
+  entries: ReadonlyArray<configMergeEntry>,
+  slot: number,
+): configMergeEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Merge one segment for the config-merge stage. */
+export function mergeSegment032(
+  entries: ReadonlyArray<configMergeEntry>,
+  slot: number,
+): configMergeEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Filter one segment for the config-merge stage. */
+export function filterSegment033(
+  entries: ReadonlyArray<configMergeEntry>,
+  slot: number,
+): configMergeEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Reduce one segment for the config-merge stage. */
+export function reduceSegment034(
+  entries: ReadonlyArray<configMergeEntry>,
+  slot: number,
+): configMergeEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Expand one segment for the config-merge stage. */
+export function expandSegment035(
+  entries: ReadonlyArray<configMergeEntry>,
+  slot: number,
+): configMergeEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Normalise one segment for the config-merge stage. */
+export function normaliseSegment036(
+  entries: ReadonlyArray<configMergeEntry>,
+  slot: number,
+): configMergeEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Compare one segment for the config-merge stage. */
+export function compareSegment037(
+  entries: ReadonlyArray<configMergeEntry>,
+  slot: number,
+): configMergeEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Select one segment for the config-merge stage. */
+export function selectSegment038(
+  entries: ReadonlyArray<configMergeEntry>,
+  slot: number,
+): configMergeEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Record one segment for the config-merge stage. */
+export function recordSegment039(
+  entries: ReadonlyArray<configMergeEntry>,
+  slot: number,
+): configMergeEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Collect one window for the config-merge stage. */
+export function collectWindow040(
+  entries: ReadonlyArray<configMergeEntry>,
+  slot: number,
+): configMergeEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Resolve one window for the config-merge stage. */
+export function resolveWindow041(
+  entries: ReadonlyArray<configMergeEntry>,
+  slot: number,
+): configMergeEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Merge one window for the config-merge stage. */
+export function mergeWindow042(
+  entries: ReadonlyArray<configMergeEntry>,
+  slot: number,
+): configMergeEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Filter one window for the config-merge stage. */
+export function filterWindow043(
+  entries: ReadonlyArray<configMergeEntry>,
+  slot: number,
+): configMergeEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Reduce one window for the config-merge stage. */
+export function reduceWindow044(
+  entries: ReadonlyArray<configMergeEntry>,
+  slot: number,
+): configMergeEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Expand one window for the config-merge stage. */
+export function expandWindow045(
+  entries: ReadonlyArray<configMergeEntry>,
+  slot: number,
+): configMergeEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Normalise one window for the config-merge stage. */
+export function normaliseWindow046(
+  entries: ReadonlyArray<configMergeEntry>,
+  slot: number,
+): configMergeEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Compare one window for the config-merge stage. */
+export function compareWindow047(
+  entries: ReadonlyArray<configMergeEntry>,
+  slot: number,
+): configMergeEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Select one window for the config-merge stage. */
+export function selectWindow048(
+  entries: ReadonlyArray<configMergeEntry>,
+  slot: number,
+): configMergeEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Record one window for the config-merge stage. */
+export function recordWindow049(
+  entries: ReadonlyArray<configMergeEntry>,
+  slot: number,
+): configMergeEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Collect one marker for the config-merge stage. */
+export function collectMarker050(
+  entries: ReadonlyArray<configMergeEntry>,
+  slot: number,
+): configMergeEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Resolve one marker for the config-merge stage. */
+export function resolveMarker051(
+  entries: ReadonlyArray<configMergeEntry>,
+  slot: number,
+): configMergeEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Merge one marker for the config-merge stage. */
+export function mergeMarker052(
+  entries: ReadonlyArray<configMergeEntry>,
+  slot: number,
+): configMergeEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Filter one marker for the config-merge stage. */
+export function filterMarker053(
+  entries: ReadonlyArray<configMergeEntry>,
+  slot: number,
+): configMergeEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Reduce one marker for the config-merge stage. */
+export function reduceMarker054(
+  entries: ReadonlyArray<configMergeEntry>,
+  slot: number,
+): configMergeEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Expand one marker for the config-merge stage. */
+export function expandMarker055(
+  entries: ReadonlyArray<configMergeEntry>,
+  slot: number,
+): configMergeEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Normalise one marker for the config-merge stage. */
+export function normaliseMarker056(
+  entries: ReadonlyArray<configMergeEntry>,
+  slot: number,
+): configMergeEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Compare one marker for the config-merge stage. */
+export function compareMarker057(
+  entries: ReadonlyArray<configMergeEntry>,
+  slot: number,
+): configMergeEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Select one marker for the config-merge stage. */
+export function selectMarker058(
+  entries: ReadonlyArray<configMergeEntry>,
+  slot: number,
+): configMergeEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Record one marker for the config-merge stage. */
+export function recordMarker059(
+  entries: ReadonlyArray<configMergeEntry>,
+  slot: number,
+): configMergeEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Collect one handle for the config-merge stage. */
+export function collectHandle060(
+  entries: ReadonlyArray<configMergeEntry>,
+  slot: number,
+): configMergeEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Resolve one handle for the config-merge stage. */
+export function resolveHandle061(
+  entries: ReadonlyArray<configMergeEntry>,
+  slot: number,
+): configMergeEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Merge one handle for the config-merge stage. */
+export function mergeHandle062(
+  entries: ReadonlyArray<configMergeEntry>,
+  slot: number,
+): configMergeEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Filter one handle for the config-merge stage. */
+export function filterHandle063(
+  entries: ReadonlyArray<configMergeEntry>,
+  slot: number,
+): configMergeEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Reduce one handle for the config-merge stage. */
+export function reduceHandle064(
+  entries: ReadonlyArray<configMergeEntry>,
+  slot: number,
+): configMergeEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Expand one handle for the config-merge stage. */
+export function expandHandle065(
+  entries: ReadonlyArray<configMergeEntry>,
+  slot: number,
+): configMergeEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Normalise one handle for the config-merge stage. */
+export function normaliseHandle066(
+  entries: ReadonlyArray<configMergeEntry>,
+  slot: number,
+): configMergeEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Compare one handle for the config-merge stage. */
+export function compareHandle067(
+  entries: ReadonlyArray<configMergeEntry>,
+  slot: number,
+): configMergeEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Select one handle for the config-merge stage. */
+export function selectHandle068(
+  entries: ReadonlyArray<configMergeEntry>,
+  slot: number,
+): configMergeEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Record one handle for the config-merge stage. */
+export function recordHandle069(
+  entries: ReadonlyArray<configMergeEntry>,
+  slot: number,
+): configMergeEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Collect one cursor for the config-merge stage. */
+export function collectCursor070(
+  entries: ReadonlyArray<configMergeEntry>,
+  slot: number,
+): configMergeEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Resolve one cursor for the config-merge stage. */
+export function resolveCursor071(
+  entries: ReadonlyArray<configMergeEntry>,
+  slot: number,
+): configMergeEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Merge one cursor for the config-merge stage. */
+export function mergeCursor072(
+  entries: ReadonlyArray<configMergeEntry>,
+  slot: number,
+): configMergeEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Filter one cursor for the config-merge stage. */
+export function filterCursor073(
+  entries: ReadonlyArray<configMergeEntry>,
+  slot: number,
+): configMergeEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+

--- a/test-fixtures/gate-acceptance/digest-table.ts
+++ b/test-fixtures/gate-acceptance/digest-table.ts
@@ -1,0 +1,1500 @@
+// Acceptance corpus for the pull request review gate.
+//
+// This file is synthetic and is not part of the shipped package. It
+// exists so that one pull request is large enough to exercise two
+// limits at once: the diff API's 20,000-changed-line ceiling, and the
+// review request budget above which the gate splits a change into
+// batches. This pull request is opened to exercise them and closed
+// again; it is not merged.
+
+export interface digestTableEntry {
+  readonly key: string;
+  readonly slot: number;
+  readonly active: boolean;
+}
+
+export interface digestTableState {
+  readonly entries: ReadonlyArray<digestTableEntry>;
+  readonly total: number;
+}
+
+/** Collect one entry for the digest-table stage. */
+export function collectEntry000(
+  entries: ReadonlyArray<digestTableEntry>,
+  slot: number,
+): digestTableEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Resolve one entry for the digest-table stage. */
+export function resolveEntry001(
+  entries: ReadonlyArray<digestTableEntry>,
+  slot: number,
+): digestTableEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Merge one entry for the digest-table stage. */
+export function mergeEntry002(
+  entries: ReadonlyArray<digestTableEntry>,
+  slot: number,
+): digestTableEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Filter one entry for the digest-table stage. */
+export function filterEntry003(
+  entries: ReadonlyArray<digestTableEntry>,
+  slot: number,
+): digestTableEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Reduce one entry for the digest-table stage. */
+export function reduceEntry004(
+  entries: ReadonlyArray<digestTableEntry>,
+  slot: number,
+): digestTableEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Expand one entry for the digest-table stage. */
+export function expandEntry005(
+  entries: ReadonlyArray<digestTableEntry>,
+  slot: number,
+): digestTableEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Normalise one entry for the digest-table stage. */
+export function normaliseEntry006(
+  entries: ReadonlyArray<digestTableEntry>,
+  slot: number,
+): digestTableEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Compare one entry for the digest-table stage. */
+export function compareEntry007(
+  entries: ReadonlyArray<digestTableEntry>,
+  slot: number,
+): digestTableEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Select one entry for the digest-table stage. */
+export function selectEntry008(
+  entries: ReadonlyArray<digestTableEntry>,
+  slot: number,
+): digestTableEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Record one entry for the digest-table stage. */
+export function recordEntry009(
+  entries: ReadonlyArray<digestTableEntry>,
+  slot: number,
+): digestTableEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Collect one record for the digest-table stage. */
+export function collectRecord010(
+  entries: ReadonlyArray<digestTableEntry>,
+  slot: number,
+): digestTableEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Resolve one record for the digest-table stage. */
+export function resolveRecord011(
+  entries: ReadonlyArray<digestTableEntry>,
+  slot: number,
+): digestTableEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Merge one record for the digest-table stage. */
+export function mergeRecord012(
+  entries: ReadonlyArray<digestTableEntry>,
+  slot: number,
+): digestTableEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Filter one record for the digest-table stage. */
+export function filterRecord013(
+  entries: ReadonlyArray<digestTableEntry>,
+  slot: number,
+): digestTableEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Reduce one record for the digest-table stage. */
+export function reduceRecord014(
+  entries: ReadonlyArray<digestTableEntry>,
+  slot: number,
+): digestTableEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Expand one record for the digest-table stage. */
+export function expandRecord015(
+  entries: ReadonlyArray<digestTableEntry>,
+  slot: number,
+): digestTableEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Normalise one record for the digest-table stage. */
+export function normaliseRecord016(
+  entries: ReadonlyArray<digestTableEntry>,
+  slot: number,
+): digestTableEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Compare one record for the digest-table stage. */
+export function compareRecord017(
+  entries: ReadonlyArray<digestTableEntry>,
+  slot: number,
+): digestTableEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Select one record for the digest-table stage. */
+export function selectRecord018(
+  entries: ReadonlyArray<digestTableEntry>,
+  slot: number,
+): digestTableEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Record one record for the digest-table stage. */
+export function recordRecord019(
+  entries: ReadonlyArray<digestTableEntry>,
+  slot: number,
+): digestTableEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Collect one bucket for the digest-table stage. */
+export function collectBucket020(
+  entries: ReadonlyArray<digestTableEntry>,
+  slot: number,
+): digestTableEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Resolve one bucket for the digest-table stage. */
+export function resolveBucket021(
+  entries: ReadonlyArray<digestTableEntry>,
+  slot: number,
+): digestTableEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Merge one bucket for the digest-table stage. */
+export function mergeBucket022(
+  entries: ReadonlyArray<digestTableEntry>,
+  slot: number,
+): digestTableEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Filter one bucket for the digest-table stage. */
+export function filterBucket023(
+  entries: ReadonlyArray<digestTableEntry>,
+  slot: number,
+): digestTableEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Reduce one bucket for the digest-table stage. */
+export function reduceBucket024(
+  entries: ReadonlyArray<digestTableEntry>,
+  slot: number,
+): digestTableEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Expand one bucket for the digest-table stage. */
+export function expandBucket025(
+  entries: ReadonlyArray<digestTableEntry>,
+  slot: number,
+): digestTableEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Normalise one bucket for the digest-table stage. */
+export function normaliseBucket026(
+  entries: ReadonlyArray<digestTableEntry>,
+  slot: number,
+): digestTableEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Compare one bucket for the digest-table stage. */
+export function compareBucket027(
+  entries: ReadonlyArray<digestTableEntry>,
+  slot: number,
+): digestTableEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Select one bucket for the digest-table stage. */
+export function selectBucket028(
+  entries: ReadonlyArray<digestTableEntry>,
+  slot: number,
+): digestTableEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Record one bucket for the digest-table stage. */
+export function recordBucket029(
+  entries: ReadonlyArray<digestTableEntry>,
+  slot: number,
+): digestTableEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Collect one segment for the digest-table stage. */
+export function collectSegment030(
+  entries: ReadonlyArray<digestTableEntry>,
+  slot: number,
+): digestTableEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Resolve one segment for the digest-table stage. */
+export function resolveSegment031(
+  entries: ReadonlyArray<digestTableEntry>,
+  slot: number,
+): digestTableEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Merge one segment for the digest-table stage. */
+export function mergeSegment032(
+  entries: ReadonlyArray<digestTableEntry>,
+  slot: number,
+): digestTableEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Filter one segment for the digest-table stage. */
+export function filterSegment033(
+  entries: ReadonlyArray<digestTableEntry>,
+  slot: number,
+): digestTableEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Reduce one segment for the digest-table stage. */
+export function reduceSegment034(
+  entries: ReadonlyArray<digestTableEntry>,
+  slot: number,
+): digestTableEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Expand one segment for the digest-table stage. */
+export function expandSegment035(
+  entries: ReadonlyArray<digestTableEntry>,
+  slot: number,
+): digestTableEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Normalise one segment for the digest-table stage. */
+export function normaliseSegment036(
+  entries: ReadonlyArray<digestTableEntry>,
+  slot: number,
+): digestTableEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Compare one segment for the digest-table stage. */
+export function compareSegment037(
+  entries: ReadonlyArray<digestTableEntry>,
+  slot: number,
+): digestTableEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Select one segment for the digest-table stage. */
+export function selectSegment038(
+  entries: ReadonlyArray<digestTableEntry>,
+  slot: number,
+): digestTableEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Record one segment for the digest-table stage. */
+export function recordSegment039(
+  entries: ReadonlyArray<digestTableEntry>,
+  slot: number,
+): digestTableEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Collect one window for the digest-table stage. */
+export function collectWindow040(
+  entries: ReadonlyArray<digestTableEntry>,
+  slot: number,
+): digestTableEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Resolve one window for the digest-table stage. */
+export function resolveWindow041(
+  entries: ReadonlyArray<digestTableEntry>,
+  slot: number,
+): digestTableEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Merge one window for the digest-table stage. */
+export function mergeWindow042(
+  entries: ReadonlyArray<digestTableEntry>,
+  slot: number,
+): digestTableEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Filter one window for the digest-table stage. */
+export function filterWindow043(
+  entries: ReadonlyArray<digestTableEntry>,
+  slot: number,
+): digestTableEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Reduce one window for the digest-table stage. */
+export function reduceWindow044(
+  entries: ReadonlyArray<digestTableEntry>,
+  slot: number,
+): digestTableEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Expand one window for the digest-table stage. */
+export function expandWindow045(
+  entries: ReadonlyArray<digestTableEntry>,
+  slot: number,
+): digestTableEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Normalise one window for the digest-table stage. */
+export function normaliseWindow046(
+  entries: ReadonlyArray<digestTableEntry>,
+  slot: number,
+): digestTableEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Compare one window for the digest-table stage. */
+export function compareWindow047(
+  entries: ReadonlyArray<digestTableEntry>,
+  slot: number,
+): digestTableEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Select one window for the digest-table stage. */
+export function selectWindow048(
+  entries: ReadonlyArray<digestTableEntry>,
+  slot: number,
+): digestTableEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Record one window for the digest-table stage. */
+export function recordWindow049(
+  entries: ReadonlyArray<digestTableEntry>,
+  slot: number,
+): digestTableEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Collect one marker for the digest-table stage. */
+export function collectMarker050(
+  entries: ReadonlyArray<digestTableEntry>,
+  slot: number,
+): digestTableEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Resolve one marker for the digest-table stage. */
+export function resolveMarker051(
+  entries: ReadonlyArray<digestTableEntry>,
+  slot: number,
+): digestTableEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Merge one marker for the digest-table stage. */
+export function mergeMarker052(
+  entries: ReadonlyArray<digestTableEntry>,
+  slot: number,
+): digestTableEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Filter one marker for the digest-table stage. */
+export function filterMarker053(
+  entries: ReadonlyArray<digestTableEntry>,
+  slot: number,
+): digestTableEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Reduce one marker for the digest-table stage. */
+export function reduceMarker054(
+  entries: ReadonlyArray<digestTableEntry>,
+  slot: number,
+): digestTableEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Expand one marker for the digest-table stage. */
+export function expandMarker055(
+  entries: ReadonlyArray<digestTableEntry>,
+  slot: number,
+): digestTableEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Normalise one marker for the digest-table stage. */
+export function normaliseMarker056(
+  entries: ReadonlyArray<digestTableEntry>,
+  slot: number,
+): digestTableEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Compare one marker for the digest-table stage. */
+export function compareMarker057(
+  entries: ReadonlyArray<digestTableEntry>,
+  slot: number,
+): digestTableEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Select one marker for the digest-table stage. */
+export function selectMarker058(
+  entries: ReadonlyArray<digestTableEntry>,
+  slot: number,
+): digestTableEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Record one marker for the digest-table stage. */
+export function recordMarker059(
+  entries: ReadonlyArray<digestTableEntry>,
+  slot: number,
+): digestTableEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Collect one handle for the digest-table stage. */
+export function collectHandle060(
+  entries: ReadonlyArray<digestTableEntry>,
+  slot: number,
+): digestTableEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Resolve one handle for the digest-table stage. */
+export function resolveHandle061(
+  entries: ReadonlyArray<digestTableEntry>,
+  slot: number,
+): digestTableEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Merge one handle for the digest-table stage. */
+export function mergeHandle062(
+  entries: ReadonlyArray<digestTableEntry>,
+  slot: number,
+): digestTableEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Filter one handle for the digest-table stage. */
+export function filterHandle063(
+  entries: ReadonlyArray<digestTableEntry>,
+  slot: number,
+): digestTableEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Reduce one handle for the digest-table stage. */
+export function reduceHandle064(
+  entries: ReadonlyArray<digestTableEntry>,
+  slot: number,
+): digestTableEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Expand one handle for the digest-table stage. */
+export function expandHandle065(
+  entries: ReadonlyArray<digestTableEntry>,
+  slot: number,
+): digestTableEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Normalise one handle for the digest-table stage. */
+export function normaliseHandle066(
+  entries: ReadonlyArray<digestTableEntry>,
+  slot: number,
+): digestTableEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Compare one handle for the digest-table stage. */
+export function compareHandle067(
+  entries: ReadonlyArray<digestTableEntry>,
+  slot: number,
+): digestTableEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Select one handle for the digest-table stage. */
+export function selectHandle068(
+  entries: ReadonlyArray<digestTableEntry>,
+  slot: number,
+): digestTableEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Record one handle for the digest-table stage. */
+export function recordHandle069(
+  entries: ReadonlyArray<digestTableEntry>,
+  slot: number,
+): digestTableEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Collect one cursor for the digest-table stage. */
+export function collectCursor070(
+  entries: ReadonlyArray<digestTableEntry>,
+  slot: number,
+): digestTableEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Resolve one cursor for the digest-table stage. */
+export function resolveCursor071(
+  entries: ReadonlyArray<digestTableEntry>,
+  slot: number,
+): digestTableEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Merge one cursor for the digest-table stage. */
+export function mergeCursor072(
+  entries: ReadonlyArray<digestTableEntry>,
+  slot: number,
+): digestTableEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Filter one cursor for the digest-table stage. */
+export function filterCursor073(
+  entries: ReadonlyArray<digestTableEntry>,
+  slot: number,
+): digestTableEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+

--- a/test-fixtures/gate-acceptance/finding-merge.ts
+++ b/test-fixtures/gate-acceptance/finding-merge.ts
@@ -1,0 +1,1500 @@
+// Acceptance corpus for the pull request review gate.
+//
+// This file is synthetic and is not part of the shipped package. It
+// exists so that one pull request is large enough to exercise two
+// limits at once: the diff API's 20,000-changed-line ceiling, and the
+// review request budget above which the gate splits a change into
+// batches. This pull request is opened to exercise them and closed
+// again; it is not merged.
+
+export interface findingMergeEntry {
+  readonly key: string;
+  readonly slot: number;
+  readonly active: boolean;
+}
+
+export interface findingMergeState {
+  readonly entries: ReadonlyArray<findingMergeEntry>;
+  readonly total: number;
+}
+
+/** Collect one entry for the finding-merge stage. */
+export function collectEntry000(
+  entries: ReadonlyArray<findingMergeEntry>,
+  slot: number,
+): findingMergeEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Resolve one entry for the finding-merge stage. */
+export function resolveEntry001(
+  entries: ReadonlyArray<findingMergeEntry>,
+  slot: number,
+): findingMergeEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Merge one entry for the finding-merge stage. */
+export function mergeEntry002(
+  entries: ReadonlyArray<findingMergeEntry>,
+  slot: number,
+): findingMergeEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Filter one entry for the finding-merge stage. */
+export function filterEntry003(
+  entries: ReadonlyArray<findingMergeEntry>,
+  slot: number,
+): findingMergeEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Reduce one entry for the finding-merge stage. */
+export function reduceEntry004(
+  entries: ReadonlyArray<findingMergeEntry>,
+  slot: number,
+): findingMergeEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Expand one entry for the finding-merge stage. */
+export function expandEntry005(
+  entries: ReadonlyArray<findingMergeEntry>,
+  slot: number,
+): findingMergeEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Normalise one entry for the finding-merge stage. */
+export function normaliseEntry006(
+  entries: ReadonlyArray<findingMergeEntry>,
+  slot: number,
+): findingMergeEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Compare one entry for the finding-merge stage. */
+export function compareEntry007(
+  entries: ReadonlyArray<findingMergeEntry>,
+  slot: number,
+): findingMergeEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Select one entry for the finding-merge stage. */
+export function selectEntry008(
+  entries: ReadonlyArray<findingMergeEntry>,
+  slot: number,
+): findingMergeEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Record one entry for the finding-merge stage. */
+export function recordEntry009(
+  entries: ReadonlyArray<findingMergeEntry>,
+  slot: number,
+): findingMergeEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Collect one record for the finding-merge stage. */
+export function collectRecord010(
+  entries: ReadonlyArray<findingMergeEntry>,
+  slot: number,
+): findingMergeEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Resolve one record for the finding-merge stage. */
+export function resolveRecord011(
+  entries: ReadonlyArray<findingMergeEntry>,
+  slot: number,
+): findingMergeEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Merge one record for the finding-merge stage. */
+export function mergeRecord012(
+  entries: ReadonlyArray<findingMergeEntry>,
+  slot: number,
+): findingMergeEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Filter one record for the finding-merge stage. */
+export function filterRecord013(
+  entries: ReadonlyArray<findingMergeEntry>,
+  slot: number,
+): findingMergeEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Reduce one record for the finding-merge stage. */
+export function reduceRecord014(
+  entries: ReadonlyArray<findingMergeEntry>,
+  slot: number,
+): findingMergeEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Expand one record for the finding-merge stage. */
+export function expandRecord015(
+  entries: ReadonlyArray<findingMergeEntry>,
+  slot: number,
+): findingMergeEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Normalise one record for the finding-merge stage. */
+export function normaliseRecord016(
+  entries: ReadonlyArray<findingMergeEntry>,
+  slot: number,
+): findingMergeEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Compare one record for the finding-merge stage. */
+export function compareRecord017(
+  entries: ReadonlyArray<findingMergeEntry>,
+  slot: number,
+): findingMergeEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Select one record for the finding-merge stage. */
+export function selectRecord018(
+  entries: ReadonlyArray<findingMergeEntry>,
+  slot: number,
+): findingMergeEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Record one record for the finding-merge stage. */
+export function recordRecord019(
+  entries: ReadonlyArray<findingMergeEntry>,
+  slot: number,
+): findingMergeEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Collect one bucket for the finding-merge stage. */
+export function collectBucket020(
+  entries: ReadonlyArray<findingMergeEntry>,
+  slot: number,
+): findingMergeEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Resolve one bucket for the finding-merge stage. */
+export function resolveBucket021(
+  entries: ReadonlyArray<findingMergeEntry>,
+  slot: number,
+): findingMergeEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Merge one bucket for the finding-merge stage. */
+export function mergeBucket022(
+  entries: ReadonlyArray<findingMergeEntry>,
+  slot: number,
+): findingMergeEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Filter one bucket for the finding-merge stage. */
+export function filterBucket023(
+  entries: ReadonlyArray<findingMergeEntry>,
+  slot: number,
+): findingMergeEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Reduce one bucket for the finding-merge stage. */
+export function reduceBucket024(
+  entries: ReadonlyArray<findingMergeEntry>,
+  slot: number,
+): findingMergeEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Expand one bucket for the finding-merge stage. */
+export function expandBucket025(
+  entries: ReadonlyArray<findingMergeEntry>,
+  slot: number,
+): findingMergeEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Normalise one bucket for the finding-merge stage. */
+export function normaliseBucket026(
+  entries: ReadonlyArray<findingMergeEntry>,
+  slot: number,
+): findingMergeEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Compare one bucket for the finding-merge stage. */
+export function compareBucket027(
+  entries: ReadonlyArray<findingMergeEntry>,
+  slot: number,
+): findingMergeEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Select one bucket for the finding-merge stage. */
+export function selectBucket028(
+  entries: ReadonlyArray<findingMergeEntry>,
+  slot: number,
+): findingMergeEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Record one bucket for the finding-merge stage. */
+export function recordBucket029(
+  entries: ReadonlyArray<findingMergeEntry>,
+  slot: number,
+): findingMergeEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Collect one segment for the finding-merge stage. */
+export function collectSegment030(
+  entries: ReadonlyArray<findingMergeEntry>,
+  slot: number,
+): findingMergeEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Resolve one segment for the finding-merge stage. */
+export function resolveSegment031(
+  entries: ReadonlyArray<findingMergeEntry>,
+  slot: number,
+): findingMergeEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Merge one segment for the finding-merge stage. */
+export function mergeSegment032(
+  entries: ReadonlyArray<findingMergeEntry>,
+  slot: number,
+): findingMergeEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Filter one segment for the finding-merge stage. */
+export function filterSegment033(
+  entries: ReadonlyArray<findingMergeEntry>,
+  slot: number,
+): findingMergeEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Reduce one segment for the finding-merge stage. */
+export function reduceSegment034(
+  entries: ReadonlyArray<findingMergeEntry>,
+  slot: number,
+): findingMergeEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Expand one segment for the finding-merge stage. */
+export function expandSegment035(
+  entries: ReadonlyArray<findingMergeEntry>,
+  slot: number,
+): findingMergeEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Normalise one segment for the finding-merge stage. */
+export function normaliseSegment036(
+  entries: ReadonlyArray<findingMergeEntry>,
+  slot: number,
+): findingMergeEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Compare one segment for the finding-merge stage. */
+export function compareSegment037(
+  entries: ReadonlyArray<findingMergeEntry>,
+  slot: number,
+): findingMergeEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Select one segment for the finding-merge stage. */
+export function selectSegment038(
+  entries: ReadonlyArray<findingMergeEntry>,
+  slot: number,
+): findingMergeEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Record one segment for the finding-merge stage. */
+export function recordSegment039(
+  entries: ReadonlyArray<findingMergeEntry>,
+  slot: number,
+): findingMergeEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Collect one window for the finding-merge stage. */
+export function collectWindow040(
+  entries: ReadonlyArray<findingMergeEntry>,
+  slot: number,
+): findingMergeEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Resolve one window for the finding-merge stage. */
+export function resolveWindow041(
+  entries: ReadonlyArray<findingMergeEntry>,
+  slot: number,
+): findingMergeEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Merge one window for the finding-merge stage. */
+export function mergeWindow042(
+  entries: ReadonlyArray<findingMergeEntry>,
+  slot: number,
+): findingMergeEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Filter one window for the finding-merge stage. */
+export function filterWindow043(
+  entries: ReadonlyArray<findingMergeEntry>,
+  slot: number,
+): findingMergeEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Reduce one window for the finding-merge stage. */
+export function reduceWindow044(
+  entries: ReadonlyArray<findingMergeEntry>,
+  slot: number,
+): findingMergeEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Expand one window for the finding-merge stage. */
+export function expandWindow045(
+  entries: ReadonlyArray<findingMergeEntry>,
+  slot: number,
+): findingMergeEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Normalise one window for the finding-merge stage. */
+export function normaliseWindow046(
+  entries: ReadonlyArray<findingMergeEntry>,
+  slot: number,
+): findingMergeEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Compare one window for the finding-merge stage. */
+export function compareWindow047(
+  entries: ReadonlyArray<findingMergeEntry>,
+  slot: number,
+): findingMergeEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Select one window for the finding-merge stage. */
+export function selectWindow048(
+  entries: ReadonlyArray<findingMergeEntry>,
+  slot: number,
+): findingMergeEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Record one window for the finding-merge stage. */
+export function recordWindow049(
+  entries: ReadonlyArray<findingMergeEntry>,
+  slot: number,
+): findingMergeEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Collect one marker for the finding-merge stage. */
+export function collectMarker050(
+  entries: ReadonlyArray<findingMergeEntry>,
+  slot: number,
+): findingMergeEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Resolve one marker for the finding-merge stage. */
+export function resolveMarker051(
+  entries: ReadonlyArray<findingMergeEntry>,
+  slot: number,
+): findingMergeEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Merge one marker for the finding-merge stage. */
+export function mergeMarker052(
+  entries: ReadonlyArray<findingMergeEntry>,
+  slot: number,
+): findingMergeEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Filter one marker for the finding-merge stage. */
+export function filterMarker053(
+  entries: ReadonlyArray<findingMergeEntry>,
+  slot: number,
+): findingMergeEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Reduce one marker for the finding-merge stage. */
+export function reduceMarker054(
+  entries: ReadonlyArray<findingMergeEntry>,
+  slot: number,
+): findingMergeEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Expand one marker for the finding-merge stage. */
+export function expandMarker055(
+  entries: ReadonlyArray<findingMergeEntry>,
+  slot: number,
+): findingMergeEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Normalise one marker for the finding-merge stage. */
+export function normaliseMarker056(
+  entries: ReadonlyArray<findingMergeEntry>,
+  slot: number,
+): findingMergeEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Compare one marker for the finding-merge stage. */
+export function compareMarker057(
+  entries: ReadonlyArray<findingMergeEntry>,
+  slot: number,
+): findingMergeEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Select one marker for the finding-merge stage. */
+export function selectMarker058(
+  entries: ReadonlyArray<findingMergeEntry>,
+  slot: number,
+): findingMergeEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Record one marker for the finding-merge stage. */
+export function recordMarker059(
+  entries: ReadonlyArray<findingMergeEntry>,
+  slot: number,
+): findingMergeEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Collect one handle for the finding-merge stage. */
+export function collectHandle060(
+  entries: ReadonlyArray<findingMergeEntry>,
+  slot: number,
+): findingMergeEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Resolve one handle for the finding-merge stage. */
+export function resolveHandle061(
+  entries: ReadonlyArray<findingMergeEntry>,
+  slot: number,
+): findingMergeEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Merge one handle for the finding-merge stage. */
+export function mergeHandle062(
+  entries: ReadonlyArray<findingMergeEntry>,
+  slot: number,
+): findingMergeEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Filter one handle for the finding-merge stage. */
+export function filterHandle063(
+  entries: ReadonlyArray<findingMergeEntry>,
+  slot: number,
+): findingMergeEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Reduce one handle for the finding-merge stage. */
+export function reduceHandle064(
+  entries: ReadonlyArray<findingMergeEntry>,
+  slot: number,
+): findingMergeEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Expand one handle for the finding-merge stage. */
+export function expandHandle065(
+  entries: ReadonlyArray<findingMergeEntry>,
+  slot: number,
+): findingMergeEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Normalise one handle for the finding-merge stage. */
+export function normaliseHandle066(
+  entries: ReadonlyArray<findingMergeEntry>,
+  slot: number,
+): findingMergeEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Compare one handle for the finding-merge stage. */
+export function compareHandle067(
+  entries: ReadonlyArray<findingMergeEntry>,
+  slot: number,
+): findingMergeEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Select one handle for the finding-merge stage. */
+export function selectHandle068(
+  entries: ReadonlyArray<findingMergeEntry>,
+  slot: number,
+): findingMergeEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Record one handle for the finding-merge stage. */
+export function recordHandle069(
+  entries: ReadonlyArray<findingMergeEntry>,
+  slot: number,
+): findingMergeEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Collect one cursor for the finding-merge stage. */
+export function collectCursor070(
+  entries: ReadonlyArray<findingMergeEntry>,
+  slot: number,
+): findingMergeEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Resolve one cursor for the finding-merge stage. */
+export function resolveCursor071(
+  entries: ReadonlyArray<findingMergeEntry>,
+  slot: number,
+): findingMergeEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Merge one cursor for the finding-merge stage. */
+export function mergeCursor072(
+  entries: ReadonlyArray<findingMergeEntry>,
+  slot: number,
+): findingMergeEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Filter one cursor for the finding-merge stage. */
+export function filterCursor073(
+  entries: ReadonlyArray<findingMergeEntry>,
+  slot: number,
+): findingMergeEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+

--- a/test-fixtures/gate-acceptance/label-index.ts
+++ b/test-fixtures/gate-acceptance/label-index.ts
@@ -1,0 +1,1500 @@
+// Acceptance corpus for the pull request review gate.
+//
+// This file is synthetic and is not part of the shipped package. It
+// exists so that one pull request is large enough to exercise two
+// limits at once: the diff API's 20,000-changed-line ceiling, and the
+// review request budget above which the gate splits a change into
+// batches. This pull request is opened to exercise them and closed
+// again; it is not merged.
+
+export interface labelIndexEntry {
+  readonly key: string;
+  readonly slot: number;
+  readonly active: boolean;
+}
+
+export interface labelIndexState {
+  readonly entries: ReadonlyArray<labelIndexEntry>;
+  readonly total: number;
+}
+
+/** Collect one entry for the label-index stage. */
+export function collectEntry000(
+  entries: ReadonlyArray<labelIndexEntry>,
+  slot: number,
+): labelIndexEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Resolve one entry for the label-index stage. */
+export function resolveEntry001(
+  entries: ReadonlyArray<labelIndexEntry>,
+  slot: number,
+): labelIndexEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Merge one entry for the label-index stage. */
+export function mergeEntry002(
+  entries: ReadonlyArray<labelIndexEntry>,
+  slot: number,
+): labelIndexEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Filter one entry for the label-index stage. */
+export function filterEntry003(
+  entries: ReadonlyArray<labelIndexEntry>,
+  slot: number,
+): labelIndexEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Reduce one entry for the label-index stage. */
+export function reduceEntry004(
+  entries: ReadonlyArray<labelIndexEntry>,
+  slot: number,
+): labelIndexEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Expand one entry for the label-index stage. */
+export function expandEntry005(
+  entries: ReadonlyArray<labelIndexEntry>,
+  slot: number,
+): labelIndexEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Normalise one entry for the label-index stage. */
+export function normaliseEntry006(
+  entries: ReadonlyArray<labelIndexEntry>,
+  slot: number,
+): labelIndexEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Compare one entry for the label-index stage. */
+export function compareEntry007(
+  entries: ReadonlyArray<labelIndexEntry>,
+  slot: number,
+): labelIndexEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Select one entry for the label-index stage. */
+export function selectEntry008(
+  entries: ReadonlyArray<labelIndexEntry>,
+  slot: number,
+): labelIndexEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Record one entry for the label-index stage. */
+export function recordEntry009(
+  entries: ReadonlyArray<labelIndexEntry>,
+  slot: number,
+): labelIndexEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Collect one record for the label-index stage. */
+export function collectRecord010(
+  entries: ReadonlyArray<labelIndexEntry>,
+  slot: number,
+): labelIndexEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Resolve one record for the label-index stage. */
+export function resolveRecord011(
+  entries: ReadonlyArray<labelIndexEntry>,
+  slot: number,
+): labelIndexEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Merge one record for the label-index stage. */
+export function mergeRecord012(
+  entries: ReadonlyArray<labelIndexEntry>,
+  slot: number,
+): labelIndexEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Filter one record for the label-index stage. */
+export function filterRecord013(
+  entries: ReadonlyArray<labelIndexEntry>,
+  slot: number,
+): labelIndexEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Reduce one record for the label-index stage. */
+export function reduceRecord014(
+  entries: ReadonlyArray<labelIndexEntry>,
+  slot: number,
+): labelIndexEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Expand one record for the label-index stage. */
+export function expandRecord015(
+  entries: ReadonlyArray<labelIndexEntry>,
+  slot: number,
+): labelIndexEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Normalise one record for the label-index stage. */
+export function normaliseRecord016(
+  entries: ReadonlyArray<labelIndexEntry>,
+  slot: number,
+): labelIndexEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Compare one record for the label-index stage. */
+export function compareRecord017(
+  entries: ReadonlyArray<labelIndexEntry>,
+  slot: number,
+): labelIndexEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Select one record for the label-index stage. */
+export function selectRecord018(
+  entries: ReadonlyArray<labelIndexEntry>,
+  slot: number,
+): labelIndexEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Record one record for the label-index stage. */
+export function recordRecord019(
+  entries: ReadonlyArray<labelIndexEntry>,
+  slot: number,
+): labelIndexEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Collect one bucket for the label-index stage. */
+export function collectBucket020(
+  entries: ReadonlyArray<labelIndexEntry>,
+  slot: number,
+): labelIndexEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Resolve one bucket for the label-index stage. */
+export function resolveBucket021(
+  entries: ReadonlyArray<labelIndexEntry>,
+  slot: number,
+): labelIndexEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Merge one bucket for the label-index stage. */
+export function mergeBucket022(
+  entries: ReadonlyArray<labelIndexEntry>,
+  slot: number,
+): labelIndexEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Filter one bucket for the label-index stage. */
+export function filterBucket023(
+  entries: ReadonlyArray<labelIndexEntry>,
+  slot: number,
+): labelIndexEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Reduce one bucket for the label-index stage. */
+export function reduceBucket024(
+  entries: ReadonlyArray<labelIndexEntry>,
+  slot: number,
+): labelIndexEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Expand one bucket for the label-index stage. */
+export function expandBucket025(
+  entries: ReadonlyArray<labelIndexEntry>,
+  slot: number,
+): labelIndexEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Normalise one bucket for the label-index stage. */
+export function normaliseBucket026(
+  entries: ReadonlyArray<labelIndexEntry>,
+  slot: number,
+): labelIndexEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Compare one bucket for the label-index stage. */
+export function compareBucket027(
+  entries: ReadonlyArray<labelIndexEntry>,
+  slot: number,
+): labelIndexEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Select one bucket for the label-index stage. */
+export function selectBucket028(
+  entries: ReadonlyArray<labelIndexEntry>,
+  slot: number,
+): labelIndexEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Record one bucket for the label-index stage. */
+export function recordBucket029(
+  entries: ReadonlyArray<labelIndexEntry>,
+  slot: number,
+): labelIndexEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Collect one segment for the label-index stage. */
+export function collectSegment030(
+  entries: ReadonlyArray<labelIndexEntry>,
+  slot: number,
+): labelIndexEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Resolve one segment for the label-index stage. */
+export function resolveSegment031(
+  entries: ReadonlyArray<labelIndexEntry>,
+  slot: number,
+): labelIndexEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Merge one segment for the label-index stage. */
+export function mergeSegment032(
+  entries: ReadonlyArray<labelIndexEntry>,
+  slot: number,
+): labelIndexEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Filter one segment for the label-index stage. */
+export function filterSegment033(
+  entries: ReadonlyArray<labelIndexEntry>,
+  slot: number,
+): labelIndexEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Reduce one segment for the label-index stage. */
+export function reduceSegment034(
+  entries: ReadonlyArray<labelIndexEntry>,
+  slot: number,
+): labelIndexEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Expand one segment for the label-index stage. */
+export function expandSegment035(
+  entries: ReadonlyArray<labelIndexEntry>,
+  slot: number,
+): labelIndexEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Normalise one segment for the label-index stage. */
+export function normaliseSegment036(
+  entries: ReadonlyArray<labelIndexEntry>,
+  slot: number,
+): labelIndexEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Compare one segment for the label-index stage. */
+export function compareSegment037(
+  entries: ReadonlyArray<labelIndexEntry>,
+  slot: number,
+): labelIndexEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Select one segment for the label-index stage. */
+export function selectSegment038(
+  entries: ReadonlyArray<labelIndexEntry>,
+  slot: number,
+): labelIndexEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Record one segment for the label-index stage. */
+export function recordSegment039(
+  entries: ReadonlyArray<labelIndexEntry>,
+  slot: number,
+): labelIndexEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Collect one window for the label-index stage. */
+export function collectWindow040(
+  entries: ReadonlyArray<labelIndexEntry>,
+  slot: number,
+): labelIndexEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Resolve one window for the label-index stage. */
+export function resolveWindow041(
+  entries: ReadonlyArray<labelIndexEntry>,
+  slot: number,
+): labelIndexEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Merge one window for the label-index stage. */
+export function mergeWindow042(
+  entries: ReadonlyArray<labelIndexEntry>,
+  slot: number,
+): labelIndexEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Filter one window for the label-index stage. */
+export function filterWindow043(
+  entries: ReadonlyArray<labelIndexEntry>,
+  slot: number,
+): labelIndexEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Reduce one window for the label-index stage. */
+export function reduceWindow044(
+  entries: ReadonlyArray<labelIndexEntry>,
+  slot: number,
+): labelIndexEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Expand one window for the label-index stage. */
+export function expandWindow045(
+  entries: ReadonlyArray<labelIndexEntry>,
+  slot: number,
+): labelIndexEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Normalise one window for the label-index stage. */
+export function normaliseWindow046(
+  entries: ReadonlyArray<labelIndexEntry>,
+  slot: number,
+): labelIndexEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Compare one window for the label-index stage. */
+export function compareWindow047(
+  entries: ReadonlyArray<labelIndexEntry>,
+  slot: number,
+): labelIndexEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Select one window for the label-index stage. */
+export function selectWindow048(
+  entries: ReadonlyArray<labelIndexEntry>,
+  slot: number,
+): labelIndexEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Record one window for the label-index stage. */
+export function recordWindow049(
+  entries: ReadonlyArray<labelIndexEntry>,
+  slot: number,
+): labelIndexEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Collect one marker for the label-index stage. */
+export function collectMarker050(
+  entries: ReadonlyArray<labelIndexEntry>,
+  slot: number,
+): labelIndexEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Resolve one marker for the label-index stage. */
+export function resolveMarker051(
+  entries: ReadonlyArray<labelIndexEntry>,
+  slot: number,
+): labelIndexEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Merge one marker for the label-index stage. */
+export function mergeMarker052(
+  entries: ReadonlyArray<labelIndexEntry>,
+  slot: number,
+): labelIndexEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Filter one marker for the label-index stage. */
+export function filterMarker053(
+  entries: ReadonlyArray<labelIndexEntry>,
+  slot: number,
+): labelIndexEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Reduce one marker for the label-index stage. */
+export function reduceMarker054(
+  entries: ReadonlyArray<labelIndexEntry>,
+  slot: number,
+): labelIndexEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Expand one marker for the label-index stage. */
+export function expandMarker055(
+  entries: ReadonlyArray<labelIndexEntry>,
+  slot: number,
+): labelIndexEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Normalise one marker for the label-index stage. */
+export function normaliseMarker056(
+  entries: ReadonlyArray<labelIndexEntry>,
+  slot: number,
+): labelIndexEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Compare one marker for the label-index stage. */
+export function compareMarker057(
+  entries: ReadonlyArray<labelIndexEntry>,
+  slot: number,
+): labelIndexEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Select one marker for the label-index stage. */
+export function selectMarker058(
+  entries: ReadonlyArray<labelIndexEntry>,
+  slot: number,
+): labelIndexEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Record one marker for the label-index stage. */
+export function recordMarker059(
+  entries: ReadonlyArray<labelIndexEntry>,
+  slot: number,
+): labelIndexEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Collect one handle for the label-index stage. */
+export function collectHandle060(
+  entries: ReadonlyArray<labelIndexEntry>,
+  slot: number,
+): labelIndexEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Resolve one handle for the label-index stage. */
+export function resolveHandle061(
+  entries: ReadonlyArray<labelIndexEntry>,
+  slot: number,
+): labelIndexEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Merge one handle for the label-index stage. */
+export function mergeHandle062(
+  entries: ReadonlyArray<labelIndexEntry>,
+  slot: number,
+): labelIndexEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Filter one handle for the label-index stage. */
+export function filterHandle063(
+  entries: ReadonlyArray<labelIndexEntry>,
+  slot: number,
+): labelIndexEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Reduce one handle for the label-index stage. */
+export function reduceHandle064(
+  entries: ReadonlyArray<labelIndexEntry>,
+  slot: number,
+): labelIndexEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Expand one handle for the label-index stage. */
+export function expandHandle065(
+  entries: ReadonlyArray<labelIndexEntry>,
+  slot: number,
+): labelIndexEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Normalise one handle for the label-index stage. */
+export function normaliseHandle066(
+  entries: ReadonlyArray<labelIndexEntry>,
+  slot: number,
+): labelIndexEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Compare one handle for the label-index stage. */
+export function compareHandle067(
+  entries: ReadonlyArray<labelIndexEntry>,
+  slot: number,
+): labelIndexEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Select one handle for the label-index stage. */
+export function selectHandle068(
+  entries: ReadonlyArray<labelIndexEntry>,
+  slot: number,
+): labelIndexEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Record one handle for the label-index stage. */
+export function recordHandle069(
+  entries: ReadonlyArray<labelIndexEntry>,
+  slot: number,
+): labelIndexEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Collect one cursor for the label-index stage. */
+export function collectCursor070(
+  entries: ReadonlyArray<labelIndexEntry>,
+  slot: number,
+): labelIndexEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Resolve one cursor for the label-index stage. */
+export function resolveCursor071(
+  entries: ReadonlyArray<labelIndexEntry>,
+  slot: number,
+): labelIndexEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Merge one cursor for the label-index stage. */
+export function mergeCursor072(
+  entries: ReadonlyArray<labelIndexEntry>,
+  slot: number,
+): labelIndexEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Filter one cursor for the label-index stage. */
+export function filterCursor073(
+  entries: ReadonlyArray<labelIndexEntry>,
+  slot: number,
+): labelIndexEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+

--- a/test-fixtures/gate-acceptance/ledger-append.ts
+++ b/test-fixtures/gate-acceptance/ledger-append.ts
@@ -1,0 +1,1500 @@
+// Acceptance corpus for the pull request review gate.
+//
+// This file is synthetic and is not part of the shipped package. It
+// exists so that one pull request is large enough to exercise two
+// limits at once: the diff API's 20,000-changed-line ceiling, and the
+// review request budget above which the gate splits a change into
+// batches. This pull request is opened to exercise them and closed
+// again; it is not merged.
+
+export interface ledgerAppendEntry {
+  readonly key: string;
+  readonly slot: number;
+  readonly active: boolean;
+}
+
+export interface ledgerAppendState {
+  readonly entries: ReadonlyArray<ledgerAppendEntry>;
+  readonly total: number;
+}
+
+/** Collect one entry for the ledger-append stage. */
+export function collectEntry000(
+  entries: ReadonlyArray<ledgerAppendEntry>,
+  slot: number,
+): ledgerAppendEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Resolve one entry for the ledger-append stage. */
+export function resolveEntry001(
+  entries: ReadonlyArray<ledgerAppendEntry>,
+  slot: number,
+): ledgerAppendEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Merge one entry for the ledger-append stage. */
+export function mergeEntry002(
+  entries: ReadonlyArray<ledgerAppendEntry>,
+  slot: number,
+): ledgerAppendEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Filter one entry for the ledger-append stage. */
+export function filterEntry003(
+  entries: ReadonlyArray<ledgerAppendEntry>,
+  slot: number,
+): ledgerAppendEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Reduce one entry for the ledger-append stage. */
+export function reduceEntry004(
+  entries: ReadonlyArray<ledgerAppendEntry>,
+  slot: number,
+): ledgerAppendEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Expand one entry for the ledger-append stage. */
+export function expandEntry005(
+  entries: ReadonlyArray<ledgerAppendEntry>,
+  slot: number,
+): ledgerAppendEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Normalise one entry for the ledger-append stage. */
+export function normaliseEntry006(
+  entries: ReadonlyArray<ledgerAppendEntry>,
+  slot: number,
+): ledgerAppendEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Compare one entry for the ledger-append stage. */
+export function compareEntry007(
+  entries: ReadonlyArray<ledgerAppendEntry>,
+  slot: number,
+): ledgerAppendEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Select one entry for the ledger-append stage. */
+export function selectEntry008(
+  entries: ReadonlyArray<ledgerAppendEntry>,
+  slot: number,
+): ledgerAppendEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Record one entry for the ledger-append stage. */
+export function recordEntry009(
+  entries: ReadonlyArray<ledgerAppendEntry>,
+  slot: number,
+): ledgerAppendEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Collect one record for the ledger-append stage. */
+export function collectRecord010(
+  entries: ReadonlyArray<ledgerAppendEntry>,
+  slot: number,
+): ledgerAppendEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Resolve one record for the ledger-append stage. */
+export function resolveRecord011(
+  entries: ReadonlyArray<ledgerAppendEntry>,
+  slot: number,
+): ledgerAppendEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Merge one record for the ledger-append stage. */
+export function mergeRecord012(
+  entries: ReadonlyArray<ledgerAppendEntry>,
+  slot: number,
+): ledgerAppendEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Filter one record for the ledger-append stage. */
+export function filterRecord013(
+  entries: ReadonlyArray<ledgerAppendEntry>,
+  slot: number,
+): ledgerAppendEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Reduce one record for the ledger-append stage. */
+export function reduceRecord014(
+  entries: ReadonlyArray<ledgerAppendEntry>,
+  slot: number,
+): ledgerAppendEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Expand one record for the ledger-append stage. */
+export function expandRecord015(
+  entries: ReadonlyArray<ledgerAppendEntry>,
+  slot: number,
+): ledgerAppendEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Normalise one record for the ledger-append stage. */
+export function normaliseRecord016(
+  entries: ReadonlyArray<ledgerAppendEntry>,
+  slot: number,
+): ledgerAppendEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Compare one record for the ledger-append stage. */
+export function compareRecord017(
+  entries: ReadonlyArray<ledgerAppendEntry>,
+  slot: number,
+): ledgerAppendEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Select one record for the ledger-append stage. */
+export function selectRecord018(
+  entries: ReadonlyArray<ledgerAppendEntry>,
+  slot: number,
+): ledgerAppendEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Record one record for the ledger-append stage. */
+export function recordRecord019(
+  entries: ReadonlyArray<ledgerAppendEntry>,
+  slot: number,
+): ledgerAppendEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Collect one bucket for the ledger-append stage. */
+export function collectBucket020(
+  entries: ReadonlyArray<ledgerAppendEntry>,
+  slot: number,
+): ledgerAppendEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Resolve one bucket for the ledger-append stage. */
+export function resolveBucket021(
+  entries: ReadonlyArray<ledgerAppendEntry>,
+  slot: number,
+): ledgerAppendEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Merge one bucket for the ledger-append stage. */
+export function mergeBucket022(
+  entries: ReadonlyArray<ledgerAppendEntry>,
+  slot: number,
+): ledgerAppendEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Filter one bucket for the ledger-append stage. */
+export function filterBucket023(
+  entries: ReadonlyArray<ledgerAppendEntry>,
+  slot: number,
+): ledgerAppendEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Reduce one bucket for the ledger-append stage. */
+export function reduceBucket024(
+  entries: ReadonlyArray<ledgerAppendEntry>,
+  slot: number,
+): ledgerAppendEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Expand one bucket for the ledger-append stage. */
+export function expandBucket025(
+  entries: ReadonlyArray<ledgerAppendEntry>,
+  slot: number,
+): ledgerAppendEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Normalise one bucket for the ledger-append stage. */
+export function normaliseBucket026(
+  entries: ReadonlyArray<ledgerAppendEntry>,
+  slot: number,
+): ledgerAppendEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Compare one bucket for the ledger-append stage. */
+export function compareBucket027(
+  entries: ReadonlyArray<ledgerAppendEntry>,
+  slot: number,
+): ledgerAppendEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Select one bucket for the ledger-append stage. */
+export function selectBucket028(
+  entries: ReadonlyArray<ledgerAppendEntry>,
+  slot: number,
+): ledgerAppendEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Record one bucket for the ledger-append stage. */
+export function recordBucket029(
+  entries: ReadonlyArray<ledgerAppendEntry>,
+  slot: number,
+): ledgerAppendEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Collect one segment for the ledger-append stage. */
+export function collectSegment030(
+  entries: ReadonlyArray<ledgerAppendEntry>,
+  slot: number,
+): ledgerAppendEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Resolve one segment for the ledger-append stage. */
+export function resolveSegment031(
+  entries: ReadonlyArray<ledgerAppendEntry>,
+  slot: number,
+): ledgerAppendEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Merge one segment for the ledger-append stage. */
+export function mergeSegment032(
+  entries: ReadonlyArray<ledgerAppendEntry>,
+  slot: number,
+): ledgerAppendEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Filter one segment for the ledger-append stage. */
+export function filterSegment033(
+  entries: ReadonlyArray<ledgerAppendEntry>,
+  slot: number,
+): ledgerAppendEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Reduce one segment for the ledger-append stage. */
+export function reduceSegment034(
+  entries: ReadonlyArray<ledgerAppendEntry>,
+  slot: number,
+): ledgerAppendEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Expand one segment for the ledger-append stage. */
+export function expandSegment035(
+  entries: ReadonlyArray<ledgerAppendEntry>,
+  slot: number,
+): ledgerAppendEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Normalise one segment for the ledger-append stage. */
+export function normaliseSegment036(
+  entries: ReadonlyArray<ledgerAppendEntry>,
+  slot: number,
+): ledgerAppendEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Compare one segment for the ledger-append stage. */
+export function compareSegment037(
+  entries: ReadonlyArray<ledgerAppendEntry>,
+  slot: number,
+): ledgerAppendEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Select one segment for the ledger-append stage. */
+export function selectSegment038(
+  entries: ReadonlyArray<ledgerAppendEntry>,
+  slot: number,
+): ledgerAppendEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Record one segment for the ledger-append stage. */
+export function recordSegment039(
+  entries: ReadonlyArray<ledgerAppendEntry>,
+  slot: number,
+): ledgerAppendEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Collect one window for the ledger-append stage. */
+export function collectWindow040(
+  entries: ReadonlyArray<ledgerAppendEntry>,
+  slot: number,
+): ledgerAppendEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Resolve one window for the ledger-append stage. */
+export function resolveWindow041(
+  entries: ReadonlyArray<ledgerAppendEntry>,
+  slot: number,
+): ledgerAppendEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Merge one window for the ledger-append stage. */
+export function mergeWindow042(
+  entries: ReadonlyArray<ledgerAppendEntry>,
+  slot: number,
+): ledgerAppendEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Filter one window for the ledger-append stage. */
+export function filterWindow043(
+  entries: ReadonlyArray<ledgerAppendEntry>,
+  slot: number,
+): ledgerAppendEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Reduce one window for the ledger-append stage. */
+export function reduceWindow044(
+  entries: ReadonlyArray<ledgerAppendEntry>,
+  slot: number,
+): ledgerAppendEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Expand one window for the ledger-append stage. */
+export function expandWindow045(
+  entries: ReadonlyArray<ledgerAppendEntry>,
+  slot: number,
+): ledgerAppendEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Normalise one window for the ledger-append stage. */
+export function normaliseWindow046(
+  entries: ReadonlyArray<ledgerAppendEntry>,
+  slot: number,
+): ledgerAppendEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Compare one window for the ledger-append stage. */
+export function compareWindow047(
+  entries: ReadonlyArray<ledgerAppendEntry>,
+  slot: number,
+): ledgerAppendEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Select one window for the ledger-append stage. */
+export function selectWindow048(
+  entries: ReadonlyArray<ledgerAppendEntry>,
+  slot: number,
+): ledgerAppendEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Record one window for the ledger-append stage. */
+export function recordWindow049(
+  entries: ReadonlyArray<ledgerAppendEntry>,
+  slot: number,
+): ledgerAppendEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Collect one marker for the ledger-append stage. */
+export function collectMarker050(
+  entries: ReadonlyArray<ledgerAppendEntry>,
+  slot: number,
+): ledgerAppendEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Resolve one marker for the ledger-append stage. */
+export function resolveMarker051(
+  entries: ReadonlyArray<ledgerAppendEntry>,
+  slot: number,
+): ledgerAppendEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Merge one marker for the ledger-append stage. */
+export function mergeMarker052(
+  entries: ReadonlyArray<ledgerAppendEntry>,
+  slot: number,
+): ledgerAppendEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Filter one marker for the ledger-append stage. */
+export function filterMarker053(
+  entries: ReadonlyArray<ledgerAppendEntry>,
+  slot: number,
+): ledgerAppendEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Reduce one marker for the ledger-append stage. */
+export function reduceMarker054(
+  entries: ReadonlyArray<ledgerAppendEntry>,
+  slot: number,
+): ledgerAppendEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Expand one marker for the ledger-append stage. */
+export function expandMarker055(
+  entries: ReadonlyArray<ledgerAppendEntry>,
+  slot: number,
+): ledgerAppendEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Normalise one marker for the ledger-append stage. */
+export function normaliseMarker056(
+  entries: ReadonlyArray<ledgerAppendEntry>,
+  slot: number,
+): ledgerAppendEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Compare one marker for the ledger-append stage. */
+export function compareMarker057(
+  entries: ReadonlyArray<ledgerAppendEntry>,
+  slot: number,
+): ledgerAppendEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Select one marker for the ledger-append stage. */
+export function selectMarker058(
+  entries: ReadonlyArray<ledgerAppendEntry>,
+  slot: number,
+): ledgerAppendEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Record one marker for the ledger-append stage. */
+export function recordMarker059(
+  entries: ReadonlyArray<ledgerAppendEntry>,
+  slot: number,
+): ledgerAppendEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Collect one handle for the ledger-append stage. */
+export function collectHandle060(
+  entries: ReadonlyArray<ledgerAppendEntry>,
+  slot: number,
+): ledgerAppendEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Resolve one handle for the ledger-append stage. */
+export function resolveHandle061(
+  entries: ReadonlyArray<ledgerAppendEntry>,
+  slot: number,
+): ledgerAppendEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Merge one handle for the ledger-append stage. */
+export function mergeHandle062(
+  entries: ReadonlyArray<ledgerAppendEntry>,
+  slot: number,
+): ledgerAppendEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Filter one handle for the ledger-append stage. */
+export function filterHandle063(
+  entries: ReadonlyArray<ledgerAppendEntry>,
+  slot: number,
+): ledgerAppendEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Reduce one handle for the ledger-append stage. */
+export function reduceHandle064(
+  entries: ReadonlyArray<ledgerAppendEntry>,
+  slot: number,
+): ledgerAppendEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Expand one handle for the ledger-append stage. */
+export function expandHandle065(
+  entries: ReadonlyArray<ledgerAppendEntry>,
+  slot: number,
+): ledgerAppendEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Normalise one handle for the ledger-append stage. */
+export function normaliseHandle066(
+  entries: ReadonlyArray<ledgerAppendEntry>,
+  slot: number,
+): ledgerAppendEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Compare one handle for the ledger-append stage. */
+export function compareHandle067(
+  entries: ReadonlyArray<ledgerAppendEntry>,
+  slot: number,
+): ledgerAppendEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Select one handle for the ledger-append stage. */
+export function selectHandle068(
+  entries: ReadonlyArray<ledgerAppendEntry>,
+  slot: number,
+): ledgerAppendEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Record one handle for the ledger-append stage. */
+export function recordHandle069(
+  entries: ReadonlyArray<ledgerAppendEntry>,
+  slot: number,
+): ledgerAppendEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Collect one cursor for the ledger-append stage. */
+export function collectCursor070(
+  entries: ReadonlyArray<ledgerAppendEntry>,
+  slot: number,
+): ledgerAppendEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Resolve one cursor for the ledger-append stage. */
+export function resolveCursor071(
+  entries: ReadonlyArray<ledgerAppendEntry>,
+  slot: number,
+): ledgerAppendEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Merge one cursor for the ledger-append stage. */
+export function mergeCursor072(
+  entries: ReadonlyArray<ledgerAppendEntry>,
+  slot: number,
+): ledgerAppendEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Filter one cursor for the ledger-append stage. */
+export function filterCursor073(
+  entries: ReadonlyArray<ledgerAppendEntry>,
+  slot: number,
+): ledgerAppendEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+

--- a/test-fixtures/gate-acceptance/manifest-reader.ts
+++ b/test-fixtures/gate-acceptance/manifest-reader.ts
@@ -1,0 +1,1500 @@
+// Acceptance corpus for the pull request review gate.
+//
+// This file is synthetic and is not part of the shipped package. It
+// exists so that one pull request is large enough to exercise two
+// limits at once: the diff API's 20,000-changed-line ceiling, and the
+// review request budget above which the gate splits a change into
+// batches. This pull request is opened to exercise them and closed
+// again; it is not merged.
+
+export interface manifestReaderEntry {
+  readonly key: string;
+  readonly slot: number;
+  readonly active: boolean;
+}
+
+export interface manifestReaderState {
+  readonly entries: ReadonlyArray<manifestReaderEntry>;
+  readonly total: number;
+}
+
+/** Collect one entry for the manifest-reader stage. */
+export function collectEntry000(
+  entries: ReadonlyArray<manifestReaderEntry>,
+  slot: number,
+): manifestReaderEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Resolve one entry for the manifest-reader stage. */
+export function resolveEntry001(
+  entries: ReadonlyArray<manifestReaderEntry>,
+  slot: number,
+): manifestReaderEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Merge one entry for the manifest-reader stage. */
+export function mergeEntry002(
+  entries: ReadonlyArray<manifestReaderEntry>,
+  slot: number,
+): manifestReaderEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Filter one entry for the manifest-reader stage. */
+export function filterEntry003(
+  entries: ReadonlyArray<manifestReaderEntry>,
+  slot: number,
+): manifestReaderEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Reduce one entry for the manifest-reader stage. */
+export function reduceEntry004(
+  entries: ReadonlyArray<manifestReaderEntry>,
+  slot: number,
+): manifestReaderEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Expand one entry for the manifest-reader stage. */
+export function expandEntry005(
+  entries: ReadonlyArray<manifestReaderEntry>,
+  slot: number,
+): manifestReaderEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Normalise one entry for the manifest-reader stage. */
+export function normaliseEntry006(
+  entries: ReadonlyArray<manifestReaderEntry>,
+  slot: number,
+): manifestReaderEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Compare one entry for the manifest-reader stage. */
+export function compareEntry007(
+  entries: ReadonlyArray<manifestReaderEntry>,
+  slot: number,
+): manifestReaderEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Select one entry for the manifest-reader stage. */
+export function selectEntry008(
+  entries: ReadonlyArray<manifestReaderEntry>,
+  slot: number,
+): manifestReaderEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Record one entry for the manifest-reader stage. */
+export function recordEntry009(
+  entries: ReadonlyArray<manifestReaderEntry>,
+  slot: number,
+): manifestReaderEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Collect one record for the manifest-reader stage. */
+export function collectRecord010(
+  entries: ReadonlyArray<manifestReaderEntry>,
+  slot: number,
+): manifestReaderEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Resolve one record for the manifest-reader stage. */
+export function resolveRecord011(
+  entries: ReadonlyArray<manifestReaderEntry>,
+  slot: number,
+): manifestReaderEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Merge one record for the manifest-reader stage. */
+export function mergeRecord012(
+  entries: ReadonlyArray<manifestReaderEntry>,
+  slot: number,
+): manifestReaderEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Filter one record for the manifest-reader stage. */
+export function filterRecord013(
+  entries: ReadonlyArray<manifestReaderEntry>,
+  slot: number,
+): manifestReaderEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Reduce one record for the manifest-reader stage. */
+export function reduceRecord014(
+  entries: ReadonlyArray<manifestReaderEntry>,
+  slot: number,
+): manifestReaderEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Expand one record for the manifest-reader stage. */
+export function expandRecord015(
+  entries: ReadonlyArray<manifestReaderEntry>,
+  slot: number,
+): manifestReaderEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Normalise one record for the manifest-reader stage. */
+export function normaliseRecord016(
+  entries: ReadonlyArray<manifestReaderEntry>,
+  slot: number,
+): manifestReaderEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Compare one record for the manifest-reader stage. */
+export function compareRecord017(
+  entries: ReadonlyArray<manifestReaderEntry>,
+  slot: number,
+): manifestReaderEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Select one record for the manifest-reader stage. */
+export function selectRecord018(
+  entries: ReadonlyArray<manifestReaderEntry>,
+  slot: number,
+): manifestReaderEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Record one record for the manifest-reader stage. */
+export function recordRecord019(
+  entries: ReadonlyArray<manifestReaderEntry>,
+  slot: number,
+): manifestReaderEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Collect one bucket for the manifest-reader stage. */
+export function collectBucket020(
+  entries: ReadonlyArray<manifestReaderEntry>,
+  slot: number,
+): manifestReaderEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Resolve one bucket for the manifest-reader stage. */
+export function resolveBucket021(
+  entries: ReadonlyArray<manifestReaderEntry>,
+  slot: number,
+): manifestReaderEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Merge one bucket for the manifest-reader stage. */
+export function mergeBucket022(
+  entries: ReadonlyArray<manifestReaderEntry>,
+  slot: number,
+): manifestReaderEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Filter one bucket for the manifest-reader stage. */
+export function filterBucket023(
+  entries: ReadonlyArray<manifestReaderEntry>,
+  slot: number,
+): manifestReaderEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Reduce one bucket for the manifest-reader stage. */
+export function reduceBucket024(
+  entries: ReadonlyArray<manifestReaderEntry>,
+  slot: number,
+): manifestReaderEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Expand one bucket for the manifest-reader stage. */
+export function expandBucket025(
+  entries: ReadonlyArray<manifestReaderEntry>,
+  slot: number,
+): manifestReaderEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Normalise one bucket for the manifest-reader stage. */
+export function normaliseBucket026(
+  entries: ReadonlyArray<manifestReaderEntry>,
+  slot: number,
+): manifestReaderEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Compare one bucket for the manifest-reader stage. */
+export function compareBucket027(
+  entries: ReadonlyArray<manifestReaderEntry>,
+  slot: number,
+): manifestReaderEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Select one bucket for the manifest-reader stage. */
+export function selectBucket028(
+  entries: ReadonlyArray<manifestReaderEntry>,
+  slot: number,
+): manifestReaderEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Record one bucket for the manifest-reader stage. */
+export function recordBucket029(
+  entries: ReadonlyArray<manifestReaderEntry>,
+  slot: number,
+): manifestReaderEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Collect one segment for the manifest-reader stage. */
+export function collectSegment030(
+  entries: ReadonlyArray<manifestReaderEntry>,
+  slot: number,
+): manifestReaderEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Resolve one segment for the manifest-reader stage. */
+export function resolveSegment031(
+  entries: ReadonlyArray<manifestReaderEntry>,
+  slot: number,
+): manifestReaderEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Merge one segment for the manifest-reader stage. */
+export function mergeSegment032(
+  entries: ReadonlyArray<manifestReaderEntry>,
+  slot: number,
+): manifestReaderEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Filter one segment for the manifest-reader stage. */
+export function filterSegment033(
+  entries: ReadonlyArray<manifestReaderEntry>,
+  slot: number,
+): manifestReaderEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Reduce one segment for the manifest-reader stage. */
+export function reduceSegment034(
+  entries: ReadonlyArray<manifestReaderEntry>,
+  slot: number,
+): manifestReaderEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Expand one segment for the manifest-reader stage. */
+export function expandSegment035(
+  entries: ReadonlyArray<manifestReaderEntry>,
+  slot: number,
+): manifestReaderEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Normalise one segment for the manifest-reader stage. */
+export function normaliseSegment036(
+  entries: ReadonlyArray<manifestReaderEntry>,
+  slot: number,
+): manifestReaderEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Compare one segment for the manifest-reader stage. */
+export function compareSegment037(
+  entries: ReadonlyArray<manifestReaderEntry>,
+  slot: number,
+): manifestReaderEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Select one segment for the manifest-reader stage. */
+export function selectSegment038(
+  entries: ReadonlyArray<manifestReaderEntry>,
+  slot: number,
+): manifestReaderEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Record one segment for the manifest-reader stage. */
+export function recordSegment039(
+  entries: ReadonlyArray<manifestReaderEntry>,
+  slot: number,
+): manifestReaderEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Collect one window for the manifest-reader stage. */
+export function collectWindow040(
+  entries: ReadonlyArray<manifestReaderEntry>,
+  slot: number,
+): manifestReaderEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Resolve one window for the manifest-reader stage. */
+export function resolveWindow041(
+  entries: ReadonlyArray<manifestReaderEntry>,
+  slot: number,
+): manifestReaderEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Merge one window for the manifest-reader stage. */
+export function mergeWindow042(
+  entries: ReadonlyArray<manifestReaderEntry>,
+  slot: number,
+): manifestReaderEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Filter one window for the manifest-reader stage. */
+export function filterWindow043(
+  entries: ReadonlyArray<manifestReaderEntry>,
+  slot: number,
+): manifestReaderEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Reduce one window for the manifest-reader stage. */
+export function reduceWindow044(
+  entries: ReadonlyArray<manifestReaderEntry>,
+  slot: number,
+): manifestReaderEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Expand one window for the manifest-reader stage. */
+export function expandWindow045(
+  entries: ReadonlyArray<manifestReaderEntry>,
+  slot: number,
+): manifestReaderEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Normalise one window for the manifest-reader stage. */
+export function normaliseWindow046(
+  entries: ReadonlyArray<manifestReaderEntry>,
+  slot: number,
+): manifestReaderEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Compare one window for the manifest-reader stage. */
+export function compareWindow047(
+  entries: ReadonlyArray<manifestReaderEntry>,
+  slot: number,
+): manifestReaderEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Select one window for the manifest-reader stage. */
+export function selectWindow048(
+  entries: ReadonlyArray<manifestReaderEntry>,
+  slot: number,
+): manifestReaderEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Record one window for the manifest-reader stage. */
+export function recordWindow049(
+  entries: ReadonlyArray<manifestReaderEntry>,
+  slot: number,
+): manifestReaderEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Collect one marker for the manifest-reader stage. */
+export function collectMarker050(
+  entries: ReadonlyArray<manifestReaderEntry>,
+  slot: number,
+): manifestReaderEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Resolve one marker for the manifest-reader stage. */
+export function resolveMarker051(
+  entries: ReadonlyArray<manifestReaderEntry>,
+  slot: number,
+): manifestReaderEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Merge one marker for the manifest-reader stage. */
+export function mergeMarker052(
+  entries: ReadonlyArray<manifestReaderEntry>,
+  slot: number,
+): manifestReaderEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Filter one marker for the manifest-reader stage. */
+export function filterMarker053(
+  entries: ReadonlyArray<manifestReaderEntry>,
+  slot: number,
+): manifestReaderEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Reduce one marker for the manifest-reader stage. */
+export function reduceMarker054(
+  entries: ReadonlyArray<manifestReaderEntry>,
+  slot: number,
+): manifestReaderEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Expand one marker for the manifest-reader stage. */
+export function expandMarker055(
+  entries: ReadonlyArray<manifestReaderEntry>,
+  slot: number,
+): manifestReaderEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Normalise one marker for the manifest-reader stage. */
+export function normaliseMarker056(
+  entries: ReadonlyArray<manifestReaderEntry>,
+  slot: number,
+): manifestReaderEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Compare one marker for the manifest-reader stage. */
+export function compareMarker057(
+  entries: ReadonlyArray<manifestReaderEntry>,
+  slot: number,
+): manifestReaderEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Select one marker for the manifest-reader stage. */
+export function selectMarker058(
+  entries: ReadonlyArray<manifestReaderEntry>,
+  slot: number,
+): manifestReaderEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Record one marker for the manifest-reader stage. */
+export function recordMarker059(
+  entries: ReadonlyArray<manifestReaderEntry>,
+  slot: number,
+): manifestReaderEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Collect one handle for the manifest-reader stage. */
+export function collectHandle060(
+  entries: ReadonlyArray<manifestReaderEntry>,
+  slot: number,
+): manifestReaderEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Resolve one handle for the manifest-reader stage. */
+export function resolveHandle061(
+  entries: ReadonlyArray<manifestReaderEntry>,
+  slot: number,
+): manifestReaderEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Merge one handle for the manifest-reader stage. */
+export function mergeHandle062(
+  entries: ReadonlyArray<manifestReaderEntry>,
+  slot: number,
+): manifestReaderEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Filter one handle for the manifest-reader stage. */
+export function filterHandle063(
+  entries: ReadonlyArray<manifestReaderEntry>,
+  slot: number,
+): manifestReaderEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Reduce one handle for the manifest-reader stage. */
+export function reduceHandle064(
+  entries: ReadonlyArray<manifestReaderEntry>,
+  slot: number,
+): manifestReaderEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Expand one handle for the manifest-reader stage. */
+export function expandHandle065(
+  entries: ReadonlyArray<manifestReaderEntry>,
+  slot: number,
+): manifestReaderEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Normalise one handle for the manifest-reader stage. */
+export function normaliseHandle066(
+  entries: ReadonlyArray<manifestReaderEntry>,
+  slot: number,
+): manifestReaderEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Compare one handle for the manifest-reader stage. */
+export function compareHandle067(
+  entries: ReadonlyArray<manifestReaderEntry>,
+  slot: number,
+): manifestReaderEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Select one handle for the manifest-reader stage. */
+export function selectHandle068(
+  entries: ReadonlyArray<manifestReaderEntry>,
+  slot: number,
+): manifestReaderEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Record one handle for the manifest-reader stage. */
+export function recordHandle069(
+  entries: ReadonlyArray<manifestReaderEntry>,
+  slot: number,
+): manifestReaderEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Collect one cursor for the manifest-reader stage. */
+export function collectCursor070(
+  entries: ReadonlyArray<manifestReaderEntry>,
+  slot: number,
+): manifestReaderEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Resolve one cursor for the manifest-reader stage. */
+export function resolveCursor071(
+  entries: ReadonlyArray<manifestReaderEntry>,
+  slot: number,
+): manifestReaderEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Merge one cursor for the manifest-reader stage. */
+export function mergeCursor072(
+  entries: ReadonlyArray<manifestReaderEntry>,
+  slot: number,
+): manifestReaderEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Filter one cursor for the manifest-reader stage. */
+export function filterCursor073(
+  entries: ReadonlyArray<manifestReaderEntry>,
+  slot: number,
+): manifestReaderEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+

--- a/test-fixtures/gate-acceptance/path-resolver.ts
+++ b/test-fixtures/gate-acceptance/path-resolver.ts
@@ -1,0 +1,1500 @@
+// Acceptance corpus for the pull request review gate.
+//
+// This file is synthetic and is not part of the shipped package. It
+// exists so that one pull request is large enough to exercise two
+// limits at once: the diff API's 20,000-changed-line ceiling, and the
+// review request budget above which the gate splits a change into
+// batches. This pull request is opened to exercise them and closed
+// again; it is not merged.
+
+export interface pathResolverEntry {
+  readonly key: string;
+  readonly slot: number;
+  readonly active: boolean;
+}
+
+export interface pathResolverState {
+  readonly entries: ReadonlyArray<pathResolverEntry>;
+  readonly total: number;
+}
+
+/** Collect one entry for the path-resolver stage. */
+export function collectEntry000(
+  entries: ReadonlyArray<pathResolverEntry>,
+  slot: number,
+): pathResolverEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Resolve one entry for the path-resolver stage. */
+export function resolveEntry001(
+  entries: ReadonlyArray<pathResolverEntry>,
+  slot: number,
+): pathResolverEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Merge one entry for the path-resolver stage. */
+export function mergeEntry002(
+  entries: ReadonlyArray<pathResolverEntry>,
+  slot: number,
+): pathResolverEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Filter one entry for the path-resolver stage. */
+export function filterEntry003(
+  entries: ReadonlyArray<pathResolverEntry>,
+  slot: number,
+): pathResolverEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Reduce one entry for the path-resolver stage. */
+export function reduceEntry004(
+  entries: ReadonlyArray<pathResolverEntry>,
+  slot: number,
+): pathResolverEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Expand one entry for the path-resolver stage. */
+export function expandEntry005(
+  entries: ReadonlyArray<pathResolverEntry>,
+  slot: number,
+): pathResolverEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Normalise one entry for the path-resolver stage. */
+export function normaliseEntry006(
+  entries: ReadonlyArray<pathResolverEntry>,
+  slot: number,
+): pathResolverEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Compare one entry for the path-resolver stage. */
+export function compareEntry007(
+  entries: ReadonlyArray<pathResolverEntry>,
+  slot: number,
+): pathResolverEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Select one entry for the path-resolver stage. */
+export function selectEntry008(
+  entries: ReadonlyArray<pathResolverEntry>,
+  slot: number,
+): pathResolverEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Record one entry for the path-resolver stage. */
+export function recordEntry009(
+  entries: ReadonlyArray<pathResolverEntry>,
+  slot: number,
+): pathResolverEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Collect one record for the path-resolver stage. */
+export function collectRecord010(
+  entries: ReadonlyArray<pathResolverEntry>,
+  slot: number,
+): pathResolverEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Resolve one record for the path-resolver stage. */
+export function resolveRecord011(
+  entries: ReadonlyArray<pathResolverEntry>,
+  slot: number,
+): pathResolverEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Merge one record for the path-resolver stage. */
+export function mergeRecord012(
+  entries: ReadonlyArray<pathResolverEntry>,
+  slot: number,
+): pathResolverEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Filter one record for the path-resolver stage. */
+export function filterRecord013(
+  entries: ReadonlyArray<pathResolverEntry>,
+  slot: number,
+): pathResolverEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Reduce one record for the path-resolver stage. */
+export function reduceRecord014(
+  entries: ReadonlyArray<pathResolverEntry>,
+  slot: number,
+): pathResolverEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Expand one record for the path-resolver stage. */
+export function expandRecord015(
+  entries: ReadonlyArray<pathResolverEntry>,
+  slot: number,
+): pathResolverEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Normalise one record for the path-resolver stage. */
+export function normaliseRecord016(
+  entries: ReadonlyArray<pathResolverEntry>,
+  slot: number,
+): pathResolverEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Compare one record for the path-resolver stage. */
+export function compareRecord017(
+  entries: ReadonlyArray<pathResolverEntry>,
+  slot: number,
+): pathResolverEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Select one record for the path-resolver stage. */
+export function selectRecord018(
+  entries: ReadonlyArray<pathResolverEntry>,
+  slot: number,
+): pathResolverEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Record one record for the path-resolver stage. */
+export function recordRecord019(
+  entries: ReadonlyArray<pathResolverEntry>,
+  slot: number,
+): pathResolverEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Collect one bucket for the path-resolver stage. */
+export function collectBucket020(
+  entries: ReadonlyArray<pathResolverEntry>,
+  slot: number,
+): pathResolverEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Resolve one bucket for the path-resolver stage. */
+export function resolveBucket021(
+  entries: ReadonlyArray<pathResolverEntry>,
+  slot: number,
+): pathResolverEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Merge one bucket for the path-resolver stage. */
+export function mergeBucket022(
+  entries: ReadonlyArray<pathResolverEntry>,
+  slot: number,
+): pathResolverEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Filter one bucket for the path-resolver stage. */
+export function filterBucket023(
+  entries: ReadonlyArray<pathResolverEntry>,
+  slot: number,
+): pathResolverEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Reduce one bucket for the path-resolver stage. */
+export function reduceBucket024(
+  entries: ReadonlyArray<pathResolverEntry>,
+  slot: number,
+): pathResolverEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Expand one bucket for the path-resolver stage. */
+export function expandBucket025(
+  entries: ReadonlyArray<pathResolverEntry>,
+  slot: number,
+): pathResolverEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Normalise one bucket for the path-resolver stage. */
+export function normaliseBucket026(
+  entries: ReadonlyArray<pathResolverEntry>,
+  slot: number,
+): pathResolverEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Compare one bucket for the path-resolver stage. */
+export function compareBucket027(
+  entries: ReadonlyArray<pathResolverEntry>,
+  slot: number,
+): pathResolverEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Select one bucket for the path-resolver stage. */
+export function selectBucket028(
+  entries: ReadonlyArray<pathResolverEntry>,
+  slot: number,
+): pathResolverEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Record one bucket for the path-resolver stage. */
+export function recordBucket029(
+  entries: ReadonlyArray<pathResolverEntry>,
+  slot: number,
+): pathResolverEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Collect one segment for the path-resolver stage. */
+export function collectSegment030(
+  entries: ReadonlyArray<pathResolverEntry>,
+  slot: number,
+): pathResolverEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Resolve one segment for the path-resolver stage. */
+export function resolveSegment031(
+  entries: ReadonlyArray<pathResolverEntry>,
+  slot: number,
+): pathResolverEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Merge one segment for the path-resolver stage. */
+export function mergeSegment032(
+  entries: ReadonlyArray<pathResolverEntry>,
+  slot: number,
+): pathResolverEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Filter one segment for the path-resolver stage. */
+export function filterSegment033(
+  entries: ReadonlyArray<pathResolverEntry>,
+  slot: number,
+): pathResolverEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Reduce one segment for the path-resolver stage. */
+export function reduceSegment034(
+  entries: ReadonlyArray<pathResolverEntry>,
+  slot: number,
+): pathResolverEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Expand one segment for the path-resolver stage. */
+export function expandSegment035(
+  entries: ReadonlyArray<pathResolverEntry>,
+  slot: number,
+): pathResolverEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Normalise one segment for the path-resolver stage. */
+export function normaliseSegment036(
+  entries: ReadonlyArray<pathResolverEntry>,
+  slot: number,
+): pathResolverEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Compare one segment for the path-resolver stage. */
+export function compareSegment037(
+  entries: ReadonlyArray<pathResolverEntry>,
+  slot: number,
+): pathResolverEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Select one segment for the path-resolver stage. */
+export function selectSegment038(
+  entries: ReadonlyArray<pathResolverEntry>,
+  slot: number,
+): pathResolverEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Record one segment for the path-resolver stage. */
+export function recordSegment039(
+  entries: ReadonlyArray<pathResolverEntry>,
+  slot: number,
+): pathResolverEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Collect one window for the path-resolver stage. */
+export function collectWindow040(
+  entries: ReadonlyArray<pathResolverEntry>,
+  slot: number,
+): pathResolverEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Resolve one window for the path-resolver stage. */
+export function resolveWindow041(
+  entries: ReadonlyArray<pathResolverEntry>,
+  slot: number,
+): pathResolverEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Merge one window for the path-resolver stage. */
+export function mergeWindow042(
+  entries: ReadonlyArray<pathResolverEntry>,
+  slot: number,
+): pathResolverEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Filter one window for the path-resolver stage. */
+export function filterWindow043(
+  entries: ReadonlyArray<pathResolverEntry>,
+  slot: number,
+): pathResolverEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Reduce one window for the path-resolver stage. */
+export function reduceWindow044(
+  entries: ReadonlyArray<pathResolverEntry>,
+  slot: number,
+): pathResolverEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Expand one window for the path-resolver stage. */
+export function expandWindow045(
+  entries: ReadonlyArray<pathResolverEntry>,
+  slot: number,
+): pathResolverEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Normalise one window for the path-resolver stage. */
+export function normaliseWindow046(
+  entries: ReadonlyArray<pathResolverEntry>,
+  slot: number,
+): pathResolverEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Compare one window for the path-resolver stage. */
+export function compareWindow047(
+  entries: ReadonlyArray<pathResolverEntry>,
+  slot: number,
+): pathResolverEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Select one window for the path-resolver stage. */
+export function selectWindow048(
+  entries: ReadonlyArray<pathResolverEntry>,
+  slot: number,
+): pathResolverEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Record one window for the path-resolver stage. */
+export function recordWindow049(
+  entries: ReadonlyArray<pathResolverEntry>,
+  slot: number,
+): pathResolverEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Collect one marker for the path-resolver stage. */
+export function collectMarker050(
+  entries: ReadonlyArray<pathResolverEntry>,
+  slot: number,
+): pathResolverEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Resolve one marker for the path-resolver stage. */
+export function resolveMarker051(
+  entries: ReadonlyArray<pathResolverEntry>,
+  slot: number,
+): pathResolverEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Merge one marker for the path-resolver stage. */
+export function mergeMarker052(
+  entries: ReadonlyArray<pathResolverEntry>,
+  slot: number,
+): pathResolverEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Filter one marker for the path-resolver stage. */
+export function filterMarker053(
+  entries: ReadonlyArray<pathResolverEntry>,
+  slot: number,
+): pathResolverEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Reduce one marker for the path-resolver stage. */
+export function reduceMarker054(
+  entries: ReadonlyArray<pathResolverEntry>,
+  slot: number,
+): pathResolverEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Expand one marker for the path-resolver stage. */
+export function expandMarker055(
+  entries: ReadonlyArray<pathResolverEntry>,
+  slot: number,
+): pathResolverEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Normalise one marker for the path-resolver stage. */
+export function normaliseMarker056(
+  entries: ReadonlyArray<pathResolverEntry>,
+  slot: number,
+): pathResolverEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Compare one marker for the path-resolver stage. */
+export function compareMarker057(
+  entries: ReadonlyArray<pathResolverEntry>,
+  slot: number,
+): pathResolverEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Select one marker for the path-resolver stage. */
+export function selectMarker058(
+  entries: ReadonlyArray<pathResolverEntry>,
+  slot: number,
+): pathResolverEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Record one marker for the path-resolver stage. */
+export function recordMarker059(
+  entries: ReadonlyArray<pathResolverEntry>,
+  slot: number,
+): pathResolverEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Collect one handle for the path-resolver stage. */
+export function collectHandle060(
+  entries: ReadonlyArray<pathResolverEntry>,
+  slot: number,
+): pathResolverEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Resolve one handle for the path-resolver stage. */
+export function resolveHandle061(
+  entries: ReadonlyArray<pathResolverEntry>,
+  slot: number,
+): pathResolverEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Merge one handle for the path-resolver stage. */
+export function mergeHandle062(
+  entries: ReadonlyArray<pathResolverEntry>,
+  slot: number,
+): pathResolverEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Filter one handle for the path-resolver stage. */
+export function filterHandle063(
+  entries: ReadonlyArray<pathResolverEntry>,
+  slot: number,
+): pathResolverEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Reduce one handle for the path-resolver stage. */
+export function reduceHandle064(
+  entries: ReadonlyArray<pathResolverEntry>,
+  slot: number,
+): pathResolverEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Expand one handle for the path-resolver stage. */
+export function expandHandle065(
+  entries: ReadonlyArray<pathResolverEntry>,
+  slot: number,
+): pathResolverEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Normalise one handle for the path-resolver stage. */
+export function normaliseHandle066(
+  entries: ReadonlyArray<pathResolverEntry>,
+  slot: number,
+): pathResolverEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Compare one handle for the path-resolver stage. */
+export function compareHandle067(
+  entries: ReadonlyArray<pathResolverEntry>,
+  slot: number,
+): pathResolverEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Select one handle for the path-resolver stage. */
+export function selectHandle068(
+  entries: ReadonlyArray<pathResolverEntry>,
+  slot: number,
+): pathResolverEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Record one handle for the path-resolver stage. */
+export function recordHandle069(
+  entries: ReadonlyArray<pathResolverEntry>,
+  slot: number,
+): pathResolverEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Collect one cursor for the path-resolver stage. */
+export function collectCursor070(
+  entries: ReadonlyArray<pathResolverEntry>,
+  slot: number,
+): pathResolverEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Resolve one cursor for the path-resolver stage. */
+export function resolveCursor071(
+  entries: ReadonlyArray<pathResolverEntry>,
+  slot: number,
+): pathResolverEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Merge one cursor for the path-resolver stage. */
+export function mergeCursor072(
+  entries: ReadonlyArray<pathResolverEntry>,
+  slot: number,
+): pathResolverEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Filter one cursor for the path-resolver stage. */
+export function filterCursor073(
+  entries: ReadonlyArray<pathResolverEntry>,
+  slot: number,
+): pathResolverEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+

--- a/test-fixtures/gate-acceptance/policy-loader.ts
+++ b/test-fixtures/gate-acceptance/policy-loader.ts
@@ -1,0 +1,1500 @@
+// Acceptance corpus for the pull request review gate.
+//
+// This file is synthetic and is not part of the shipped package. It
+// exists so that one pull request is large enough to exercise two
+// limits at once: the diff API's 20,000-changed-line ceiling, and the
+// review request budget above which the gate splits a change into
+// batches. This pull request is opened to exercise them and closed
+// again; it is not merged.
+
+export interface policyLoaderEntry {
+  readonly key: string;
+  readonly slot: number;
+  readonly active: boolean;
+}
+
+export interface policyLoaderState {
+  readonly entries: ReadonlyArray<policyLoaderEntry>;
+  readonly total: number;
+}
+
+/** Collect one entry for the policy-loader stage. */
+export function collectEntry000(
+  entries: ReadonlyArray<policyLoaderEntry>,
+  slot: number,
+): policyLoaderEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Resolve one entry for the policy-loader stage. */
+export function resolveEntry001(
+  entries: ReadonlyArray<policyLoaderEntry>,
+  slot: number,
+): policyLoaderEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Merge one entry for the policy-loader stage. */
+export function mergeEntry002(
+  entries: ReadonlyArray<policyLoaderEntry>,
+  slot: number,
+): policyLoaderEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Filter one entry for the policy-loader stage. */
+export function filterEntry003(
+  entries: ReadonlyArray<policyLoaderEntry>,
+  slot: number,
+): policyLoaderEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Reduce one entry for the policy-loader stage. */
+export function reduceEntry004(
+  entries: ReadonlyArray<policyLoaderEntry>,
+  slot: number,
+): policyLoaderEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Expand one entry for the policy-loader stage. */
+export function expandEntry005(
+  entries: ReadonlyArray<policyLoaderEntry>,
+  slot: number,
+): policyLoaderEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Normalise one entry for the policy-loader stage. */
+export function normaliseEntry006(
+  entries: ReadonlyArray<policyLoaderEntry>,
+  slot: number,
+): policyLoaderEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Compare one entry for the policy-loader stage. */
+export function compareEntry007(
+  entries: ReadonlyArray<policyLoaderEntry>,
+  slot: number,
+): policyLoaderEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Select one entry for the policy-loader stage. */
+export function selectEntry008(
+  entries: ReadonlyArray<policyLoaderEntry>,
+  slot: number,
+): policyLoaderEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Record one entry for the policy-loader stage. */
+export function recordEntry009(
+  entries: ReadonlyArray<policyLoaderEntry>,
+  slot: number,
+): policyLoaderEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Collect one record for the policy-loader stage. */
+export function collectRecord010(
+  entries: ReadonlyArray<policyLoaderEntry>,
+  slot: number,
+): policyLoaderEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Resolve one record for the policy-loader stage. */
+export function resolveRecord011(
+  entries: ReadonlyArray<policyLoaderEntry>,
+  slot: number,
+): policyLoaderEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Merge one record for the policy-loader stage. */
+export function mergeRecord012(
+  entries: ReadonlyArray<policyLoaderEntry>,
+  slot: number,
+): policyLoaderEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Filter one record for the policy-loader stage. */
+export function filterRecord013(
+  entries: ReadonlyArray<policyLoaderEntry>,
+  slot: number,
+): policyLoaderEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Reduce one record for the policy-loader stage. */
+export function reduceRecord014(
+  entries: ReadonlyArray<policyLoaderEntry>,
+  slot: number,
+): policyLoaderEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Expand one record for the policy-loader stage. */
+export function expandRecord015(
+  entries: ReadonlyArray<policyLoaderEntry>,
+  slot: number,
+): policyLoaderEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Normalise one record for the policy-loader stage. */
+export function normaliseRecord016(
+  entries: ReadonlyArray<policyLoaderEntry>,
+  slot: number,
+): policyLoaderEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Compare one record for the policy-loader stage. */
+export function compareRecord017(
+  entries: ReadonlyArray<policyLoaderEntry>,
+  slot: number,
+): policyLoaderEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Select one record for the policy-loader stage. */
+export function selectRecord018(
+  entries: ReadonlyArray<policyLoaderEntry>,
+  slot: number,
+): policyLoaderEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Record one record for the policy-loader stage. */
+export function recordRecord019(
+  entries: ReadonlyArray<policyLoaderEntry>,
+  slot: number,
+): policyLoaderEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Collect one bucket for the policy-loader stage. */
+export function collectBucket020(
+  entries: ReadonlyArray<policyLoaderEntry>,
+  slot: number,
+): policyLoaderEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Resolve one bucket for the policy-loader stage. */
+export function resolveBucket021(
+  entries: ReadonlyArray<policyLoaderEntry>,
+  slot: number,
+): policyLoaderEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Merge one bucket for the policy-loader stage. */
+export function mergeBucket022(
+  entries: ReadonlyArray<policyLoaderEntry>,
+  slot: number,
+): policyLoaderEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Filter one bucket for the policy-loader stage. */
+export function filterBucket023(
+  entries: ReadonlyArray<policyLoaderEntry>,
+  slot: number,
+): policyLoaderEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Reduce one bucket for the policy-loader stage. */
+export function reduceBucket024(
+  entries: ReadonlyArray<policyLoaderEntry>,
+  slot: number,
+): policyLoaderEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Expand one bucket for the policy-loader stage. */
+export function expandBucket025(
+  entries: ReadonlyArray<policyLoaderEntry>,
+  slot: number,
+): policyLoaderEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Normalise one bucket for the policy-loader stage. */
+export function normaliseBucket026(
+  entries: ReadonlyArray<policyLoaderEntry>,
+  slot: number,
+): policyLoaderEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Compare one bucket for the policy-loader stage. */
+export function compareBucket027(
+  entries: ReadonlyArray<policyLoaderEntry>,
+  slot: number,
+): policyLoaderEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Select one bucket for the policy-loader stage. */
+export function selectBucket028(
+  entries: ReadonlyArray<policyLoaderEntry>,
+  slot: number,
+): policyLoaderEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Record one bucket for the policy-loader stage. */
+export function recordBucket029(
+  entries: ReadonlyArray<policyLoaderEntry>,
+  slot: number,
+): policyLoaderEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Collect one segment for the policy-loader stage. */
+export function collectSegment030(
+  entries: ReadonlyArray<policyLoaderEntry>,
+  slot: number,
+): policyLoaderEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Resolve one segment for the policy-loader stage. */
+export function resolveSegment031(
+  entries: ReadonlyArray<policyLoaderEntry>,
+  slot: number,
+): policyLoaderEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Merge one segment for the policy-loader stage. */
+export function mergeSegment032(
+  entries: ReadonlyArray<policyLoaderEntry>,
+  slot: number,
+): policyLoaderEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Filter one segment for the policy-loader stage. */
+export function filterSegment033(
+  entries: ReadonlyArray<policyLoaderEntry>,
+  slot: number,
+): policyLoaderEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Reduce one segment for the policy-loader stage. */
+export function reduceSegment034(
+  entries: ReadonlyArray<policyLoaderEntry>,
+  slot: number,
+): policyLoaderEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Expand one segment for the policy-loader stage. */
+export function expandSegment035(
+  entries: ReadonlyArray<policyLoaderEntry>,
+  slot: number,
+): policyLoaderEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Normalise one segment for the policy-loader stage. */
+export function normaliseSegment036(
+  entries: ReadonlyArray<policyLoaderEntry>,
+  slot: number,
+): policyLoaderEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Compare one segment for the policy-loader stage. */
+export function compareSegment037(
+  entries: ReadonlyArray<policyLoaderEntry>,
+  slot: number,
+): policyLoaderEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Select one segment for the policy-loader stage. */
+export function selectSegment038(
+  entries: ReadonlyArray<policyLoaderEntry>,
+  slot: number,
+): policyLoaderEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Record one segment for the policy-loader stage. */
+export function recordSegment039(
+  entries: ReadonlyArray<policyLoaderEntry>,
+  slot: number,
+): policyLoaderEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Collect one window for the policy-loader stage. */
+export function collectWindow040(
+  entries: ReadonlyArray<policyLoaderEntry>,
+  slot: number,
+): policyLoaderEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Resolve one window for the policy-loader stage. */
+export function resolveWindow041(
+  entries: ReadonlyArray<policyLoaderEntry>,
+  slot: number,
+): policyLoaderEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Merge one window for the policy-loader stage. */
+export function mergeWindow042(
+  entries: ReadonlyArray<policyLoaderEntry>,
+  slot: number,
+): policyLoaderEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Filter one window for the policy-loader stage. */
+export function filterWindow043(
+  entries: ReadonlyArray<policyLoaderEntry>,
+  slot: number,
+): policyLoaderEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Reduce one window for the policy-loader stage. */
+export function reduceWindow044(
+  entries: ReadonlyArray<policyLoaderEntry>,
+  slot: number,
+): policyLoaderEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Expand one window for the policy-loader stage. */
+export function expandWindow045(
+  entries: ReadonlyArray<policyLoaderEntry>,
+  slot: number,
+): policyLoaderEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Normalise one window for the policy-loader stage. */
+export function normaliseWindow046(
+  entries: ReadonlyArray<policyLoaderEntry>,
+  slot: number,
+): policyLoaderEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Compare one window for the policy-loader stage. */
+export function compareWindow047(
+  entries: ReadonlyArray<policyLoaderEntry>,
+  slot: number,
+): policyLoaderEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Select one window for the policy-loader stage. */
+export function selectWindow048(
+  entries: ReadonlyArray<policyLoaderEntry>,
+  slot: number,
+): policyLoaderEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Record one window for the policy-loader stage. */
+export function recordWindow049(
+  entries: ReadonlyArray<policyLoaderEntry>,
+  slot: number,
+): policyLoaderEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Collect one marker for the policy-loader stage. */
+export function collectMarker050(
+  entries: ReadonlyArray<policyLoaderEntry>,
+  slot: number,
+): policyLoaderEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Resolve one marker for the policy-loader stage. */
+export function resolveMarker051(
+  entries: ReadonlyArray<policyLoaderEntry>,
+  slot: number,
+): policyLoaderEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Merge one marker for the policy-loader stage. */
+export function mergeMarker052(
+  entries: ReadonlyArray<policyLoaderEntry>,
+  slot: number,
+): policyLoaderEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Filter one marker for the policy-loader stage. */
+export function filterMarker053(
+  entries: ReadonlyArray<policyLoaderEntry>,
+  slot: number,
+): policyLoaderEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Reduce one marker for the policy-loader stage. */
+export function reduceMarker054(
+  entries: ReadonlyArray<policyLoaderEntry>,
+  slot: number,
+): policyLoaderEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Expand one marker for the policy-loader stage. */
+export function expandMarker055(
+  entries: ReadonlyArray<policyLoaderEntry>,
+  slot: number,
+): policyLoaderEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Normalise one marker for the policy-loader stage. */
+export function normaliseMarker056(
+  entries: ReadonlyArray<policyLoaderEntry>,
+  slot: number,
+): policyLoaderEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Compare one marker for the policy-loader stage. */
+export function compareMarker057(
+  entries: ReadonlyArray<policyLoaderEntry>,
+  slot: number,
+): policyLoaderEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Select one marker for the policy-loader stage. */
+export function selectMarker058(
+  entries: ReadonlyArray<policyLoaderEntry>,
+  slot: number,
+): policyLoaderEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Record one marker for the policy-loader stage. */
+export function recordMarker059(
+  entries: ReadonlyArray<policyLoaderEntry>,
+  slot: number,
+): policyLoaderEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Collect one handle for the policy-loader stage. */
+export function collectHandle060(
+  entries: ReadonlyArray<policyLoaderEntry>,
+  slot: number,
+): policyLoaderEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Resolve one handle for the policy-loader stage. */
+export function resolveHandle061(
+  entries: ReadonlyArray<policyLoaderEntry>,
+  slot: number,
+): policyLoaderEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Merge one handle for the policy-loader stage. */
+export function mergeHandle062(
+  entries: ReadonlyArray<policyLoaderEntry>,
+  slot: number,
+): policyLoaderEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Filter one handle for the policy-loader stage. */
+export function filterHandle063(
+  entries: ReadonlyArray<policyLoaderEntry>,
+  slot: number,
+): policyLoaderEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Reduce one handle for the policy-loader stage. */
+export function reduceHandle064(
+  entries: ReadonlyArray<policyLoaderEntry>,
+  slot: number,
+): policyLoaderEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Expand one handle for the policy-loader stage. */
+export function expandHandle065(
+  entries: ReadonlyArray<policyLoaderEntry>,
+  slot: number,
+): policyLoaderEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Normalise one handle for the policy-loader stage. */
+export function normaliseHandle066(
+  entries: ReadonlyArray<policyLoaderEntry>,
+  slot: number,
+): policyLoaderEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Compare one handle for the policy-loader stage. */
+export function compareHandle067(
+  entries: ReadonlyArray<policyLoaderEntry>,
+  slot: number,
+): policyLoaderEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Select one handle for the policy-loader stage. */
+export function selectHandle068(
+  entries: ReadonlyArray<policyLoaderEntry>,
+  slot: number,
+): policyLoaderEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Record one handle for the policy-loader stage. */
+export function recordHandle069(
+  entries: ReadonlyArray<policyLoaderEntry>,
+  slot: number,
+): policyLoaderEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Collect one cursor for the policy-loader stage. */
+export function collectCursor070(
+  entries: ReadonlyArray<policyLoaderEntry>,
+  slot: number,
+): policyLoaderEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Resolve one cursor for the policy-loader stage. */
+export function resolveCursor071(
+  entries: ReadonlyArray<policyLoaderEntry>,
+  slot: number,
+): policyLoaderEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Merge one cursor for the policy-loader stage. */
+export function mergeCursor072(
+  entries: ReadonlyArray<policyLoaderEntry>,
+  slot: number,
+): policyLoaderEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Filter one cursor for the policy-loader stage. */
+export function filterCursor073(
+  entries: ReadonlyArray<policyLoaderEntry>,
+  slot: number,
+): policyLoaderEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+

--- a/test-fixtures/gate-acceptance/queue-drain.ts
+++ b/test-fixtures/gate-acceptance/queue-drain.ts
@@ -1,0 +1,1500 @@
+// Acceptance corpus for the pull request review gate.
+//
+// This file is synthetic and is not part of the shipped package. It
+// exists so that one pull request is large enough to exercise two
+// limits at once: the diff API's 20,000-changed-line ceiling, and the
+// review request budget above which the gate splits a change into
+// batches. This pull request is opened to exercise them and closed
+// again; it is not merged.
+
+export interface queueDrainEntry {
+  readonly key: string;
+  readonly slot: number;
+  readonly active: boolean;
+}
+
+export interface queueDrainState {
+  readonly entries: ReadonlyArray<queueDrainEntry>;
+  readonly total: number;
+}
+
+/** Collect one entry for the queue-drain stage. */
+export function collectEntry000(
+  entries: ReadonlyArray<queueDrainEntry>,
+  slot: number,
+): queueDrainEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Resolve one entry for the queue-drain stage. */
+export function resolveEntry001(
+  entries: ReadonlyArray<queueDrainEntry>,
+  slot: number,
+): queueDrainEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Merge one entry for the queue-drain stage. */
+export function mergeEntry002(
+  entries: ReadonlyArray<queueDrainEntry>,
+  slot: number,
+): queueDrainEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Filter one entry for the queue-drain stage. */
+export function filterEntry003(
+  entries: ReadonlyArray<queueDrainEntry>,
+  slot: number,
+): queueDrainEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Reduce one entry for the queue-drain stage. */
+export function reduceEntry004(
+  entries: ReadonlyArray<queueDrainEntry>,
+  slot: number,
+): queueDrainEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Expand one entry for the queue-drain stage. */
+export function expandEntry005(
+  entries: ReadonlyArray<queueDrainEntry>,
+  slot: number,
+): queueDrainEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Normalise one entry for the queue-drain stage. */
+export function normaliseEntry006(
+  entries: ReadonlyArray<queueDrainEntry>,
+  slot: number,
+): queueDrainEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Compare one entry for the queue-drain stage. */
+export function compareEntry007(
+  entries: ReadonlyArray<queueDrainEntry>,
+  slot: number,
+): queueDrainEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Select one entry for the queue-drain stage. */
+export function selectEntry008(
+  entries: ReadonlyArray<queueDrainEntry>,
+  slot: number,
+): queueDrainEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Record one entry for the queue-drain stage. */
+export function recordEntry009(
+  entries: ReadonlyArray<queueDrainEntry>,
+  slot: number,
+): queueDrainEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Collect one record for the queue-drain stage. */
+export function collectRecord010(
+  entries: ReadonlyArray<queueDrainEntry>,
+  slot: number,
+): queueDrainEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Resolve one record for the queue-drain stage. */
+export function resolveRecord011(
+  entries: ReadonlyArray<queueDrainEntry>,
+  slot: number,
+): queueDrainEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Merge one record for the queue-drain stage. */
+export function mergeRecord012(
+  entries: ReadonlyArray<queueDrainEntry>,
+  slot: number,
+): queueDrainEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Filter one record for the queue-drain stage. */
+export function filterRecord013(
+  entries: ReadonlyArray<queueDrainEntry>,
+  slot: number,
+): queueDrainEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Reduce one record for the queue-drain stage. */
+export function reduceRecord014(
+  entries: ReadonlyArray<queueDrainEntry>,
+  slot: number,
+): queueDrainEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Expand one record for the queue-drain stage. */
+export function expandRecord015(
+  entries: ReadonlyArray<queueDrainEntry>,
+  slot: number,
+): queueDrainEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Normalise one record for the queue-drain stage. */
+export function normaliseRecord016(
+  entries: ReadonlyArray<queueDrainEntry>,
+  slot: number,
+): queueDrainEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Compare one record for the queue-drain stage. */
+export function compareRecord017(
+  entries: ReadonlyArray<queueDrainEntry>,
+  slot: number,
+): queueDrainEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Select one record for the queue-drain stage. */
+export function selectRecord018(
+  entries: ReadonlyArray<queueDrainEntry>,
+  slot: number,
+): queueDrainEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Record one record for the queue-drain stage. */
+export function recordRecord019(
+  entries: ReadonlyArray<queueDrainEntry>,
+  slot: number,
+): queueDrainEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Collect one bucket for the queue-drain stage. */
+export function collectBucket020(
+  entries: ReadonlyArray<queueDrainEntry>,
+  slot: number,
+): queueDrainEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Resolve one bucket for the queue-drain stage. */
+export function resolveBucket021(
+  entries: ReadonlyArray<queueDrainEntry>,
+  slot: number,
+): queueDrainEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Merge one bucket for the queue-drain stage. */
+export function mergeBucket022(
+  entries: ReadonlyArray<queueDrainEntry>,
+  slot: number,
+): queueDrainEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Filter one bucket for the queue-drain stage. */
+export function filterBucket023(
+  entries: ReadonlyArray<queueDrainEntry>,
+  slot: number,
+): queueDrainEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Reduce one bucket for the queue-drain stage. */
+export function reduceBucket024(
+  entries: ReadonlyArray<queueDrainEntry>,
+  slot: number,
+): queueDrainEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Expand one bucket for the queue-drain stage. */
+export function expandBucket025(
+  entries: ReadonlyArray<queueDrainEntry>,
+  slot: number,
+): queueDrainEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Normalise one bucket for the queue-drain stage. */
+export function normaliseBucket026(
+  entries: ReadonlyArray<queueDrainEntry>,
+  slot: number,
+): queueDrainEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Compare one bucket for the queue-drain stage. */
+export function compareBucket027(
+  entries: ReadonlyArray<queueDrainEntry>,
+  slot: number,
+): queueDrainEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Select one bucket for the queue-drain stage. */
+export function selectBucket028(
+  entries: ReadonlyArray<queueDrainEntry>,
+  slot: number,
+): queueDrainEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Record one bucket for the queue-drain stage. */
+export function recordBucket029(
+  entries: ReadonlyArray<queueDrainEntry>,
+  slot: number,
+): queueDrainEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Collect one segment for the queue-drain stage. */
+export function collectSegment030(
+  entries: ReadonlyArray<queueDrainEntry>,
+  slot: number,
+): queueDrainEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Resolve one segment for the queue-drain stage. */
+export function resolveSegment031(
+  entries: ReadonlyArray<queueDrainEntry>,
+  slot: number,
+): queueDrainEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Merge one segment for the queue-drain stage. */
+export function mergeSegment032(
+  entries: ReadonlyArray<queueDrainEntry>,
+  slot: number,
+): queueDrainEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Filter one segment for the queue-drain stage. */
+export function filterSegment033(
+  entries: ReadonlyArray<queueDrainEntry>,
+  slot: number,
+): queueDrainEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Reduce one segment for the queue-drain stage. */
+export function reduceSegment034(
+  entries: ReadonlyArray<queueDrainEntry>,
+  slot: number,
+): queueDrainEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Expand one segment for the queue-drain stage. */
+export function expandSegment035(
+  entries: ReadonlyArray<queueDrainEntry>,
+  slot: number,
+): queueDrainEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Normalise one segment for the queue-drain stage. */
+export function normaliseSegment036(
+  entries: ReadonlyArray<queueDrainEntry>,
+  slot: number,
+): queueDrainEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Compare one segment for the queue-drain stage. */
+export function compareSegment037(
+  entries: ReadonlyArray<queueDrainEntry>,
+  slot: number,
+): queueDrainEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Select one segment for the queue-drain stage. */
+export function selectSegment038(
+  entries: ReadonlyArray<queueDrainEntry>,
+  slot: number,
+): queueDrainEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Record one segment for the queue-drain stage. */
+export function recordSegment039(
+  entries: ReadonlyArray<queueDrainEntry>,
+  slot: number,
+): queueDrainEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Collect one window for the queue-drain stage. */
+export function collectWindow040(
+  entries: ReadonlyArray<queueDrainEntry>,
+  slot: number,
+): queueDrainEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Resolve one window for the queue-drain stage. */
+export function resolveWindow041(
+  entries: ReadonlyArray<queueDrainEntry>,
+  slot: number,
+): queueDrainEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Merge one window for the queue-drain stage. */
+export function mergeWindow042(
+  entries: ReadonlyArray<queueDrainEntry>,
+  slot: number,
+): queueDrainEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Filter one window for the queue-drain stage. */
+export function filterWindow043(
+  entries: ReadonlyArray<queueDrainEntry>,
+  slot: number,
+): queueDrainEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Reduce one window for the queue-drain stage. */
+export function reduceWindow044(
+  entries: ReadonlyArray<queueDrainEntry>,
+  slot: number,
+): queueDrainEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Expand one window for the queue-drain stage. */
+export function expandWindow045(
+  entries: ReadonlyArray<queueDrainEntry>,
+  slot: number,
+): queueDrainEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Normalise one window for the queue-drain stage. */
+export function normaliseWindow046(
+  entries: ReadonlyArray<queueDrainEntry>,
+  slot: number,
+): queueDrainEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Compare one window for the queue-drain stage. */
+export function compareWindow047(
+  entries: ReadonlyArray<queueDrainEntry>,
+  slot: number,
+): queueDrainEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Select one window for the queue-drain stage. */
+export function selectWindow048(
+  entries: ReadonlyArray<queueDrainEntry>,
+  slot: number,
+): queueDrainEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Record one window for the queue-drain stage. */
+export function recordWindow049(
+  entries: ReadonlyArray<queueDrainEntry>,
+  slot: number,
+): queueDrainEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Collect one marker for the queue-drain stage. */
+export function collectMarker050(
+  entries: ReadonlyArray<queueDrainEntry>,
+  slot: number,
+): queueDrainEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Resolve one marker for the queue-drain stage. */
+export function resolveMarker051(
+  entries: ReadonlyArray<queueDrainEntry>,
+  slot: number,
+): queueDrainEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Merge one marker for the queue-drain stage. */
+export function mergeMarker052(
+  entries: ReadonlyArray<queueDrainEntry>,
+  slot: number,
+): queueDrainEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Filter one marker for the queue-drain stage. */
+export function filterMarker053(
+  entries: ReadonlyArray<queueDrainEntry>,
+  slot: number,
+): queueDrainEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Reduce one marker for the queue-drain stage. */
+export function reduceMarker054(
+  entries: ReadonlyArray<queueDrainEntry>,
+  slot: number,
+): queueDrainEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Expand one marker for the queue-drain stage. */
+export function expandMarker055(
+  entries: ReadonlyArray<queueDrainEntry>,
+  slot: number,
+): queueDrainEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Normalise one marker for the queue-drain stage. */
+export function normaliseMarker056(
+  entries: ReadonlyArray<queueDrainEntry>,
+  slot: number,
+): queueDrainEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Compare one marker for the queue-drain stage. */
+export function compareMarker057(
+  entries: ReadonlyArray<queueDrainEntry>,
+  slot: number,
+): queueDrainEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Select one marker for the queue-drain stage. */
+export function selectMarker058(
+  entries: ReadonlyArray<queueDrainEntry>,
+  slot: number,
+): queueDrainEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Record one marker for the queue-drain stage. */
+export function recordMarker059(
+  entries: ReadonlyArray<queueDrainEntry>,
+  slot: number,
+): queueDrainEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Collect one handle for the queue-drain stage. */
+export function collectHandle060(
+  entries: ReadonlyArray<queueDrainEntry>,
+  slot: number,
+): queueDrainEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Resolve one handle for the queue-drain stage. */
+export function resolveHandle061(
+  entries: ReadonlyArray<queueDrainEntry>,
+  slot: number,
+): queueDrainEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Merge one handle for the queue-drain stage. */
+export function mergeHandle062(
+  entries: ReadonlyArray<queueDrainEntry>,
+  slot: number,
+): queueDrainEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Filter one handle for the queue-drain stage. */
+export function filterHandle063(
+  entries: ReadonlyArray<queueDrainEntry>,
+  slot: number,
+): queueDrainEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Reduce one handle for the queue-drain stage. */
+export function reduceHandle064(
+  entries: ReadonlyArray<queueDrainEntry>,
+  slot: number,
+): queueDrainEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Expand one handle for the queue-drain stage. */
+export function expandHandle065(
+  entries: ReadonlyArray<queueDrainEntry>,
+  slot: number,
+): queueDrainEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Normalise one handle for the queue-drain stage. */
+export function normaliseHandle066(
+  entries: ReadonlyArray<queueDrainEntry>,
+  slot: number,
+): queueDrainEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Compare one handle for the queue-drain stage. */
+export function compareHandle067(
+  entries: ReadonlyArray<queueDrainEntry>,
+  slot: number,
+): queueDrainEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Select one handle for the queue-drain stage. */
+export function selectHandle068(
+  entries: ReadonlyArray<queueDrainEntry>,
+  slot: number,
+): queueDrainEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Record one handle for the queue-drain stage. */
+export function recordHandle069(
+  entries: ReadonlyArray<queueDrainEntry>,
+  slot: number,
+): queueDrainEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Collect one cursor for the queue-drain stage. */
+export function collectCursor070(
+  entries: ReadonlyArray<queueDrainEntry>,
+  slot: number,
+): queueDrainEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Resolve one cursor for the queue-drain stage. */
+export function resolveCursor071(
+  entries: ReadonlyArray<queueDrainEntry>,
+  slot: number,
+): queueDrainEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Merge one cursor for the queue-drain stage. */
+export function mergeCursor072(
+  entries: ReadonlyArray<queueDrainEntry>,
+  slot: number,
+): queueDrainEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Filter one cursor for the queue-drain stage. */
+export function filterCursor073(
+  entries: ReadonlyArray<queueDrainEntry>,
+  slot: number,
+): queueDrainEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+

--- a/test-fixtures/gate-acceptance/range-tracker.ts
+++ b/test-fixtures/gate-acceptance/range-tracker.ts
@@ -1,0 +1,1500 @@
+// Acceptance corpus for the pull request review gate.
+//
+// This file is synthetic and is not part of the shipped package. It
+// exists so that one pull request is large enough to exercise two
+// limits at once: the diff API's 20,000-changed-line ceiling, and the
+// review request budget above which the gate splits a change into
+// batches. This pull request is opened to exercise them and closed
+// again; it is not merged.
+
+export interface rangeTrackerEntry {
+  readonly key: string;
+  readonly slot: number;
+  readonly active: boolean;
+}
+
+export interface rangeTrackerState {
+  readonly entries: ReadonlyArray<rangeTrackerEntry>;
+  readonly total: number;
+}
+
+/** Collect one entry for the range-tracker stage. */
+export function collectEntry000(
+  entries: ReadonlyArray<rangeTrackerEntry>,
+  slot: number,
+): rangeTrackerEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Resolve one entry for the range-tracker stage. */
+export function resolveEntry001(
+  entries: ReadonlyArray<rangeTrackerEntry>,
+  slot: number,
+): rangeTrackerEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Merge one entry for the range-tracker stage. */
+export function mergeEntry002(
+  entries: ReadonlyArray<rangeTrackerEntry>,
+  slot: number,
+): rangeTrackerEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Filter one entry for the range-tracker stage. */
+export function filterEntry003(
+  entries: ReadonlyArray<rangeTrackerEntry>,
+  slot: number,
+): rangeTrackerEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Reduce one entry for the range-tracker stage. */
+export function reduceEntry004(
+  entries: ReadonlyArray<rangeTrackerEntry>,
+  slot: number,
+): rangeTrackerEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Expand one entry for the range-tracker stage. */
+export function expandEntry005(
+  entries: ReadonlyArray<rangeTrackerEntry>,
+  slot: number,
+): rangeTrackerEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Normalise one entry for the range-tracker stage. */
+export function normaliseEntry006(
+  entries: ReadonlyArray<rangeTrackerEntry>,
+  slot: number,
+): rangeTrackerEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Compare one entry for the range-tracker stage. */
+export function compareEntry007(
+  entries: ReadonlyArray<rangeTrackerEntry>,
+  slot: number,
+): rangeTrackerEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Select one entry for the range-tracker stage. */
+export function selectEntry008(
+  entries: ReadonlyArray<rangeTrackerEntry>,
+  slot: number,
+): rangeTrackerEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Record one entry for the range-tracker stage. */
+export function recordEntry009(
+  entries: ReadonlyArray<rangeTrackerEntry>,
+  slot: number,
+): rangeTrackerEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Collect one record for the range-tracker stage. */
+export function collectRecord010(
+  entries: ReadonlyArray<rangeTrackerEntry>,
+  slot: number,
+): rangeTrackerEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Resolve one record for the range-tracker stage. */
+export function resolveRecord011(
+  entries: ReadonlyArray<rangeTrackerEntry>,
+  slot: number,
+): rangeTrackerEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Merge one record for the range-tracker stage. */
+export function mergeRecord012(
+  entries: ReadonlyArray<rangeTrackerEntry>,
+  slot: number,
+): rangeTrackerEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Filter one record for the range-tracker stage. */
+export function filterRecord013(
+  entries: ReadonlyArray<rangeTrackerEntry>,
+  slot: number,
+): rangeTrackerEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Reduce one record for the range-tracker stage. */
+export function reduceRecord014(
+  entries: ReadonlyArray<rangeTrackerEntry>,
+  slot: number,
+): rangeTrackerEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Expand one record for the range-tracker stage. */
+export function expandRecord015(
+  entries: ReadonlyArray<rangeTrackerEntry>,
+  slot: number,
+): rangeTrackerEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Normalise one record for the range-tracker stage. */
+export function normaliseRecord016(
+  entries: ReadonlyArray<rangeTrackerEntry>,
+  slot: number,
+): rangeTrackerEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Compare one record for the range-tracker stage. */
+export function compareRecord017(
+  entries: ReadonlyArray<rangeTrackerEntry>,
+  slot: number,
+): rangeTrackerEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Select one record for the range-tracker stage. */
+export function selectRecord018(
+  entries: ReadonlyArray<rangeTrackerEntry>,
+  slot: number,
+): rangeTrackerEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Record one record for the range-tracker stage. */
+export function recordRecord019(
+  entries: ReadonlyArray<rangeTrackerEntry>,
+  slot: number,
+): rangeTrackerEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Collect one bucket for the range-tracker stage. */
+export function collectBucket020(
+  entries: ReadonlyArray<rangeTrackerEntry>,
+  slot: number,
+): rangeTrackerEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Resolve one bucket for the range-tracker stage. */
+export function resolveBucket021(
+  entries: ReadonlyArray<rangeTrackerEntry>,
+  slot: number,
+): rangeTrackerEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Merge one bucket for the range-tracker stage. */
+export function mergeBucket022(
+  entries: ReadonlyArray<rangeTrackerEntry>,
+  slot: number,
+): rangeTrackerEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Filter one bucket for the range-tracker stage. */
+export function filterBucket023(
+  entries: ReadonlyArray<rangeTrackerEntry>,
+  slot: number,
+): rangeTrackerEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Reduce one bucket for the range-tracker stage. */
+export function reduceBucket024(
+  entries: ReadonlyArray<rangeTrackerEntry>,
+  slot: number,
+): rangeTrackerEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Expand one bucket for the range-tracker stage. */
+export function expandBucket025(
+  entries: ReadonlyArray<rangeTrackerEntry>,
+  slot: number,
+): rangeTrackerEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Normalise one bucket for the range-tracker stage. */
+export function normaliseBucket026(
+  entries: ReadonlyArray<rangeTrackerEntry>,
+  slot: number,
+): rangeTrackerEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Compare one bucket for the range-tracker stage. */
+export function compareBucket027(
+  entries: ReadonlyArray<rangeTrackerEntry>,
+  slot: number,
+): rangeTrackerEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Select one bucket for the range-tracker stage. */
+export function selectBucket028(
+  entries: ReadonlyArray<rangeTrackerEntry>,
+  slot: number,
+): rangeTrackerEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Record one bucket for the range-tracker stage. */
+export function recordBucket029(
+  entries: ReadonlyArray<rangeTrackerEntry>,
+  slot: number,
+): rangeTrackerEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Collect one segment for the range-tracker stage. */
+export function collectSegment030(
+  entries: ReadonlyArray<rangeTrackerEntry>,
+  slot: number,
+): rangeTrackerEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Resolve one segment for the range-tracker stage. */
+export function resolveSegment031(
+  entries: ReadonlyArray<rangeTrackerEntry>,
+  slot: number,
+): rangeTrackerEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Merge one segment for the range-tracker stage. */
+export function mergeSegment032(
+  entries: ReadonlyArray<rangeTrackerEntry>,
+  slot: number,
+): rangeTrackerEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Filter one segment for the range-tracker stage. */
+export function filterSegment033(
+  entries: ReadonlyArray<rangeTrackerEntry>,
+  slot: number,
+): rangeTrackerEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Reduce one segment for the range-tracker stage. */
+export function reduceSegment034(
+  entries: ReadonlyArray<rangeTrackerEntry>,
+  slot: number,
+): rangeTrackerEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Expand one segment for the range-tracker stage. */
+export function expandSegment035(
+  entries: ReadonlyArray<rangeTrackerEntry>,
+  slot: number,
+): rangeTrackerEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Normalise one segment for the range-tracker stage. */
+export function normaliseSegment036(
+  entries: ReadonlyArray<rangeTrackerEntry>,
+  slot: number,
+): rangeTrackerEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Compare one segment for the range-tracker stage. */
+export function compareSegment037(
+  entries: ReadonlyArray<rangeTrackerEntry>,
+  slot: number,
+): rangeTrackerEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Select one segment for the range-tracker stage. */
+export function selectSegment038(
+  entries: ReadonlyArray<rangeTrackerEntry>,
+  slot: number,
+): rangeTrackerEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Record one segment for the range-tracker stage. */
+export function recordSegment039(
+  entries: ReadonlyArray<rangeTrackerEntry>,
+  slot: number,
+): rangeTrackerEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Collect one window for the range-tracker stage. */
+export function collectWindow040(
+  entries: ReadonlyArray<rangeTrackerEntry>,
+  slot: number,
+): rangeTrackerEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Resolve one window for the range-tracker stage. */
+export function resolveWindow041(
+  entries: ReadonlyArray<rangeTrackerEntry>,
+  slot: number,
+): rangeTrackerEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Merge one window for the range-tracker stage. */
+export function mergeWindow042(
+  entries: ReadonlyArray<rangeTrackerEntry>,
+  slot: number,
+): rangeTrackerEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Filter one window for the range-tracker stage. */
+export function filterWindow043(
+  entries: ReadonlyArray<rangeTrackerEntry>,
+  slot: number,
+): rangeTrackerEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Reduce one window for the range-tracker stage. */
+export function reduceWindow044(
+  entries: ReadonlyArray<rangeTrackerEntry>,
+  slot: number,
+): rangeTrackerEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Expand one window for the range-tracker stage. */
+export function expandWindow045(
+  entries: ReadonlyArray<rangeTrackerEntry>,
+  slot: number,
+): rangeTrackerEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Normalise one window for the range-tracker stage. */
+export function normaliseWindow046(
+  entries: ReadonlyArray<rangeTrackerEntry>,
+  slot: number,
+): rangeTrackerEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Compare one window for the range-tracker stage. */
+export function compareWindow047(
+  entries: ReadonlyArray<rangeTrackerEntry>,
+  slot: number,
+): rangeTrackerEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Select one window for the range-tracker stage. */
+export function selectWindow048(
+  entries: ReadonlyArray<rangeTrackerEntry>,
+  slot: number,
+): rangeTrackerEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Record one window for the range-tracker stage. */
+export function recordWindow049(
+  entries: ReadonlyArray<rangeTrackerEntry>,
+  slot: number,
+): rangeTrackerEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Collect one marker for the range-tracker stage. */
+export function collectMarker050(
+  entries: ReadonlyArray<rangeTrackerEntry>,
+  slot: number,
+): rangeTrackerEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Resolve one marker for the range-tracker stage. */
+export function resolveMarker051(
+  entries: ReadonlyArray<rangeTrackerEntry>,
+  slot: number,
+): rangeTrackerEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Merge one marker for the range-tracker stage. */
+export function mergeMarker052(
+  entries: ReadonlyArray<rangeTrackerEntry>,
+  slot: number,
+): rangeTrackerEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Filter one marker for the range-tracker stage. */
+export function filterMarker053(
+  entries: ReadonlyArray<rangeTrackerEntry>,
+  slot: number,
+): rangeTrackerEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Reduce one marker for the range-tracker stage. */
+export function reduceMarker054(
+  entries: ReadonlyArray<rangeTrackerEntry>,
+  slot: number,
+): rangeTrackerEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Expand one marker for the range-tracker stage. */
+export function expandMarker055(
+  entries: ReadonlyArray<rangeTrackerEntry>,
+  slot: number,
+): rangeTrackerEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Normalise one marker for the range-tracker stage. */
+export function normaliseMarker056(
+  entries: ReadonlyArray<rangeTrackerEntry>,
+  slot: number,
+): rangeTrackerEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Compare one marker for the range-tracker stage. */
+export function compareMarker057(
+  entries: ReadonlyArray<rangeTrackerEntry>,
+  slot: number,
+): rangeTrackerEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Select one marker for the range-tracker stage. */
+export function selectMarker058(
+  entries: ReadonlyArray<rangeTrackerEntry>,
+  slot: number,
+): rangeTrackerEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Record one marker for the range-tracker stage. */
+export function recordMarker059(
+  entries: ReadonlyArray<rangeTrackerEntry>,
+  slot: number,
+): rangeTrackerEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Collect one handle for the range-tracker stage. */
+export function collectHandle060(
+  entries: ReadonlyArray<rangeTrackerEntry>,
+  slot: number,
+): rangeTrackerEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Resolve one handle for the range-tracker stage. */
+export function resolveHandle061(
+  entries: ReadonlyArray<rangeTrackerEntry>,
+  slot: number,
+): rangeTrackerEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Merge one handle for the range-tracker stage. */
+export function mergeHandle062(
+  entries: ReadonlyArray<rangeTrackerEntry>,
+  slot: number,
+): rangeTrackerEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Filter one handle for the range-tracker stage. */
+export function filterHandle063(
+  entries: ReadonlyArray<rangeTrackerEntry>,
+  slot: number,
+): rangeTrackerEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Reduce one handle for the range-tracker stage. */
+export function reduceHandle064(
+  entries: ReadonlyArray<rangeTrackerEntry>,
+  slot: number,
+): rangeTrackerEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Expand one handle for the range-tracker stage. */
+export function expandHandle065(
+  entries: ReadonlyArray<rangeTrackerEntry>,
+  slot: number,
+): rangeTrackerEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Normalise one handle for the range-tracker stage. */
+export function normaliseHandle066(
+  entries: ReadonlyArray<rangeTrackerEntry>,
+  slot: number,
+): rangeTrackerEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Compare one handle for the range-tracker stage. */
+export function compareHandle067(
+  entries: ReadonlyArray<rangeTrackerEntry>,
+  slot: number,
+): rangeTrackerEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Select one handle for the range-tracker stage. */
+export function selectHandle068(
+  entries: ReadonlyArray<rangeTrackerEntry>,
+  slot: number,
+): rangeTrackerEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Record one handle for the range-tracker stage. */
+export function recordHandle069(
+  entries: ReadonlyArray<rangeTrackerEntry>,
+  slot: number,
+): rangeTrackerEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Collect one cursor for the range-tracker stage. */
+export function collectCursor070(
+  entries: ReadonlyArray<rangeTrackerEntry>,
+  slot: number,
+): rangeTrackerEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Resolve one cursor for the range-tracker stage. */
+export function resolveCursor071(
+  entries: ReadonlyArray<rangeTrackerEntry>,
+  slot: number,
+): rangeTrackerEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Merge one cursor for the range-tracker stage. */
+export function mergeCursor072(
+  entries: ReadonlyArray<rangeTrackerEntry>,
+  slot: number,
+): rangeTrackerEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Filter one cursor for the range-tracker stage. */
+export function filterCursor073(
+  entries: ReadonlyArray<rangeTrackerEntry>,
+  slot: number,
+): rangeTrackerEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+

--- a/test-fixtures/gate-acceptance/report-writer.ts
+++ b/test-fixtures/gate-acceptance/report-writer.ts
@@ -1,0 +1,1500 @@
+// Acceptance corpus for the pull request review gate.
+//
+// This file is synthetic and is not part of the shipped package. It
+// exists so that one pull request is large enough to exercise two
+// limits at once: the diff API's 20,000-changed-line ceiling, and the
+// review request budget above which the gate splits a change into
+// batches. This pull request is opened to exercise them and closed
+// again; it is not merged.
+
+export interface reportWriterEntry {
+  readonly key: string;
+  readonly slot: number;
+  readonly active: boolean;
+}
+
+export interface reportWriterState {
+  readonly entries: ReadonlyArray<reportWriterEntry>;
+  readonly total: number;
+}
+
+/** Collect one entry for the report-writer stage. */
+export function collectEntry000(
+  entries: ReadonlyArray<reportWriterEntry>,
+  slot: number,
+): reportWriterEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Resolve one entry for the report-writer stage. */
+export function resolveEntry001(
+  entries: ReadonlyArray<reportWriterEntry>,
+  slot: number,
+): reportWriterEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Merge one entry for the report-writer stage. */
+export function mergeEntry002(
+  entries: ReadonlyArray<reportWriterEntry>,
+  slot: number,
+): reportWriterEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Filter one entry for the report-writer stage. */
+export function filterEntry003(
+  entries: ReadonlyArray<reportWriterEntry>,
+  slot: number,
+): reportWriterEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Reduce one entry for the report-writer stage. */
+export function reduceEntry004(
+  entries: ReadonlyArray<reportWriterEntry>,
+  slot: number,
+): reportWriterEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Expand one entry for the report-writer stage. */
+export function expandEntry005(
+  entries: ReadonlyArray<reportWriterEntry>,
+  slot: number,
+): reportWriterEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Normalise one entry for the report-writer stage. */
+export function normaliseEntry006(
+  entries: ReadonlyArray<reportWriterEntry>,
+  slot: number,
+): reportWriterEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Compare one entry for the report-writer stage. */
+export function compareEntry007(
+  entries: ReadonlyArray<reportWriterEntry>,
+  slot: number,
+): reportWriterEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Select one entry for the report-writer stage. */
+export function selectEntry008(
+  entries: ReadonlyArray<reportWriterEntry>,
+  slot: number,
+): reportWriterEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Record one entry for the report-writer stage. */
+export function recordEntry009(
+  entries: ReadonlyArray<reportWriterEntry>,
+  slot: number,
+): reportWriterEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Collect one record for the report-writer stage. */
+export function collectRecord010(
+  entries: ReadonlyArray<reportWriterEntry>,
+  slot: number,
+): reportWriterEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Resolve one record for the report-writer stage. */
+export function resolveRecord011(
+  entries: ReadonlyArray<reportWriterEntry>,
+  slot: number,
+): reportWriterEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Merge one record for the report-writer stage. */
+export function mergeRecord012(
+  entries: ReadonlyArray<reportWriterEntry>,
+  slot: number,
+): reportWriterEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Filter one record for the report-writer stage. */
+export function filterRecord013(
+  entries: ReadonlyArray<reportWriterEntry>,
+  slot: number,
+): reportWriterEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Reduce one record for the report-writer stage. */
+export function reduceRecord014(
+  entries: ReadonlyArray<reportWriterEntry>,
+  slot: number,
+): reportWriterEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Expand one record for the report-writer stage. */
+export function expandRecord015(
+  entries: ReadonlyArray<reportWriterEntry>,
+  slot: number,
+): reportWriterEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Normalise one record for the report-writer stage. */
+export function normaliseRecord016(
+  entries: ReadonlyArray<reportWriterEntry>,
+  slot: number,
+): reportWriterEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Compare one record for the report-writer stage. */
+export function compareRecord017(
+  entries: ReadonlyArray<reportWriterEntry>,
+  slot: number,
+): reportWriterEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Select one record for the report-writer stage. */
+export function selectRecord018(
+  entries: ReadonlyArray<reportWriterEntry>,
+  slot: number,
+): reportWriterEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Record one record for the report-writer stage. */
+export function recordRecord019(
+  entries: ReadonlyArray<reportWriterEntry>,
+  slot: number,
+): reportWriterEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Collect one bucket for the report-writer stage. */
+export function collectBucket020(
+  entries: ReadonlyArray<reportWriterEntry>,
+  slot: number,
+): reportWriterEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Resolve one bucket for the report-writer stage. */
+export function resolveBucket021(
+  entries: ReadonlyArray<reportWriterEntry>,
+  slot: number,
+): reportWriterEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Merge one bucket for the report-writer stage. */
+export function mergeBucket022(
+  entries: ReadonlyArray<reportWriterEntry>,
+  slot: number,
+): reportWriterEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Filter one bucket for the report-writer stage. */
+export function filterBucket023(
+  entries: ReadonlyArray<reportWriterEntry>,
+  slot: number,
+): reportWriterEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Reduce one bucket for the report-writer stage. */
+export function reduceBucket024(
+  entries: ReadonlyArray<reportWriterEntry>,
+  slot: number,
+): reportWriterEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Expand one bucket for the report-writer stage. */
+export function expandBucket025(
+  entries: ReadonlyArray<reportWriterEntry>,
+  slot: number,
+): reportWriterEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Normalise one bucket for the report-writer stage. */
+export function normaliseBucket026(
+  entries: ReadonlyArray<reportWriterEntry>,
+  slot: number,
+): reportWriterEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Compare one bucket for the report-writer stage. */
+export function compareBucket027(
+  entries: ReadonlyArray<reportWriterEntry>,
+  slot: number,
+): reportWriterEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Select one bucket for the report-writer stage. */
+export function selectBucket028(
+  entries: ReadonlyArray<reportWriterEntry>,
+  slot: number,
+): reportWriterEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Record one bucket for the report-writer stage. */
+export function recordBucket029(
+  entries: ReadonlyArray<reportWriterEntry>,
+  slot: number,
+): reportWriterEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Collect one segment for the report-writer stage. */
+export function collectSegment030(
+  entries: ReadonlyArray<reportWriterEntry>,
+  slot: number,
+): reportWriterEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Resolve one segment for the report-writer stage. */
+export function resolveSegment031(
+  entries: ReadonlyArray<reportWriterEntry>,
+  slot: number,
+): reportWriterEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Merge one segment for the report-writer stage. */
+export function mergeSegment032(
+  entries: ReadonlyArray<reportWriterEntry>,
+  slot: number,
+): reportWriterEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Filter one segment for the report-writer stage. */
+export function filterSegment033(
+  entries: ReadonlyArray<reportWriterEntry>,
+  slot: number,
+): reportWriterEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Reduce one segment for the report-writer stage. */
+export function reduceSegment034(
+  entries: ReadonlyArray<reportWriterEntry>,
+  slot: number,
+): reportWriterEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Expand one segment for the report-writer stage. */
+export function expandSegment035(
+  entries: ReadonlyArray<reportWriterEntry>,
+  slot: number,
+): reportWriterEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Normalise one segment for the report-writer stage. */
+export function normaliseSegment036(
+  entries: ReadonlyArray<reportWriterEntry>,
+  slot: number,
+): reportWriterEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Compare one segment for the report-writer stage. */
+export function compareSegment037(
+  entries: ReadonlyArray<reportWriterEntry>,
+  slot: number,
+): reportWriterEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Select one segment for the report-writer stage. */
+export function selectSegment038(
+  entries: ReadonlyArray<reportWriterEntry>,
+  slot: number,
+): reportWriterEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Record one segment for the report-writer stage. */
+export function recordSegment039(
+  entries: ReadonlyArray<reportWriterEntry>,
+  slot: number,
+): reportWriterEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Collect one window for the report-writer stage. */
+export function collectWindow040(
+  entries: ReadonlyArray<reportWriterEntry>,
+  slot: number,
+): reportWriterEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Resolve one window for the report-writer stage. */
+export function resolveWindow041(
+  entries: ReadonlyArray<reportWriterEntry>,
+  slot: number,
+): reportWriterEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Merge one window for the report-writer stage. */
+export function mergeWindow042(
+  entries: ReadonlyArray<reportWriterEntry>,
+  slot: number,
+): reportWriterEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Filter one window for the report-writer stage. */
+export function filterWindow043(
+  entries: ReadonlyArray<reportWriterEntry>,
+  slot: number,
+): reportWriterEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Reduce one window for the report-writer stage. */
+export function reduceWindow044(
+  entries: ReadonlyArray<reportWriterEntry>,
+  slot: number,
+): reportWriterEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Expand one window for the report-writer stage. */
+export function expandWindow045(
+  entries: ReadonlyArray<reportWriterEntry>,
+  slot: number,
+): reportWriterEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Normalise one window for the report-writer stage. */
+export function normaliseWindow046(
+  entries: ReadonlyArray<reportWriterEntry>,
+  slot: number,
+): reportWriterEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Compare one window for the report-writer stage. */
+export function compareWindow047(
+  entries: ReadonlyArray<reportWriterEntry>,
+  slot: number,
+): reportWriterEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Select one window for the report-writer stage. */
+export function selectWindow048(
+  entries: ReadonlyArray<reportWriterEntry>,
+  slot: number,
+): reportWriterEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Record one window for the report-writer stage. */
+export function recordWindow049(
+  entries: ReadonlyArray<reportWriterEntry>,
+  slot: number,
+): reportWriterEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Collect one marker for the report-writer stage. */
+export function collectMarker050(
+  entries: ReadonlyArray<reportWriterEntry>,
+  slot: number,
+): reportWriterEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Resolve one marker for the report-writer stage. */
+export function resolveMarker051(
+  entries: ReadonlyArray<reportWriterEntry>,
+  slot: number,
+): reportWriterEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Merge one marker for the report-writer stage. */
+export function mergeMarker052(
+  entries: ReadonlyArray<reportWriterEntry>,
+  slot: number,
+): reportWriterEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Filter one marker for the report-writer stage. */
+export function filterMarker053(
+  entries: ReadonlyArray<reportWriterEntry>,
+  slot: number,
+): reportWriterEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Reduce one marker for the report-writer stage. */
+export function reduceMarker054(
+  entries: ReadonlyArray<reportWriterEntry>,
+  slot: number,
+): reportWriterEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Expand one marker for the report-writer stage. */
+export function expandMarker055(
+  entries: ReadonlyArray<reportWriterEntry>,
+  slot: number,
+): reportWriterEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Normalise one marker for the report-writer stage. */
+export function normaliseMarker056(
+  entries: ReadonlyArray<reportWriterEntry>,
+  slot: number,
+): reportWriterEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Compare one marker for the report-writer stage. */
+export function compareMarker057(
+  entries: ReadonlyArray<reportWriterEntry>,
+  slot: number,
+): reportWriterEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Select one marker for the report-writer stage. */
+export function selectMarker058(
+  entries: ReadonlyArray<reportWriterEntry>,
+  slot: number,
+): reportWriterEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Record one marker for the report-writer stage. */
+export function recordMarker059(
+  entries: ReadonlyArray<reportWriterEntry>,
+  slot: number,
+): reportWriterEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Collect one handle for the report-writer stage. */
+export function collectHandle060(
+  entries: ReadonlyArray<reportWriterEntry>,
+  slot: number,
+): reportWriterEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Resolve one handle for the report-writer stage. */
+export function resolveHandle061(
+  entries: ReadonlyArray<reportWriterEntry>,
+  slot: number,
+): reportWriterEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Merge one handle for the report-writer stage. */
+export function mergeHandle062(
+  entries: ReadonlyArray<reportWriterEntry>,
+  slot: number,
+): reportWriterEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Filter one handle for the report-writer stage. */
+export function filterHandle063(
+  entries: ReadonlyArray<reportWriterEntry>,
+  slot: number,
+): reportWriterEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Reduce one handle for the report-writer stage. */
+export function reduceHandle064(
+  entries: ReadonlyArray<reportWriterEntry>,
+  slot: number,
+): reportWriterEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Expand one handle for the report-writer stage. */
+export function expandHandle065(
+  entries: ReadonlyArray<reportWriterEntry>,
+  slot: number,
+): reportWriterEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Normalise one handle for the report-writer stage. */
+export function normaliseHandle066(
+  entries: ReadonlyArray<reportWriterEntry>,
+  slot: number,
+): reportWriterEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Compare one handle for the report-writer stage. */
+export function compareHandle067(
+  entries: ReadonlyArray<reportWriterEntry>,
+  slot: number,
+): reportWriterEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Select one handle for the report-writer stage. */
+export function selectHandle068(
+  entries: ReadonlyArray<reportWriterEntry>,
+  slot: number,
+): reportWriterEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Record one handle for the report-writer stage. */
+export function recordHandle069(
+  entries: ReadonlyArray<reportWriterEntry>,
+  slot: number,
+): reportWriterEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Collect one cursor for the report-writer stage. */
+export function collectCursor070(
+  entries: ReadonlyArray<reportWriterEntry>,
+  slot: number,
+): reportWriterEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Resolve one cursor for the report-writer stage. */
+export function resolveCursor071(
+  entries: ReadonlyArray<reportWriterEntry>,
+  slot: number,
+): reportWriterEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Merge one cursor for the report-writer stage. */
+export function mergeCursor072(
+  entries: ReadonlyArray<reportWriterEntry>,
+  slot: number,
+): reportWriterEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Filter one cursor for the report-writer stage. */
+export function filterCursor073(
+  entries: ReadonlyArray<reportWriterEntry>,
+  slot: number,
+): reportWriterEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+

--- a/test-fixtures/gate-acceptance/retry-plan.ts
+++ b/test-fixtures/gate-acceptance/retry-plan.ts
@@ -1,0 +1,1500 @@
+// Acceptance corpus for the pull request review gate.
+//
+// This file is synthetic and is not part of the shipped package. It
+// exists so that one pull request is large enough to exercise two
+// limits at once: the diff API's 20,000-changed-line ceiling, and the
+// review request budget above which the gate splits a change into
+// batches. This pull request is opened to exercise them and closed
+// again; it is not merged.
+
+export interface retryPlanEntry {
+  readonly key: string;
+  readonly slot: number;
+  readonly active: boolean;
+}
+
+export interface retryPlanState {
+  readonly entries: ReadonlyArray<retryPlanEntry>;
+  readonly total: number;
+}
+
+/** Collect one entry for the retry-plan stage. */
+export function collectEntry000(
+  entries: ReadonlyArray<retryPlanEntry>,
+  slot: number,
+): retryPlanEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Resolve one entry for the retry-plan stage. */
+export function resolveEntry001(
+  entries: ReadonlyArray<retryPlanEntry>,
+  slot: number,
+): retryPlanEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Merge one entry for the retry-plan stage. */
+export function mergeEntry002(
+  entries: ReadonlyArray<retryPlanEntry>,
+  slot: number,
+): retryPlanEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Filter one entry for the retry-plan stage. */
+export function filterEntry003(
+  entries: ReadonlyArray<retryPlanEntry>,
+  slot: number,
+): retryPlanEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Reduce one entry for the retry-plan stage. */
+export function reduceEntry004(
+  entries: ReadonlyArray<retryPlanEntry>,
+  slot: number,
+): retryPlanEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Expand one entry for the retry-plan stage. */
+export function expandEntry005(
+  entries: ReadonlyArray<retryPlanEntry>,
+  slot: number,
+): retryPlanEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Normalise one entry for the retry-plan stage. */
+export function normaliseEntry006(
+  entries: ReadonlyArray<retryPlanEntry>,
+  slot: number,
+): retryPlanEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Compare one entry for the retry-plan stage. */
+export function compareEntry007(
+  entries: ReadonlyArray<retryPlanEntry>,
+  slot: number,
+): retryPlanEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Select one entry for the retry-plan stage. */
+export function selectEntry008(
+  entries: ReadonlyArray<retryPlanEntry>,
+  slot: number,
+): retryPlanEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Record one entry for the retry-plan stage. */
+export function recordEntry009(
+  entries: ReadonlyArray<retryPlanEntry>,
+  slot: number,
+): retryPlanEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Collect one record for the retry-plan stage. */
+export function collectRecord010(
+  entries: ReadonlyArray<retryPlanEntry>,
+  slot: number,
+): retryPlanEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Resolve one record for the retry-plan stage. */
+export function resolveRecord011(
+  entries: ReadonlyArray<retryPlanEntry>,
+  slot: number,
+): retryPlanEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Merge one record for the retry-plan stage. */
+export function mergeRecord012(
+  entries: ReadonlyArray<retryPlanEntry>,
+  slot: number,
+): retryPlanEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Filter one record for the retry-plan stage. */
+export function filterRecord013(
+  entries: ReadonlyArray<retryPlanEntry>,
+  slot: number,
+): retryPlanEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Reduce one record for the retry-plan stage. */
+export function reduceRecord014(
+  entries: ReadonlyArray<retryPlanEntry>,
+  slot: number,
+): retryPlanEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Expand one record for the retry-plan stage. */
+export function expandRecord015(
+  entries: ReadonlyArray<retryPlanEntry>,
+  slot: number,
+): retryPlanEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Normalise one record for the retry-plan stage. */
+export function normaliseRecord016(
+  entries: ReadonlyArray<retryPlanEntry>,
+  slot: number,
+): retryPlanEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Compare one record for the retry-plan stage. */
+export function compareRecord017(
+  entries: ReadonlyArray<retryPlanEntry>,
+  slot: number,
+): retryPlanEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Select one record for the retry-plan stage. */
+export function selectRecord018(
+  entries: ReadonlyArray<retryPlanEntry>,
+  slot: number,
+): retryPlanEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Record one record for the retry-plan stage. */
+export function recordRecord019(
+  entries: ReadonlyArray<retryPlanEntry>,
+  slot: number,
+): retryPlanEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Collect one bucket for the retry-plan stage. */
+export function collectBucket020(
+  entries: ReadonlyArray<retryPlanEntry>,
+  slot: number,
+): retryPlanEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Resolve one bucket for the retry-plan stage. */
+export function resolveBucket021(
+  entries: ReadonlyArray<retryPlanEntry>,
+  slot: number,
+): retryPlanEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Merge one bucket for the retry-plan stage. */
+export function mergeBucket022(
+  entries: ReadonlyArray<retryPlanEntry>,
+  slot: number,
+): retryPlanEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Filter one bucket for the retry-plan stage. */
+export function filterBucket023(
+  entries: ReadonlyArray<retryPlanEntry>,
+  slot: number,
+): retryPlanEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Reduce one bucket for the retry-plan stage. */
+export function reduceBucket024(
+  entries: ReadonlyArray<retryPlanEntry>,
+  slot: number,
+): retryPlanEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Expand one bucket for the retry-plan stage. */
+export function expandBucket025(
+  entries: ReadonlyArray<retryPlanEntry>,
+  slot: number,
+): retryPlanEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Normalise one bucket for the retry-plan stage. */
+export function normaliseBucket026(
+  entries: ReadonlyArray<retryPlanEntry>,
+  slot: number,
+): retryPlanEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Compare one bucket for the retry-plan stage. */
+export function compareBucket027(
+  entries: ReadonlyArray<retryPlanEntry>,
+  slot: number,
+): retryPlanEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Select one bucket for the retry-plan stage. */
+export function selectBucket028(
+  entries: ReadonlyArray<retryPlanEntry>,
+  slot: number,
+): retryPlanEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Record one bucket for the retry-plan stage. */
+export function recordBucket029(
+  entries: ReadonlyArray<retryPlanEntry>,
+  slot: number,
+): retryPlanEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Collect one segment for the retry-plan stage. */
+export function collectSegment030(
+  entries: ReadonlyArray<retryPlanEntry>,
+  slot: number,
+): retryPlanEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Resolve one segment for the retry-plan stage. */
+export function resolveSegment031(
+  entries: ReadonlyArray<retryPlanEntry>,
+  slot: number,
+): retryPlanEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Merge one segment for the retry-plan stage. */
+export function mergeSegment032(
+  entries: ReadonlyArray<retryPlanEntry>,
+  slot: number,
+): retryPlanEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Filter one segment for the retry-plan stage. */
+export function filterSegment033(
+  entries: ReadonlyArray<retryPlanEntry>,
+  slot: number,
+): retryPlanEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Reduce one segment for the retry-plan stage. */
+export function reduceSegment034(
+  entries: ReadonlyArray<retryPlanEntry>,
+  slot: number,
+): retryPlanEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Expand one segment for the retry-plan stage. */
+export function expandSegment035(
+  entries: ReadonlyArray<retryPlanEntry>,
+  slot: number,
+): retryPlanEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Normalise one segment for the retry-plan stage. */
+export function normaliseSegment036(
+  entries: ReadonlyArray<retryPlanEntry>,
+  slot: number,
+): retryPlanEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Compare one segment for the retry-plan stage. */
+export function compareSegment037(
+  entries: ReadonlyArray<retryPlanEntry>,
+  slot: number,
+): retryPlanEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Select one segment for the retry-plan stage. */
+export function selectSegment038(
+  entries: ReadonlyArray<retryPlanEntry>,
+  slot: number,
+): retryPlanEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Record one segment for the retry-plan stage. */
+export function recordSegment039(
+  entries: ReadonlyArray<retryPlanEntry>,
+  slot: number,
+): retryPlanEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Collect one window for the retry-plan stage. */
+export function collectWindow040(
+  entries: ReadonlyArray<retryPlanEntry>,
+  slot: number,
+): retryPlanEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Resolve one window for the retry-plan stage. */
+export function resolveWindow041(
+  entries: ReadonlyArray<retryPlanEntry>,
+  slot: number,
+): retryPlanEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Merge one window for the retry-plan stage. */
+export function mergeWindow042(
+  entries: ReadonlyArray<retryPlanEntry>,
+  slot: number,
+): retryPlanEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Filter one window for the retry-plan stage. */
+export function filterWindow043(
+  entries: ReadonlyArray<retryPlanEntry>,
+  slot: number,
+): retryPlanEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Reduce one window for the retry-plan stage. */
+export function reduceWindow044(
+  entries: ReadonlyArray<retryPlanEntry>,
+  slot: number,
+): retryPlanEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Expand one window for the retry-plan stage. */
+export function expandWindow045(
+  entries: ReadonlyArray<retryPlanEntry>,
+  slot: number,
+): retryPlanEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Normalise one window for the retry-plan stage. */
+export function normaliseWindow046(
+  entries: ReadonlyArray<retryPlanEntry>,
+  slot: number,
+): retryPlanEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Compare one window for the retry-plan stage. */
+export function compareWindow047(
+  entries: ReadonlyArray<retryPlanEntry>,
+  slot: number,
+): retryPlanEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Select one window for the retry-plan stage. */
+export function selectWindow048(
+  entries: ReadonlyArray<retryPlanEntry>,
+  slot: number,
+): retryPlanEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Record one window for the retry-plan stage. */
+export function recordWindow049(
+  entries: ReadonlyArray<retryPlanEntry>,
+  slot: number,
+): retryPlanEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Collect one marker for the retry-plan stage. */
+export function collectMarker050(
+  entries: ReadonlyArray<retryPlanEntry>,
+  slot: number,
+): retryPlanEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Resolve one marker for the retry-plan stage. */
+export function resolveMarker051(
+  entries: ReadonlyArray<retryPlanEntry>,
+  slot: number,
+): retryPlanEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Merge one marker for the retry-plan stage. */
+export function mergeMarker052(
+  entries: ReadonlyArray<retryPlanEntry>,
+  slot: number,
+): retryPlanEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Filter one marker for the retry-plan stage. */
+export function filterMarker053(
+  entries: ReadonlyArray<retryPlanEntry>,
+  slot: number,
+): retryPlanEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Reduce one marker for the retry-plan stage. */
+export function reduceMarker054(
+  entries: ReadonlyArray<retryPlanEntry>,
+  slot: number,
+): retryPlanEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Expand one marker for the retry-plan stage. */
+export function expandMarker055(
+  entries: ReadonlyArray<retryPlanEntry>,
+  slot: number,
+): retryPlanEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Normalise one marker for the retry-plan stage. */
+export function normaliseMarker056(
+  entries: ReadonlyArray<retryPlanEntry>,
+  slot: number,
+): retryPlanEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Compare one marker for the retry-plan stage. */
+export function compareMarker057(
+  entries: ReadonlyArray<retryPlanEntry>,
+  slot: number,
+): retryPlanEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Select one marker for the retry-plan stage. */
+export function selectMarker058(
+  entries: ReadonlyArray<retryPlanEntry>,
+  slot: number,
+): retryPlanEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Record one marker for the retry-plan stage. */
+export function recordMarker059(
+  entries: ReadonlyArray<retryPlanEntry>,
+  slot: number,
+): retryPlanEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Collect one handle for the retry-plan stage. */
+export function collectHandle060(
+  entries: ReadonlyArray<retryPlanEntry>,
+  slot: number,
+): retryPlanEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Resolve one handle for the retry-plan stage. */
+export function resolveHandle061(
+  entries: ReadonlyArray<retryPlanEntry>,
+  slot: number,
+): retryPlanEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Merge one handle for the retry-plan stage. */
+export function mergeHandle062(
+  entries: ReadonlyArray<retryPlanEntry>,
+  slot: number,
+): retryPlanEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Filter one handle for the retry-plan stage. */
+export function filterHandle063(
+  entries: ReadonlyArray<retryPlanEntry>,
+  slot: number,
+): retryPlanEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Reduce one handle for the retry-plan stage. */
+export function reduceHandle064(
+  entries: ReadonlyArray<retryPlanEntry>,
+  slot: number,
+): retryPlanEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Expand one handle for the retry-plan stage. */
+export function expandHandle065(
+  entries: ReadonlyArray<retryPlanEntry>,
+  slot: number,
+): retryPlanEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Normalise one handle for the retry-plan stage. */
+export function normaliseHandle066(
+  entries: ReadonlyArray<retryPlanEntry>,
+  slot: number,
+): retryPlanEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Compare one handle for the retry-plan stage. */
+export function compareHandle067(
+  entries: ReadonlyArray<retryPlanEntry>,
+  slot: number,
+): retryPlanEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Select one handle for the retry-plan stage. */
+export function selectHandle068(
+  entries: ReadonlyArray<retryPlanEntry>,
+  slot: number,
+): retryPlanEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Record one handle for the retry-plan stage. */
+export function recordHandle069(
+  entries: ReadonlyArray<retryPlanEntry>,
+  slot: number,
+): retryPlanEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Collect one cursor for the retry-plan stage. */
+export function collectCursor070(
+  entries: ReadonlyArray<retryPlanEntry>,
+  slot: number,
+): retryPlanEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Resolve one cursor for the retry-plan stage. */
+export function resolveCursor071(
+  entries: ReadonlyArray<retryPlanEntry>,
+  slot: number,
+): retryPlanEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Merge one cursor for the retry-plan stage. */
+export function mergeCursor072(
+  entries: ReadonlyArray<retryPlanEntry>,
+  slot: number,
+): retryPlanEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Filter one cursor for the retry-plan stage. */
+export function filterCursor073(
+  entries: ReadonlyArray<retryPlanEntry>,
+  slot: number,
+): retryPlanEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+

--- a/test-fixtures/gate-acceptance/rule-registry.ts
+++ b/test-fixtures/gate-acceptance/rule-registry.ts
@@ -1,0 +1,1500 @@
+// Acceptance corpus for the pull request review gate.
+//
+// This file is synthetic and is not part of the shipped package. It
+// exists so that one pull request is large enough to exercise two
+// limits at once: the diff API's 20,000-changed-line ceiling, and the
+// review request budget above which the gate splits a change into
+// batches. This pull request is opened to exercise them and closed
+// again; it is not merged.
+
+export interface ruleRegistryEntry {
+  readonly key: string;
+  readonly slot: number;
+  readonly active: boolean;
+}
+
+export interface ruleRegistryState {
+  readonly entries: ReadonlyArray<ruleRegistryEntry>;
+  readonly total: number;
+}
+
+/** Collect one entry for the rule-registry stage. */
+export function collectEntry000(
+  entries: ReadonlyArray<ruleRegistryEntry>,
+  slot: number,
+): ruleRegistryEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Resolve one entry for the rule-registry stage. */
+export function resolveEntry001(
+  entries: ReadonlyArray<ruleRegistryEntry>,
+  slot: number,
+): ruleRegistryEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Merge one entry for the rule-registry stage. */
+export function mergeEntry002(
+  entries: ReadonlyArray<ruleRegistryEntry>,
+  slot: number,
+): ruleRegistryEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Filter one entry for the rule-registry stage. */
+export function filterEntry003(
+  entries: ReadonlyArray<ruleRegistryEntry>,
+  slot: number,
+): ruleRegistryEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Reduce one entry for the rule-registry stage. */
+export function reduceEntry004(
+  entries: ReadonlyArray<ruleRegistryEntry>,
+  slot: number,
+): ruleRegistryEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Expand one entry for the rule-registry stage. */
+export function expandEntry005(
+  entries: ReadonlyArray<ruleRegistryEntry>,
+  slot: number,
+): ruleRegistryEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Normalise one entry for the rule-registry stage. */
+export function normaliseEntry006(
+  entries: ReadonlyArray<ruleRegistryEntry>,
+  slot: number,
+): ruleRegistryEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Compare one entry for the rule-registry stage. */
+export function compareEntry007(
+  entries: ReadonlyArray<ruleRegistryEntry>,
+  slot: number,
+): ruleRegistryEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Select one entry for the rule-registry stage. */
+export function selectEntry008(
+  entries: ReadonlyArray<ruleRegistryEntry>,
+  slot: number,
+): ruleRegistryEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Record one entry for the rule-registry stage. */
+export function recordEntry009(
+  entries: ReadonlyArray<ruleRegistryEntry>,
+  slot: number,
+): ruleRegistryEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Collect one record for the rule-registry stage. */
+export function collectRecord010(
+  entries: ReadonlyArray<ruleRegistryEntry>,
+  slot: number,
+): ruleRegistryEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Resolve one record for the rule-registry stage. */
+export function resolveRecord011(
+  entries: ReadonlyArray<ruleRegistryEntry>,
+  slot: number,
+): ruleRegistryEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Merge one record for the rule-registry stage. */
+export function mergeRecord012(
+  entries: ReadonlyArray<ruleRegistryEntry>,
+  slot: number,
+): ruleRegistryEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Filter one record for the rule-registry stage. */
+export function filterRecord013(
+  entries: ReadonlyArray<ruleRegistryEntry>,
+  slot: number,
+): ruleRegistryEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Reduce one record for the rule-registry stage. */
+export function reduceRecord014(
+  entries: ReadonlyArray<ruleRegistryEntry>,
+  slot: number,
+): ruleRegistryEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Expand one record for the rule-registry stage. */
+export function expandRecord015(
+  entries: ReadonlyArray<ruleRegistryEntry>,
+  slot: number,
+): ruleRegistryEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Normalise one record for the rule-registry stage. */
+export function normaliseRecord016(
+  entries: ReadonlyArray<ruleRegistryEntry>,
+  slot: number,
+): ruleRegistryEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Compare one record for the rule-registry stage. */
+export function compareRecord017(
+  entries: ReadonlyArray<ruleRegistryEntry>,
+  slot: number,
+): ruleRegistryEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Select one record for the rule-registry stage. */
+export function selectRecord018(
+  entries: ReadonlyArray<ruleRegistryEntry>,
+  slot: number,
+): ruleRegistryEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Record one record for the rule-registry stage. */
+export function recordRecord019(
+  entries: ReadonlyArray<ruleRegistryEntry>,
+  slot: number,
+): ruleRegistryEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Collect one bucket for the rule-registry stage. */
+export function collectBucket020(
+  entries: ReadonlyArray<ruleRegistryEntry>,
+  slot: number,
+): ruleRegistryEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Resolve one bucket for the rule-registry stage. */
+export function resolveBucket021(
+  entries: ReadonlyArray<ruleRegistryEntry>,
+  slot: number,
+): ruleRegistryEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Merge one bucket for the rule-registry stage. */
+export function mergeBucket022(
+  entries: ReadonlyArray<ruleRegistryEntry>,
+  slot: number,
+): ruleRegistryEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Filter one bucket for the rule-registry stage. */
+export function filterBucket023(
+  entries: ReadonlyArray<ruleRegistryEntry>,
+  slot: number,
+): ruleRegistryEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Reduce one bucket for the rule-registry stage. */
+export function reduceBucket024(
+  entries: ReadonlyArray<ruleRegistryEntry>,
+  slot: number,
+): ruleRegistryEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Expand one bucket for the rule-registry stage. */
+export function expandBucket025(
+  entries: ReadonlyArray<ruleRegistryEntry>,
+  slot: number,
+): ruleRegistryEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Normalise one bucket for the rule-registry stage. */
+export function normaliseBucket026(
+  entries: ReadonlyArray<ruleRegistryEntry>,
+  slot: number,
+): ruleRegistryEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Compare one bucket for the rule-registry stage. */
+export function compareBucket027(
+  entries: ReadonlyArray<ruleRegistryEntry>,
+  slot: number,
+): ruleRegistryEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Select one bucket for the rule-registry stage. */
+export function selectBucket028(
+  entries: ReadonlyArray<ruleRegistryEntry>,
+  slot: number,
+): ruleRegistryEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Record one bucket for the rule-registry stage. */
+export function recordBucket029(
+  entries: ReadonlyArray<ruleRegistryEntry>,
+  slot: number,
+): ruleRegistryEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Collect one segment for the rule-registry stage. */
+export function collectSegment030(
+  entries: ReadonlyArray<ruleRegistryEntry>,
+  slot: number,
+): ruleRegistryEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Resolve one segment for the rule-registry stage. */
+export function resolveSegment031(
+  entries: ReadonlyArray<ruleRegistryEntry>,
+  slot: number,
+): ruleRegistryEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Merge one segment for the rule-registry stage. */
+export function mergeSegment032(
+  entries: ReadonlyArray<ruleRegistryEntry>,
+  slot: number,
+): ruleRegistryEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Filter one segment for the rule-registry stage. */
+export function filterSegment033(
+  entries: ReadonlyArray<ruleRegistryEntry>,
+  slot: number,
+): ruleRegistryEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Reduce one segment for the rule-registry stage. */
+export function reduceSegment034(
+  entries: ReadonlyArray<ruleRegistryEntry>,
+  slot: number,
+): ruleRegistryEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Expand one segment for the rule-registry stage. */
+export function expandSegment035(
+  entries: ReadonlyArray<ruleRegistryEntry>,
+  slot: number,
+): ruleRegistryEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Normalise one segment for the rule-registry stage. */
+export function normaliseSegment036(
+  entries: ReadonlyArray<ruleRegistryEntry>,
+  slot: number,
+): ruleRegistryEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Compare one segment for the rule-registry stage. */
+export function compareSegment037(
+  entries: ReadonlyArray<ruleRegistryEntry>,
+  slot: number,
+): ruleRegistryEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Select one segment for the rule-registry stage. */
+export function selectSegment038(
+  entries: ReadonlyArray<ruleRegistryEntry>,
+  slot: number,
+): ruleRegistryEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Record one segment for the rule-registry stage. */
+export function recordSegment039(
+  entries: ReadonlyArray<ruleRegistryEntry>,
+  slot: number,
+): ruleRegistryEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Collect one window for the rule-registry stage. */
+export function collectWindow040(
+  entries: ReadonlyArray<ruleRegistryEntry>,
+  slot: number,
+): ruleRegistryEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Resolve one window for the rule-registry stage. */
+export function resolveWindow041(
+  entries: ReadonlyArray<ruleRegistryEntry>,
+  slot: number,
+): ruleRegistryEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Merge one window for the rule-registry stage. */
+export function mergeWindow042(
+  entries: ReadonlyArray<ruleRegistryEntry>,
+  slot: number,
+): ruleRegistryEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Filter one window for the rule-registry stage. */
+export function filterWindow043(
+  entries: ReadonlyArray<ruleRegistryEntry>,
+  slot: number,
+): ruleRegistryEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Reduce one window for the rule-registry stage. */
+export function reduceWindow044(
+  entries: ReadonlyArray<ruleRegistryEntry>,
+  slot: number,
+): ruleRegistryEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Expand one window for the rule-registry stage. */
+export function expandWindow045(
+  entries: ReadonlyArray<ruleRegistryEntry>,
+  slot: number,
+): ruleRegistryEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Normalise one window for the rule-registry stage. */
+export function normaliseWindow046(
+  entries: ReadonlyArray<ruleRegistryEntry>,
+  slot: number,
+): ruleRegistryEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Compare one window for the rule-registry stage. */
+export function compareWindow047(
+  entries: ReadonlyArray<ruleRegistryEntry>,
+  slot: number,
+): ruleRegistryEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Select one window for the rule-registry stage. */
+export function selectWindow048(
+  entries: ReadonlyArray<ruleRegistryEntry>,
+  slot: number,
+): ruleRegistryEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Record one window for the rule-registry stage. */
+export function recordWindow049(
+  entries: ReadonlyArray<ruleRegistryEntry>,
+  slot: number,
+): ruleRegistryEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Collect one marker for the rule-registry stage. */
+export function collectMarker050(
+  entries: ReadonlyArray<ruleRegistryEntry>,
+  slot: number,
+): ruleRegistryEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Resolve one marker for the rule-registry stage. */
+export function resolveMarker051(
+  entries: ReadonlyArray<ruleRegistryEntry>,
+  slot: number,
+): ruleRegistryEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Merge one marker for the rule-registry stage. */
+export function mergeMarker052(
+  entries: ReadonlyArray<ruleRegistryEntry>,
+  slot: number,
+): ruleRegistryEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Filter one marker for the rule-registry stage. */
+export function filterMarker053(
+  entries: ReadonlyArray<ruleRegistryEntry>,
+  slot: number,
+): ruleRegistryEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Reduce one marker for the rule-registry stage. */
+export function reduceMarker054(
+  entries: ReadonlyArray<ruleRegistryEntry>,
+  slot: number,
+): ruleRegistryEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Expand one marker for the rule-registry stage. */
+export function expandMarker055(
+  entries: ReadonlyArray<ruleRegistryEntry>,
+  slot: number,
+): ruleRegistryEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Normalise one marker for the rule-registry stage. */
+export function normaliseMarker056(
+  entries: ReadonlyArray<ruleRegistryEntry>,
+  slot: number,
+): ruleRegistryEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Compare one marker for the rule-registry stage. */
+export function compareMarker057(
+  entries: ReadonlyArray<ruleRegistryEntry>,
+  slot: number,
+): ruleRegistryEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Select one marker for the rule-registry stage. */
+export function selectMarker058(
+  entries: ReadonlyArray<ruleRegistryEntry>,
+  slot: number,
+): ruleRegistryEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Record one marker for the rule-registry stage. */
+export function recordMarker059(
+  entries: ReadonlyArray<ruleRegistryEntry>,
+  slot: number,
+): ruleRegistryEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Collect one handle for the rule-registry stage. */
+export function collectHandle060(
+  entries: ReadonlyArray<ruleRegistryEntry>,
+  slot: number,
+): ruleRegistryEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Resolve one handle for the rule-registry stage. */
+export function resolveHandle061(
+  entries: ReadonlyArray<ruleRegistryEntry>,
+  slot: number,
+): ruleRegistryEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Merge one handle for the rule-registry stage. */
+export function mergeHandle062(
+  entries: ReadonlyArray<ruleRegistryEntry>,
+  slot: number,
+): ruleRegistryEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Filter one handle for the rule-registry stage. */
+export function filterHandle063(
+  entries: ReadonlyArray<ruleRegistryEntry>,
+  slot: number,
+): ruleRegistryEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Reduce one handle for the rule-registry stage. */
+export function reduceHandle064(
+  entries: ReadonlyArray<ruleRegistryEntry>,
+  slot: number,
+): ruleRegistryEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Expand one handle for the rule-registry stage. */
+export function expandHandle065(
+  entries: ReadonlyArray<ruleRegistryEntry>,
+  slot: number,
+): ruleRegistryEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Normalise one handle for the rule-registry stage. */
+export function normaliseHandle066(
+  entries: ReadonlyArray<ruleRegistryEntry>,
+  slot: number,
+): ruleRegistryEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Compare one handle for the rule-registry stage. */
+export function compareHandle067(
+  entries: ReadonlyArray<ruleRegistryEntry>,
+  slot: number,
+): ruleRegistryEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Select one handle for the rule-registry stage. */
+export function selectHandle068(
+  entries: ReadonlyArray<ruleRegistryEntry>,
+  slot: number,
+): ruleRegistryEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Record one handle for the rule-registry stage. */
+export function recordHandle069(
+  entries: ReadonlyArray<ruleRegistryEntry>,
+  slot: number,
+): ruleRegistryEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Collect one cursor for the rule-registry stage. */
+export function collectCursor070(
+  entries: ReadonlyArray<ruleRegistryEntry>,
+  slot: number,
+): ruleRegistryEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Resolve one cursor for the rule-registry stage. */
+export function resolveCursor071(
+  entries: ReadonlyArray<ruleRegistryEntry>,
+  slot: number,
+): ruleRegistryEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Merge one cursor for the rule-registry stage. */
+export function mergeCursor072(
+  entries: ReadonlyArray<ruleRegistryEntry>,
+  slot: number,
+): ruleRegistryEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Filter one cursor for the rule-registry stage. */
+export function filterCursor073(
+  entries: ReadonlyArray<ruleRegistryEntry>,
+  slot: number,
+): ruleRegistryEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+

--- a/test-fixtures/gate-acceptance/scope-filter.ts
+++ b/test-fixtures/gate-acceptance/scope-filter.ts
@@ -1,0 +1,1500 @@
+// Acceptance corpus for the pull request review gate.
+//
+// This file is synthetic and is not part of the shipped package. It
+// exists so that one pull request is large enough to exercise two
+// limits at once: the diff API's 20,000-changed-line ceiling, and the
+// review request budget above which the gate splits a change into
+// batches. This pull request is opened to exercise them and closed
+// again; it is not merged.
+
+export interface scopeFilterEntry {
+  readonly key: string;
+  readonly slot: number;
+  readonly active: boolean;
+}
+
+export interface scopeFilterState {
+  readonly entries: ReadonlyArray<scopeFilterEntry>;
+  readonly total: number;
+}
+
+/** Collect one entry for the scope-filter stage. */
+export function collectEntry000(
+  entries: ReadonlyArray<scopeFilterEntry>,
+  slot: number,
+): scopeFilterEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Resolve one entry for the scope-filter stage. */
+export function resolveEntry001(
+  entries: ReadonlyArray<scopeFilterEntry>,
+  slot: number,
+): scopeFilterEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Merge one entry for the scope-filter stage. */
+export function mergeEntry002(
+  entries: ReadonlyArray<scopeFilterEntry>,
+  slot: number,
+): scopeFilterEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Filter one entry for the scope-filter stage. */
+export function filterEntry003(
+  entries: ReadonlyArray<scopeFilterEntry>,
+  slot: number,
+): scopeFilterEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Reduce one entry for the scope-filter stage. */
+export function reduceEntry004(
+  entries: ReadonlyArray<scopeFilterEntry>,
+  slot: number,
+): scopeFilterEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Expand one entry for the scope-filter stage. */
+export function expandEntry005(
+  entries: ReadonlyArray<scopeFilterEntry>,
+  slot: number,
+): scopeFilterEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Normalise one entry for the scope-filter stage. */
+export function normaliseEntry006(
+  entries: ReadonlyArray<scopeFilterEntry>,
+  slot: number,
+): scopeFilterEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Compare one entry for the scope-filter stage. */
+export function compareEntry007(
+  entries: ReadonlyArray<scopeFilterEntry>,
+  slot: number,
+): scopeFilterEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Select one entry for the scope-filter stage. */
+export function selectEntry008(
+  entries: ReadonlyArray<scopeFilterEntry>,
+  slot: number,
+): scopeFilterEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Record one entry for the scope-filter stage. */
+export function recordEntry009(
+  entries: ReadonlyArray<scopeFilterEntry>,
+  slot: number,
+): scopeFilterEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Collect one record for the scope-filter stage. */
+export function collectRecord010(
+  entries: ReadonlyArray<scopeFilterEntry>,
+  slot: number,
+): scopeFilterEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Resolve one record for the scope-filter stage. */
+export function resolveRecord011(
+  entries: ReadonlyArray<scopeFilterEntry>,
+  slot: number,
+): scopeFilterEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Merge one record for the scope-filter stage. */
+export function mergeRecord012(
+  entries: ReadonlyArray<scopeFilterEntry>,
+  slot: number,
+): scopeFilterEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Filter one record for the scope-filter stage. */
+export function filterRecord013(
+  entries: ReadonlyArray<scopeFilterEntry>,
+  slot: number,
+): scopeFilterEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Reduce one record for the scope-filter stage. */
+export function reduceRecord014(
+  entries: ReadonlyArray<scopeFilterEntry>,
+  slot: number,
+): scopeFilterEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Expand one record for the scope-filter stage. */
+export function expandRecord015(
+  entries: ReadonlyArray<scopeFilterEntry>,
+  slot: number,
+): scopeFilterEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Normalise one record for the scope-filter stage. */
+export function normaliseRecord016(
+  entries: ReadonlyArray<scopeFilterEntry>,
+  slot: number,
+): scopeFilterEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Compare one record for the scope-filter stage. */
+export function compareRecord017(
+  entries: ReadonlyArray<scopeFilterEntry>,
+  slot: number,
+): scopeFilterEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Select one record for the scope-filter stage. */
+export function selectRecord018(
+  entries: ReadonlyArray<scopeFilterEntry>,
+  slot: number,
+): scopeFilterEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Record one record for the scope-filter stage. */
+export function recordRecord019(
+  entries: ReadonlyArray<scopeFilterEntry>,
+  slot: number,
+): scopeFilterEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Collect one bucket for the scope-filter stage. */
+export function collectBucket020(
+  entries: ReadonlyArray<scopeFilterEntry>,
+  slot: number,
+): scopeFilterEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Resolve one bucket for the scope-filter stage. */
+export function resolveBucket021(
+  entries: ReadonlyArray<scopeFilterEntry>,
+  slot: number,
+): scopeFilterEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Merge one bucket for the scope-filter stage. */
+export function mergeBucket022(
+  entries: ReadonlyArray<scopeFilterEntry>,
+  slot: number,
+): scopeFilterEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Filter one bucket for the scope-filter stage. */
+export function filterBucket023(
+  entries: ReadonlyArray<scopeFilterEntry>,
+  slot: number,
+): scopeFilterEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Reduce one bucket for the scope-filter stage. */
+export function reduceBucket024(
+  entries: ReadonlyArray<scopeFilterEntry>,
+  slot: number,
+): scopeFilterEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Expand one bucket for the scope-filter stage. */
+export function expandBucket025(
+  entries: ReadonlyArray<scopeFilterEntry>,
+  slot: number,
+): scopeFilterEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Normalise one bucket for the scope-filter stage. */
+export function normaliseBucket026(
+  entries: ReadonlyArray<scopeFilterEntry>,
+  slot: number,
+): scopeFilterEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Compare one bucket for the scope-filter stage. */
+export function compareBucket027(
+  entries: ReadonlyArray<scopeFilterEntry>,
+  slot: number,
+): scopeFilterEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Select one bucket for the scope-filter stage. */
+export function selectBucket028(
+  entries: ReadonlyArray<scopeFilterEntry>,
+  slot: number,
+): scopeFilterEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Record one bucket for the scope-filter stage. */
+export function recordBucket029(
+  entries: ReadonlyArray<scopeFilterEntry>,
+  slot: number,
+): scopeFilterEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Collect one segment for the scope-filter stage. */
+export function collectSegment030(
+  entries: ReadonlyArray<scopeFilterEntry>,
+  slot: number,
+): scopeFilterEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Resolve one segment for the scope-filter stage. */
+export function resolveSegment031(
+  entries: ReadonlyArray<scopeFilterEntry>,
+  slot: number,
+): scopeFilterEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Merge one segment for the scope-filter stage. */
+export function mergeSegment032(
+  entries: ReadonlyArray<scopeFilterEntry>,
+  slot: number,
+): scopeFilterEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Filter one segment for the scope-filter stage. */
+export function filterSegment033(
+  entries: ReadonlyArray<scopeFilterEntry>,
+  slot: number,
+): scopeFilterEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Reduce one segment for the scope-filter stage. */
+export function reduceSegment034(
+  entries: ReadonlyArray<scopeFilterEntry>,
+  slot: number,
+): scopeFilterEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Expand one segment for the scope-filter stage. */
+export function expandSegment035(
+  entries: ReadonlyArray<scopeFilterEntry>,
+  slot: number,
+): scopeFilterEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Normalise one segment for the scope-filter stage. */
+export function normaliseSegment036(
+  entries: ReadonlyArray<scopeFilterEntry>,
+  slot: number,
+): scopeFilterEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Compare one segment for the scope-filter stage. */
+export function compareSegment037(
+  entries: ReadonlyArray<scopeFilterEntry>,
+  slot: number,
+): scopeFilterEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Select one segment for the scope-filter stage. */
+export function selectSegment038(
+  entries: ReadonlyArray<scopeFilterEntry>,
+  slot: number,
+): scopeFilterEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Record one segment for the scope-filter stage. */
+export function recordSegment039(
+  entries: ReadonlyArray<scopeFilterEntry>,
+  slot: number,
+): scopeFilterEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Collect one window for the scope-filter stage. */
+export function collectWindow040(
+  entries: ReadonlyArray<scopeFilterEntry>,
+  slot: number,
+): scopeFilterEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Resolve one window for the scope-filter stage. */
+export function resolveWindow041(
+  entries: ReadonlyArray<scopeFilterEntry>,
+  slot: number,
+): scopeFilterEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Merge one window for the scope-filter stage. */
+export function mergeWindow042(
+  entries: ReadonlyArray<scopeFilterEntry>,
+  slot: number,
+): scopeFilterEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Filter one window for the scope-filter stage. */
+export function filterWindow043(
+  entries: ReadonlyArray<scopeFilterEntry>,
+  slot: number,
+): scopeFilterEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Reduce one window for the scope-filter stage. */
+export function reduceWindow044(
+  entries: ReadonlyArray<scopeFilterEntry>,
+  slot: number,
+): scopeFilterEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Expand one window for the scope-filter stage. */
+export function expandWindow045(
+  entries: ReadonlyArray<scopeFilterEntry>,
+  slot: number,
+): scopeFilterEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Normalise one window for the scope-filter stage. */
+export function normaliseWindow046(
+  entries: ReadonlyArray<scopeFilterEntry>,
+  slot: number,
+): scopeFilterEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Compare one window for the scope-filter stage. */
+export function compareWindow047(
+  entries: ReadonlyArray<scopeFilterEntry>,
+  slot: number,
+): scopeFilterEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Select one window for the scope-filter stage. */
+export function selectWindow048(
+  entries: ReadonlyArray<scopeFilterEntry>,
+  slot: number,
+): scopeFilterEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Record one window for the scope-filter stage. */
+export function recordWindow049(
+  entries: ReadonlyArray<scopeFilterEntry>,
+  slot: number,
+): scopeFilterEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Collect one marker for the scope-filter stage. */
+export function collectMarker050(
+  entries: ReadonlyArray<scopeFilterEntry>,
+  slot: number,
+): scopeFilterEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Resolve one marker for the scope-filter stage. */
+export function resolveMarker051(
+  entries: ReadonlyArray<scopeFilterEntry>,
+  slot: number,
+): scopeFilterEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Merge one marker for the scope-filter stage. */
+export function mergeMarker052(
+  entries: ReadonlyArray<scopeFilterEntry>,
+  slot: number,
+): scopeFilterEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Filter one marker for the scope-filter stage. */
+export function filterMarker053(
+  entries: ReadonlyArray<scopeFilterEntry>,
+  slot: number,
+): scopeFilterEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Reduce one marker for the scope-filter stage. */
+export function reduceMarker054(
+  entries: ReadonlyArray<scopeFilterEntry>,
+  slot: number,
+): scopeFilterEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Expand one marker for the scope-filter stage. */
+export function expandMarker055(
+  entries: ReadonlyArray<scopeFilterEntry>,
+  slot: number,
+): scopeFilterEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Normalise one marker for the scope-filter stage. */
+export function normaliseMarker056(
+  entries: ReadonlyArray<scopeFilterEntry>,
+  slot: number,
+): scopeFilterEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Compare one marker for the scope-filter stage. */
+export function compareMarker057(
+  entries: ReadonlyArray<scopeFilterEntry>,
+  slot: number,
+): scopeFilterEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Select one marker for the scope-filter stage. */
+export function selectMarker058(
+  entries: ReadonlyArray<scopeFilterEntry>,
+  slot: number,
+): scopeFilterEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Record one marker for the scope-filter stage. */
+export function recordMarker059(
+  entries: ReadonlyArray<scopeFilterEntry>,
+  slot: number,
+): scopeFilterEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Collect one handle for the scope-filter stage. */
+export function collectHandle060(
+  entries: ReadonlyArray<scopeFilterEntry>,
+  slot: number,
+): scopeFilterEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Resolve one handle for the scope-filter stage. */
+export function resolveHandle061(
+  entries: ReadonlyArray<scopeFilterEntry>,
+  slot: number,
+): scopeFilterEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Merge one handle for the scope-filter stage. */
+export function mergeHandle062(
+  entries: ReadonlyArray<scopeFilterEntry>,
+  slot: number,
+): scopeFilterEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Filter one handle for the scope-filter stage. */
+export function filterHandle063(
+  entries: ReadonlyArray<scopeFilterEntry>,
+  slot: number,
+): scopeFilterEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Reduce one handle for the scope-filter stage. */
+export function reduceHandle064(
+  entries: ReadonlyArray<scopeFilterEntry>,
+  slot: number,
+): scopeFilterEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Expand one handle for the scope-filter stage. */
+export function expandHandle065(
+  entries: ReadonlyArray<scopeFilterEntry>,
+  slot: number,
+): scopeFilterEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Normalise one handle for the scope-filter stage. */
+export function normaliseHandle066(
+  entries: ReadonlyArray<scopeFilterEntry>,
+  slot: number,
+): scopeFilterEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Compare one handle for the scope-filter stage. */
+export function compareHandle067(
+  entries: ReadonlyArray<scopeFilterEntry>,
+  slot: number,
+): scopeFilterEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Select one handle for the scope-filter stage. */
+export function selectHandle068(
+  entries: ReadonlyArray<scopeFilterEntry>,
+  slot: number,
+): scopeFilterEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Record one handle for the scope-filter stage. */
+export function recordHandle069(
+  entries: ReadonlyArray<scopeFilterEntry>,
+  slot: number,
+): scopeFilterEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Collect one cursor for the scope-filter stage. */
+export function collectCursor070(
+  entries: ReadonlyArray<scopeFilterEntry>,
+  slot: number,
+): scopeFilterEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Resolve one cursor for the scope-filter stage. */
+export function resolveCursor071(
+  entries: ReadonlyArray<scopeFilterEntry>,
+  slot: number,
+): scopeFilterEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Merge one cursor for the scope-filter stage. */
+export function mergeCursor072(
+  entries: ReadonlyArray<scopeFilterEntry>,
+  slot: number,
+): scopeFilterEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Filter one cursor for the scope-filter stage. */
+export function filterCursor073(
+  entries: ReadonlyArray<scopeFilterEntry>,
+  slot: number,
+): scopeFilterEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+

--- a/test-fixtures/gate-acceptance/severity-ladder.ts
+++ b/test-fixtures/gate-acceptance/severity-ladder.ts
@@ -1,0 +1,1500 @@
+// Acceptance corpus for the pull request review gate.
+//
+// This file is synthetic and is not part of the shipped package. It
+// exists so that one pull request is large enough to exercise two
+// limits at once: the diff API's 20,000-changed-line ceiling, and the
+// review request budget above which the gate splits a change into
+// batches. This pull request is opened to exercise them and closed
+// again; it is not merged.
+
+export interface severityLadderEntry {
+  readonly key: string;
+  readonly slot: number;
+  readonly active: boolean;
+}
+
+export interface severityLadderState {
+  readonly entries: ReadonlyArray<severityLadderEntry>;
+  readonly total: number;
+}
+
+/** Collect one entry for the severity-ladder stage. */
+export function collectEntry000(
+  entries: ReadonlyArray<severityLadderEntry>,
+  slot: number,
+): severityLadderEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Resolve one entry for the severity-ladder stage. */
+export function resolveEntry001(
+  entries: ReadonlyArray<severityLadderEntry>,
+  slot: number,
+): severityLadderEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Merge one entry for the severity-ladder stage. */
+export function mergeEntry002(
+  entries: ReadonlyArray<severityLadderEntry>,
+  slot: number,
+): severityLadderEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Filter one entry for the severity-ladder stage. */
+export function filterEntry003(
+  entries: ReadonlyArray<severityLadderEntry>,
+  slot: number,
+): severityLadderEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Reduce one entry for the severity-ladder stage. */
+export function reduceEntry004(
+  entries: ReadonlyArray<severityLadderEntry>,
+  slot: number,
+): severityLadderEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Expand one entry for the severity-ladder stage. */
+export function expandEntry005(
+  entries: ReadonlyArray<severityLadderEntry>,
+  slot: number,
+): severityLadderEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Normalise one entry for the severity-ladder stage. */
+export function normaliseEntry006(
+  entries: ReadonlyArray<severityLadderEntry>,
+  slot: number,
+): severityLadderEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Compare one entry for the severity-ladder stage. */
+export function compareEntry007(
+  entries: ReadonlyArray<severityLadderEntry>,
+  slot: number,
+): severityLadderEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Select one entry for the severity-ladder stage. */
+export function selectEntry008(
+  entries: ReadonlyArray<severityLadderEntry>,
+  slot: number,
+): severityLadderEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Record one entry for the severity-ladder stage. */
+export function recordEntry009(
+  entries: ReadonlyArray<severityLadderEntry>,
+  slot: number,
+): severityLadderEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Collect one record for the severity-ladder stage. */
+export function collectRecord010(
+  entries: ReadonlyArray<severityLadderEntry>,
+  slot: number,
+): severityLadderEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Resolve one record for the severity-ladder stage. */
+export function resolveRecord011(
+  entries: ReadonlyArray<severityLadderEntry>,
+  slot: number,
+): severityLadderEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Merge one record for the severity-ladder stage. */
+export function mergeRecord012(
+  entries: ReadonlyArray<severityLadderEntry>,
+  slot: number,
+): severityLadderEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Filter one record for the severity-ladder stage. */
+export function filterRecord013(
+  entries: ReadonlyArray<severityLadderEntry>,
+  slot: number,
+): severityLadderEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Reduce one record for the severity-ladder stage. */
+export function reduceRecord014(
+  entries: ReadonlyArray<severityLadderEntry>,
+  slot: number,
+): severityLadderEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Expand one record for the severity-ladder stage. */
+export function expandRecord015(
+  entries: ReadonlyArray<severityLadderEntry>,
+  slot: number,
+): severityLadderEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Normalise one record for the severity-ladder stage. */
+export function normaliseRecord016(
+  entries: ReadonlyArray<severityLadderEntry>,
+  slot: number,
+): severityLadderEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Compare one record for the severity-ladder stage. */
+export function compareRecord017(
+  entries: ReadonlyArray<severityLadderEntry>,
+  slot: number,
+): severityLadderEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Select one record for the severity-ladder stage. */
+export function selectRecord018(
+  entries: ReadonlyArray<severityLadderEntry>,
+  slot: number,
+): severityLadderEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Record one record for the severity-ladder stage. */
+export function recordRecord019(
+  entries: ReadonlyArray<severityLadderEntry>,
+  slot: number,
+): severityLadderEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Collect one bucket for the severity-ladder stage. */
+export function collectBucket020(
+  entries: ReadonlyArray<severityLadderEntry>,
+  slot: number,
+): severityLadderEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Resolve one bucket for the severity-ladder stage. */
+export function resolveBucket021(
+  entries: ReadonlyArray<severityLadderEntry>,
+  slot: number,
+): severityLadderEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Merge one bucket for the severity-ladder stage. */
+export function mergeBucket022(
+  entries: ReadonlyArray<severityLadderEntry>,
+  slot: number,
+): severityLadderEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Filter one bucket for the severity-ladder stage. */
+export function filterBucket023(
+  entries: ReadonlyArray<severityLadderEntry>,
+  slot: number,
+): severityLadderEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Reduce one bucket for the severity-ladder stage. */
+export function reduceBucket024(
+  entries: ReadonlyArray<severityLadderEntry>,
+  slot: number,
+): severityLadderEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Expand one bucket for the severity-ladder stage. */
+export function expandBucket025(
+  entries: ReadonlyArray<severityLadderEntry>,
+  slot: number,
+): severityLadderEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Normalise one bucket for the severity-ladder stage. */
+export function normaliseBucket026(
+  entries: ReadonlyArray<severityLadderEntry>,
+  slot: number,
+): severityLadderEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Compare one bucket for the severity-ladder stage. */
+export function compareBucket027(
+  entries: ReadonlyArray<severityLadderEntry>,
+  slot: number,
+): severityLadderEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Select one bucket for the severity-ladder stage. */
+export function selectBucket028(
+  entries: ReadonlyArray<severityLadderEntry>,
+  slot: number,
+): severityLadderEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Record one bucket for the severity-ladder stage. */
+export function recordBucket029(
+  entries: ReadonlyArray<severityLadderEntry>,
+  slot: number,
+): severityLadderEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Collect one segment for the severity-ladder stage. */
+export function collectSegment030(
+  entries: ReadonlyArray<severityLadderEntry>,
+  slot: number,
+): severityLadderEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Resolve one segment for the severity-ladder stage. */
+export function resolveSegment031(
+  entries: ReadonlyArray<severityLadderEntry>,
+  slot: number,
+): severityLadderEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Merge one segment for the severity-ladder stage. */
+export function mergeSegment032(
+  entries: ReadonlyArray<severityLadderEntry>,
+  slot: number,
+): severityLadderEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Filter one segment for the severity-ladder stage. */
+export function filterSegment033(
+  entries: ReadonlyArray<severityLadderEntry>,
+  slot: number,
+): severityLadderEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Reduce one segment for the severity-ladder stage. */
+export function reduceSegment034(
+  entries: ReadonlyArray<severityLadderEntry>,
+  slot: number,
+): severityLadderEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Expand one segment for the severity-ladder stage. */
+export function expandSegment035(
+  entries: ReadonlyArray<severityLadderEntry>,
+  slot: number,
+): severityLadderEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Normalise one segment for the severity-ladder stage. */
+export function normaliseSegment036(
+  entries: ReadonlyArray<severityLadderEntry>,
+  slot: number,
+): severityLadderEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Compare one segment for the severity-ladder stage. */
+export function compareSegment037(
+  entries: ReadonlyArray<severityLadderEntry>,
+  slot: number,
+): severityLadderEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Select one segment for the severity-ladder stage. */
+export function selectSegment038(
+  entries: ReadonlyArray<severityLadderEntry>,
+  slot: number,
+): severityLadderEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Record one segment for the severity-ladder stage. */
+export function recordSegment039(
+  entries: ReadonlyArray<severityLadderEntry>,
+  slot: number,
+): severityLadderEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Collect one window for the severity-ladder stage. */
+export function collectWindow040(
+  entries: ReadonlyArray<severityLadderEntry>,
+  slot: number,
+): severityLadderEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Resolve one window for the severity-ladder stage. */
+export function resolveWindow041(
+  entries: ReadonlyArray<severityLadderEntry>,
+  slot: number,
+): severityLadderEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Merge one window for the severity-ladder stage. */
+export function mergeWindow042(
+  entries: ReadonlyArray<severityLadderEntry>,
+  slot: number,
+): severityLadderEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Filter one window for the severity-ladder stage. */
+export function filterWindow043(
+  entries: ReadonlyArray<severityLadderEntry>,
+  slot: number,
+): severityLadderEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Reduce one window for the severity-ladder stage. */
+export function reduceWindow044(
+  entries: ReadonlyArray<severityLadderEntry>,
+  slot: number,
+): severityLadderEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Expand one window for the severity-ladder stage. */
+export function expandWindow045(
+  entries: ReadonlyArray<severityLadderEntry>,
+  slot: number,
+): severityLadderEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Normalise one window for the severity-ladder stage. */
+export function normaliseWindow046(
+  entries: ReadonlyArray<severityLadderEntry>,
+  slot: number,
+): severityLadderEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Compare one window for the severity-ladder stage. */
+export function compareWindow047(
+  entries: ReadonlyArray<severityLadderEntry>,
+  slot: number,
+): severityLadderEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Select one window for the severity-ladder stage. */
+export function selectWindow048(
+  entries: ReadonlyArray<severityLadderEntry>,
+  slot: number,
+): severityLadderEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Record one window for the severity-ladder stage. */
+export function recordWindow049(
+  entries: ReadonlyArray<severityLadderEntry>,
+  slot: number,
+): severityLadderEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Collect one marker for the severity-ladder stage. */
+export function collectMarker050(
+  entries: ReadonlyArray<severityLadderEntry>,
+  slot: number,
+): severityLadderEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Resolve one marker for the severity-ladder stage. */
+export function resolveMarker051(
+  entries: ReadonlyArray<severityLadderEntry>,
+  slot: number,
+): severityLadderEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Merge one marker for the severity-ladder stage. */
+export function mergeMarker052(
+  entries: ReadonlyArray<severityLadderEntry>,
+  slot: number,
+): severityLadderEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Filter one marker for the severity-ladder stage. */
+export function filterMarker053(
+  entries: ReadonlyArray<severityLadderEntry>,
+  slot: number,
+): severityLadderEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Reduce one marker for the severity-ladder stage. */
+export function reduceMarker054(
+  entries: ReadonlyArray<severityLadderEntry>,
+  slot: number,
+): severityLadderEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Expand one marker for the severity-ladder stage. */
+export function expandMarker055(
+  entries: ReadonlyArray<severityLadderEntry>,
+  slot: number,
+): severityLadderEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Normalise one marker for the severity-ladder stage. */
+export function normaliseMarker056(
+  entries: ReadonlyArray<severityLadderEntry>,
+  slot: number,
+): severityLadderEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Compare one marker for the severity-ladder stage. */
+export function compareMarker057(
+  entries: ReadonlyArray<severityLadderEntry>,
+  slot: number,
+): severityLadderEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Select one marker for the severity-ladder stage. */
+export function selectMarker058(
+  entries: ReadonlyArray<severityLadderEntry>,
+  slot: number,
+): severityLadderEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Record one marker for the severity-ladder stage. */
+export function recordMarker059(
+  entries: ReadonlyArray<severityLadderEntry>,
+  slot: number,
+): severityLadderEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Collect one handle for the severity-ladder stage. */
+export function collectHandle060(
+  entries: ReadonlyArray<severityLadderEntry>,
+  slot: number,
+): severityLadderEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Resolve one handle for the severity-ladder stage. */
+export function resolveHandle061(
+  entries: ReadonlyArray<severityLadderEntry>,
+  slot: number,
+): severityLadderEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Merge one handle for the severity-ladder stage. */
+export function mergeHandle062(
+  entries: ReadonlyArray<severityLadderEntry>,
+  slot: number,
+): severityLadderEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Filter one handle for the severity-ladder stage. */
+export function filterHandle063(
+  entries: ReadonlyArray<severityLadderEntry>,
+  slot: number,
+): severityLadderEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Reduce one handle for the severity-ladder stage. */
+export function reduceHandle064(
+  entries: ReadonlyArray<severityLadderEntry>,
+  slot: number,
+): severityLadderEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Expand one handle for the severity-ladder stage. */
+export function expandHandle065(
+  entries: ReadonlyArray<severityLadderEntry>,
+  slot: number,
+): severityLadderEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Normalise one handle for the severity-ladder stage. */
+export function normaliseHandle066(
+  entries: ReadonlyArray<severityLadderEntry>,
+  slot: number,
+): severityLadderEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Compare one handle for the severity-ladder stage. */
+export function compareHandle067(
+  entries: ReadonlyArray<severityLadderEntry>,
+  slot: number,
+): severityLadderEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Select one handle for the severity-ladder stage. */
+export function selectHandle068(
+  entries: ReadonlyArray<severityLadderEntry>,
+  slot: number,
+): severityLadderEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Record one handle for the severity-ladder stage. */
+export function recordHandle069(
+  entries: ReadonlyArray<severityLadderEntry>,
+  slot: number,
+): severityLadderEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Collect one cursor for the severity-ladder stage. */
+export function collectCursor070(
+  entries: ReadonlyArray<severityLadderEntry>,
+  slot: number,
+): severityLadderEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Resolve one cursor for the severity-ladder stage. */
+export function resolveCursor071(
+  entries: ReadonlyArray<severityLadderEntry>,
+  slot: number,
+): severityLadderEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Merge one cursor for the severity-ladder stage. */
+export function mergeCursor072(
+  entries: ReadonlyArray<severityLadderEntry>,
+  slot: number,
+): severityLadderEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Filter one cursor for the severity-ladder stage. */
+export function filterCursor073(
+  entries: ReadonlyArray<severityLadderEntry>,
+  slot: number,
+): severityLadderEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+

--- a/test-fixtures/gate-acceptance/stream-reader.ts
+++ b/test-fixtures/gate-acceptance/stream-reader.ts
@@ -1,0 +1,1500 @@
+// Acceptance corpus for the pull request review gate.
+//
+// This file is synthetic and is not part of the shipped package. It
+// exists so that one pull request is large enough to exercise two
+// limits at once: the diff API's 20,000-changed-line ceiling, and the
+// review request budget above which the gate splits a change into
+// batches. This pull request is opened to exercise them and closed
+// again; it is not merged.
+
+export interface streamReaderEntry {
+  readonly key: string;
+  readonly slot: number;
+  readonly active: boolean;
+}
+
+export interface streamReaderState {
+  readonly entries: ReadonlyArray<streamReaderEntry>;
+  readonly total: number;
+}
+
+/** Collect one entry for the stream-reader stage. */
+export function collectEntry000(
+  entries: ReadonlyArray<streamReaderEntry>,
+  slot: number,
+): streamReaderEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Resolve one entry for the stream-reader stage. */
+export function resolveEntry001(
+  entries: ReadonlyArray<streamReaderEntry>,
+  slot: number,
+): streamReaderEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Merge one entry for the stream-reader stage. */
+export function mergeEntry002(
+  entries: ReadonlyArray<streamReaderEntry>,
+  slot: number,
+): streamReaderEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Filter one entry for the stream-reader stage. */
+export function filterEntry003(
+  entries: ReadonlyArray<streamReaderEntry>,
+  slot: number,
+): streamReaderEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Reduce one entry for the stream-reader stage. */
+export function reduceEntry004(
+  entries: ReadonlyArray<streamReaderEntry>,
+  slot: number,
+): streamReaderEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Expand one entry for the stream-reader stage. */
+export function expandEntry005(
+  entries: ReadonlyArray<streamReaderEntry>,
+  slot: number,
+): streamReaderEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Normalise one entry for the stream-reader stage. */
+export function normaliseEntry006(
+  entries: ReadonlyArray<streamReaderEntry>,
+  slot: number,
+): streamReaderEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Compare one entry for the stream-reader stage. */
+export function compareEntry007(
+  entries: ReadonlyArray<streamReaderEntry>,
+  slot: number,
+): streamReaderEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Select one entry for the stream-reader stage. */
+export function selectEntry008(
+  entries: ReadonlyArray<streamReaderEntry>,
+  slot: number,
+): streamReaderEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Record one entry for the stream-reader stage. */
+export function recordEntry009(
+  entries: ReadonlyArray<streamReaderEntry>,
+  slot: number,
+): streamReaderEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Collect one record for the stream-reader stage. */
+export function collectRecord010(
+  entries: ReadonlyArray<streamReaderEntry>,
+  slot: number,
+): streamReaderEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Resolve one record for the stream-reader stage. */
+export function resolveRecord011(
+  entries: ReadonlyArray<streamReaderEntry>,
+  slot: number,
+): streamReaderEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Merge one record for the stream-reader stage. */
+export function mergeRecord012(
+  entries: ReadonlyArray<streamReaderEntry>,
+  slot: number,
+): streamReaderEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Filter one record for the stream-reader stage. */
+export function filterRecord013(
+  entries: ReadonlyArray<streamReaderEntry>,
+  slot: number,
+): streamReaderEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Reduce one record for the stream-reader stage. */
+export function reduceRecord014(
+  entries: ReadonlyArray<streamReaderEntry>,
+  slot: number,
+): streamReaderEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Expand one record for the stream-reader stage. */
+export function expandRecord015(
+  entries: ReadonlyArray<streamReaderEntry>,
+  slot: number,
+): streamReaderEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Normalise one record for the stream-reader stage. */
+export function normaliseRecord016(
+  entries: ReadonlyArray<streamReaderEntry>,
+  slot: number,
+): streamReaderEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Compare one record for the stream-reader stage. */
+export function compareRecord017(
+  entries: ReadonlyArray<streamReaderEntry>,
+  slot: number,
+): streamReaderEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Select one record for the stream-reader stage. */
+export function selectRecord018(
+  entries: ReadonlyArray<streamReaderEntry>,
+  slot: number,
+): streamReaderEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Record one record for the stream-reader stage. */
+export function recordRecord019(
+  entries: ReadonlyArray<streamReaderEntry>,
+  slot: number,
+): streamReaderEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Collect one bucket for the stream-reader stage. */
+export function collectBucket020(
+  entries: ReadonlyArray<streamReaderEntry>,
+  slot: number,
+): streamReaderEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Resolve one bucket for the stream-reader stage. */
+export function resolveBucket021(
+  entries: ReadonlyArray<streamReaderEntry>,
+  slot: number,
+): streamReaderEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Merge one bucket for the stream-reader stage. */
+export function mergeBucket022(
+  entries: ReadonlyArray<streamReaderEntry>,
+  slot: number,
+): streamReaderEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Filter one bucket for the stream-reader stage. */
+export function filterBucket023(
+  entries: ReadonlyArray<streamReaderEntry>,
+  slot: number,
+): streamReaderEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Reduce one bucket for the stream-reader stage. */
+export function reduceBucket024(
+  entries: ReadonlyArray<streamReaderEntry>,
+  slot: number,
+): streamReaderEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Expand one bucket for the stream-reader stage. */
+export function expandBucket025(
+  entries: ReadonlyArray<streamReaderEntry>,
+  slot: number,
+): streamReaderEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Normalise one bucket for the stream-reader stage. */
+export function normaliseBucket026(
+  entries: ReadonlyArray<streamReaderEntry>,
+  slot: number,
+): streamReaderEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Compare one bucket for the stream-reader stage. */
+export function compareBucket027(
+  entries: ReadonlyArray<streamReaderEntry>,
+  slot: number,
+): streamReaderEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Select one bucket for the stream-reader stage. */
+export function selectBucket028(
+  entries: ReadonlyArray<streamReaderEntry>,
+  slot: number,
+): streamReaderEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Record one bucket for the stream-reader stage. */
+export function recordBucket029(
+  entries: ReadonlyArray<streamReaderEntry>,
+  slot: number,
+): streamReaderEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Collect one segment for the stream-reader stage. */
+export function collectSegment030(
+  entries: ReadonlyArray<streamReaderEntry>,
+  slot: number,
+): streamReaderEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Resolve one segment for the stream-reader stage. */
+export function resolveSegment031(
+  entries: ReadonlyArray<streamReaderEntry>,
+  slot: number,
+): streamReaderEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Merge one segment for the stream-reader stage. */
+export function mergeSegment032(
+  entries: ReadonlyArray<streamReaderEntry>,
+  slot: number,
+): streamReaderEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Filter one segment for the stream-reader stage. */
+export function filterSegment033(
+  entries: ReadonlyArray<streamReaderEntry>,
+  slot: number,
+): streamReaderEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Reduce one segment for the stream-reader stage. */
+export function reduceSegment034(
+  entries: ReadonlyArray<streamReaderEntry>,
+  slot: number,
+): streamReaderEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Expand one segment for the stream-reader stage. */
+export function expandSegment035(
+  entries: ReadonlyArray<streamReaderEntry>,
+  slot: number,
+): streamReaderEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Normalise one segment for the stream-reader stage. */
+export function normaliseSegment036(
+  entries: ReadonlyArray<streamReaderEntry>,
+  slot: number,
+): streamReaderEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Compare one segment for the stream-reader stage. */
+export function compareSegment037(
+  entries: ReadonlyArray<streamReaderEntry>,
+  slot: number,
+): streamReaderEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Select one segment for the stream-reader stage. */
+export function selectSegment038(
+  entries: ReadonlyArray<streamReaderEntry>,
+  slot: number,
+): streamReaderEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Record one segment for the stream-reader stage. */
+export function recordSegment039(
+  entries: ReadonlyArray<streamReaderEntry>,
+  slot: number,
+): streamReaderEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Collect one window for the stream-reader stage. */
+export function collectWindow040(
+  entries: ReadonlyArray<streamReaderEntry>,
+  slot: number,
+): streamReaderEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Resolve one window for the stream-reader stage. */
+export function resolveWindow041(
+  entries: ReadonlyArray<streamReaderEntry>,
+  slot: number,
+): streamReaderEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Merge one window for the stream-reader stage. */
+export function mergeWindow042(
+  entries: ReadonlyArray<streamReaderEntry>,
+  slot: number,
+): streamReaderEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Filter one window for the stream-reader stage. */
+export function filterWindow043(
+  entries: ReadonlyArray<streamReaderEntry>,
+  slot: number,
+): streamReaderEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Reduce one window for the stream-reader stage. */
+export function reduceWindow044(
+  entries: ReadonlyArray<streamReaderEntry>,
+  slot: number,
+): streamReaderEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Expand one window for the stream-reader stage. */
+export function expandWindow045(
+  entries: ReadonlyArray<streamReaderEntry>,
+  slot: number,
+): streamReaderEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Normalise one window for the stream-reader stage. */
+export function normaliseWindow046(
+  entries: ReadonlyArray<streamReaderEntry>,
+  slot: number,
+): streamReaderEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Compare one window for the stream-reader stage. */
+export function compareWindow047(
+  entries: ReadonlyArray<streamReaderEntry>,
+  slot: number,
+): streamReaderEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Select one window for the stream-reader stage. */
+export function selectWindow048(
+  entries: ReadonlyArray<streamReaderEntry>,
+  slot: number,
+): streamReaderEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Record one window for the stream-reader stage. */
+export function recordWindow049(
+  entries: ReadonlyArray<streamReaderEntry>,
+  slot: number,
+): streamReaderEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Collect one marker for the stream-reader stage. */
+export function collectMarker050(
+  entries: ReadonlyArray<streamReaderEntry>,
+  slot: number,
+): streamReaderEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Resolve one marker for the stream-reader stage. */
+export function resolveMarker051(
+  entries: ReadonlyArray<streamReaderEntry>,
+  slot: number,
+): streamReaderEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Merge one marker for the stream-reader stage. */
+export function mergeMarker052(
+  entries: ReadonlyArray<streamReaderEntry>,
+  slot: number,
+): streamReaderEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Filter one marker for the stream-reader stage. */
+export function filterMarker053(
+  entries: ReadonlyArray<streamReaderEntry>,
+  slot: number,
+): streamReaderEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Reduce one marker for the stream-reader stage. */
+export function reduceMarker054(
+  entries: ReadonlyArray<streamReaderEntry>,
+  slot: number,
+): streamReaderEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Expand one marker for the stream-reader stage. */
+export function expandMarker055(
+  entries: ReadonlyArray<streamReaderEntry>,
+  slot: number,
+): streamReaderEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Normalise one marker for the stream-reader stage. */
+export function normaliseMarker056(
+  entries: ReadonlyArray<streamReaderEntry>,
+  slot: number,
+): streamReaderEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Compare one marker for the stream-reader stage. */
+export function compareMarker057(
+  entries: ReadonlyArray<streamReaderEntry>,
+  slot: number,
+): streamReaderEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Select one marker for the stream-reader stage. */
+export function selectMarker058(
+  entries: ReadonlyArray<streamReaderEntry>,
+  slot: number,
+): streamReaderEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Record one marker for the stream-reader stage. */
+export function recordMarker059(
+  entries: ReadonlyArray<streamReaderEntry>,
+  slot: number,
+): streamReaderEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Collect one handle for the stream-reader stage. */
+export function collectHandle060(
+  entries: ReadonlyArray<streamReaderEntry>,
+  slot: number,
+): streamReaderEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Resolve one handle for the stream-reader stage. */
+export function resolveHandle061(
+  entries: ReadonlyArray<streamReaderEntry>,
+  slot: number,
+): streamReaderEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Merge one handle for the stream-reader stage. */
+export function mergeHandle062(
+  entries: ReadonlyArray<streamReaderEntry>,
+  slot: number,
+): streamReaderEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Filter one handle for the stream-reader stage. */
+export function filterHandle063(
+  entries: ReadonlyArray<streamReaderEntry>,
+  slot: number,
+): streamReaderEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Reduce one handle for the stream-reader stage. */
+export function reduceHandle064(
+  entries: ReadonlyArray<streamReaderEntry>,
+  slot: number,
+): streamReaderEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Expand one handle for the stream-reader stage. */
+export function expandHandle065(
+  entries: ReadonlyArray<streamReaderEntry>,
+  slot: number,
+): streamReaderEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Normalise one handle for the stream-reader stage. */
+export function normaliseHandle066(
+  entries: ReadonlyArray<streamReaderEntry>,
+  slot: number,
+): streamReaderEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Compare one handle for the stream-reader stage. */
+export function compareHandle067(
+  entries: ReadonlyArray<streamReaderEntry>,
+  slot: number,
+): streamReaderEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Select one handle for the stream-reader stage. */
+export function selectHandle068(
+  entries: ReadonlyArray<streamReaderEntry>,
+  slot: number,
+): streamReaderEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Record one handle for the stream-reader stage. */
+export function recordHandle069(
+  entries: ReadonlyArray<streamReaderEntry>,
+  slot: number,
+): streamReaderEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Collect one cursor for the stream-reader stage. */
+export function collectCursor070(
+  entries: ReadonlyArray<streamReaderEntry>,
+  slot: number,
+): streamReaderEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Resolve one cursor for the stream-reader stage. */
+export function resolveCursor071(
+  entries: ReadonlyArray<streamReaderEntry>,
+  slot: number,
+): streamReaderEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Merge one cursor for the stream-reader stage. */
+export function mergeCursor072(
+  entries: ReadonlyArray<streamReaderEntry>,
+  slot: number,
+): streamReaderEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Filter one cursor for the stream-reader stage. */
+export function filterCursor073(
+  entries: ReadonlyArray<streamReaderEntry>,
+  slot: number,
+): streamReaderEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+

--- a/test-fixtures/gate-acceptance/surface-map.ts
+++ b/test-fixtures/gate-acceptance/surface-map.ts
@@ -1,0 +1,1500 @@
+// Acceptance corpus for the pull request review gate.
+//
+// This file is synthetic and is not part of the shipped package. It
+// exists so that one pull request is large enough to exercise two
+// limits at once: the diff API's 20,000-changed-line ceiling, and the
+// review request budget above which the gate splits a change into
+// batches. This pull request is opened to exercise them and closed
+// again; it is not merged.
+
+export interface surfaceMapEntry {
+  readonly key: string;
+  readonly slot: number;
+  readonly active: boolean;
+}
+
+export interface surfaceMapState {
+  readonly entries: ReadonlyArray<surfaceMapEntry>;
+  readonly total: number;
+}
+
+/** Collect one entry for the surface-map stage. */
+export function collectEntry000(
+  entries: ReadonlyArray<surfaceMapEntry>,
+  slot: number,
+): surfaceMapEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Resolve one entry for the surface-map stage. */
+export function resolveEntry001(
+  entries: ReadonlyArray<surfaceMapEntry>,
+  slot: number,
+): surfaceMapEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Merge one entry for the surface-map stage. */
+export function mergeEntry002(
+  entries: ReadonlyArray<surfaceMapEntry>,
+  slot: number,
+): surfaceMapEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Filter one entry for the surface-map stage. */
+export function filterEntry003(
+  entries: ReadonlyArray<surfaceMapEntry>,
+  slot: number,
+): surfaceMapEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Reduce one entry for the surface-map stage. */
+export function reduceEntry004(
+  entries: ReadonlyArray<surfaceMapEntry>,
+  slot: number,
+): surfaceMapEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Expand one entry for the surface-map stage. */
+export function expandEntry005(
+  entries: ReadonlyArray<surfaceMapEntry>,
+  slot: number,
+): surfaceMapEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Normalise one entry for the surface-map stage. */
+export function normaliseEntry006(
+  entries: ReadonlyArray<surfaceMapEntry>,
+  slot: number,
+): surfaceMapEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Compare one entry for the surface-map stage. */
+export function compareEntry007(
+  entries: ReadonlyArray<surfaceMapEntry>,
+  slot: number,
+): surfaceMapEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Select one entry for the surface-map stage. */
+export function selectEntry008(
+  entries: ReadonlyArray<surfaceMapEntry>,
+  slot: number,
+): surfaceMapEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Record one entry for the surface-map stage. */
+export function recordEntry009(
+  entries: ReadonlyArray<surfaceMapEntry>,
+  slot: number,
+): surfaceMapEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Collect one record for the surface-map stage. */
+export function collectRecord010(
+  entries: ReadonlyArray<surfaceMapEntry>,
+  slot: number,
+): surfaceMapEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Resolve one record for the surface-map stage. */
+export function resolveRecord011(
+  entries: ReadonlyArray<surfaceMapEntry>,
+  slot: number,
+): surfaceMapEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Merge one record for the surface-map stage. */
+export function mergeRecord012(
+  entries: ReadonlyArray<surfaceMapEntry>,
+  slot: number,
+): surfaceMapEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Filter one record for the surface-map stage. */
+export function filterRecord013(
+  entries: ReadonlyArray<surfaceMapEntry>,
+  slot: number,
+): surfaceMapEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Reduce one record for the surface-map stage. */
+export function reduceRecord014(
+  entries: ReadonlyArray<surfaceMapEntry>,
+  slot: number,
+): surfaceMapEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Expand one record for the surface-map stage. */
+export function expandRecord015(
+  entries: ReadonlyArray<surfaceMapEntry>,
+  slot: number,
+): surfaceMapEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Normalise one record for the surface-map stage. */
+export function normaliseRecord016(
+  entries: ReadonlyArray<surfaceMapEntry>,
+  slot: number,
+): surfaceMapEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Compare one record for the surface-map stage. */
+export function compareRecord017(
+  entries: ReadonlyArray<surfaceMapEntry>,
+  slot: number,
+): surfaceMapEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Select one record for the surface-map stage. */
+export function selectRecord018(
+  entries: ReadonlyArray<surfaceMapEntry>,
+  slot: number,
+): surfaceMapEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Record one record for the surface-map stage. */
+export function recordRecord019(
+  entries: ReadonlyArray<surfaceMapEntry>,
+  slot: number,
+): surfaceMapEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Collect one bucket for the surface-map stage. */
+export function collectBucket020(
+  entries: ReadonlyArray<surfaceMapEntry>,
+  slot: number,
+): surfaceMapEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Resolve one bucket for the surface-map stage. */
+export function resolveBucket021(
+  entries: ReadonlyArray<surfaceMapEntry>,
+  slot: number,
+): surfaceMapEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Merge one bucket for the surface-map stage. */
+export function mergeBucket022(
+  entries: ReadonlyArray<surfaceMapEntry>,
+  slot: number,
+): surfaceMapEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Filter one bucket for the surface-map stage. */
+export function filterBucket023(
+  entries: ReadonlyArray<surfaceMapEntry>,
+  slot: number,
+): surfaceMapEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Reduce one bucket for the surface-map stage. */
+export function reduceBucket024(
+  entries: ReadonlyArray<surfaceMapEntry>,
+  slot: number,
+): surfaceMapEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Expand one bucket for the surface-map stage. */
+export function expandBucket025(
+  entries: ReadonlyArray<surfaceMapEntry>,
+  slot: number,
+): surfaceMapEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Normalise one bucket for the surface-map stage. */
+export function normaliseBucket026(
+  entries: ReadonlyArray<surfaceMapEntry>,
+  slot: number,
+): surfaceMapEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Compare one bucket for the surface-map stage. */
+export function compareBucket027(
+  entries: ReadonlyArray<surfaceMapEntry>,
+  slot: number,
+): surfaceMapEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Select one bucket for the surface-map stage. */
+export function selectBucket028(
+  entries: ReadonlyArray<surfaceMapEntry>,
+  slot: number,
+): surfaceMapEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Record one bucket for the surface-map stage. */
+export function recordBucket029(
+  entries: ReadonlyArray<surfaceMapEntry>,
+  slot: number,
+): surfaceMapEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Collect one segment for the surface-map stage. */
+export function collectSegment030(
+  entries: ReadonlyArray<surfaceMapEntry>,
+  slot: number,
+): surfaceMapEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Resolve one segment for the surface-map stage. */
+export function resolveSegment031(
+  entries: ReadonlyArray<surfaceMapEntry>,
+  slot: number,
+): surfaceMapEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Merge one segment for the surface-map stage. */
+export function mergeSegment032(
+  entries: ReadonlyArray<surfaceMapEntry>,
+  slot: number,
+): surfaceMapEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Filter one segment for the surface-map stage. */
+export function filterSegment033(
+  entries: ReadonlyArray<surfaceMapEntry>,
+  slot: number,
+): surfaceMapEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Reduce one segment for the surface-map stage. */
+export function reduceSegment034(
+  entries: ReadonlyArray<surfaceMapEntry>,
+  slot: number,
+): surfaceMapEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Expand one segment for the surface-map stage. */
+export function expandSegment035(
+  entries: ReadonlyArray<surfaceMapEntry>,
+  slot: number,
+): surfaceMapEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Normalise one segment for the surface-map stage. */
+export function normaliseSegment036(
+  entries: ReadonlyArray<surfaceMapEntry>,
+  slot: number,
+): surfaceMapEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Compare one segment for the surface-map stage. */
+export function compareSegment037(
+  entries: ReadonlyArray<surfaceMapEntry>,
+  slot: number,
+): surfaceMapEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Select one segment for the surface-map stage. */
+export function selectSegment038(
+  entries: ReadonlyArray<surfaceMapEntry>,
+  slot: number,
+): surfaceMapEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Record one segment for the surface-map stage. */
+export function recordSegment039(
+  entries: ReadonlyArray<surfaceMapEntry>,
+  slot: number,
+): surfaceMapEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Collect one window for the surface-map stage. */
+export function collectWindow040(
+  entries: ReadonlyArray<surfaceMapEntry>,
+  slot: number,
+): surfaceMapEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Resolve one window for the surface-map stage. */
+export function resolveWindow041(
+  entries: ReadonlyArray<surfaceMapEntry>,
+  slot: number,
+): surfaceMapEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Merge one window for the surface-map stage. */
+export function mergeWindow042(
+  entries: ReadonlyArray<surfaceMapEntry>,
+  slot: number,
+): surfaceMapEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Filter one window for the surface-map stage. */
+export function filterWindow043(
+  entries: ReadonlyArray<surfaceMapEntry>,
+  slot: number,
+): surfaceMapEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Reduce one window for the surface-map stage. */
+export function reduceWindow044(
+  entries: ReadonlyArray<surfaceMapEntry>,
+  slot: number,
+): surfaceMapEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Expand one window for the surface-map stage. */
+export function expandWindow045(
+  entries: ReadonlyArray<surfaceMapEntry>,
+  slot: number,
+): surfaceMapEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Normalise one window for the surface-map stage. */
+export function normaliseWindow046(
+  entries: ReadonlyArray<surfaceMapEntry>,
+  slot: number,
+): surfaceMapEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Compare one window for the surface-map stage. */
+export function compareWindow047(
+  entries: ReadonlyArray<surfaceMapEntry>,
+  slot: number,
+): surfaceMapEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Select one window for the surface-map stage. */
+export function selectWindow048(
+  entries: ReadonlyArray<surfaceMapEntry>,
+  slot: number,
+): surfaceMapEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Record one window for the surface-map stage. */
+export function recordWindow049(
+  entries: ReadonlyArray<surfaceMapEntry>,
+  slot: number,
+): surfaceMapEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Collect one marker for the surface-map stage. */
+export function collectMarker050(
+  entries: ReadonlyArray<surfaceMapEntry>,
+  slot: number,
+): surfaceMapEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Resolve one marker for the surface-map stage. */
+export function resolveMarker051(
+  entries: ReadonlyArray<surfaceMapEntry>,
+  slot: number,
+): surfaceMapEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Merge one marker for the surface-map stage. */
+export function mergeMarker052(
+  entries: ReadonlyArray<surfaceMapEntry>,
+  slot: number,
+): surfaceMapEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Filter one marker for the surface-map stage. */
+export function filterMarker053(
+  entries: ReadonlyArray<surfaceMapEntry>,
+  slot: number,
+): surfaceMapEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Reduce one marker for the surface-map stage. */
+export function reduceMarker054(
+  entries: ReadonlyArray<surfaceMapEntry>,
+  slot: number,
+): surfaceMapEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Expand one marker for the surface-map stage. */
+export function expandMarker055(
+  entries: ReadonlyArray<surfaceMapEntry>,
+  slot: number,
+): surfaceMapEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Normalise one marker for the surface-map stage. */
+export function normaliseMarker056(
+  entries: ReadonlyArray<surfaceMapEntry>,
+  slot: number,
+): surfaceMapEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Compare one marker for the surface-map stage. */
+export function compareMarker057(
+  entries: ReadonlyArray<surfaceMapEntry>,
+  slot: number,
+): surfaceMapEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Select one marker for the surface-map stage. */
+export function selectMarker058(
+  entries: ReadonlyArray<surfaceMapEntry>,
+  slot: number,
+): surfaceMapEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Record one marker for the surface-map stage. */
+export function recordMarker059(
+  entries: ReadonlyArray<surfaceMapEntry>,
+  slot: number,
+): surfaceMapEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Collect one handle for the surface-map stage. */
+export function collectHandle060(
+  entries: ReadonlyArray<surfaceMapEntry>,
+  slot: number,
+): surfaceMapEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Resolve one handle for the surface-map stage. */
+export function resolveHandle061(
+  entries: ReadonlyArray<surfaceMapEntry>,
+  slot: number,
+): surfaceMapEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Merge one handle for the surface-map stage. */
+export function mergeHandle062(
+  entries: ReadonlyArray<surfaceMapEntry>,
+  slot: number,
+): surfaceMapEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Filter one handle for the surface-map stage. */
+export function filterHandle063(
+  entries: ReadonlyArray<surfaceMapEntry>,
+  slot: number,
+): surfaceMapEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Reduce one handle for the surface-map stage. */
+export function reduceHandle064(
+  entries: ReadonlyArray<surfaceMapEntry>,
+  slot: number,
+): surfaceMapEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Expand one handle for the surface-map stage. */
+export function expandHandle065(
+  entries: ReadonlyArray<surfaceMapEntry>,
+  slot: number,
+): surfaceMapEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Normalise one handle for the surface-map stage. */
+export function normaliseHandle066(
+  entries: ReadonlyArray<surfaceMapEntry>,
+  slot: number,
+): surfaceMapEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Compare one handle for the surface-map stage. */
+export function compareHandle067(
+  entries: ReadonlyArray<surfaceMapEntry>,
+  slot: number,
+): surfaceMapEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Select one handle for the surface-map stage. */
+export function selectHandle068(
+  entries: ReadonlyArray<surfaceMapEntry>,
+  slot: number,
+): surfaceMapEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Record one handle for the surface-map stage. */
+export function recordHandle069(
+  entries: ReadonlyArray<surfaceMapEntry>,
+  slot: number,
+): surfaceMapEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Collect one cursor for the surface-map stage. */
+export function collectCursor070(
+  entries: ReadonlyArray<surfaceMapEntry>,
+  slot: number,
+): surfaceMapEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Resolve one cursor for the surface-map stage. */
+export function resolveCursor071(
+  entries: ReadonlyArray<surfaceMapEntry>,
+  slot: number,
+): surfaceMapEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Merge one cursor for the surface-map stage. */
+export function mergeCursor072(
+  entries: ReadonlyArray<surfaceMapEntry>,
+  slot: number,
+): surfaceMapEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Filter one cursor for the surface-map stage. */
+export function filterCursor073(
+  entries: ReadonlyArray<surfaceMapEntry>,
+  slot: number,
+): surfaceMapEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+

--- a/test-fixtures/gate-acceptance/token-window.ts
+++ b/test-fixtures/gate-acceptance/token-window.ts
@@ -1,0 +1,1500 @@
+// Acceptance corpus for the pull request review gate.
+//
+// This file is synthetic and is not part of the shipped package. It
+// exists so that one pull request is large enough to exercise two
+// limits at once: the diff API's 20,000-changed-line ceiling, and the
+// review request budget above which the gate splits a change into
+// batches. This pull request is opened to exercise them and closed
+// again; it is not merged.
+
+export interface tokenWindowEntry {
+  readonly key: string;
+  readonly slot: number;
+  readonly active: boolean;
+}
+
+export interface tokenWindowState {
+  readonly entries: ReadonlyArray<tokenWindowEntry>;
+  readonly total: number;
+}
+
+/** Collect one entry for the token-window stage. */
+export function collectEntry000(
+  entries: ReadonlyArray<tokenWindowEntry>,
+  slot: number,
+): tokenWindowEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Resolve one entry for the token-window stage. */
+export function resolveEntry001(
+  entries: ReadonlyArray<tokenWindowEntry>,
+  slot: number,
+): tokenWindowEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Merge one entry for the token-window stage. */
+export function mergeEntry002(
+  entries: ReadonlyArray<tokenWindowEntry>,
+  slot: number,
+): tokenWindowEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Filter one entry for the token-window stage. */
+export function filterEntry003(
+  entries: ReadonlyArray<tokenWindowEntry>,
+  slot: number,
+): tokenWindowEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Reduce one entry for the token-window stage. */
+export function reduceEntry004(
+  entries: ReadonlyArray<tokenWindowEntry>,
+  slot: number,
+): tokenWindowEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Expand one entry for the token-window stage. */
+export function expandEntry005(
+  entries: ReadonlyArray<tokenWindowEntry>,
+  slot: number,
+): tokenWindowEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Normalise one entry for the token-window stage. */
+export function normaliseEntry006(
+  entries: ReadonlyArray<tokenWindowEntry>,
+  slot: number,
+): tokenWindowEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Compare one entry for the token-window stage. */
+export function compareEntry007(
+  entries: ReadonlyArray<tokenWindowEntry>,
+  slot: number,
+): tokenWindowEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Select one entry for the token-window stage. */
+export function selectEntry008(
+  entries: ReadonlyArray<tokenWindowEntry>,
+  slot: number,
+): tokenWindowEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Record one entry for the token-window stage. */
+export function recordEntry009(
+  entries: ReadonlyArray<tokenWindowEntry>,
+  slot: number,
+): tokenWindowEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Collect one record for the token-window stage. */
+export function collectRecord010(
+  entries: ReadonlyArray<tokenWindowEntry>,
+  slot: number,
+): tokenWindowEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Resolve one record for the token-window stage. */
+export function resolveRecord011(
+  entries: ReadonlyArray<tokenWindowEntry>,
+  slot: number,
+): tokenWindowEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Merge one record for the token-window stage. */
+export function mergeRecord012(
+  entries: ReadonlyArray<tokenWindowEntry>,
+  slot: number,
+): tokenWindowEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Filter one record for the token-window stage. */
+export function filterRecord013(
+  entries: ReadonlyArray<tokenWindowEntry>,
+  slot: number,
+): tokenWindowEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Reduce one record for the token-window stage. */
+export function reduceRecord014(
+  entries: ReadonlyArray<tokenWindowEntry>,
+  slot: number,
+): tokenWindowEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Expand one record for the token-window stage. */
+export function expandRecord015(
+  entries: ReadonlyArray<tokenWindowEntry>,
+  slot: number,
+): tokenWindowEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Normalise one record for the token-window stage. */
+export function normaliseRecord016(
+  entries: ReadonlyArray<tokenWindowEntry>,
+  slot: number,
+): tokenWindowEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Compare one record for the token-window stage. */
+export function compareRecord017(
+  entries: ReadonlyArray<tokenWindowEntry>,
+  slot: number,
+): tokenWindowEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Select one record for the token-window stage. */
+export function selectRecord018(
+  entries: ReadonlyArray<tokenWindowEntry>,
+  slot: number,
+): tokenWindowEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Record one record for the token-window stage. */
+export function recordRecord019(
+  entries: ReadonlyArray<tokenWindowEntry>,
+  slot: number,
+): tokenWindowEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Collect one bucket for the token-window stage. */
+export function collectBucket020(
+  entries: ReadonlyArray<tokenWindowEntry>,
+  slot: number,
+): tokenWindowEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Resolve one bucket for the token-window stage. */
+export function resolveBucket021(
+  entries: ReadonlyArray<tokenWindowEntry>,
+  slot: number,
+): tokenWindowEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Merge one bucket for the token-window stage. */
+export function mergeBucket022(
+  entries: ReadonlyArray<tokenWindowEntry>,
+  slot: number,
+): tokenWindowEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Filter one bucket for the token-window stage. */
+export function filterBucket023(
+  entries: ReadonlyArray<tokenWindowEntry>,
+  slot: number,
+): tokenWindowEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Reduce one bucket for the token-window stage. */
+export function reduceBucket024(
+  entries: ReadonlyArray<tokenWindowEntry>,
+  slot: number,
+): tokenWindowEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Expand one bucket for the token-window stage. */
+export function expandBucket025(
+  entries: ReadonlyArray<tokenWindowEntry>,
+  slot: number,
+): tokenWindowEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Normalise one bucket for the token-window stage. */
+export function normaliseBucket026(
+  entries: ReadonlyArray<tokenWindowEntry>,
+  slot: number,
+): tokenWindowEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Compare one bucket for the token-window stage. */
+export function compareBucket027(
+  entries: ReadonlyArray<tokenWindowEntry>,
+  slot: number,
+): tokenWindowEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Select one bucket for the token-window stage. */
+export function selectBucket028(
+  entries: ReadonlyArray<tokenWindowEntry>,
+  slot: number,
+): tokenWindowEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Record one bucket for the token-window stage. */
+export function recordBucket029(
+  entries: ReadonlyArray<tokenWindowEntry>,
+  slot: number,
+): tokenWindowEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Collect one segment for the token-window stage. */
+export function collectSegment030(
+  entries: ReadonlyArray<tokenWindowEntry>,
+  slot: number,
+): tokenWindowEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Resolve one segment for the token-window stage. */
+export function resolveSegment031(
+  entries: ReadonlyArray<tokenWindowEntry>,
+  slot: number,
+): tokenWindowEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Merge one segment for the token-window stage. */
+export function mergeSegment032(
+  entries: ReadonlyArray<tokenWindowEntry>,
+  slot: number,
+): tokenWindowEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Filter one segment for the token-window stage. */
+export function filterSegment033(
+  entries: ReadonlyArray<tokenWindowEntry>,
+  slot: number,
+): tokenWindowEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Reduce one segment for the token-window stage. */
+export function reduceSegment034(
+  entries: ReadonlyArray<tokenWindowEntry>,
+  slot: number,
+): tokenWindowEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Expand one segment for the token-window stage. */
+export function expandSegment035(
+  entries: ReadonlyArray<tokenWindowEntry>,
+  slot: number,
+): tokenWindowEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Normalise one segment for the token-window stage. */
+export function normaliseSegment036(
+  entries: ReadonlyArray<tokenWindowEntry>,
+  slot: number,
+): tokenWindowEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Compare one segment for the token-window stage. */
+export function compareSegment037(
+  entries: ReadonlyArray<tokenWindowEntry>,
+  slot: number,
+): tokenWindowEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Select one segment for the token-window stage. */
+export function selectSegment038(
+  entries: ReadonlyArray<tokenWindowEntry>,
+  slot: number,
+): tokenWindowEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Record one segment for the token-window stage. */
+export function recordSegment039(
+  entries: ReadonlyArray<tokenWindowEntry>,
+  slot: number,
+): tokenWindowEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Collect one window for the token-window stage. */
+export function collectWindow040(
+  entries: ReadonlyArray<tokenWindowEntry>,
+  slot: number,
+): tokenWindowEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Resolve one window for the token-window stage. */
+export function resolveWindow041(
+  entries: ReadonlyArray<tokenWindowEntry>,
+  slot: number,
+): tokenWindowEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Merge one window for the token-window stage. */
+export function mergeWindow042(
+  entries: ReadonlyArray<tokenWindowEntry>,
+  slot: number,
+): tokenWindowEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Filter one window for the token-window stage. */
+export function filterWindow043(
+  entries: ReadonlyArray<tokenWindowEntry>,
+  slot: number,
+): tokenWindowEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Reduce one window for the token-window stage. */
+export function reduceWindow044(
+  entries: ReadonlyArray<tokenWindowEntry>,
+  slot: number,
+): tokenWindowEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Expand one window for the token-window stage. */
+export function expandWindow045(
+  entries: ReadonlyArray<tokenWindowEntry>,
+  slot: number,
+): tokenWindowEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Normalise one window for the token-window stage. */
+export function normaliseWindow046(
+  entries: ReadonlyArray<tokenWindowEntry>,
+  slot: number,
+): tokenWindowEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Compare one window for the token-window stage. */
+export function compareWindow047(
+  entries: ReadonlyArray<tokenWindowEntry>,
+  slot: number,
+): tokenWindowEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Select one window for the token-window stage. */
+export function selectWindow048(
+  entries: ReadonlyArray<tokenWindowEntry>,
+  slot: number,
+): tokenWindowEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Record one window for the token-window stage. */
+export function recordWindow049(
+  entries: ReadonlyArray<tokenWindowEntry>,
+  slot: number,
+): tokenWindowEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Collect one marker for the token-window stage. */
+export function collectMarker050(
+  entries: ReadonlyArray<tokenWindowEntry>,
+  slot: number,
+): tokenWindowEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Resolve one marker for the token-window stage. */
+export function resolveMarker051(
+  entries: ReadonlyArray<tokenWindowEntry>,
+  slot: number,
+): tokenWindowEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Merge one marker for the token-window stage. */
+export function mergeMarker052(
+  entries: ReadonlyArray<tokenWindowEntry>,
+  slot: number,
+): tokenWindowEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Filter one marker for the token-window stage. */
+export function filterMarker053(
+  entries: ReadonlyArray<tokenWindowEntry>,
+  slot: number,
+): tokenWindowEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Reduce one marker for the token-window stage. */
+export function reduceMarker054(
+  entries: ReadonlyArray<tokenWindowEntry>,
+  slot: number,
+): tokenWindowEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Expand one marker for the token-window stage. */
+export function expandMarker055(
+  entries: ReadonlyArray<tokenWindowEntry>,
+  slot: number,
+): tokenWindowEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Normalise one marker for the token-window stage. */
+export function normaliseMarker056(
+  entries: ReadonlyArray<tokenWindowEntry>,
+  slot: number,
+): tokenWindowEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Compare one marker for the token-window stage. */
+export function compareMarker057(
+  entries: ReadonlyArray<tokenWindowEntry>,
+  slot: number,
+): tokenWindowEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Select one marker for the token-window stage. */
+export function selectMarker058(
+  entries: ReadonlyArray<tokenWindowEntry>,
+  slot: number,
+): tokenWindowEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Record one marker for the token-window stage. */
+export function recordMarker059(
+  entries: ReadonlyArray<tokenWindowEntry>,
+  slot: number,
+): tokenWindowEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Collect one handle for the token-window stage. */
+export function collectHandle060(
+  entries: ReadonlyArray<tokenWindowEntry>,
+  slot: number,
+): tokenWindowEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Resolve one handle for the token-window stage. */
+export function resolveHandle061(
+  entries: ReadonlyArray<tokenWindowEntry>,
+  slot: number,
+): tokenWindowEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Merge one handle for the token-window stage. */
+export function mergeHandle062(
+  entries: ReadonlyArray<tokenWindowEntry>,
+  slot: number,
+): tokenWindowEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Filter one handle for the token-window stage. */
+export function filterHandle063(
+  entries: ReadonlyArray<tokenWindowEntry>,
+  slot: number,
+): tokenWindowEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Reduce one handle for the token-window stage. */
+export function reduceHandle064(
+  entries: ReadonlyArray<tokenWindowEntry>,
+  slot: number,
+): tokenWindowEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Expand one handle for the token-window stage. */
+export function expandHandle065(
+  entries: ReadonlyArray<tokenWindowEntry>,
+  slot: number,
+): tokenWindowEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Normalise one handle for the token-window stage. */
+export function normaliseHandle066(
+  entries: ReadonlyArray<tokenWindowEntry>,
+  slot: number,
+): tokenWindowEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Compare one handle for the token-window stage. */
+export function compareHandle067(
+  entries: ReadonlyArray<tokenWindowEntry>,
+  slot: number,
+): tokenWindowEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Select one handle for the token-window stage. */
+export function selectHandle068(
+  entries: ReadonlyArray<tokenWindowEntry>,
+  slot: number,
+): tokenWindowEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Record one handle for the token-window stage. */
+export function recordHandle069(
+  entries: ReadonlyArray<tokenWindowEntry>,
+  slot: number,
+): tokenWindowEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Collect one cursor for the token-window stage. */
+export function collectCursor070(
+  entries: ReadonlyArray<tokenWindowEntry>,
+  slot: number,
+): tokenWindowEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Resolve one cursor for the token-window stage. */
+export function resolveCursor071(
+  entries: ReadonlyArray<tokenWindowEntry>,
+  slot: number,
+): tokenWindowEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Merge one cursor for the token-window stage. */
+export function mergeCursor072(
+  entries: ReadonlyArray<tokenWindowEntry>,
+  slot: number,
+): tokenWindowEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Filter one cursor for the token-window stage. */
+export function filterCursor073(
+  entries: ReadonlyArray<tokenWindowEntry>,
+  slot: number,
+): tokenWindowEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+

--- a/test-fixtures/gate-acceptance/verdict-table.ts
+++ b/test-fixtures/gate-acceptance/verdict-table.ts
@@ -1,0 +1,1500 @@
+// Acceptance corpus for the pull request review gate.
+//
+// This file is synthetic and is not part of the shipped package. It
+// exists so that one pull request is large enough to exercise two
+// limits at once: the diff API's 20,000-changed-line ceiling, and the
+// review request budget above which the gate splits a change into
+// batches. This pull request is opened to exercise them and closed
+// again; it is not merged.
+
+export interface verdictTableEntry {
+  readonly key: string;
+  readonly slot: number;
+  readonly active: boolean;
+}
+
+export interface verdictTableState {
+  readonly entries: ReadonlyArray<verdictTableEntry>;
+  readonly total: number;
+}
+
+/** Collect one entry for the verdict-table stage. */
+export function collectEntry000(
+  entries: ReadonlyArray<verdictTableEntry>,
+  slot: number,
+): verdictTableEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Resolve one entry for the verdict-table stage. */
+export function resolveEntry001(
+  entries: ReadonlyArray<verdictTableEntry>,
+  slot: number,
+): verdictTableEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Merge one entry for the verdict-table stage. */
+export function mergeEntry002(
+  entries: ReadonlyArray<verdictTableEntry>,
+  slot: number,
+): verdictTableEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Filter one entry for the verdict-table stage. */
+export function filterEntry003(
+  entries: ReadonlyArray<verdictTableEntry>,
+  slot: number,
+): verdictTableEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Reduce one entry for the verdict-table stage. */
+export function reduceEntry004(
+  entries: ReadonlyArray<verdictTableEntry>,
+  slot: number,
+): verdictTableEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Expand one entry for the verdict-table stage. */
+export function expandEntry005(
+  entries: ReadonlyArray<verdictTableEntry>,
+  slot: number,
+): verdictTableEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Normalise one entry for the verdict-table stage. */
+export function normaliseEntry006(
+  entries: ReadonlyArray<verdictTableEntry>,
+  slot: number,
+): verdictTableEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Compare one entry for the verdict-table stage. */
+export function compareEntry007(
+  entries: ReadonlyArray<verdictTableEntry>,
+  slot: number,
+): verdictTableEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Select one entry for the verdict-table stage. */
+export function selectEntry008(
+  entries: ReadonlyArray<verdictTableEntry>,
+  slot: number,
+): verdictTableEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Record one entry for the verdict-table stage. */
+export function recordEntry009(
+  entries: ReadonlyArray<verdictTableEntry>,
+  slot: number,
+): verdictTableEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Collect one record for the verdict-table stage. */
+export function collectRecord010(
+  entries: ReadonlyArray<verdictTableEntry>,
+  slot: number,
+): verdictTableEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Resolve one record for the verdict-table stage. */
+export function resolveRecord011(
+  entries: ReadonlyArray<verdictTableEntry>,
+  slot: number,
+): verdictTableEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Merge one record for the verdict-table stage. */
+export function mergeRecord012(
+  entries: ReadonlyArray<verdictTableEntry>,
+  slot: number,
+): verdictTableEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Filter one record for the verdict-table stage. */
+export function filterRecord013(
+  entries: ReadonlyArray<verdictTableEntry>,
+  slot: number,
+): verdictTableEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Reduce one record for the verdict-table stage. */
+export function reduceRecord014(
+  entries: ReadonlyArray<verdictTableEntry>,
+  slot: number,
+): verdictTableEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Expand one record for the verdict-table stage. */
+export function expandRecord015(
+  entries: ReadonlyArray<verdictTableEntry>,
+  slot: number,
+): verdictTableEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Normalise one record for the verdict-table stage. */
+export function normaliseRecord016(
+  entries: ReadonlyArray<verdictTableEntry>,
+  slot: number,
+): verdictTableEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Compare one record for the verdict-table stage. */
+export function compareRecord017(
+  entries: ReadonlyArray<verdictTableEntry>,
+  slot: number,
+): verdictTableEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Select one record for the verdict-table stage. */
+export function selectRecord018(
+  entries: ReadonlyArray<verdictTableEntry>,
+  slot: number,
+): verdictTableEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Record one record for the verdict-table stage. */
+export function recordRecord019(
+  entries: ReadonlyArray<verdictTableEntry>,
+  slot: number,
+): verdictTableEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Collect one bucket for the verdict-table stage. */
+export function collectBucket020(
+  entries: ReadonlyArray<verdictTableEntry>,
+  slot: number,
+): verdictTableEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Resolve one bucket for the verdict-table stage. */
+export function resolveBucket021(
+  entries: ReadonlyArray<verdictTableEntry>,
+  slot: number,
+): verdictTableEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Merge one bucket for the verdict-table stage. */
+export function mergeBucket022(
+  entries: ReadonlyArray<verdictTableEntry>,
+  slot: number,
+): verdictTableEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Filter one bucket for the verdict-table stage. */
+export function filterBucket023(
+  entries: ReadonlyArray<verdictTableEntry>,
+  slot: number,
+): verdictTableEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Reduce one bucket for the verdict-table stage. */
+export function reduceBucket024(
+  entries: ReadonlyArray<verdictTableEntry>,
+  slot: number,
+): verdictTableEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Expand one bucket for the verdict-table stage. */
+export function expandBucket025(
+  entries: ReadonlyArray<verdictTableEntry>,
+  slot: number,
+): verdictTableEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Normalise one bucket for the verdict-table stage. */
+export function normaliseBucket026(
+  entries: ReadonlyArray<verdictTableEntry>,
+  slot: number,
+): verdictTableEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Compare one bucket for the verdict-table stage. */
+export function compareBucket027(
+  entries: ReadonlyArray<verdictTableEntry>,
+  slot: number,
+): verdictTableEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Select one bucket for the verdict-table stage. */
+export function selectBucket028(
+  entries: ReadonlyArray<verdictTableEntry>,
+  slot: number,
+): verdictTableEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Record one bucket for the verdict-table stage. */
+export function recordBucket029(
+  entries: ReadonlyArray<verdictTableEntry>,
+  slot: number,
+): verdictTableEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Collect one segment for the verdict-table stage. */
+export function collectSegment030(
+  entries: ReadonlyArray<verdictTableEntry>,
+  slot: number,
+): verdictTableEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Resolve one segment for the verdict-table stage. */
+export function resolveSegment031(
+  entries: ReadonlyArray<verdictTableEntry>,
+  slot: number,
+): verdictTableEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Merge one segment for the verdict-table stage. */
+export function mergeSegment032(
+  entries: ReadonlyArray<verdictTableEntry>,
+  slot: number,
+): verdictTableEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Filter one segment for the verdict-table stage. */
+export function filterSegment033(
+  entries: ReadonlyArray<verdictTableEntry>,
+  slot: number,
+): verdictTableEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Reduce one segment for the verdict-table stage. */
+export function reduceSegment034(
+  entries: ReadonlyArray<verdictTableEntry>,
+  slot: number,
+): verdictTableEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Expand one segment for the verdict-table stage. */
+export function expandSegment035(
+  entries: ReadonlyArray<verdictTableEntry>,
+  slot: number,
+): verdictTableEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Normalise one segment for the verdict-table stage. */
+export function normaliseSegment036(
+  entries: ReadonlyArray<verdictTableEntry>,
+  slot: number,
+): verdictTableEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Compare one segment for the verdict-table stage. */
+export function compareSegment037(
+  entries: ReadonlyArray<verdictTableEntry>,
+  slot: number,
+): verdictTableEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Select one segment for the verdict-table stage. */
+export function selectSegment038(
+  entries: ReadonlyArray<verdictTableEntry>,
+  slot: number,
+): verdictTableEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Record one segment for the verdict-table stage. */
+export function recordSegment039(
+  entries: ReadonlyArray<verdictTableEntry>,
+  slot: number,
+): verdictTableEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Collect one window for the verdict-table stage. */
+export function collectWindow040(
+  entries: ReadonlyArray<verdictTableEntry>,
+  slot: number,
+): verdictTableEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Resolve one window for the verdict-table stage. */
+export function resolveWindow041(
+  entries: ReadonlyArray<verdictTableEntry>,
+  slot: number,
+): verdictTableEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Merge one window for the verdict-table stage. */
+export function mergeWindow042(
+  entries: ReadonlyArray<verdictTableEntry>,
+  slot: number,
+): verdictTableEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Filter one window for the verdict-table stage. */
+export function filterWindow043(
+  entries: ReadonlyArray<verdictTableEntry>,
+  slot: number,
+): verdictTableEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Reduce one window for the verdict-table stage. */
+export function reduceWindow044(
+  entries: ReadonlyArray<verdictTableEntry>,
+  slot: number,
+): verdictTableEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Expand one window for the verdict-table stage. */
+export function expandWindow045(
+  entries: ReadonlyArray<verdictTableEntry>,
+  slot: number,
+): verdictTableEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Normalise one window for the verdict-table stage. */
+export function normaliseWindow046(
+  entries: ReadonlyArray<verdictTableEntry>,
+  slot: number,
+): verdictTableEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Compare one window for the verdict-table stage. */
+export function compareWindow047(
+  entries: ReadonlyArray<verdictTableEntry>,
+  slot: number,
+): verdictTableEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Select one window for the verdict-table stage. */
+export function selectWindow048(
+  entries: ReadonlyArray<verdictTableEntry>,
+  slot: number,
+): verdictTableEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Record one window for the verdict-table stage. */
+export function recordWindow049(
+  entries: ReadonlyArray<verdictTableEntry>,
+  slot: number,
+): verdictTableEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Collect one marker for the verdict-table stage. */
+export function collectMarker050(
+  entries: ReadonlyArray<verdictTableEntry>,
+  slot: number,
+): verdictTableEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Resolve one marker for the verdict-table stage. */
+export function resolveMarker051(
+  entries: ReadonlyArray<verdictTableEntry>,
+  slot: number,
+): verdictTableEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Merge one marker for the verdict-table stage. */
+export function mergeMarker052(
+  entries: ReadonlyArray<verdictTableEntry>,
+  slot: number,
+): verdictTableEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Filter one marker for the verdict-table stage. */
+export function filterMarker053(
+  entries: ReadonlyArray<verdictTableEntry>,
+  slot: number,
+): verdictTableEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Reduce one marker for the verdict-table stage. */
+export function reduceMarker054(
+  entries: ReadonlyArray<verdictTableEntry>,
+  slot: number,
+): verdictTableEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Expand one marker for the verdict-table stage. */
+export function expandMarker055(
+  entries: ReadonlyArray<verdictTableEntry>,
+  slot: number,
+): verdictTableEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Normalise one marker for the verdict-table stage. */
+export function normaliseMarker056(
+  entries: ReadonlyArray<verdictTableEntry>,
+  slot: number,
+): verdictTableEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Compare one marker for the verdict-table stage. */
+export function compareMarker057(
+  entries: ReadonlyArray<verdictTableEntry>,
+  slot: number,
+): verdictTableEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Select one marker for the verdict-table stage. */
+export function selectMarker058(
+  entries: ReadonlyArray<verdictTableEntry>,
+  slot: number,
+): verdictTableEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Record one marker for the verdict-table stage. */
+export function recordMarker059(
+  entries: ReadonlyArray<verdictTableEntry>,
+  slot: number,
+): verdictTableEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Collect one handle for the verdict-table stage. */
+export function collectHandle060(
+  entries: ReadonlyArray<verdictTableEntry>,
+  slot: number,
+): verdictTableEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Resolve one handle for the verdict-table stage. */
+export function resolveHandle061(
+  entries: ReadonlyArray<verdictTableEntry>,
+  slot: number,
+): verdictTableEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Merge one handle for the verdict-table stage. */
+export function mergeHandle062(
+  entries: ReadonlyArray<verdictTableEntry>,
+  slot: number,
+): verdictTableEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Filter one handle for the verdict-table stage. */
+export function filterHandle063(
+  entries: ReadonlyArray<verdictTableEntry>,
+  slot: number,
+): verdictTableEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Reduce one handle for the verdict-table stage. */
+export function reduceHandle064(
+  entries: ReadonlyArray<verdictTableEntry>,
+  slot: number,
+): verdictTableEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Expand one handle for the verdict-table stage. */
+export function expandHandle065(
+  entries: ReadonlyArray<verdictTableEntry>,
+  slot: number,
+): verdictTableEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Normalise one handle for the verdict-table stage. */
+export function normaliseHandle066(
+  entries: ReadonlyArray<verdictTableEntry>,
+  slot: number,
+): verdictTableEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Compare one handle for the verdict-table stage. */
+export function compareHandle067(
+  entries: ReadonlyArray<verdictTableEntry>,
+  slot: number,
+): verdictTableEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Select one handle for the verdict-table stage. */
+export function selectHandle068(
+  entries: ReadonlyArray<verdictTableEntry>,
+  slot: number,
+): verdictTableEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Record one handle for the verdict-table stage. */
+export function recordHandle069(
+  entries: ReadonlyArray<verdictTableEntry>,
+  slot: number,
+): verdictTableEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Collect one cursor for the verdict-table stage. */
+export function collectCursor070(
+  entries: ReadonlyArray<verdictTableEntry>,
+  slot: number,
+): verdictTableEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Resolve one cursor for the verdict-table stage. */
+export function resolveCursor071(
+  entries: ReadonlyArray<verdictTableEntry>,
+  slot: number,
+): verdictTableEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Merge one cursor for the verdict-table stage. */
+export function mergeCursor072(
+  entries: ReadonlyArray<verdictTableEntry>,
+  slot: number,
+): verdictTableEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+
+/** Filter one cursor for the verdict-table stage. */
+export function filterCursor073(
+  entries: ReadonlyArray<verdictTableEntry>,
+  slot: number,
+): verdictTableEntry | undefined {
+  if (slot < 0) {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (entry.slot !== slot) {
+      continue;
+    }
+    if (!entry.active) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
+}
+


### PR DESCRIPTION
**Do not merge.** This pull request exists to exercise the automated review gate
at two limits at once, and it is closed as soon as the run completes. It is
opened as a draft so it cannot be merged by accident.

## What it contains

24 generated files under `test-fixtures/gate-acceptance/`, 36,000 added lines.
Nothing else changes: no source, no tests, no workflow.

## The two limits

- **36,000 changed lines.** GitHub's diff API returns HTTP 406 above 20,000, so
  `gh pr diff` cannot produce the diff and the review workflow's local
  `git diff origin/$BASE_REF...HEAD` fallback is the path that does. The gather
  step records which path ran, so this is readable in the run log rather than
  inferred from an error message.
- **A request larger than one review call.** Composed against the shipped
  workflow the single request measures 1,025,932 bytes against the
  420,000-byte per-request target, so the partitioner cuts the change into
  batches on file boundaries and each batch is reviewed as its own request.

Measured locally against the shipped workflow before this was pushed: **5
batches**, with the partitioner's own byte-conservation check confirming the
batches rejoin to exactly the diff they came from.

## Safety of the corpus

- Generated from a fixed vocabulary. It contains no string literals, no
  network, filesystem, process or `eval` calls, and no regular expressions.
- No credentials and no high-entropy literals.
- Outside the published package: `files` in `package.json` is
  `dist`/`README.md`/`LICENSE`, and `.npmignore` excludes `test-fixtures/`.
- Outside the type-check and test scopes: `tsconfig.json` includes `src/**/*`
  and the vitest config includes `src/**/*.test.ts` and `__tests__/**/*.ts`.
