### PR TITLE
Settle --fail-below once, on every channel, and only ever raise the exit code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,44 @@ All notable changes to HackMyAgent are documented in this file.
 
 ## [Unreleased]
 
+### `secure --fail-below` settles once, on every channel, and only ever raises the exit code
+
+`--fail-below N` was checked by two per-channel copies — one on the text arm, one on `--json`
+— so under `--format sarif`, `--format html` and `--format asff` it was never read: a score
+below the threshold exited 0 with nothing on stderr (#494). SARIF is the format CI uploads,
+so the flag was inert exactly where it is used. Measured on the published 0.29.0 and on
+`main`: an empty package directory scoring 98 with `--fail-below 99` exited `text: 1`,
+`json: 1`, `sarif: 0`, `html: 0`, `asff: 0`.
+
+The two copies also sat below the exit-2 unmeasured floor (#438) and ASSIGNED exit 1 over
+it, so a tree holding an input the run could not read reported "I measured this and it
+failed" as soon as a threshold was supplied — a stricter flag returned a weaker signal
+(#512).
+
+Both are one change. The threshold is settled once, at the same settlement point the
+coverage floor uses and above every output channel, through a `raiseExitCode` helper that
+never lowers the code; the per-channel copies of the gate are deleted. The precedence rule
+is stated in one place, on that helper: an unread input settles a floor of 2; a
+`--fail-below` breach raises to at least 1 and cannot lower that floor; a critical/high
+finding still exits 1 on every channel as before. On the text channel the one-line reason
+keeps its old place at the end of the report (measured on published 0.30.0, whose text-arm
+threshold block is unchanged through 0.32.0: line 44 of 45, before the version footer); on the document channels it goes to stderr at settlement,
+where its position beside a JSON or SARIF body is immaterial.
+
+What moves, measured against a `main` build with the same fixtures:
+
+| run | before | after |
+|---|---|---|
+| clean tree below threshold, `--format sarif` / `html` / `asff` | 0 | **1**, stderr `Score N is below threshold M` |
+| clean tree below threshold, text / `--json` | 1 | 1 |
+| clean tree at or above threshold, any channel | 0 | 0 |
+| tree with an unreadable input, below threshold, any channel | 1 | **2** (the breach is still printed) |
+| tree with an unreadable input, no threshold | 2 | 2 |
+
+A pipeline that requested SARIF with a score floor and has been passing on a low score
+will start failing; that is the flag doing what its help text says. The `-b oasb-1` and
+`-b oasb-2` arms keep their own compliance-percentage threshold and are not touched here
+(their exit-2 arm is #511 / #514).
 ### The verdict line now says when the analyst dissents
 
 `secure --nanomind` could route a file to a named attack class at high severity and still

--- a/README.md
+++ b/README.md
@@ -341,7 +341,8 @@ HIGH-severity SOUL finding (a governance violation, a profile mismatch, or an un
 `--profile` value) that renders as a warning and passes CI without the flag — deliberate,
 so a pipeline can opt into treating a misleading SOUL verdict as a failure. To gate a
 pipeline on severity, read the exit code the command already returns; to gate on the
-score, use `--fail-below <n>` on the text and JSON channels.
+score, use `--fail-below <n>` on any output channel. A threshold only raises the exit
+code: a run that could not read one of its inputs still exits 2, not 1.
 
 ```yaml
 name: Agent Security

--- a/__tests__/cli/secure-fail-below-exit-settlement.test.ts
+++ b/__tests__/cli/secure-fail-below-exit-settlement.test.ts
@@ -1,0 +1,243 @@
+/**
+ * #494 / #512 — `--fail-below` settles once, above every output channel, and
+ * only ever RAISES the exit code.
+ *
+ * Two directions, both red on the build before the fix:
+ *
+ * - #494: under `--format sarif|html|asff` the flag was never read — the check
+ *   was a per-channel copy on text and json only — so a below-threshold score
+ *   exited 0 with nothing on stderr. SARIF is the format CI uploads.
+ * - #512: over a tree holding an input the run could not read, `secure`
+ *   settles a floor of exit 2 (#438). The per-channel copies then ASSIGNED
+ *   exit 1 over it, so adding a stricter flag turned "I could not measure
+ *   this" into "I measured it and it failed".
+ *
+ * Every threshold here is pinned from both sides. Each fixture's score is
+ * measured first through `--format json`, and the assertions use one
+ * threshold above it (triggering) and one at it (not triggering). A fixture
+ * that stopped scoring what this file assumes would otherwise leave every
+ * exit-code assertion green while measuring nothing.
+ *
+ * `chmod 000` does not deny root, so the #512 cases probe for real
+ * unreadability and skip with a warning when they cannot get it.
+ */
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { spawnSync } from 'node:child_process';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { assertDistFreshIfPresent, BUILT_CLI as CLI } from '../helpers/dist-freshness';
+
+beforeAll(assertDistFreshIfPresent);
+
+/** Measured, and the result is one the command promises to pass. */
+const EXIT_PASS = 0;
+/** Measured, and the result is one the command promises to fail on. */
+const EXIT_FAIL = 1;
+/** The run did not examine everything it found. */
+const EXIT_UNMEASURED = 2;
+
+/**
+ * Every renderer the non-benchmark `secure` has. `--format asp` is also
+ * accepted by the validator but is a benchmark-only renderer; outside `-b` it
+ * falls through to the text arm (#563), so it would exercise `text` twice.
+ */
+const FORMATS = ['text', 'json', 'sarif', 'html', 'asff'] as const;
+type Format = (typeof FORMATS)[number];
+
+let root: string;
+/** Files whose modes must be restored before the tree can be removed. */
+const restore: string[] = [];
+
+function run(args: string[]) {
+  const res = spawnSync(process.execPath, [CLI, ...args], {
+    encoding: 'utf-8',
+    timeout: 240_000,
+    env: {
+      ...process.env,
+      NO_COLOR: '1',
+      OPENA2A_TELEMETRY: 'off',
+      HOME: fs.mkdtempSync(path.join(os.tmpdir(), 'hma-home-')),
+    },
+  });
+  return { status: res.status, stdout: res.stdout ?? '', stderr: res.stderr ?? '' };
+}
+
+function withFormat(format: Format, args: string[]): string[] {
+  return format === 'text' ? args : [...args, '--format', format];
+}
+
+/** The score the CLI itself reports for `dir`, read off the JSON channel. */
+function scoreOf(dir: string): number {
+  const res = run(['secure', dir, '--format', 'json']);
+  const body = JSON.parse(res.stdout.slice(res.stdout.indexOf('{')));
+  expect(typeof body.score, 'the json channel must report a numeric score').toBe('number');
+  return body.score as number;
+}
+
+/**
+ * A tree that scores below 100 for a reason that is neither critical nor high,
+ * so nothing but the threshold can move its exit code off 0: `package.json`,
+ * two benign sources and an incomplete `.gitignore` — the shape of #494's own
+ * reproduction.
+ */
+function cleanTree(name: string): string {
+  const dir = path.join(root, name);
+  fs.mkdirSync(path.join(dir, 'src'), { recursive: true });
+  fs.writeFileSync(path.join(dir, 'package.json'), '{ "name": "fb-probe", "version": "1.0.0", "private": true }\n');
+  fs.writeFileSync(path.join(dir, 'src', 'util.js'), 'function add(a,b){return a+b;}\nmodule.exports={add};\n');
+  fs.writeFileSync(path.join(dir, 'src', 'greet.js'), 'module.exports = (n) => `hi ${n}`;\n');
+  fs.writeFileSync(path.join(dir, '.gitignore'), 'node_modules/\n');
+  return dir;
+}
+
+/** Make a path unreadable and PROVE it. Returns false when the OS declined. */
+function makeUnreadable(file: string): boolean {
+  fs.chmodSync(file, 0o000);
+  restore.push(file);
+  try {
+    fs.readFileSync(file);
+    return false; // root, or a filesystem without permission support
+  } catch {
+    return true;
+  }
+}
+
+beforeAll(() => {
+  root = fs.mkdtempSync(path.join(os.tmpdir(), 'hma-494-512-'));
+});
+
+afterAll(() => {
+  // Restore modes here rather than in a try/finally in a test body: a vitest
+  // timeout skips a `finally`, and an unreadable file blocks the rmSync.
+  for (const p of restore) {
+    try { fs.chmodSync(p, 0o644); } catch { /* already gone */ }
+  }
+  try { fs.rmSync(root, { recursive: true, force: true }); } catch { /* best effort */ }
+});
+
+describe('#494 --fail-below is honoured on every output channel', () => {
+  let dir: string;
+  let score: number;
+
+  beforeAll(() => {
+    dir = cleanTree('clean');
+    score = scoreOf(dir);
+  });
+
+  it('the fixture scores strictly between 0 and 100 and exits 0 with no threshold', () => {
+    expect(score).toBeGreaterThan(0);
+    expect(score).toBeLessThan(100);
+    // Nothing but `--fail-below` can move this tree off exit 0.
+    expect(run(['secure', dir]).status).toBe(EXIT_PASS);
+  });
+
+  for (const format of FORMATS) {
+    it(`${format}: a score below the threshold exits 1 and says so on stderr`, () => {
+      const res = run(withFormat(format, ['secure', dir, '--fail-below', String(score + 1)]));
+      expect(res.status).toBe(EXIT_FAIL);
+      expect(res.stderr).toContain(`Score ${score} is below threshold ${score + 1}`);
+    });
+
+    it(`${format}: a score at the threshold exits 0 and says nothing`, () => {
+      const res = run(withFormat(format, ['secure', dir, '--fail-below', String(score)]));
+      expect(res.status).toBe(EXIT_PASS);
+      expect(res.stderr).not.toContain('is below threshold');
+    });
+  }
+
+  it('the breach is reported once, not once per channel copy', () => {
+    const res = run(['secure', dir, '--format', 'sarif', '--fail-below', String(score + 1)]);
+    expect(res.stderr.split('is below threshold').length - 1).toBe(1);
+  });
+
+  it('text: the reason follows the report, where a reader at a terminal expects it', () => {
+    // Settling the exit code above the channels must not move the sentence
+    // that explains it to the top of a 45-line run. Separate stdout/stderr
+    // pipes cannot see that: stderr holds only progress lines and the reason
+    // on EITHER placement, so "last on stderr" passes vacuously. Both streams
+    // are written through one file descriptor instead, which records the
+    // interleaving a terminal shows.
+    const capture = path.join(root, 'text-order.log');
+    const fd = fs.openSync(capture, 'w');
+    let status: number | null;
+    try {
+      status = spawnSync(process.execPath, [CLI, 'secure', dir, '--fail-below', String(score + 1)], {
+        stdio: ['ignore', fd, fd],
+        timeout: 240_000,
+        env: { ...process.env, NO_COLOR: '1', OPENA2A_TELEMETRY: 'off', HOME: fs.mkdtempSync(path.join(os.tmpdir(), 'hma-home-')) },
+      }).status;
+    } finally {
+      fs.closeSync(fd);
+    }
+    const merged = fs.readFileSync(capture, 'utf-8');
+    expect(status).toBe(EXIT_FAIL);
+    // The report's last body line is the `All commands:` hint; the version
+    // footer is printed from a `process.on('exit')` handler and is always the
+    // final line, before and after this change. Measured on published 0.30.0
+    // (its text-arm threshold block is unchanged through 0.32.0): reason at
+    // line 44 of 45, footer at 45 — and that is the order pinned here. `indexOf` finds the FIRST occurrence, so a second copy
+    // emitted at the settlement point (line 5) fails this too.
+    const lastReportLine = merged.indexOf('All commands:');
+    const footer = merged.indexOf('Scanned with hackmyagent');
+    const reason = merged.indexOf('is below threshold');
+    expect(lastReportLine, 'the report body must be in the capture').toBeGreaterThan(-1);
+    expect(footer, 'the exit footer must be in the capture').toBeGreaterThan(-1);
+    expect(reason, 'the reason must be in the capture').toBeGreaterThan(-1);
+    expect(reason).toBeGreaterThan(lastReportLine);
+    expect(reason).toBeLessThan(footer);
+  });
+
+  it('the report still reaches stdout when the threshold trips (sarif stays parseable)', () => {
+    const res = run(['secure', dir, '--format', 'sarif', '--fail-below', String(score + 1)]);
+    const sarif = JSON.parse(res.stdout.slice(res.stdout.indexOf('{')));
+    expect(sarif.version).toBe('2.1.0');
+  });
+});
+
+describe('#512 --fail-below never lowers the exit-2 unmeasured floor', () => {
+  let dir: string;
+  let unreadable = false;
+  let score: number;
+
+  beforeAll(() => {
+    dir = cleanTree('unread');
+    unreadable = makeUnreadable(path.join(dir, 'src', 'greet.js'));
+    if (unreadable) score = scoreOf(dir);
+  });
+
+  /** True when the environment could not give us a genuinely unreadable file. */
+  function cannotProbe(): boolean {
+    if (!unreadable) console.warn('skipped: this process can read a mode-000 file (running as root?)');
+    return !unreadable;
+  }
+
+  it('the fixture is unmeasured with no threshold, and still reports a score', () => {
+    if (cannotProbe()) return;
+    expect(run(['secure', dir]).status).toBe(EXIT_UNMEASURED);
+    expect(score).toBeLessThan(100);
+  });
+
+  for (const format of FORMATS) {
+    it(`${format}: a triggering threshold still exits 2, because a stricter flag cannot weaken the signal`, () => {
+      if (cannotProbe()) return;
+      const res = run(withFormat(format, ['secure', dir, '--fail-below', String(score + 1)]));
+      expect(res.status).toBe(EXIT_UNMEASURED);
+      // The breach is still reported; only the exit code is held at the floor.
+      expect(res.stderr).toContain(`Score ${score} is below threshold ${score + 1}`);
+    });
+  }
+
+  it('a non-triggering threshold leaves the floor alone', () => {
+    if (cannotProbe()) return;
+    expect(run(['secure', dir, '--fail-below', String(score)]).status).toBe(EXIT_UNMEASURED);
+  });
+
+  it('CONTROL: the same tree, once readable, exits 1 on a triggering threshold', () => {
+    if (cannotProbe()) return;
+    fs.chmodSync(path.join(dir, 'src', 'greet.js'), 0o644);
+    const readable = scoreOf(dir);
+    expect(readable).toBeLessThan(100);
+    expect(run(['secure', dir, '--fail-below', String(readable + 1)]).status).toBe(EXIT_FAIL);
+  });
+});

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -216,6 +216,32 @@ async function finishWithFindings(code: number): Promise<void> {
 }
 
 /**
+ * Raise the exit code to at least `code`; never lower it.
+ *
+ * THE PRECEDENCE RULE for `secure`, stated here and nowhere else (#512):
+ *
+ * - An input the run discovered and could not read settles a FLOOR of
+ *   `EXIT_UNMEASURED` (2) above every output channel (#438). "The command
+ *   cannot say, and does not pretend to."
+ * - A `--fail-below` breach raises the code to at least `EXIT_FAIL` (1) and
+ *   never lowers that floor. A threshold is a claim about the SCORE, and over
+ *   a tree with an unread input the score is an upper bound, not a
+ *   measurement — so "I could not measure this" outranks "I measured it and
+ *   it failed". A caller who adds a stricter flag must not get a weaker
+ *   signal back. Before this, the per-channel copies assigned 1 over the 2.
+ * - A critical/high FINDING is a fact about findings, not about the score;
+ *   each channel's `finishWithFindings(1)` is the recorded #438 behaviour
+ *   ("a run that also found a critical must still exit 1") and is untouched.
+ *
+ * `process.exitCode` is read, not assumed 0, because the floor may already
+ * have set it. `Number()` because newer Node typings allow a string here.
+ */
+function raiseExitCode(code: number): void {
+  const current = Number(process.exitCode ?? 0);
+  if (!(current >= code)) process.exitCode = code;
+}
+
+/**
  * Settle a `check` verdict's exit code. Called ABOVE the output-channel
  * branch on every `check` target path, so no renderer — and no `return`
  * inside one — can change it. See `src/check/verdict.ts` for why (#373).
@@ -4845,10 +4871,10 @@ Examples:
       // Placed here because this is the first statement at which the findings
       // and the score are final and NO output channel has branched yet. Every
       // one of the command's other exit statements is below it: the two
-      // benchmark arms, the json / sarif / html / asff returns, the text arm,
-      // and — the reason a per-channel gate could not work — the two
-      // `--fail-below` early returns that sit ABOVE each channel's own
-      // critical/high line and return before reaching it.
+      // benchmark arms, the json / sarif / html / asff returns and the text
+      // arm. The two per-channel `--fail-below` early returns that used to sit
+      // ABOVE each channel's own critical/high line — the reason a per-channel
+      // gate could not work — are gone; the threshold settles here (#494).
       //
       // It settles a FLOOR, not the whole code. An incomplete run must not exit
       // 0; a run that also found a critical must still exit 1, and every arm
@@ -4859,14 +4885,35 @@ Examples:
       // wrong. A `return` inside any renderer leaves it standing.
       //
       // This is deliberately NOT a fifth copy of the three-line
-      // `critHigh / deepScanIncomplete` block each channel carries. #494 is what
-      // per-channel copies produce: `--fail-below` is checked on text and json
-      // only, so it is silently inert under `--format sarif|html|asff` on
-      // published 0.29.0. A per-channel coverage gate would be the third
+      // `critHigh / deepScanIncomplete` block each channel carries. #494 was
+      // what per-channel copies produced: `--fail-below` was checked on text
+      // and json only, so it was silently inert under `--format sarif|html|asff`
+      // on published 0.29.0. A per-channel coverage gate would be the third
       // generation of that same bug.
       const unreadInputs = unreadInputCount(result);
       if (unreadInputs > 0) {
         process.exitCode = EXIT_UNMEASURED;
+      }
+
+      // `--fail-below` settles here too — once, for every channel (#494).
+      // SARIF is the format CI uploads, so a per-channel check that skipped it
+      // left the flag inert exactly where it is used: a job that asked for a
+      // score floor got a green build regardless of score, with nothing on
+      // stderr. A breach RAISES the code and never lowers the floor set just
+      // above (#512); the rule lives on `raiseExitCode`.
+      //
+      // The exit code is settled HERE for every channel. The one-line stderr
+      // reason is printed here for the document channels (json / sarif / html
+      // / asff), where stdout is a report and the sentence's position beside
+      // it is immaterial — and at the END of the text arm, after the report,
+      // where the published builds print it (0.30.0 measured: line 44 of 45,
+      // before the exit footer). Emitting it here in text mode put the reason
+      // five lines into a 45-line run, above the score it explains. One boolean drives the code and both sites, so the
+      // sentence cannot print without the code moving, or the reverse.
+      const thresholdBreached = failBelow !== undefined && result.score < failBelow;
+      if (thresholdBreached) {
+        raiseExitCode(EXIT_FAIL);
+        if (format !== 'text') console.error(`Score ${result.score} is below threshold ${failBelow}`);
       }
 
       // AI Infrastructure auto-detection — scan NemoClaw, OpenClaw, etc. if present.
@@ -5265,16 +5312,10 @@ Examples:
         }
         // Community contribution (non-blocking, runs in JSON mode too)
         await handleContribution(options.contribute, targetDir, result.findings, scanDurationMs, options.registryUrl, format);
-        // `--fail-below` is honored here, not only on the text path. It returns
-        // before the check near the end of the action, so `--json --fail-below 99`
-        // exited 0 on a score of 98 while the same run without `--json` exited 1.
-        // CI is precisely where a threshold is used and precisely where `--json`
-        // is used, so the flag was inert exactly where it matters.
-        if (failBelow !== undefined && result.score < failBelow) {
-          console.error(`Score ${result.score} is below threshold ${failBelow}`);
-          process.exitCode = 1;
-          return;
-        }
+        // `--fail-below` is settled once at the settlement point above (#494);
+        // no per-channel copy here. The copy this replaced returned before the
+        // critical/high line below, and its sibling on sarif/html/asff did not
+        // exist at all.
         const critHigh = gateSet(result).filter((f: any) => countsAgainstScore(f) && (f.severity === 'critical' || f.severity === 'high'));
         if (critHigh.length > 0) await finishWithFindings(1);
         else if (deepScanIncomplete(result)) await finishWithFindings(2);
@@ -5751,10 +5792,12 @@ Examples:
         console.log(`${colors.cyan}Helpful?${RESET()} Star the project: https://github.com/opena2a-org/opena2a\n`);
       }
 
-      // Check --fail-below threshold (standard mode)
-      if (failBelow !== undefined && result.score < failBelow) {
+      // `--fail-below` was settled once at the settlement point above (#494);
+      // this is the text channel's copy of the REASON, not of the gate — the
+      // exit code is already raised. The hard `process.exit(1)` that sat here
+      // also skipped the deep-scan line below it.
+      if (thresholdBreached) {
         console.error(`Score ${result.score} is below threshold ${failBelow}`);
-        process.exit(1);
       }
 
       // #454 -- an any-finding `--ci` gate used to sit here. It never ran: `--ci`


### PR DESCRIPTION
## What changes

`secure --fail-below N` is settled once, at the same settlement point the coverage floor uses and above every output channel, and it only ever raises the exit code.

Closes #494. Closes #512.

**#494** — the threshold was two per-channel copies (text, `--json`), so under `--format sarif|html|asff` it was never read. Measured on the published 0.29.0 and on `main` with an empty package directory scoring 98 and `--fail-below 99`: `text: 1, json: 1, sarif: 0, html: 0, asff: 0`. SARIF is the format CI uploads.

**#512** — both copies sat below the exit-2 unmeasured floor (#438) and ASSIGNED 1 over it. A tree holding an input the run could not read went from "I could not measure this" (2) to "I measured it and it failed" (1) the moment a threshold was supplied — a stricter flag returned a weaker signal.

## How

- `raiseExitCode(code)` beside `finishWithFindings`: raises `process.exitCode` to at least `code`, never lowers it. The precedence rule is written once, on that helper: unread input → floor 2; threshold breach → at least 1, never below the floor; critical/high finding → 1 on every channel as before.
- The threshold check moves to the `#438` settlement point, directly under the floor. The json and text copies are deleted (the text one was a hard `process.exit(1)` that also skipped the deep-scan line below it).
- The two benchmark arms keep their own compliance-percentage threshold; not touched here (#511 / #514).

## Measured (this branch vs a `main` build, same fixtures, exit codes captured unpiped)

| run | main | this branch |
|---|---|---|
| clean tree below threshold, `--format sarif` / `html` / `asff` | 0 | **1** + `Score N is below threshold M` on stderr |
| clean tree below threshold, text / `--json` | 1 | 1 |
| clean tree at the threshold, every channel | 0 | 0 |
| tree with a mode-000 input, below threshold, every channel | 1 | **2** (breach still printed) |
| tree with a mode-000 input, no threshold | 2 | 2 |

`__tests__/cli/secure-fail-below-exit-settlement.test.ts` (22 tests) pins every cell with thresholds derived from the fixture's own measured score. Red-proof against the `main` build: 9 failed / 12 passed — exactly the three #494 channels, the once-not-per-copy assertion, and the five #512 channels. Five mutations are each killed by name: assign-instead-of-raise, delete the settlement check, `<=` for `<`, delete the text channel's reason line, and emit the reason at the settlement point in text mode.

**Text channel ordering.** The one-line reason keeps its old place at the end of the report (published 0.30.0, whose text-arm block is unchanged through 0.32.0: line 44 of 45, before the version footer). Emitting it at the settlement point put it at line 5, above the score it explains. One `thresholdBreached` boolean drives the exit code and both message sites; a merged-stream test pins the order.

## Contract note

A pipeline that requested SARIF/HTML/ASFF with a score floor and has been passing on a low score will start failing. That is the flag doing what `--help` says. README's "on the text and JSON channels" sentence is restated. Found alongside: `--format asp` is accepted outside `-b` and renders the text report (#563, not changed here).
