### PR TITLE
Name the file the Verify line names, and render our own guidance on its own lines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,33 @@ All notable changes to HackMyAgent are documented in this file.
 
 ## [Unreleased]
 
+### Finding headers name the whole path; usage errors keep their lines
+
+Two display fixes on one boundary: developer-authored line structure now renders, and
+attacker-influenced content is escaped exactly as before.
+
+`secure` and `check` finding headers printed only the last two path segments, silently —
+`packages/a/src/config/db.json` and `packages/b/src/config/db.json` both rendered
+`config/db.json`, and the header could name a different real file than the `Verify:` line
+under it (#377). Headers now carry the full relative path, the same one `Verify:` cites, and
+the `+ N more` collapse line display-escapes whichever name it renders — the artifact's, or
+the full directory when no artifact name applies. The #374 archive carve-out is subsumed and
+removed.
+
+`check <bad-identifier>` and the registry-timeout guidance rendered as one line carrying
+literal `\n` (#523): the display escape that stops a newline inside scanned content from
+splitting or forging output lines (#324/#334) was applied to our own static help text.
+Developer-authored usage messages now travel as `UsageError` (src/checker/errors.ts), whose
+tagged-template builder escapes every interpolated value at construction — a newline planted
+in argv or environment cannot add, split, or forge a line through a `UsageError` message — and
+catch sites render each
+authored line individually, escaped again on the printing line. Everything that is not a
+`UsageError` renders exactly as before. Twelve error renders that printed a caught message
+unescaped now escape it — the same #324 boundary, applied in the direction it was missing —
+and so do the finding-header name fallback, the collapse label, and a plugin-error line that
+printed through `console.log` beneath the structural test's earlier sight line.
+
+
 ### The benchmark arms say what the run could not read
 
 `secure -b oasb-1` and `-b oasb-2` could exit 2 — the unmeasured floor firing for an input the

--- a/__tests__/cli/error-render-idiom.test.ts
+++ b/__tests__/cli/error-render-idiom.test.ts
@@ -1,0 +1,67 @@
+/**
+ * Structural tripwire (#523 follow-through): every render of a caught error's
+ * `.message` in src/cli.ts either whole-string-escapes it on the printing
+ * line or is the exact UsageError per-line idiom. The render-source gate
+ * cannot see these sites (its PATH_NAME heuristic matches path-named
+ * identifiers, not `message`), so without this test a raw catch-site render
+ * ships on discipline alone.
+ *
+ * Scope, stated honestly: the predicate is line-based. A site that copies
+ * `error.message` into a local and prints the local on another line evades
+ * it, as does a reformat that splits the render across lines. It is a
+ * tripwire against the observed failure mode — a raw `${error.message}`
+ * inside a print call — not a taint analysis.
+ */
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+
+const src = readFileSync(path.join(__dirname, '..', '..', 'src', 'cli.ts'), 'utf8');
+const lines = src.split('\n');
+
+describe('error.message render idiom (src/cli.ts)', () => {
+  it('every .message inside a print call is escaped on that line', () => {
+    const offenders: string[] = [];
+    lines.forEach((l, i) => {
+      if (!(l.includes('console.error(') || l.includes('console.log(') || l.includes('console.warn(') || l.includes('process.stderr.write('))) return;
+      if (!/\.message\b/.test(l)) return;
+      if (l.includes('escapeForDisplay(')) return;
+      offenders.push(`${i + 1}: ${l.trim()}`);
+    });
+    expect(offenders).toEqual([]);
+  });
+
+  it('every UsageError branch uses the per-line idiom', () => {
+    const branches = (src.match(/instanceof UsageError/g) ?? []).length;
+    expect(branches).toBeGreaterThanOrEqual(12);
+    const idiom = /instanceof UsageError\) \{\s*\n\s*error\.message\.split\('\\n'\)\.forEach/g;
+    expect((src.match(idiom) ?? []).length).toBe(branches);
+  });
+
+  it('message-family locals inside a print call are escaped on that line', () => {
+    // ${msg} / ${message} / ${nMsg} ... — locals assigned from a caught
+    // error's message and printed later. The RootRefusalError branch renders
+    // its own refusal text raw BY DESIGN (multi-line ternary, every
+    // interpolated path escaped where the message was built); its render
+    // spans lines and so sits outside this line-based predicate, consistent
+    // with the scope note above.
+    const offenders: string[] = [];
+    lines.forEach((l, i) => {
+      if (!(l.includes('console.error(') || l.includes('console.log(') || l.includes('console.warn(') || l.includes('process.stderr.write('))) return;
+      if (!/\$\{[A-Za-z]*[mM](sg|essage)\}/.test(l)) return;
+      if (l.includes('escapeForDisplay(')) return;
+      offenders.push(`${i + 1}: ${l.trim()}`);
+    });
+    expect(offenders).toEqual([]);
+  });
+
+  it('UsageError is never constructed here with raw interpolation', () => {
+    // The tagged-template builder is the one allowed construction path; a
+    // direct `new UsageError(...)` in cli.ts would bypass value escaping.
+    expect((src.match(/new UsageError\(/g) ?? []).length).toBe(0);
+  });
+
+  it('shortenPath stayed deleted (#377)', () => {
+    expect(src.includes('shortenPath')).toBe(false);
+  });
+});

--- a/__tests__/cli/header-path-full.test.ts
+++ b/__tests__/cli/header-path-full.test.ts
@@ -1,0 +1,95 @@
+/**
+ * #377 — the finding header names the file the `Verify:` line names: the FULL
+ * relative path. `shortenPath` kept only the last two segments and returned
+ * the result indistinguishable from a genuinely two-segment path, so in any
+ * tree three-plus segments deep the header could name a different real file
+ * than the one the finding is about (`packages/a/src/config/db.json` and
+ * `packages/b/src/config/db.json` both rendered `config/db.json`).
+ *
+ * The credential key below is synthesized at run time from a fixed seed and
+ * written into a temp directory, never committed: the detector skips any
+ * value carrying the house FAKE/PLACEHOLDER markers, and committing a
+ * credential-shaped literal to a public repo is worse. Same convention and
+ * constraints as locatable-runnable-citations.test.ts: 48+ consecutive
+ * alphanumerics after `sk-`, no placeholder marker anywhere in the key bytes,
+ * no fixture/test/example directory segment in the fixture path.
+ */
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { spawnSync } from 'node:child_process';
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { assertDistFresh, BUILT_CLI } from '../helpers/dist-freshness';
+
+function syntheticKey(): string {
+  const alpha = 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789';
+  let seed = 42;
+  let body = '';
+  for (let i = 0; i < 52; i++) {
+    seed = (seed * 1103515245 + 12345) % 2147483648;
+    body += alpha[seed % alpha.length];
+  }
+  return `sk-${body}`;
+}
+
+function run(args: string[]): string {
+  const r = spawnSync(process.execPath, [BUILT_CLI, ...args], {
+    encoding: 'utf8',
+    timeout: 180_000,
+    maxBuffer: 64 * 1024 * 1024,
+    env: { ...process.env, NO_COLOR: '1' },
+  });
+  return String(r.stdout ?? '') + String(r.stderr ?? '');
+}
+
+let root: string;
+const DEEP = 'packages/api/src/config.ts';
+
+beforeAll(() => {
+  assertDistFresh();
+  root = mkdtempSync(path.join(tmpdir(), 'hma-377-'));
+  mkdirSync(path.join(root, 'deep', path.dirname(DEEP)), { recursive: true });
+  writeFileSync(path.join(root, 'deep', DEEP), `export const apiKey = "${syntheticKey()}";\n`);
+  mkdirSync(path.join(root, 'shallow', 'src'), { recursive: true });
+  writeFileSync(path.join(root, 'shallow', 'src', 'config.ts'), `export const apiKey = "${syntheticKey()}";\n`);
+});
+
+afterAll(() => {
+  rmSync(root, { recursive: true, force: true });
+});
+
+describe('finding headers carry the full relative path (#377)', () => {
+  it('a depth-3 finding header names the path the Verify line cites', () => {
+    const out = run(['secure', path.join(root, 'deep')]);
+    expect(out).toContain(`│ ${DEEP}:1`);
+    // never the old two-segment elision as the whole header path
+    expect(out).not.toMatch(/│ src\/config\.ts:1/);
+    // header/Verify agreement: the Verify citation carries the same path
+    const verify = out.split('\n').find((l) => l.includes('Verify:') && l.includes('config.ts'));
+    expect(verify).toBeDefined();
+    expect(verify as string).toContain(DEEP);
+  });
+
+  it('a two-segment path renders unchanged', () => {
+    const out = run(['secure', path.join(root, 'shallow')]);
+    expect(out).toContain('│ src/config.ts:1');
+  });
+
+  it('the collapse line escapes the artifact name it renders', () => {
+    // Two same-name findings in one directory make the second collapse into
+    // `+ 1 more <severity> in <artifactName>`; the shown finding's file name
+    // carries a real newline plus a forged severity line. Escaped, the token
+    // renders as a visible \n mid-line; unescaped, it starts a line of its
+    // own — the #324 harm class, proven live in adversarial review.
+    const forged = 'FORGED-COLLAPSE-LINE.ts';
+    const dir = path.join(root, 'collapse', 'src');
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(path.join(dir, 'a\n' + forged), `export const k1 = "${syntheticKey()}";\n`);
+    writeFileSync(path.join(dir, 'zz-sibling.ts'), `export const k2 = "${syntheticKey()}";\n`);
+    const out = run(['secure', path.join(root, 'collapse')]);
+    expect(out).toContain(forged);
+    for (const line of out.split('\n')) {
+      expect(line.startsWith(forged)).toBe(false);
+    }
+  });
+});

--- a/__tests__/cli/usage-error-render.test.ts
+++ b/__tests__/cli/usage-error-render.test.ts
@@ -1,0 +1,67 @@
+/**
+ * #523 — developer-authored usage errors render their real newlines; nothing
+ * else does.
+ *
+ * `escapeForDisplay` maps LF to a literal backslash-n so a newline inside
+ * scanned content cannot split or forge a rendered line (#324/#334). Applied
+ * to the WHOLE of every caught error's message it also flattened our own
+ * multi-line usage guidance: the `check` identifier help rendered as one line
+ * carrying literal \n. Developer-authored messages now travel as `UsageError`
+ * (src/checker/errors.ts), whose tagged-template builder escapes every
+ * interpolated value at construction; catch sites render its lines
+ * individually, each escaped again on the printing line.
+ *
+ * Trust boundary pinned here: `${cli}` inside the usage block comes from
+ * HMA_CHECK_COMMAND / HMA_CLI_PREFIX (environment), so the forgery case
+ * plants a real LF plus a forged severity line THERE and asserts it can
+ * never start a line. Non-UsageError rendering (one escaped line) stays
+ * pinned by __tests__/cli/report-render-safety.test.ts and by
+ * error-render-idiom.test.ts.
+ */
+import { describe, it, expect, beforeAll } from 'vitest';
+import { spawnSync } from 'node:child_process';
+import { assertDistFresh, BUILT_CLI } from '../helpers/dist-freshness';
+
+function run(args: string[], extraEnv: Record<string, string> = {}) {
+  const r = spawnSync(process.execPath, [BUILT_CLI, ...args], {
+    encoding: 'utf8',
+    timeout: 60_000,
+    maxBuffer: 16 * 1024 * 1024,
+    env: { ...process.env, NO_COLOR: '1', ...extraEnv },
+  });
+  return { stderr: String(r.stderr ?? ''), status: r.status };
+}
+
+beforeAll(() => {
+  assertDistFresh();
+});
+
+describe('usage errors render authored lines (#523)', () => {
+  it('check <unrecognized> renders the usage block on real lines, exit unchanged', () => {
+    const { stderr, status } = run(['check', 'definitely@@not@@a@@skill']);
+    expect(status).toBe(1);
+    const lines = stderr.split('\n');
+    const i = lines.indexOf('Error: Invalid skill identifier: unrecognized format.');
+    expect(i).toBeGreaterThanOrEqual(0);
+    expect(lines[i + 1]).toBe('Expected one of:');
+    expect(lines.some((l) => l.startsWith('  @publisher/skill-name'))).toBe(true);
+    expect(stderr).not.toContain('\\n');
+  });
+
+  it('the Error: prefix appears on the first authored line only', () => {
+    const { stderr } = run(['check', 'definitely@@not@@a@@skill']);
+    expect(stderr.split('\n').filter((l) => l.startsWith('Error: '))).toHaveLength(1);
+  });
+
+  it('a newline planted in the env interpolation cannot start a line', () => {
+    const forged = 'CRITICAL forged-severity-line';
+    const { stderr } = run(['check', 'definitely@@not@@a@@skill'], {
+      HMA_CHECK_COMMAND: `x\n${forged}`,
+    });
+    expect(stderr).toContain(forged);
+    for (const line of stderr.split('\n')) {
+      expect(line.startsWith(forged)).toBe(false);
+    }
+    expect(stderr).toContain(`\\n${forged}`);
+  });
+});

--- a/src/checker/errors.ts
+++ b/src/checker/errors.ts
@@ -1,0 +1,44 @@
+/**
+ * Errors whose message text is DEVELOPER-AUTHORED, so its line structure is
+ * trusted and the CLI catch sites may render it across real lines (#523).
+ */
+
+import { escapeForDisplay } from '../ui/display-safe';
+
+/**
+ * A usage/guidance error: multi-line help text written by us, not derived from
+ * scanned trees, argv, or the environment.
+ *
+ * Trust is a property of the construction site, not the type (#324/#334): every
+ * value interpolated into the message must be display-escaped at interpolation
+ * time, so an embedded newline in argv or env cannot become a line boundary.
+ * Build instances with the `usageError` tagged template, which does that
+ * escaping for every interpolated value. The constructor additionally escapes
+ * each authored line — idempotent on text `usageError` produced — so a hazard
+ * that slips into a literal still renders visibly instead of steering the
+ * terminal.
+ *
+ * Never construct one from another error's `message`, a `cause` chain, or any
+ * text that concatenated bytes from a scanned artifact: wrapping does not
+ * launder trust, and the catch sites will render every line of this message as
+ * our own.
+ */
+export class UsageError extends Error {
+  constructor(message: string) {
+    super(message.split('\n').map(escapeForDisplay).join('\n'));
+    this.name = 'UsageError';
+  }
+}
+
+/**
+ * Tagged template for `UsageError`: authored literals keep their line
+ * structure; every interpolated value is display-escaped, so it cannot add,
+ * split, or forge a line.
+ */
+export function usageError(strings: TemplateStringsArray, ...values: unknown[]): UsageError {
+  let text = strings[0];
+  for (let i = 0; i < values.length; i++) {
+    text += escapeForDisplay(String(values[i])) + strings[i + 1];
+  }
+  return new UsageError(text);
+}

--- a/src/checker/skill-identifier.ts
+++ b/src/checker/skill-identifier.ts
@@ -3,6 +3,8 @@
  * Parses skill identifiers like @publisher/skill, ./local/path, or GitHub URLs
  */
 
+import { usageError } from './errors';
+
 export interface SkillIdentifier {
   publisher?: string;
   name: string;
@@ -63,15 +65,14 @@ export function parseSkillIdentifier(identifier: string): SkillIdentifier {
   }
 
   const cli = process.env.HMA_CHECK_COMMAND ?? `${process.env.HMA_CLI_PREFIX ?? 'hackmyagent'} check`;
-  throw new Error(
-    'Invalid skill identifier: unrecognized format.\n' +
-    'Expected one of:\n' +
-    '  @publisher/skill-name    Scoped registry identifier\n' +
-    '  https://github.com/...   GitHub URL\n' +
-    '  ./path/to/skill          Local file or directory\n' +
-    '\nExamples:\n' +
-    `  ${cli} @anthropic/code-review\n` +
-    `  ${cli} https://github.com/org/skill\n` +
-    `  ${cli} ./skills/my-skill.md`
-  );
+  throw usageError`Invalid skill identifier: unrecognized format.
+Expected one of:
+  @publisher/skill-name    Scoped registry identifier
+  https://github.com/...   GitHub URL
+  ./path/to/skill          Local file or directory
+
+Examples:
+  ${cli} @anthropic/code-review
+  ${cli} https://github.com/org/skill
+  ${cli} ./skills/my-skill.md`;
 }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -340,6 +340,7 @@ import { shouldShowDeepProgress } from './ui/progress-gate';
 import { generateVerifyCommand } from './ui/verify-command';
 import { commandSucceeded } from './telemetry/command-success';
 import { escapeForDisplay, escapePathForDisplay } from './ui/display-safe';
+import { UsageError, usageError } from './checker/errors';
 import { RootRefusalError } from './mcp/roots';
 import { shellQuote, citationPath, citationTarget, commandNaming } from './ui/shell-quote';
 import { CONCEPT_EXPLAINERS, inferConceptFromFix } from './ui/concept-explainers';
@@ -919,10 +920,8 @@ Examples:
         skipDnsVerification: options.offline,
       });
       const timeoutPromise = new Promise<never>((_, reject) =>
-        setTimeout(() => reject(new Error(
-          `Timed out verifying "${skill}" (10s). The publisher may not exist or DNS is unreachable.\n` +
-          `Try: ${getCheckCommand()} ${skill} --offline`
-        )), 10000)
+        setTimeout(() => reject(usageError`Timed out verifying "${skill}" (10s). The publisher may not exist or DNS is unreachable.
+Try: ${getCheckCommand()} ${skill} --offline`), 10000)
       );
       const result = await Promise.race([checkPromise, timeoutPromise]);
 
@@ -996,7 +995,12 @@ Examples:
         process.exit(1);
       }
     } catch (error) {
-      console.error(`Error: ${escapeForDisplay(error instanceof Error ? error.message : 'Unknown error')}`);
+      if (error instanceof UsageError) {
+        error.message.split('\n').forEach((line, i) =>
+          console.error(i === 0 ? `Error: ${escapeForDisplay(line)}` : escapeForDisplay(line)));
+      } else {
+        console.error(`Error: ${escapeForDisplay(error instanceof Error ? error.message : 'Unknown error')}`);
+      }
       process.exit(1);
     }
   });
