### PR TITLE
Say beside the benchmark rating what the run could not read

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,26 @@ All notable changes to HackMyAgent are documented in this file.
 
 ## [Unreleased]
 
+### The benchmark arms say what the run could not read
+
+`secure -b oasb-1` and `-b oasb-2` could exit 2 — the unmeasured floor firing for an input the
+run discovered and could not read — while printing a rating and nothing else: the output said
+`Rating: Certified`, the exit code said "not fully measured", and nothing connected them (#514,
+the disclosure half). The cause: the benchmark report maps findings through control `checkIds`,
+and `SCAN-UNREAD-001` belongs to no control, so the one finding that explains the exit code
+vanished from every benchmark channel.
+
+Both arms now print the run's own read-failure record beside the rating on the text channel —
+`Unread inputs: N — the compliance above is an upper bound over what was read.` with each path
+and errno under it — and carry `unreadableInputs {count, codes}` in `--format json`, the same
+shape `secure --json` and `check --json` use.
+
+Deliberately NOT here: whether a passing rating may be issued at all over an unread input. That
+is the #513 rating-design question, which is deferred with its own record; this change discloses
+and decides nothing. The ratings, compliance numbers and exit codes are byte-identical on a
+fully readable tree, and the SARIF / HTML / ASP benchmark channels still carry no unread record
+— stated so the gap is on the record rather than silent.
+
 ### `secure --fail-below` settles once, on every channel, and only ever raises the exit code
 
 `--fail-below N` was checked by two per-channel copies — one on the text arm, one on `--json`