@@ -1023,7 +1027,7 @@ function displayCheckFindings(
     for (const f of failed.slice(0, limit)) {
       const sev = SEVERITY_DISPLAY[f.severity];
       const attackClass = (f as any).attackClass ? ` (${(f as any).attackClass})` : '';
-      console.log(`  ${sev.color()}${sev.symbol}${RESET()} ${f.name}: ${f.message}${colors.dim}${attackClass}${RESET()}`);
+      console.log(`  ${sev.color()}${sev.symbol}${RESET()} ${f.name}: ${escapeForDisplay(f.message)}${colors.dim}${attackClass}${RESET()}`);
       if (verbose) {
         console.log(`    ${colors.dim}Check:    ${f.checkId}${RESET()}`);
         if (f.category) {
@@ -1333,16 +1337,9 @@ function renderConceptForFinding(
   }
 }
 
-/** Shorten a file path for display — show filename + parent dir only */
-function shortenPath(filePath: string): string {
-  const parts = filePath.split('/');
-  if (parts.length <= 2) return filePath;
-  return parts.slice(-2).join('/');
-}
-
-// #374 note on the two finding-header renderers below (`Top Issues` and the
-// normal findings list): both choose between `f.file` and `shortenPath(f.file)`
-// INLINE rather than through a helper, and both escape on the line that prints.
+// #377 note on the two finding-header renderers below (`Top Issues` and the
+// normal findings list): both render the FULL relative path — the path the
+// `Verify:` line prints — escaped INLINE on the line that prints.
 // A helper would read better and would defeat `render-source-gate`, which proves
 // the escape is applied by reading the printing line — it cannot see through an
 // indirection, and a guard that has to trust a helper's name proves nothing
@@ -2462,18 +2459,13 @@ function displayUnifiedCheck(opts: UnifiedCheckDisplayOptions): void {
       // the list (issue #134).
       const topFindings = [...failed].sort(compareFindingsByTier).slice(0, 3);
       for (const f of topFindings) {
-        // #374 — a finding inside the archive `--fix` just created needs its FULL
-                // relative path. `shortenPath` keeps the last two segments, so
-                // `.hackmyagent-backup/<stamp>/.claude/settings.json` collapses to
-                // `.claude/settings.json` — the live file, which that run just redacted —
-                // and the two render under one header, distinguishable only by `Verify:`.
-                const shortFile = f.file
-                  ? escapePathForDisplay(f.inOwnArchive ? f.file : shortenPath(f.file))
-                  : '';
-        const loc = shortFile + (f.line ? `:${f.line}` : '');
+        // #377 — the header names the file the `Verify:` line names: the full
+        // relative path, never elided (subsumes the #374 archive case).
+        const headerPath = f.file ? escapePathForDisplay(f.file) : '';
+        const loc = headerPath + (f.line ? `:${f.line}` : '');
         const borderColor = SEVERITY_DISPLAY[f.severity].color();
         console.log();
-        console.log(`  ${borderColor}│${RESET()} ${sevBadge(f.severity)}  ${colors.bold}${colors.white}${f.name || f.message}${RESET()}`);
+        console.log(`  ${borderColor}│${RESET()} ${sevBadge(f.severity)}  ${colors.bold}${colors.white}${escapeForDisplay(f.name || f.message)}${RESET()}`);
         if (loc) console.log(`  ${borderColor}│${RESET()} ${colors.dim}${loc}${RESET()}`);
         if (f.guidance) {
           console.log(`  ${borderColor}│${RESET()} ${escapeForDisplay(cleanFixText(f.guidance, f.file))}`);
@@ -2505,18 +2497,13 @@ function displayUnifiedCheck(opts: UnifiedCheckDisplayOptions): void {
         // #324 — the finding header, the guidance and the fix all interpolate a
         // path that came from the scanned tree. A newline in one split the
         // location line and truncated the fix command mid-quote.
-        // #374 — a finding inside the archive `--fix` just created needs its FULL
-                // relative path. `shortenPath` keeps the last two segments, so
-                // `.hackmyagent-backup/<stamp>/.claude/settings.json` collapses to
-                // `.claude/settings.json` — the live file, which that run just redacted —
-                // and the two render under one header, distinguishable only by `Verify:`.
-                const shortFile = f.file
-                  ? escapePathForDisplay(f.inOwnArchive ? f.file : shortenPath(f.file))
-                  : '';
-        const loc = shortFile + (f.line ? `:${f.line}` : '');
+        // #377 — the header names the file the `Verify:` line names: the full
+        // relative path, never elided (subsumes the #374 archive case).
+        const headerPath = f.file ? escapePathForDisplay(f.file) : '';
+        const loc = headerPath + (f.line ? `:${f.line}` : '');
         const borderColor = SEVERITY_DISPLAY[f.severity].color();
         console.log();
-        console.log(`  ${borderColor}│${RESET()} ${sevBadge(f.severity)}  ${colors.bold}${colors.white}${f.name || f.message}${RESET()}`);
+        console.log(`  ${borderColor}│${RESET()} ${sevBadge(f.severity)}  ${colors.bold}${colors.white}${escapeForDisplay(f.name || f.message)}${RESET()}`);
         if (loc) console.log(`  ${borderColor}│${RESET()} ${colors.dim}${loc}${RESET()}`);
         if (f.guidance) {
           console.log(`  ${borderColor}│${RESET()} ${escapeForDisplay(cleanFixText(f.guidance, f.file))}`);
@@ -2550,7 +2537,7 @@ function displayUnifiedCheck(opts: UnifiedCheckDisplayOptions): void {
           }
           if (similarCount > 0) {
             const sevColor = SEVERITY_DISPLAY[f.severity]?.color() ?? colors.dim;
-            const collapseCtx = artifactName ? ` in ${artifactName}` : (dir ? ` in ${shortenPath(dir)}` : '');
+            const collapseCtx = artifactName ? ` in ${escapePathForDisplay(artifactName)}` : (dir ? ` in ${escapePathForDisplay(dir)}` : '');
             console.log(`  ${borderColor}│${RESET()} ${colors.dim}+ ${similarCount} more ${RESET()}${sevColor}${f.severity}${collapseCtx ? `${RESET()}${colors.dim}${collapseCtx}` : ''}${RESET()}${colors.dim}  (run with --verbose to see all)${RESET()}`);
           }
         }
@@ -5056,7 +5043,7 @@ Examples:
             process.stderr.write(`[Simulation] Complete.\n\n`);
           } // end skillFiles.length > 0
         } catch (err) {
-          process.stderr.write(`[Simulation] Skipped: ${err instanceof Error ? err.message : 'unknown error'}\n\n`);
+          process.stderr.write(`[Simulation] Skipped: ${escapeForDisplay(err instanceof Error ? err.message : 'unknown error')}\n\n`);
         }
       }
 
@@ -5503,7 +5490,7 @@ Examples:
           }
         } catch (govFixErr: unknown) {
           const msg = govFixErr instanceof Error ? govFixErr.message : 'unknown error';
-          process.stderr.write(`Governance auto-fix skipped: ${msg}\n`);
+          process.stderr.write(`Governance auto-fix skipped: ${escapeForDisplay(msg)}\n`);
         }
       }
 
@@ -5727,14 +5714,14 @@ Examples:
             } catch (nErr: unknown) {
               if (options.verbose) {
                 const nMsg = nErr instanceof Error ? nErr.message : 'unknown error';
-                console.error(`Narrative emission skipped: ${nMsg}`);
+                console.error(`Narrative emission skipped: ${escapeForDisplay(nMsg)}`);
               }
             }
           }
         } catch (publishErr: unknown) {
           rethrowIfRedactionProvenance(publishErr);
           const msg = publishErr instanceof Error ? publishErr.message : 'unknown error';
-          console.error(`\nFailed to publish to registry: ${msg}`);
+          console.error(`\nFailed to publish to registry: ${escapeForDisplay(msg)}`);
           console.error('Scan results are still available locally.');
         }
       }
@@ -5824,7 +5811,7 @@ Examples:
           }
         } catch (ciErr: unknown) {
           const msg = ciErr instanceof Error ? ciErr.message : 'unknown error';
-          console.error(`\nFailed to submit CI scan result: ${msg}`);
+          console.error(`\nFailed to submit CI scan result: ${escapeForDisplay(msg)}`);
           console.error('Scan results are still available locally.');
         }
       }
@@ -5866,7 +5853,12 @@ Examples:
         return finishWithFindings(2);
       }
     } catch (error) {
-      console.error(`Error: ${escapeForDisplay(error instanceof Error ? error.message : 'Unknown error')}`);
+      if (error instanceof UsageError) {
+        error.message.split('\n').forEach((line, i) =>
+          console.error(i === 0 ? `Error: ${escapeForDisplay(line)}` : escapeForDisplay(line)));
+      } else {
+        console.error(`Error: ${escapeForDisplay(error instanceof Error ? error.message : 'Unknown error')}`);
+      }
       process.exit(1);
     }
   });
@@ -6262,7 +6254,12 @@ Examples:
 
       // Exit code settled above, before the `--json` branch.
     } catch (error) {
-      console.error(`Error: ${escapeForDisplay(error instanceof Error ? error.message : 'Unknown error')}`);
+      if (error instanceof UsageError) {
+        error.message.split('\n').forEach((line, i) =>
+          console.error(i === 0 ? `Error: ${escapeForDisplay(line)}` : escapeForDisplay(line)));
+      } else {
+        console.error(`Error: ${escapeForDisplay(error instanceof Error ? error.message : 'Unknown error')}`);
+      }
       process.exit(1);
     }
   });