--- a/__tests__/cli/benchmark-unread-disclosure.test.ts
+++ b/__tests__/cli/benchmark-unread-disclosure.test.ts
@@ -1,0 +1,129 @@
+/**
+ * #514 (disclosure half) — a benchmark run that exits 2 for an input it could
+ * not read must say so beside the rating.
+ *
+ * Before: `generateBenchmarkReport` maps findings through control `checkIds`,
+ * and `SCAN-UNREAD-001` belongs to no control, so the one finding explaining
+ * the exit code vanished from every benchmark channel — the output printed
+ * `Rating: ...` and nothing else while `$?` was 2.
+ *
+ * This pins the DISCLOSURE only. What a rating may claim over an unread input
+ * is the #513 design question, deferred with its own record; the rating and
+ * the exit codes here are asserted only for direction-agreement (#514's rule:
+ * exit and verdict must not point opposite ways silently).
+ *
+ * `chmod 000` does not deny root, so the unread cases prove unreadability
+ * first and skip with a warning when they cannot get it.
+ */
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { spawnSync } from 'node:child_process';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { assertDistFreshIfPresent, BUILT_CLI as CLI } from '../helpers/dist-freshness';
+
+beforeAll(assertDistFreshIfPresent);
+
+let root: string;
+const restore: string[] = [];
+
+function run(args: string[]) {
+  const res = spawnSync(process.execPath, [CLI, ...args], {
+    encoding: 'utf-8',
+    timeout: 240_000,
+    env: {
+      ...process.env,
+      NO_COLOR: '1',
+      OPENA2A_TELEMETRY: 'off',
+      HOME: fs.mkdtempSync(path.join(os.tmpdir(), 'hma-home-')),
+    },
+  });
+  return { status: res.status, out: `${res.stdout ?? ''}${res.stderr ?? ''}`, stdout: res.stdout ?? '' };
+}
+
+function tree(name: string): string {
+  const dir = path.join(root, name);
+  fs.mkdirSync(path.join(dir, 'src'), { recursive: true });
+  fs.writeFileSync(path.join(dir, '.gitignore'), 'node_modules/\n.env\n*.pem\n*.key\n');
+  fs.writeFileSync(path.join(dir, 'package.json'), '{ "name": "fx514", "version": "1.0.0", "private": true }\n');
+  fs.writeFileSync(path.join(dir, 'src', 'util.js'), 'function add(a,b){return a+b;}\nmodule.exports={add};\n');
+  fs.writeFileSync(path.join(dir, 'src', 'greet.js'), 'module.exports = (n) => `hi ${n}`;\n');
+  return dir;
+}
+
+function makeUnreadable(file: string): boolean {
+  fs.chmodSync(file, 0o000);
+  restore.push(file);
+  try {
+    fs.readFileSync(file);
+    return false;
+  } catch {
+    return true;
+  }
+}
+
+let unreadable = false;
+function cannotProbe(): boolean {
+  if (!unreadable) console.warn('skipped: this process can read a mode-000 file (running as root?)');
+  return !unreadable;
+}
+
+beforeAll(() => {
+  root = fs.mkdtempSync(path.join(os.tmpdir(), 'hma-514-'));
+  const probe = path.join(root, 'probe');
+  fs.writeFileSync(probe, 'x');
+  unreadable = makeUnreadable(probe);
+});
+
+afterAll(() => {
+  for (const p of restore) {
+    try { fs.chmodSync(p, 0o644); } catch { /* already gone */ }
+  }
+  try { fs.rmSync(root, { recursive: true, force: true }); } catch { /* best effort */ }
+});
+
+describe('#514 the benchmark arms disclose what the run could not read', () => {
+  it('CONTROL: a fully readable tree prints no unread disclosure and carries count 0 in json', () => {
+    const dir = tree('clean');
+    const text = run(['secure', dir, '-b', 'oasb-1', '-l', 'L1', '--no-machine-posture']);
+    expect(text.out).not.toContain('Unread inputs:');
+    const json = run(['secure', dir, '-b', 'oasb-1', '-l', 'L1', '--no-machine-posture', '--format', 'json']);
+    const body = JSON.parse(json.stdout.slice(json.stdout.indexOf('{')));
+    expect(body.unreadableInputs).toEqual({ count: 0, codes: {} });
+  });
+
+  it('text: -b oasb-1 names the unread input and frames compliance as an upper bound', () => {
+    if (cannotProbe()) return;
+    const dir = tree('mixed');
+    makeUnreadable(path.join(dir, 'src', 'greet.js'));
+    const res = run(['secure', dir, '-b', 'oasb-1', '-l', 'L1', '--no-machine-posture']);
+    expect(res.out).toContain('Unread inputs: 1');
+    expect(res.out).toContain('upper bound');
+    expect(res.out).toContain('src/greet.js');
+    // Direction agreement (#514): the run must not read as complete while the
+    // exit code says it was not. The disclosure IS the agreement; the exit
+    // code itself is the floor's and is asserted non-zero only.
+    expect(res.status).not.toBe(0);
+  });
+
+  it('json: -b oasb-1 carries the record beside the rating', () => {
+    if (cannotProbe()) return;
+    const dir = tree('mixed-json');
+    makeUnreadable(path.join(dir, 'src', 'greet.js'));
+    const res = run(['secure', dir, '-b', 'oasb-1', '-l', 'L1', '--no-machine-posture', '--format', 'json']);
+    const body = JSON.parse(res.stdout.slice(res.stdout.indexOf('{')));
+    expect(body.rating).toBeDefined();
+    expect(body.unreadableInputs.count).toBe(1);
+    expect(body.unreadableInputs.codes.EACCES).toBe(1);
+    expect(res.status).not.toBe(0);
+  });
+
+  it('text: the -b oasb-2 composite discloses too', () => {
+    if (cannotProbe()) return;
+    const dir = tree('composite');
+    makeUnreadable(path.join(dir, 'src', 'greet.js'));
+    const res = run(['secure', dir, '-b', 'oasb-2', '--no-machine-posture']);
+    expect(res.out).toContain('Unread inputs: 1');
+    expect(res.out).toContain('src/greet.js');
+  });
+});

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -2961,6 +2961,33 @@ interface LocalControlResult {
   remediation?: string;
 }
 