@@ -6497,7 +6494,12 @@ Examples:
 
       // Exit code settled above, before the `--json` branch.
     } catch (error) {
-      console.error(`Error: ${escapeForDisplay(error instanceof Error ? error.message : 'Unknown error')}`);
+      if (error instanceof UsageError) {
+        error.message.split('\n').forEach((line, i) =>
+          console.error(i === 0 ? `Error: ${escapeForDisplay(line)}` : escapeForDisplay(line)));
+      } else {
+        console.error(`Error: ${escapeForDisplay(error instanceof Error ? error.message : 'Unknown error')}`);
+      }
       process.exit(1);
     }
   });
@@ -6630,7 +6632,12 @@ Examples:
           process.exit(1);
         }
       } catch (error) {
-        console.error(`Error: ${escapeForDisplay(error instanceof Error ? error.message : 'Unknown error')}`);
+        if (error instanceof UsageError) {
+          error.message.split('\n').forEach((line, i) =>
+            console.error(i === 0 ? `Error: ${escapeForDisplay(line)}` : escapeForDisplay(line)));
+        } else {
+          console.error(`Error: ${escapeForDisplay(error instanceof Error ? error.message : 'Unknown error')}`);
+        }
         process.exit(1);
       }
     }
@@ -6882,7 +6889,12 @@ Examples:
       // possible, on the code path #327 added to make failure recoverable.
       if (incomplete) process.exitCode = 1;
     } catch (error) {
-      console.error(`Error: ${escapeForDisplay(error instanceof Error ? error.message : 'Unknown error')}`);
+      if (error instanceof UsageError) {
+        error.message.split('\n').forEach((line, i) =>
+          console.error(i === 0 ? `Error: ${escapeForDisplay(line)}` : escapeForDisplay(line)));
+      } else {
+        console.error(`Error: ${escapeForDisplay(error instanceof Error ? error.message : 'Unknown error')}`);
+      }
       process.exit(1);
     }
   });
@@ -7250,7 +7262,7 @@ Examples:
         } catch (publishErr: unknown) {
           rethrowIfRedactionProvenance(publishErr);
           const msg = publishErr instanceof Error ? publishErr.message : 'unknown error';
-          console.error(`\nFailed to publish to registry: ${msg}`);
+          console.error(`\nFailed to publish to registry: ${escapeForDisplay(msg)}`);
           console.error('Scan results are still available locally.');
         }
       }
@@ -7262,7 +7274,12 @@ Examples:
         process.exit(attackCode);
       }
     } catch (error) {
-      console.error(`Error: ${escapeForDisplay(error instanceof Error ? error.message : 'Unknown error')}`);
+      if (error instanceof UsageError) {
+        error.message.split('\n').forEach((line, i) =>
+          console.error(i === 0 ? `Error: ${escapeForDisplay(line)}` : escapeForDisplay(line)));
+      } else {
+        console.error(`Error: ${escapeForDisplay(error instanceof Error ? error.message : 'Unknown error')}`);
+      }
       process.exit(1);
     }
   });
@@ -8385,7 +8402,7 @@ Examples:
             pluginErrors++;
             results.push({ name, findings: [], remediations: [] });
             if (!options.json) {
-              console.log(`  ${colors.brightRed}[!!] Plugin error: ${pluginErr instanceof Error ? pluginErr.message : String(pluginErr)}${RESET()}`);
+              console.log(`  ${colors.brightRed}[!!] Plugin error: ${escapeForDisplay(pluginErr instanceof Error ? pluginErr.message : String(pluginErr))}${RESET()}`);
               if (pluginErr instanceof Error && pluginErr.stack) {
                 console.error(pluginErr.stack);
               }
@@ -8551,9 +8568,12 @@ Examples:
           process.exit(1);
         }
       } catch (error) {
-        console.error(
-          `Error: ${escapeForDisplay(error instanceof Error ? error.message : 'Unknown error')}`
-        );
+        if (error instanceof UsageError) {
+          error.message.split('\n').forEach((line, i) =>
+            console.error(i === 0 ? `Error: ${escapeForDisplay(line)}` : escapeForDisplay(line)));
+        } else {
+          console.error(`Error: ${escapeForDisplay(error instanceof Error ? error.message : 'Unknown error')}`);
+        }
         process.exit(1);
       }
     }