+/**
+ * #514 (disclosure half) — a benchmark run can exit 2 for an input it could
+ * not read while printing a passing rating, and nothing in the output said
+ * why: `generateBenchmarkReport` maps findings through control `checkIds`,
+ * and `SCAN-UNREAD-001` belongs to no control, so the one finding that
+ * explains the exit code vanished from the report. These two helpers surface
+ * the run's own read-failure record beside the rating. The rating itself and
+ * the exit code are untouched: what a rating may CLAIM over an unread input
+ * is the #513 design question, which is deferred with its own record, and
+ * this discloses rather than decides.
+ */
+function benchmarkUnreadFindings(result: { findings: SecurityFinding[] }): SecurityFinding[] {
+  return result.findings.filter((f) => f.checkId === 'SCAN-UNREAD-001');
+}
+
+function printBenchmarkUnreadDisclosure(result: ScanResult): void {
+  const count = unreadInputCount(result);
+  if (count === 0) return;
+  console.log(`${colors.yellow}Unread inputs: ${count}${RESET()} — the compliance above is an upper bound over what was read.`);
+  for (const f of benchmarkUnreadFindings(result)) {
+    // The message already leads with the path ("src/greet.js could not be
+    // read (EACCES)"), so printing `f.file` beside it named the path twice.
+    console.log(`  ${escapeForDisplay(f.message ?? f.file ?? '')}`);
+  }
+  console.log();
+}
+
 function generateBenchmarkReport(
   findings: SecurityFinding[],
   level: BenchmarkLevel,
@@ -5058,6 +5085,11 @@ Examples:
             conformance: govResult.conformance,
             infraResult,
             govResult,
+            // #514 — the record that explains an exit-2 run; absent when a
+            // ledger kept none, {count: 0, ...} when everything was read.
+            ...(result.coverage?.unreadableInputs
+              ? { unreadableInputs: result.coverage.unreadableInputs }
+              : {}),
           };
           // This arm bypasses writeJsonStdout (writeFileSync(1, ...) below),
           // so it carries its own boundary read.
@@ -5082,6 +5114,7 @@ Examples:
 
           // Show infra report then governance report
           printBenchmarkReport(infraResult, options.verbose ?? false);
+          printBenchmarkUnreadDisclosure(result);
 
           process.stdout.write('\nGovernance Domains (scan-soul):\n');
           for (const domain of govResult.domains) {
@@ -5138,7 +5171,18 @@ Examples:
         let output: string;
         switch (format) {
           case 'json':
-            output = JSON.stringify(benchmarkResult, null, 2);
+            // #514 — the record that explains an exit-2 run rides beside the
+            // rating, in the same shape `secure --json` carries.
+            output = JSON.stringify(
+              {
+                ...benchmarkResult,
+                ...(result.coverage?.unreadableInputs
+                  ? { unreadableInputs: result.coverage.unreadableInputs }
+                  : {}),
+              },
+              null,
+              2,
+            );
             break;
           case 'sarif':
             output = generateSarifOutput(benchmarkResult, result.findings, targetDir);
@@ -5151,6 +5195,7 @@ Examples:
             break;
           default: // text
             printBenchmarkReport(benchmarkResult, options.verbose ?? false);
+            printBenchmarkUnreadDisclosure(result);
             output = '';
         }
 


### PR DESCRIPTION
## What changes

`secure -b oasb-1` and `-b oasb-2` could exit 2 — the unmeasured floor firing for an input the run discovered and could not read — while printing a rating and nothing else: `Rating: Certified` on stdout, "not fully measured" in `$?`, and nothing connecting them. The benchmark report maps findings through control `checkIds`, and `SCAN-UNREAD-001` belongs to no control, so the one finding that explains the exit code vanished from every benchmark channel.

Both arms now surface the run's own read-failure record beside the rating:

- **text** — `Unread inputs: N — the compliance above is an upper bound over what was read.` with each path and errno under it, on `-b oasb-1` and on the `-b oasb-2` composite;
- **`--format json`** — `unreadableInputs {count, codes}`, the shape `secure --json` already carries (`{count: 0, codes: {}}` on a fully readable tree, so absence is never ambiguous).

The record drives both the disclosure and the exit code, so they cannot drift apart (#514's acceptance rule).

## Deliberately not here

- **Whether a passing rating may be issued over an unread input.** That is the #513 rating-design question, which is deferred with its own record. This change discloses; it decides nothing: ratings, compliance numbers and exit codes are unchanged on a fully readable tree.
- The SARIF, HTML and ASP benchmark channels still carry no unread record — stated here so the gap is on the record rather than silent.

**Part of #514 (the disclosure half). It does not close #514.**

## Measured

`__tests__/cli/benchmark-unread-disclosure.test.ts`: four cells, all red on a `main` build (the disclosure did not exist), green here; the readable control asserts no disclosure line and the count-0 key. Mutations: deleting the two text calls, or the two json spreads, each fails its test by name. Fixture unreadability is proven in-process and the suite skips with a warning as root.