@@ -8573,7 +8593,7 @@ program
       const { startMcpServer } = await import('./mcp-server');
       await startMcpServer(options.root ?? []);
     } catch (error) {
-      console.error(`Error starting MCP server: ${error instanceof Error ? error.message : error}`);
+      console.error(`Error starting MCP server: ${escapeForDisplay(error instanceof Error ? error.message : String(error))}`);
       process.exit(1);
     }
   });
@@ -9505,7 +9525,7 @@ Examples:
         } catch (publishErr: unknown) {
           rethrowIfRedactionProvenance(publishErr);
           const msg = publishErr instanceof Error ? publishErr.message : 'unknown error';
-          process.stderr.write(`Failed to publish to registry: ${msg}\n`);
+          process.stderr.write(`Failed to publish to registry: ${escapeForDisplay(msg)}\n`);
           process.stderr.write('Scan results are still available locally.\n');
         }
       }
@@ -9610,7 +9630,12 @@ Examples:
         process.exit(1);
       }
     } catch (error) {
-      process.stderr.write(`Error: ${escapeForDisplay(error instanceof Error ? error.message : 'Unknown error')}\n`);
+      if (error instanceof UsageError) {
+        error.message.split('\n').forEach((line, i) =>
+          process.stderr.write(i === 0 ? `Error: ${escapeForDisplay(line)}\n` : `${escapeForDisplay(line)}\n`));
+      } else {
+        process.stderr.write(`Error: ${escapeForDisplay(error instanceof Error ? error.message : 'Unknown error')}\n`);
+      }
       process.exit(1);
     }
   });
@@ -9767,7 +9792,12 @@ Examples:
         console.log();
       }
     } catch (error) {
-      process.stderr.write(`Error: ${escapeForDisplay(error instanceof Error ? error.message : 'Unknown error')}\n`);
+      if (error instanceof UsageError) {
+        error.message.split('\n').forEach((line, i) =>
+          process.stderr.write(i === 0 ? `Error: ${escapeForDisplay(line)}\n` : `${escapeForDisplay(line)}\n`));
+      } else {
+        process.stderr.write(`Error: ${escapeForDisplay(error instanceof Error ? error.message : 'Unknown error')}\n`);
+      }
       process.exit(1);
     }
   });
@@ -10306,7 +10336,12 @@ Examples:
         process.exitCode = 1;
       }
     } catch (error) {
-      process.stderr.write(`Error: ${escapeForDisplay(error instanceof Error ? error.message : 'Unknown error')}\n`);
+      if (error instanceof UsageError) {
+        error.message.split('\n').forEach((line, i) =>
+          process.stderr.write(i === 0 ? `Error: ${escapeForDisplay(line)}\n` : `${escapeForDisplay(line)}\n`));
+      } else {
+        process.stderr.write(`Error: ${escapeForDisplay(error instanceof Error ? error.message : 'Unknown error')}\n`);
+      }
       process.exit(1);
     }
   });
@@ -10794,7 +10829,12 @@ Examples:
         process.exit(1);
       }
     } catch (error) {
-      console.error(`Error: ${escapeForDisplay(error instanceof Error ? error.message : 'Unknown error')}`);
+      if (error instanceof UsageError) {
+        error.message.split('\n').forEach((line, i) =>
+          console.error(i === 0 ? `Error: ${escapeForDisplay(line)}` : escapeForDisplay(line)));
+      } else {
+        console.error(`Error: ${escapeForDisplay(error instanceof Error ? error.message : 'Unknown error')}`);
+      }
       process.exit(1);
     }
   });
@@ -11028,7 +11068,7 @@ Examples:
       } else {
         process.stderr.write(`Error: Could not reach the registry.\n`);
         process.stderr.write(`  URL: ${endpoint}\n`);
-        process.stderr.write(`  ${err instanceof Error ? err.message : String(err)}\n`);
+        process.stderr.write(`  ${escapeForDisplay(err instanceof Error ? err.message : String(err))}\n`);
       }
       process.exit(1);
     }
@@ -12534,7 +12574,7 @@ async function checkPyPiPackage(
     if (message.includes('not found on PyPI')) {
       console.error(`Error: ${escapeForDisplay(String(message))}`);
     } else {
-      console.error(`Error scanning PyPI package "${name}": ${message}`);
+      console.error(`Error scanning PyPI package "${escapeForDisplay(name)}": ${escapeForDisplay(String(message))}`);
     }
     process.exitCode = 1;
   } finally {
@@ -12758,7 +12798,7 @@ async function checkRawUrl(
       console.error(`\nTry downloading manually and scanning the local path:`);
       console.error(`  ${getCheckCommand()} ./downloaded-dir/`);
     } else {
-      console.error(`Error scanning URL: ${message}`);
+      console.error(`Error scanning URL: ${escapeForDisplay(String(message))}`);
     }
     process.exitCode = 1;
   } finally {
@@ -13092,7 +13132,7 @@ async function checkNpmPackage(
     // itself) is visible rather than silently swallowed. Set HMA_INTEGRITY_DEBUG=1
     // to see the full stack.
     const msg = err instanceof Error ? err.message : String(err);
-    process.stderr.write(`hackmyagent: integrity check skipped (${msg})\n`);
+    process.stderr.write(`hackmyagent: integrity check skipped (${escapeForDisplay(msg)})\n`);
     if (process.env.HMA_INTEGRITY_DEBUG && err instanceof Error && err.stack) {
       process.stderr.write(err.stack + '\n');
     }


### PR DESCRIPTION
Two display fixes on one boundary: developer-authored line structure now renders, and attacker-influenced content is escaped exactly as before.

**Headers name the whole path (#377).** Finding headers kept only the last two path segments, silently — `packages/a/src/config/db.json` and `packages/b/src/config/db.json` both rendered `config/db.json`, and the header could name a different real file than the `Verify:` line under it. Headers now carry the full relative path at both render sites, the `+ N more` collapse line display-escapes whichever name it renders (artifact or full directory), and `shortenPath` plus the #374 archive carve-out are deleted — the general rule subsumes the special case. Goldens carry no paths, so no re-bake.

**Usage errors keep their lines (#523).** `check <bad-identifier>` and the registry-timeout guidance rendered as one line carrying literal `\n`: the display escape that stops a newline inside scanned content from splitting or forging output lines (#324/#334) was applied to our own static help text. Developer-authored messages now travel as `UsageError` (`src/checker/errors.ts`), built through a tagged template that escapes every interpolated value at construction — a newline planted in argv or environment cannot add, split, or forge a line (`HMA_CHECK_COMMAND` carrying a real LF renders it as a visible `\n` mid-line) — and all 12 catch sites render its lines individually, each escaped again on the printing line. Non-`UsageError` errors render byte-identically to before.

**The same boundary, other direction.** Twelve renders that printed a caught message unescaped (registry publish failures, CI submit, URL scan, governance auto-fix, MCP startup, integrity note, simulation skip) now escape it. A new structural test walks `src/cli.ts` and fails on any print-call line that renders an error message or message-family local without escaping on that line, so the next raw site cannot ship on discipline alone; its line-based scope is stated in the test header.

**Adversarial round.** An independent reviewer built both trees and probed live: zero regressions; every finding pre-existing and proven against base. Two were fixed here because they sit on or beside edited lines — the collapse label rendered the artifact name raw (an LF in a filename forged a report line; now escaped, with a red-proofed regression test) and a plugin-error line printed through `console.log` beneath the structural test's sight line (now escaped; the tripwire watches `console.log`/`console.warn` too). The pre-existing env-only footer forgery through `HMA_CLI_PREFIX` is filed as #574 — its vector is the local environment, outside the finding renderers this change touches. The reviewer also confirmed `display-safe.ts` and `verify-command.ts` byte-identical to base, the non-`UsageError` branches byte-identical live, and all three new tests red on base. Known limits, stated: the idiom test's line-based predicate can be satisfied by a raw message co-located with another escaped token on one line (documented in its header), and the registry-timeout `UsageError` path is reviewed but not exercised by a test (both interpolations flow through the escaping template).

**Gate evidence.** Each new test was shown red on a deliberately broken variant, then the original restored byte-identically and re-run green: two-segment elision reintroduced → header test red; `UsageError` branch removed → usage-block test red; tag value-escaping removed → env-LF forgery test red; raw render reintroduced → structural test red. Terminal-only change: no `--json`/SARIF/exit-code behavior moved.

Closes #377. Closes #523.
