### PR TITLE
fix-all keeps every private key outside the tree it fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,52 @@ All notable changes to HackMyAgent are documented in this file.
 
 ## [Unreleased]
 
+### Security
+
+#### `fix-all` no longer writes private keys into the tree it fixes
+
+`fix-all --with-aim` wrote the agent's Ed25519 signing identity — secret key included — to
+`<target>/.opena2a/aim/identity.json`, and `fix-all` wrote an AES key to
+`<target>/.opena2a/credvault/store.key`, both inside the project, neither gitignored, one
+`git add -A` from a commit (#534, #431). The only message called them "plugin data". Affected:
+`hackmyagent` from 0.5.0 (identity) and from 0.5.4 (vault key) through every release before this
+one, and the deprecated `@opena2a/credvault-openclaw` 0.1.2 and earlier.
+
+The identity now lives in your user store, `$OPENA2A_HOME/projects/<key>/aim/` (default root
+`~/.opena2a`; `key` is derived from the project's real path, so each project has its own
+identity). `fix-all --with-aim` refuses to write (exit 1) if that store would sit inside the target; a
+scan, a dry-run or a plain `fix-all` on such a target still runs. The output names
+the private key, its path, and that it is outside the project the moment it is created; `--json`
+carries `privateKeyPaths`, `store`, and `legacyKeyMaterial`. Files that stay in the tree —
+`.opena2a/signcrypt/signatures.json`, `.opena2a/skillguard/pins.json`, `.env.example` — are
+public and correct to commit (the report lists only what the run itself wrote). `--dry-run` and
+`--scan-only` write nothing under the target and create no identity — so `aimEnabled` in their
+`--json` is now `false`, where it used to report the identity that was being constructed.
+
+The vault key is not relocated: it is no longer generated. In every shipped version the
+credvault store encrypted the literal `{}` and nothing ever wrote to it or read from it, so the
+key protected nothing. `fix-all` removes a hardcoded credential from the config file and does not
+store it — recover the value from your provider or from history — and the output now says so.
+
+**If you have run `fix-all` before this version:** check for the two files above. Identity file
+present: regenerate by running `fix-all --with-aim` on the tree (the new identity is created
+outside the project and the files are re-signed), then take the old file out of the tree. Vault
+key present: there is nothing to regenerate; take `.opena2a/credvault/` out of the tree. If either
+file was ever committed or pushed, treat that key as public. `fix-all` reports such files on every
+run, with their git state and the verify commands, and never reads, moves or deletes them. The
+0.26.1 notes scheduled the vault-key fix for 0.27.0; every release through the one before this
+carried it unchanged. Those notes called `store.key` the key to the `secrets.enc` "it decrypts",
+which implied the store held the removed credential; it held `{}`. `secure` reports an in-tree
+vault key as `Private Key Files` and has no check that sees `identity.json` (#577); use the git
+commands, not `secure`, to check a tree.
+
+This closes the class for `fix-all`. `secure --fix` and `harden-soul` still copy `.env` and other
+sensitive files into `<target>/.hackmyagent-backup/` (#389, #376); that is a separate, open change.
+
+Plugin authors: `PluginInitOptions.store` carries the `ProjectStore`; a plugin reads private
+paths from it and never derives them from `agentDir` (a repository test fails on the old shape).
+`CredVaultConfig.dataDir` and `SignCryptConfig.dataDir`, never read, are removed.
+
 ### Finding headers name the whole path; usage errors keep their lines
 
 Two display fixes on one boundary: developer-authored line structure now renders, and

--- a/__tests__/cli/fix-all-dry-run-gate-parity.test.ts
+++ b/__tests__/cli/fix-all-dry-run-gate-parity.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeAll } from 'vitest';
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
 import { spawnSync } from 'node:child_process';
 import { mkdtempSync, writeFileSync, mkdirSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
@@ -53,10 +53,15 @@ function makeFixture(): string {
   return dir;
 }
 
+// #534 — `fix-all --with-aim` writes a real identity into the user store.
+// Isolated here so a test run never writes into the developer's own ~/.opena2a.
+const ISOLATED_HOME = mkdtempSync(join(tmpdir(), 'hma-isolated-home-'));
+afterAll(() => rmSync(ISOLATED_HOME, { recursive: true, force: true }));
+
 function run(dir: string, ...args: string[]) {
   const res = spawnSync(process.execPath, [CLI, 'fix-all', dir, ...args], {
     encoding: 'utf-8',
-    env: { ...process.env, NO_COLOR: '1' },
+    env: { ...process.env, NO_COLOR: '1', HOME: ISOLATED_HOME, OPENA2A_HOME: ISOLATED_HOME },
   });
   return { status: res.status, stdout: res.stdout ?? '', stderr: res.stderr ?? '' };
 }

--- a/__tests__/cli/fix-all-exit-parity.test.ts
+++ b/__tests__/cli/fix-all-exit-parity.test.ts
@@ -19,7 +19,7 @@
 // evidence. They now share one predicate, so the number in the payload and
 // the exit code can never be computed off different sets again.
 
-import { describe, it, expect, afterEach, beforeAll } from 'vitest';
+import { describe, it, expect, afterEach, afterAll, beforeAll } from 'vitest';
 import { spawnSync } from 'node:child_process';
 import { mkdtempSync, rmSync, writeFileSync, mkdirSync, existsSync } from 'node:fs';
 import { tmpdir } from 'node:os';
@@ -63,11 +63,16 @@ function makeFixture(): string {
   return dir;
 }
 
+// #534 — `fix-all --with-aim` writes a real identity into the user store.
+// Isolated here so a test run never writes into the developer's own ~/.opena2a.
+const ISOLATED_HOME = mkdtempSync(join(tmpdir(), 'hma-isolated-home-'));
+afterAll(() => rmSync(ISOLATED_HOME, { recursive: true, force: true }));
+
 function run(dir: string, args: string[]) {
   return spawnSync('node', [CLI, 'fix-all', dir, ...args], {
     encoding: 'utf8',
     timeout: 180_000,
-    env: { ...process.env, NO_COLOR: '1', OPENA2A_TELEMETRY: 'off' },
+    env: { ...process.env, NO_COLOR: '1', OPENA2A_TELEMETRY: 'off', HOME: ISOLATED_HOME, OPENA2A_HOME: ISOLATED_HOME },
   });
 }
 

--- a/__tests__/cli/fix-all-key-material.test.ts
+++ b/__tests__/cli/fix-all-key-material.test.ts
@@ -1,0 +1,284 @@
+/**
+ * #534 / #431 — `fix-all` leaves no private key inside the tree it fixes.
+ *
+ * Measured before the fix (2026-08-24, 0.32.0): `fix-all --with-aim` on a
+ * fresh `git init` tree wrote the Ed25519 identity (secret key included) to
+ * `.opena2a/aim/identity.json` and an AES key to `.opena2a/credvault/store.key`,
+ * both staged by `git add -A`, no `.gitignore` written, and the only message
+ * called them "plugin data". `--dry-run --with-aim` still wrote
+ * `.opena2a/aim/audit.jsonl` into the tree.
+ *
+ * Every spawn here isolates HOME and OPENA2A_HOME: without that, a run writes a
+ * real identity into the developer's own ~/.opena2a.
+ *
+ * The credential is synthesized at run time from a fixed seed and never
+ * committed: the detector skips FAKE/PLACEHOLDER markers, and a real-shaped
+ * key in a public repo is worse. The allowlist of in-tree writes below is
+ * hand-written on purpose — copied from the implementation it would be a
+ * tautology.
+ */
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { spawnSync } from 'node:child_process';
+import { mkdirSync, mkdtempSync, readdirSync, readFileSync, realpathSync, rmSync, statSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { assertDistFresh, BUILT_CLI } from '../helpers/dist-freshness';
+import { gitFreeEnv, initThrowawayRepo } from '../helpers/throwaway-repo';
+
+const PUBLIC_IN_TREE = new Set(['.opena2a/signcrypt/signatures.json', '.opena2a/skillguard/pins.json', '.env.example', 'SKILL.md']);
+const B64_88 = /[A-Za-z0-9+/]{86}==/;
+const HEX_64_LINE = /^[0-9a-f]{64}\s*$/;
+
+function syntheticKey(): string {
+  const alpha = 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789';
+  let seed = 7;
+  let body = '';
+  for (let i = 0; i < 52; i++) {
+    seed = (seed * 1103515245 + 12345) % 2147483648;
+    body += alpha[seed % alpha.length];
+  }
+  return `sk-${body}`;
+}
+
+function walk(dir: string, base = dir): string[] {
+  return readdirSync(dir).flatMap((name) => {
+    if (name === '.git') return [];
+    const p = path.join(dir, name);
+    return statSync(p).isDirectory() ? walk(p, base) : [path.relative(base, p).split(path.sep).join('/')];
+  });
+}
+
+let root: string;
+let home: string;
+let opena2aHome: string;
+
+function makeTree(name: string, opts: { git: boolean }): string {
+  const dir = path.join(root, name);
+  mkdirSync(dir, { recursive: true });
+  writeFileSync(path.join(dir, 'package.json'), '{"name":"p","version":"1.0.0"}\n');
+  writeFileSync(path.join(dir, 'SKILL.md'), '---\nname: p\ndescription: root skill\n---\n# P\nhello\n');
+  writeFileSync(path.join(dir, 'config.json'), JSON.stringify({ apiKey: syntheticKey() }, null, 2) + '\n');
+  // #348 — a fixture repository is created with git isolated from this one
+  if (opts.git) initThrowawayRepo(dir);
+  return dir;
+}
+
+function run(dir: string, args: string[]) {
+  const r = spawnSync(process.execPath, [BUILT_CLI, 'fix-all', dir, ...args], {
+    encoding: 'utf8',
+    timeout: 180_000,
+    maxBuffer: 64 * 1024 * 1024,
+    env: { ...process.env, NO_COLOR: '1', OPENA2A_TELEMETRY: 'off', HOME: home, OPENA2A_HOME: opena2aHome },
+  });
+  return { status: r.status, out: String(r.stdout ?? '') + String(r.stderr ?? ''), stdout: String(r.stdout ?? '') };
+}
+
+function assertNoPrivateMaterialUnder(dir: string): string[] {
+  const files = walk(dir);
+  for (const rel of files) {
+    const base = path.basename(rel);
+    expect(base, `private-material filename under target: ${rel}`).not.toBe('identity.json');
+    expect(base, `private-material filename under target: ${rel}`).not.toBe('store.key');
+    const text = readFileSync(path.join(dir, rel), 'utf8');
+    expect(text, `88-char base64 run (Ed25519 secret shape) in ${rel}`).not.toMatch(B64_88);
+    expect(text, `64-hex single line (AES key shape) in ${rel}`).not.toMatch(HEX_64_LINE);
+    if (rel.endsWith('.json')) {
+      expect(text, `secretKey field in ${rel}`).not.toMatch(/"secretKey"/);
+    }
+  }
+  return files;
+}
+
+beforeAll(() => {
+  assertDistFresh();
+  // real-path form throughout: the CLI reports real paths, and tmpdir is a symlink on macOS
+  root = realpathSync.native(mkdtempSync(path.join(tmpdir(), 'hma-534-')));
+  home = path.join(root, 'home');
+  opena2aHome = path.join(root, 'opena2a-home');
+  mkdirSync(home);
+  mkdirSync(opena2aHome);
+});
+
+afterAll(() => {
+  rmSync(root, { recursive: true, force: true });
+});
+
+describe('fix-all --with-aim leaves no private key in the tree (#534, #431)', () => {
+  it('git tree: nothing key-bearing is written under the target; only public files appear, and the identity lands in the user store', () => {
+    const dir = makeTree('git-tree', { git: true });
+    const before = new Set(walk(dir));
+    const { status, out } = run(dir, ['--with-aim']);
+    expect(status).toBe(0);
+
+    const after = assertNoPrivateMaterialUnder(dir);
+    const written = after.filter((f) => !before.has(f));
+    for (const rel of written) {
+      expect(PUBLIC_IN_TREE.has(rel), `unexpected in-tree write: ${rel}`).toBe(true);
+    }
+    const staged = spawnSync('git', ['add', '-A'], { cwd: dir, env: gitFreeEnv() });
+    expect(staged.status).toBe(0);
+    const porcelain = spawnSync('git', ['status', '--porcelain', '--untracked-files=all'], { cwd: dir, encoding: 'utf8', env: gitFreeEnv() }).stdout;
+    expect(porcelain).not.toMatch(/identity\.json|store\.key/);
+
+    // the identity exists in the user store, named in the output, at the path printed
+    const stores = readdirSync(path.join(opena2aHome, 'projects'));
+    expect(stores).toHaveLength(1);
+    const identityPath = path.join(opena2aHome, 'projects', stores[0], 'aim', 'identity.json');
+    expect(statSync(identityPath).isFile()).toBe(true);
+    expect(out).toContain('Signing identity:');
+    expect(out).toContain('(Ed25519, created)');
+    expect(out).toContain('outside the project; do not copy it into the tree');
+    expect(out).toContain(identityPath);
+    expect(out).not.toContain('Plugin data stored');
+    expect(out).not.toContain('rm -rf');
+    if (process.platform !== 'win32') {
+      expect(statSync(path.join(opena2aHome, 'projects', stores[0])).mode & 0o777).toBe(0o700);
+      expect(statSync(identityPath).mode & 0o777).toBe(0o600);
+    }
+    // a second run reuses it and says so
+    const again = run(dir, ['--with-aim']);
+    expect(again.out).toContain('(Ed25519, reused)');
+  });
+
+  it('non-git tree: the same invariant holds without a repository', () => {
+    const dir = makeTree('plain-tree', { git: false });
+    const before = new Set(walk(dir));
+    expect(run(dir, ['--with-aim']).status).toBe(0);
+    const written = assertNoPrivateMaterialUnder(dir).filter((f) => !before.has(f));
+    for (const rel of written) expect(PUBLIC_IN_TREE.has(rel), `unexpected in-tree write: ${rel}`).toBe(true);
+  });
+
+  it('--json names the key path outside the target, the store, and no legacy material', () => {
+    const dir = makeTree('json-tree', { git: true });
+    const { status, stdout } = run(dir, ['--with-aim', '--json']);
+    expect(status).toBe(0);
+    const body = JSON.parse(stdout.slice(stdout.indexOf('{')));
+    expect(body.privateKeyPaths.identity).toBeTypeOf('string');
+    expect(path.isAbsolute(body.privateKeyPaths.identity)).toBe(true);
+    expect(path.relative(dir, body.privateKeyPaths.identity).startsWith('..')).toBe(true);
+    expect(body.privateKeyPaths.vault).toBeNull();
+    expect(body.store.root.startsWith(opena2aHome)).toBe(true);
+    expect(body.store.credvaultDir).toBeNull();
+    expect(body.store.legacyInTree).toEqual({ identity: { found: false, path: null }, vault: { found: false, path: null } });
+    expect(body.legacyKeyMaterial).toEqual([]);
+  });
+
+  it('--dry-run and --scan-only write nothing under the target and create no identity', () => {
+    for (const flag of ['--dry-run', '--scan-only']) {
+      const dir = makeTree(`nowrite${flag}`, { git: true });
+      const before = walk(dir).sort();
+      const storesBefore = readdirSync(path.join(opena2aHome, 'projects')).length;
+      const { status, stdout } = run(dir, ['--with-aim', flag, '--json']);
+      // the exit code keeps its meaning (1 while a critical finding would remain — the
+      // fixture's credential is not fixed in these modes); what must not change is the disk
+      expect([0, 1], flag).toContain(status);
+      expect(walk(dir).sort(), `${flag} wrote into the target`).toEqual(before);
+      expect(readdirSync(path.join(opena2aHome, 'projects')).length, `${flag} created a store`).toBe(storesBefore);
+      const body = JSON.parse(stdout.slice(stdout.indexOf('{')));
+      expect(body.privateKeyPaths).toEqual({ identity: null, vault: null });
+      // no identity is constructed, so the field that reports one says so
+      expect(body.aimEnabled).toBe(false);
+    }
+  });
+
+  it('read-only modes still scan a target the store would sit inside; only a writing --with-aim refuses', () => {
+    const dir = makeTree('self-home-scan', { git: false });
+    const env = { ...process.env, NO_COLOR: '1', OPENA2A_TELEMETRY: 'off', HOME: home, OPENA2A_HOME: path.join(dir, 'home') };
+    const scan = spawnSync(process.execPath, [BUILT_CLI, 'fix-all', dir, '--scan-only', '--json'], { encoding: 'utf8', timeout: 60_000, env });
+    const body = JSON.parse(String(scan.stdout).slice(String(scan.stdout).indexOf('{')));
+    expect(body.mode).toBe('scan-only');
+    expect(body.store).toBeNull();
+    expect(body.privateKeyPaths).toEqual({ identity: null, vault: null });
+    expect(walk(dir).some((f) => f.startsWith('home/'))).toBe(false);
+  });
+
+  it('lists as "safe to commit" only what this run wrote, never a file that merely exists', () => {
+    const dir = makeTree('preexisting-example', { git: false });
+    // a pre-existing example file with a live-looking value, and no credential finding to rewrite it
+    writeFileSync(path.join(dir, '.env.example'), 'DB_PASSWORD=hunter2-realvalue\n');
+    writeFileSync(path.join(dir, 'config.json'), '{}\n');
+    const { out } = run(dir, []);
+    const block = out.slice(out.indexOf('Written to the project'));
+    expect(block).not.toContain('.env.example'.slice(1, -1));
+  });
+
+  it('SIGN-TIP resolves through the store: absent identity tips creation, present identity names it', () => {
+    const dir = makeTree('tip-tree', { git: true });
+    const first = run(dir, ['--json']);
+    const tips = (body: any) => body.plugins.flatMap((p: any) => p.remediations).filter((r: any) => r.findingId === 'SIGN-TIP');
+    const t1 = tips(JSON.parse(first.stdout.slice(first.stdout.indexOf('{'))));
+    expect(t1).toHaveLength(1);
+    expect(t1[0].description).toContain('stored outside the project');
+
+    // create the identity out of tree, then re-run plain on a tree that still needs signing
+    const dir2 = makeTree('tip-tree-2', { git: true });
+    expect(run(dir2, ['--with-aim']).status).toBe(0);
+    writeFileSync(path.join(dir2, 'HEARTBEAT.md'), '# beat\n');
+    const second = run(dir2, ['--json']);
+    const t2 = tips(JSON.parse(second.stdout.slice(second.stdout.indexOf('{'))));
+    expect(t2).toHaveLength(1);
+    expect(t2[0].description).toContain('An identity for this project exists at');
+    expect(t2[0].description).toContain(opena2aHome);
+  });
+
+  it('a key an earlier version left in the tree is named with its git state, on every channel, and never touched', () => {
+    const dir = makeTree('legacy-tree', { git: true });
+    const legacy = path.join(dir, '.opena2a', 'aim', 'identity.json');
+    mkdirSync(path.dirname(legacy), { recursive: true });
+    writeFileSync(legacy, '{"agentName":"FAKE","secretKey":"FAKE-PLACEHOLDER"}\n');
+    spawnSync('git', ['add', '.opena2a/aim/identity.json'], { cwd: dir, env: gitFreeEnv() });
+    const stat = statSync(legacy);
+
+    const text = run(dir, ['--with-aim']);
+    expect(text.status).toBe(0);
+    expect(text.out).toContain('Private key inside the project');
+    expect(text.out).toContain('(tracked)');
+    expect(text.out).toContain('git -C ');
+    expect(text.out).toContain('ls-files --error-unmatch');
+    expect(text.out).toContain('regenerate');
+    expect(text.out).not.toMatch(/remove the key/i);
+    expect(statSync(legacy).mtimeMs).toBe(stat.mtimeMs);
+    expect(readFileSync(legacy, 'utf8')).toContain('FAKE-PLACEHOLDER');
+
+    const json = run(dir, ['--dry-run', '--json']);
+    const body = JSON.parse(json.stdout.slice(json.stdout.indexOf('{')));
+    expect(body.legacyKeyMaterial).toEqual([
+      { kind: 'identity', path: legacy, relativePath: path.join('.opena2a', 'aim', 'identity.json'), gitState: 'tracked' },
+    ]);
+    expect(body.store.legacyInTree.identity).toEqual({ found: true, path: legacy });
+  });
+
+  it('a vault key an earlier version left in the tree gets its own remedy: nothing to regenerate', () => {
+    const dir = makeTree('legacy-vault-tree', { git: true });
+    const legacy = path.join(dir, '.opena2a', 'credvault', 'store.key');
+    mkdirSync(path.dirname(legacy), { recursive: true });
+    writeFileSync(legacy, 'FAKE-PLACEHOLDER\n');
+    const stat = statSync(legacy);
+
+    const text = run(dir, []);
+    expect(text.out).toContain('Private key inside the project');
+    expect(text.out).toContain('(vault key)');
+    expect(text.out).toContain('(untracked)');
+    expect(text.out).toContain('nothing to regenerate');
+    expect(text.out).toContain('git -C ');
+    expect(text.out).not.toMatch(/re-signed/);
+    expect(statSync(legacy).mtimeMs).toBe(stat.mtimeMs);
+
+    const json = run(dir, ['--scan-only', '--json']);
+    const body = JSON.parse(json.stdout.slice(json.stdout.indexOf('{')));
+    expect(body.legacyKeyMaterial.map((l: any) => l.kind)).toEqual(['vault']);
+    expect(body.store.legacyInTree.vault).toEqual({ found: true, path: legacy });
+  });
+
+  it('refuses to run when the store would sit inside the target', () => {
+    const dir = makeTree('self-home', { git: false });
+    const r = spawnSync(process.execPath, [BUILT_CLI, 'fix-all', dir, '--with-aim'], {
+      encoding: 'utf8',
+      timeout: 60_000,
+      env: { ...process.env, NO_COLOR: '1', OPENA2A_TELEMETRY: 'off', HOME: home, OPENA2A_HOME: path.join(dir, 'home') },
+    });
+    expect(r.status).not.toBe(0);
+    expect(String(r.stderr)).toContain('inside the target');
+    expect(walk(dir).some((f) => f.startsWith('home/'))).toBe(false);
+  });
+});

--- a/__tests__/cli/json-exit-code-parity.test.ts
+++ b/__tests__/cli/json-exit-code-parity.test.ts
@@ -22,9 +22,9 @@
  * 0 under `--json` on a fixture that exits 1 without it. Three commands, one
  * defect, and only one of them had been reported.
  */
-import { describe, it, expect, beforeAll } from 'vitest';
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
 import { spawnSync } from 'node:child_process';
-import { existsSync, mkdtempSync, readFileSync, writeFileSync } from 'node:fs';
+import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
 import { assertDistFreshIfPresent } from '../helpers/dist-freshness';
@@ -125,11 +125,16 @@ function jsonCommands(): string[] {
   return out.sort();
 }
 
+// #534 — `fix-all --with-aim` writes a real identity into the user store.
+// Isolated here so a test run never writes into the developer's own ~/.opena2a.
+const ISOLATED_HOME = mkdtempSync(path.join(tmpdir(), 'hma-isolated-home-'));
+afterAll(() => rmSync(ISOLATED_HOME, { recursive: true, force: true }));
+
 function run(args: string[]): { status: number | null; stdout: string } {
   const r = spawnSync(process.execPath, [CLI, ...args], {
     encoding: 'utf8',
     timeout: 90_000,
-    env: { ...process.env, NO_COLOR: '1' },
+    env: { ...process.env, NO_COLOR: '1', HOME: ISOLATED_HOME, OPENA2A_HOME: ISOLATED_HOME },
   });
   if (r.error) throw r.error;
   return { status: r.status, stdout: r.stdout ?? '' };

--- a/__tests__/plugins/credvault/deep.test.ts
+++ b/__tests__/plugins/credvault/deep.test.ts
@@ -352,7 +352,7 @@ describe('CredVaultPlugin (deep)', () => {
   // ─── Fix output verification ──────────────────────────────────────
 
   describe('fix output verification', () => {
-    it('creates encrypted store with key and meta files', async () => {
+    it('creates no store and no key; writes the example env file', async () => {
       fs.writeFileSync(
         path.join(tmpDir, 'config.json'),
         JSON.stringify({ key: 'sk-ant-api03-abcdefghijklmnopqrstuvwxyz' }),
@@ -361,27 +361,13 @@ describe('CredVaultPlugin (deep)', () => {
 
       await plugin.fix(tmpDir);
 
+      // #431 — the fix replaces the value and writes .env.example; it creates
+      // no store and no key (the store only ever held `{}`, and the key sat
+      // ungitignored in the tree).
       const storeDir = path.join(tmpDir, '.opena2a', 'credvault');
-      expect(fs.existsSync(path.join(storeDir, 'secrets.meta.json'))).toBe(true);
-      expect(fs.existsSync(path.join(storeDir, 'secrets.enc'))).toBe(true);
-      expect(fs.existsSync(path.join(storeDir, 'store.key'))).toBe(true);
+      expect(fs.existsSync(storeDir)).toBe(false);
+      expect(fs.existsSync(path.join(tmpDir, '.env.example'))).toBe(true);
 
-      // Verify meta is valid JSON
-      const meta = JSON.parse(fs.readFileSync(path.join(storeDir, 'secrets.meta.json'), 'utf-8'));
-      expect(meta.version).toBe('1');
-
-      // Verify store key is hex-encoded 32 bytes (64 hex chars)
-      const keyHex = fs.readFileSync(path.join(storeDir, 'store.key'), 'utf-8');
-      expect(keyHex.length).toBe(64);
-      expect(/^[0-9a-f]+$/.test(keyHex)).toBe(true);
-
-      // Verify encrypted store has iv:authTag:ciphertext format (AES-256-GCM)
-      const enc = fs.readFileSync(path.join(storeDir, 'secrets.enc'), 'utf-8');
-      const parts = enc.split(':');
-      expect(parts.length).toBe(3);
-      expect(parts[0].length).toBe(24); // 12 bytes IV = 24 hex chars (GCM)
-      expect(parts[1].length).toBe(32); // 16 bytes auth tag = 32 hex chars
-      expect(parts[2].length).toBeGreaterThan(0);
     });
 
     it('.env.example contains correct variable names', async () => {

--- a/__tests__/plugins/credvault/index.test.ts
+++ b/__tests__/plugins/credvault/index.test.ts
@@ -143,9 +143,11 @@ describe('CredVaultPlugin', () => {
 
       await plugin.fix(tmpDir);
 
+      // #431 — no store, no key: every store this plugin ever wrote encrypted
+      // the literal `{}`, and the key beside it sat ungitignored in the tree.
       const storeDir = path.join(tmpDir, '.opena2a', 'credvault');
-      expect(fs.existsSync(storeDir)).toBe(true);
-      expect(fs.existsSync(path.join(storeDir, 'secrets.meta.json'))).toBe(true);
+      expect(fs.existsSync(storeDir)).toBe(false);
+      expect(fs.existsSync(path.join(tmpDir, '.opena2a'))).toBe(false);
     });
 
     it('dry run does not modify files', async () => {

--- a/__tests__/repo/no-in-tree-secret-store.test.ts
+++ b/__tests__/repo/no-in-tree-secret-store.test.ts
@@ -1,0 +1,65 @@
+/**
+ * Tripwire (#534, #431): the only module that may spell a private-material
+ * filename, or join a target directory with a private store name, is
+ * src/store/project-store.ts. A plugin that computes `agentDir/.opena2a/<x>`
+ * for anything but the two public control files fails here, so a new in-tree
+ * private directory is a reviewed edit rather than a quiet regression.
+ *
+ * Scope, honestly: this reads source text with comments stripped. It catches
+ * the shape that shipped the defect (a literal join on `agentDir` / a literal
+ * filename); it is not a taint analysis.
+ */
+import { describe, it, expect } from 'vitest';
+import { readdirSync, readFileSync, statSync } from 'node:fs';
+import path from 'node:path';
+
+const SRC = path.join(__dirname, '..', '..', 'src');
+const RESOLVER = path.join(SRC, 'store', 'project-store.ts');
+const PUBLIC_IN_TREE = new Set(['signcrypt', 'skillguard']);
+
+function walk(dir: string): string[] {
+  return readdirSync(dir).flatMap((name) => {
+    const p = path.join(dir, name);
+    return statSync(p).isDirectory() ? walk(p) : p.endsWith('.ts') ? [p] : [];
+  });
+}
+
+function stripComments(src: string): string {
+  return src.replace(/\/\*[\s\S]*?\*\//g, '').replace(/^\s*\/\/.*$/gm, '');
+}
+
+describe('private material never resolves inside the audited tree', () => {
+  const files = walk(SRC).filter((f) => f !== RESOLVER);
+
+  it('only the resolver spells the private-material filenames', () => {
+    const offenders: string[] = [];
+    for (const f of files) {
+      const code = stripComments(readFileSync(f, 'utf8'));
+      for (const literal of ['identity.json', 'store.key']) {
+        if (code.includes(`'${literal}'`) || code.includes(`"${literal}"`) || code.includes('`' + literal + '`')) {
+          offenders.push(`${path.relative(SRC, f)}: ${literal}`);
+        }
+      }
+    }
+    expect(offenders).toEqual([]);
+  });
+
+  it('no plugin joins the target with a private store directory', () => {
+    const offenders: string[] = [];
+    const pluginDir = path.join(SRC, 'plugins');
+    for (const f of walk(pluginDir)) {
+      const code = stripComments(readFileSync(f, 'utf8'));
+      const joins = [...code.matchAll(/\.opena2a['"`]?\s*,\s*['"`]([a-zA-Z0-9_-]+)['"`]/g), ...code.matchAll(/['"`]\.opena2a\/([a-zA-Z0-9_-]+)/g)];
+      for (const m of joins) {
+        if (!PUBLIC_IN_TREE.has(m[1])) offenders.push(`${path.relative(SRC, f)}: .opena2a/${m[1]}`);
+      }
+    }
+    expect(offenders).toEqual([]);
+  });
+
+  it('the CLI never hands aim-core a dataDir under the target', () => {
+    const code = stripComments(readFileSync(path.join(SRC, 'cli.ts'), 'utf8'));
+    expect(code).not.toMatch(/dataDir:\s*path\.join\(targetDir/);
+    expect(code).toMatch(/dataDir:\s*store\.aimDir/);
+  });
+});

--- a/__tests__/store/project-store.test.ts
+++ b/__tests__/store/project-store.test.ts
@@ -1,0 +1,156 @@
+/**
+ * The user store resolver (#534, #431): keyed on the project's real path,
+ * rooted at $OPENA2A_HOME, never inside the target.
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { spawnSync } from 'child_process';
+import { gitFreeEnv, initThrowawayRepo } from '../helpers/throwaway-repo';
+import {
+  findLegacyKeyMaterial,
+  projectKey,
+  resolveProjectStore,
+  userStoreRoot,
+} from '../../src/store/project-store';
+
+let tmp: string;
+let home: string;
+let target: string;
+const savedHome = process.env.OPENA2A_HOME;
+
+beforeEach(() => {
+  tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'hma-store-'));
+  home = path.join(tmp, 'home');
+  target = path.join(tmp, 'proj');
+  fs.mkdirSync(home);
+  fs.mkdirSync(target);
+  process.env.OPENA2A_HOME = home;
+});
+
+afterEach(() => {
+  if (savedHome === undefined) delete process.env.OPENA2A_HOME;
+  else process.env.OPENA2A_HOME = savedHome;
+  fs.rmSync(tmp, { recursive: true, force: true });
+});
+
+describe('projectKey', () => {
+  it('pins the conformance vector every implementation must reproduce', () => {
+    // Computed independently with node's crypto before being written here.
+    expect(projectKey('/srv/example-project')).toBe('2550ea6e13e5f88a');
+  });
+
+  it('is sixteen lowercase hex characters', () => {
+    expect(projectKey(target)).toMatch(/^[0-9a-f]{16}$/);
+  });
+});
+
+describe('resolveProjectStore', () => {
+  it('roots the store at $OPENA2A_HOME/projects/<key> and keys on the real path', () => {
+    const store = resolveProjectStore(target);
+    const real = fs.realpathSync.native(target);
+    expect(store.projectPath).toBe(real);
+    expect(store.key).toBe(projectKey(real));
+    // the root is compared and reported in real-path form (tmpdir is a symlink on macOS)
+    expect(store.root).toBe(path.join(fs.realpathSync.native(home), 'projects', store.key));
+    expect(store.aimDir).toBe(path.join(store.root, 'aim'));
+    expect(path.dirname(store.identityPath)).toBe(store.aimDir);
+    expect(store.dirFor('anything')).toBe(path.join(store.root, 'anything'));
+  });
+
+  it('falls back to ~/.opena2a when OPENA2A_HOME is unset', () => {
+    delete process.env.OPENA2A_HOME;
+    expect(userStoreRoot()).toBe(path.join(os.homedir(), '.opena2a'));
+  });
+
+  it('gives one key to one directory however it is reached', () => {
+    const link = path.join(tmp, 'link-to-proj');
+    fs.symlinkSync(target, link);
+    expect(resolveProjectStore(link).key).toBe(resolveProjectStore(target).key);
+    expect(resolveProjectStore(target + path.sep).key).toBe(resolveProjectStore(target).key);
+  });
+
+  it('gives different projects different stores', () => {
+    const other = path.join(tmp, 'other');
+    fs.mkdirSync(other);
+    expect(resolveProjectStore(other).root).not.toBe(resolveProjectStore(target).root);
+  });
+
+  it('refuses a store that would sit inside the target', () => {
+    process.env.OPENA2A_HOME = path.join(target, '.home');
+    expect(() => resolveProjectStore(target)).toThrow(/inside the target/);
+    // and the inverse framing: the target IS the store root's ancestor
+    process.env.OPENA2A_HOME = target;
+    expect(() => resolveProjectStore(target)).toThrow(/inside the target/);
+    // a component that merely BEGINS with `..` is still inside
+    process.env.OPENA2A_HOME = path.join(target, '..hidden');
+    expect(() => resolveProjectStore(target)).toThrow(/inside the target/);
+    // and the parent directory itself is outside
+    process.env.OPENA2A_HOME = path.dirname(target);
+    expect(() => resolveProjectStore(target)).not.toThrow();
+  });
+
+  it('does not create anything until ensure() is called, then creates the root and manifest', () => {
+    const store = resolveProjectStore(target, { createdBy: 'hackmyagent@test' });
+    expect(fs.existsSync(store.root)).toBe(false);
+    store.ensure();
+    expect(fs.existsSync(store.root)).toBe(true);
+    const manifest = JSON.parse(fs.readFileSync(path.join(store.root, 'project.json'), 'utf8'));
+    expect(manifest).toMatchObject({ schemaVersion: 1, path: store.projectPath, createdBy: 'hackmyagent@test' });
+    if (process.platform !== 'win32') {
+      expect(fs.statSync(store.root).mode & 0o777).toBe(0o700);
+      expect(fs.statSync(path.join(store.root, 'project.json')).mode & 0o777).toBe(0o600);
+    }
+    // idempotent: a second ensure() keeps the first manifest
+    const before = fs.readFileSync(path.join(store.root, 'project.json'), 'utf8');
+    store.ensure();
+    expect(fs.readFileSync(path.join(store.root, 'project.json'), 'utf8')).toBe(before);
+  });
+});
+
+describe('findLegacyKeyMaterial', () => {
+  it('reports nothing on a clean tree', () => {
+    expect(findLegacyKeyMaterial(target)).toEqual([]);
+  });
+
+  it('names an in-tree identity and vault key with their git state, and touches neither', () => {
+    const legacyIdentity = path.join(target, '.opena2a', 'aim', 'identity.json');
+    const legacyVault = path.join(target, '.opena2a', 'credvault', 'store.key');
+    fs.mkdirSync(path.dirname(legacyIdentity), { recursive: true });
+    fs.mkdirSync(path.dirname(legacyVault), { recursive: true });
+    fs.writeFileSync(legacyIdentity, '{"agentName":"FAKE","secretKey":"FAKE-PLACEHOLDER"}\n');
+    fs.writeFileSync(legacyVault, 'FAKE-PLACEHOLDER\n');
+    // #348 — fixture repositories are created and driven with git isolated
+    // from this one (a git hook exports GIT_DIR at the real repository).
+    initThrowawayRepo(target);
+    spawnSync('git', ['add', '.opena2a/aim/identity.json'], { cwd: target, env: gitFreeEnv() });
+    const beforeId = fs.statSync(legacyIdentity);
+    const beforeVault = fs.statSync(legacyVault);
+
+    const found = findLegacyKeyMaterial(target);
+    expect(found.map((f) => [f.kind, f.gitState])).toEqual([
+      ['identity', 'tracked'],
+      ['vault', 'untracked'],
+    ]);
+    expect(found[0].path).toBe(legacyIdentity);
+    expect(found[0].relativePath).toBe(path.join('.opena2a', 'aim', 'identity.json'));
+    expect(fs.statSync(legacyIdentity).mtimeMs).toBe(beforeId.mtimeMs);
+    expect(fs.statSync(legacyVault).mtimeMs).toBe(beforeVault.mtimeMs);
+  });
+
+  it('ignores a symlinked .opena2a that points outside the tree', () => {
+    const elsewhere = path.join(tmp, 'elsewhere');
+    fs.mkdirSync(path.join(elsewhere, 'aim'), { recursive: true });
+    fs.writeFileSync(path.join(elsewhere, 'aim', 'identity.json'), '{"secretKey":"FAKE-PLACEHOLDER"}\n');
+    fs.symlinkSync(elsewhere, path.join(target, '.opena2a'));
+    expect(findLegacyKeyMaterial(target)).toEqual([]);
+  });
+
+  it('says not-a-repo outside git', () => {
+    const legacyVault = path.join(target, '.opena2a', 'credvault', 'store.key');
+    fs.mkdirSync(path.dirname(legacyVault), { recursive: true });
+    fs.writeFileSync(legacyVault, 'FAKE-PLACEHOLDER\n');
+    expect(findLegacyKeyMaterial(target)[0].gitState).toBe('not-a-repo');
+  });
+});

--- a/docs/PLUGIN_API.md
+++ b/docs/PLUGIN_API.md
@@ -110,9 +110,24 @@ interface PluginMetadata {
 ```typescript
 interface PluginInitOptions {
   aimCore?: AIMCore;                  // Optional: AIM identity integration
+  store?: ProjectStore;               // The project's user store (see below)
   config?: Record<string, unknown>;   // Plugin-specific config
 }
 ```
+
+### ProjectStore
+
+Private material a plugin writes on a project's behalf — a signing identity,
+a key — never lives inside the project. `fix-all` resolves one `ProjectStore`
+per run at `$OPENA2A_HOME/projects/<key>/` (default root `~/.opena2a`; `key`
+is `sha256(realpath(project))[:16]`) and hands it to every plugin through
+`PluginInitOptions.store`. A plugin reads paths from it (`store.aimDir`,
+`store.identityPath`, `store.dirFor(name)`) and never derives them from
+`agentDir`. Callers that predate the field may omit it; a plugin then resolves
+the store itself with `resolveProjectStore(agentDir)`, exported from
+`hackmyagent`. Everything a plugin does write under `<project>/.opena2a/` is
+public material that is correct to commit — today `signcrypt/signatures.json`
+and `skillguard/pins.json`.
 
 ## Registry Functions
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -8205,7 +8205,8 @@ import { createPlugin as createCredVaultPlugin } from './plugins/credvault';
 import { createPlugin as createSecretlessPlugin } from './plugins/secretless';
 import { createPlugin as createSigncryptPlugin } from './plugins/signcrypt';
 import { createPlugin as createSkillguardPlugin } from './plugins/skillguard';
-import { AIMCore } from '@opena2a/aim-core';
+import { AIMCore, loadIdentity } from '@opena2a/aim-core';
+import { resolveProjectStore, findLegacyKeyMaterial, type ProjectStore } from './store/project-store';
 import type {
   Finding as PluginFinding,
   Remediation,
@@ -8238,8 +8239,13 @@ Step 2 requires secretless-ai (npm install -g secretless-ai). If not
 installed, the plugin reports this and continues with the remaining steps.
 
 Use --with-aim to create a cryptographic identity for your agent.
-This enables automatic file signing, audit logging, and trust scoring
-so you don't need to manage keys or track files manually.
+This enables automatic file signing and audit logging.
+The private key never enters the project tree: it lives in your user
+store, $OPENA2A_HOME/projects/<key>/aim/ (default root ~/.opena2a); each
+run prints the exact path.
+
+fix-all keeps no backup: commit before running it, or preview with
+--dry-run. rollback does not cover fix-all.
 
 Exit code 1 if critical/high issues remain after fixing.
 
@@ -8254,7 +8260,7 @@ Examples:
   .option('--dry-run', 'Preview fixes without applying them')
   .option('--scan-only', 'Only scan, do not fix')
   .option('--json', 'Output as JSON (for scripting/CI)')
-  .option('--with-aim', 'Create agent identity for automatic signing, audit logging, and trust scoring')
+  .option('--with-aim', 'Create agent identity (Ed25519, stored outside the project under $OPENA2A_HOME or ~/.opena2a) for automatic signing and audit logging')
   .option('-v, --verbose', 'Show all findings including passed plugins')
   .action(
     async (
@@ -8306,13 +8312,41 @@ Examples:
         }
         targetDir = realTarget;
 
+        // #534 — every private key this command creates lives in the user
+        // store, never under the target. Resolved once here; every plugin
+        // receives the same object, and the identity's own path is what the
+        // report prints. A dry-run or scan-only run constructs no identity and
+        // writes nothing anywhere.
+        // Resolving can refuse — the store would sit inside the target. Only a
+        // run that is about to WRITE the identity needs the store; a scan, a
+        // dry-run or a plain fix-all on such a target still runs, as before.
+        let store: ProjectStore | null = null;
+        let storeRefusal: Error | null = null;
+        try {
+          store = resolveProjectStore(targetDir, { createdBy: `hackmyagent@${VERSION}` });
+        } catch (e) {
+          storeRefusal = e instanceof Error ? e : new Error(String(e));
+        }
+        const writes = !options.dryRun && !options.scanOnly;
+        // Private key material an earlier version wrote INTO this tree. Named
+        // in every mode, touched in none: regenerating is the remedy, and what
+        // becomes of the old file is the user's call with its git state shown.
+        const legacyKeyMaterial = findLegacyKeyMaterial(targetDir);
+
         // Initialize AIM Core if requested
         let aimCore: AIMCore | undefined;
-        if (options.withAim) {
+        let identityReused = false;
+        if (options.withAim && writes) {
+          if (!store) throw storeRefusal;
+          store.ensure();
+          identityReused = loadIdentity(store.aimDir) !== null;
           aimCore = new AIMCore({
             agentName: path.basename(targetDir),
-            dataDir: path.join(targetDir, '.opena2a', 'aim'),
+            dataDir: store.aimDir,
           });
+          // Created eagerly so every plugin signs with the same identity and
+          // the report can name it whether or not a plugin needed it.
+          aimCore.getIdentity();
         }
 
         // Create and initialize plugins in execution order
@@ -8330,7 +8364,7 @@ Examples:
         const plugins: Array<{ name: string; plugin: OpenA2APlugin }> = [];
         for (const factory of pluginFactories) {
           const plugin = factory.create();
-          await plugin.init(aimCore ? { aimCore } : undefined);
+          await plugin.init({ ...(aimCore ? { aimCore } : {}), ...(store ? { store } : {}) });
           plugins.push({ name: factory.name, plugin });
         }
 
@@ -8344,6 +8378,27 @@ Examples:
             console.log(`Scanning ${escapePathForDisplay(targetDir)} (scan-only -- no fixes applied)...\n`);
           } else {
             console.log(`Scanning and fixing ${escapePathForDisplay(targetDir)}...\n`);
+          }
+
+          for (const legacy of legacyKeyMaterial) {
+            // `git -C <target>` so the command runs from any cwd (#286); the
+            // path operand is target-relative, which is what ls-files expects.
+            const citedTarget = citationTarget(targetDir);
+            const cited = citationPath(legacy.relativePath);
+            console.log(`${colors.brightRed}[!!] Private key inside the project${RESET()} — written by an earlier hackmyagent release (${legacy.kind === 'identity' ? 'signing identity' : 'vault key'})`);
+            console.log(`   ${escapePathForDisplay(legacy.relativePath)}  (${legacy.gitState})`);
+            if (citedTarget && cited) {
+              console.log(`   Verify: git -C ${citedTarget} ls-files --error-unmatch -- ${cited}   (exit 0 means git tracks it)`);
+              console.log(`           git -C ${citedTarget} log --all --oneline -- ${cited}`);
+            }
+            if (legacy.kind === 'identity') {
+              console.log(`   Fix: regenerate. Run ${CLI_PREFIX} fix-all --with-aim on this tree: the new identity is created outside`);
+              console.log(`        the project and the files are re-signed. Then take the old file out of the tree; if it was`);
+              console.log(`        ever committed or pushed, treat that key as public.\n`);
+            } else {
+              console.log(`   Fix: nothing to regenerate. The vault never held a value (it encrypted \`{}\`); take .opena2a/credvault/`);
+              console.log(`        out of the tree. If it was ever committed or pushed, treat the key as public.\n`);
+            }
           }
         }
 
@@ -8457,6 +8512,25 @@ Examples:
               findings: r.findings,
               remediations: r.remediations,
             })),
+            // #534 — where the private key went (null when this run created
+            // none), the store it went to, and any key an earlier version
+            // left inside the tree. Absolute paths, so a pipeline can assert
+            // in one loop that none of them resolves under `target`.
+            privateKeyPaths: {
+              identity: aimCore && store ? store.identityPath : null,
+              vault: null,
+            },
+            store: store === null ? null : {
+              root: store.root,
+              key: store.key,
+              aimDir: aimCore ? store.aimDir : null,
+              credvaultDir: null,
+              legacyInTree: {
+                identity: { found: legacyKeyMaterial.some((l) => l.kind === 'identity'), path: legacyKeyMaterial.find((l) => l.kind === 'identity')?.path ?? null },
+                vault: { found: legacyKeyMaterial.some((l) => l.kind === 'vault'), path: legacyKeyMaterial.find((l) => l.kind === 'vault')?.path ?? null },
+              },
+            },
+            legacyKeyMaterial,
           };
           writeJsonStdout(jsonOutput);
           if (pluginErrors > 0) process.exit(2);
@@ -8521,26 +8595,47 @@ Examples:
           }
           console.log();
 
-          if (!options.dryRun) {
-            console.log(
-              `${colors.cyan}Note:${RESET()} Plugin data stored in ${escapePathForDisplay(targetDir)}/.opena2a/`
-            );
-            // `fix-all --uninstall` was never a registered option and
-            // `fix-all` writes no backup, so `rollback` cannot undo it
-            // either. The instruction names the directory it just wrote
-            // instead of a command that does not exist (#372).
-            //
-            // A path the reader is invited to paste goes through
-            // `citationPath`, and its null — a path that cannot be shown
-            // truthfully — omits the command rather than printing an `rm -rf`
-            // whose operand is not the directory the reader sees. The line
-            // above already names the location, which is what makes dropping
-            // this one safe.
-            const dataDir = citationPath(`${targetDir}/.opena2a`);
-            if (dataDir) {
-              console.log(`      Remove it with: rm -rf ${dataDir}\n`);
+        }
+
+        // #534 — what this run wrote, and where. A private key is named as a
+        // private key, at the path it was written to, the moment it exists;
+        // the in-tree residue is public material that is correct to commit.
+        if (writes) {
+          if (aimCore && store) {
+            const identity = aimCore.getIdentity();
+            const keyPath = citationPath(store.identityPath);
+            console.log(`Signing identity: ${escapeForDisplay(identity.agentName)}  (Ed25519, ${identityReused ? 'reused' : 'created'})`);
+            if (keyPath) {
+              console.log(`  Private key  ${keyPath}   outside the project; do not copy it into the tree`);
+            } else {
+              // The path carries a display hazard; name the store it is in rather than a directory as the key.
+              console.log(`  Private key  in the store ${escapePathForDisplay(store.root)} (path not printable)   outside the project`);
+            }
+            console.log(`  Public key   ${escapeForDisplay(identity.publicKey)}`);
+          }
+          const credentialFixes = results.find((r) => r.name === 'Credential Protection')?.remediations.length ?? 0;
+          if (credentialFixes > 0) {
+            console.log(`Credential vault: none — fix-all removes credentials from config files and stores nothing;`);
+            console.log(`  recover each value from your provider or from history, then set it in the environment.`);
+          }
+          // Only what THIS run wrote, by the plugins' own filesModified — a file
+          // that merely exists may hold anything and is not ours to call safe.
+          const written = new Set(
+            results.flatMap((r) => r.remediations.flatMap((m) => m.filesModified))
+              .map((f) => path.relative(targetDir, path.resolve(targetDir, f)).split(path.sep).join('/')),
+          );
+          const publicWrites: Array<[string, string]> = [
+            ['.opena2a/signcrypt/signatures.json', 'hash pins and signatures'],
+            ['.opena2a/skillguard/pins.json', 'SHA-256 skill pins'],
+            ['.env.example', 'variable names only'],
+          ].filter(([rel]) => written.has(rel)) as Array<[string, string]>;
+          if (publicWrites.length > 0) {
+            console.log(`Written to the project (public, safe to commit):`);
+            for (const [rel, what] of publicWrites) {
+              console.log(`  ${rel.padEnd(36)} ${what}`);
             }
           }
+          console.log(`fix-all keeps no backup: commit before running it, or preview with --dry-run. rollback does not cover fix-all.\n`);
         }
 
         // All clear message

--- a/src/index.ts
+++ b/src/index.ts
@@ -195,6 +195,10 @@ export type {
   PluginInitOptions,
 } from './plugins/core';
 
+// The user store plugins read private-material paths from (#534)
+export { resolveProjectStore, findLegacyKeyMaterial } from './store/project-store';
+export type { ProjectStore, LegacyKeyMaterial } from './store/project-store';
+
 // OpenClaw plugins
 export { createPlugin as createCredVaultPlugin } from './plugins/credvault';
 export { createPlugin as createSigncryptPlugin } from './plugins/signcrypt';

--- a/src/plugins/core.ts
+++ b/src/plugins/core.ts
@@ -1,6 +1,7 @@
 export const VERSION = '0.1.0';
 
 import type { AIMCore } from '@opena2a/aim-core';
+import type { ProjectStore } from '../store/project-store';
 import type { Evidence, Rationale, ConceptId } from '../types/finding-evidence';
 
 // --- Plugin Interface ---
@@ -117,6 +118,13 @@ export interface OpenA2APlugin {
 export interface PluginInitOptions {
   /** Optional aim-core instance for identity-aware features */
   aimCore?: AIMCore;
+  /**
+   * The user store for the project being fixed (#534). The only source of a
+   * path for private material: a plugin that needs one reads it from here and
+   * never derives it from `agentDir`. Absent for callers that predate it;
+   * plugins then resolve it themselves with `resolveProjectStore(agentDir)`.
+   */
+  store?: ProjectStore;
   /** Plugin-specific configuration */
   config?: Record<string, unknown>;
 }

--- a/src/plugins/credvault.ts
+++ b/src/plugins/credvault.ts
@@ -12,7 +12,6 @@ import type {
 import type { AIMCore } from '@opena2a/aim-core';
 import * as fs from 'fs';
 import * as path from 'path';
-import * as crypto from 'crypto';
 
 // --- Credential patterns (aligned with hackmyagent-core CRED-001) ---
 // Catalog is exported for introspection by the lockstep test against
@@ -57,61 +56,13 @@ export interface SecretEntry {
   backend: 'local' | 'env';
 }
 
-export interface CredVaultConfig {
-  dataDir?: string;
-}
-
-// --- Encrypted Store ---
-
-const STORE_FILE = 'secrets.enc';
-const STORE_META_FILE = 'secrets.meta.json';
-
-interface SecretStoreMeta {
-  version: string;
-  entries: Record<string, { allowedSkills: string[]; backend: string }>;
-}
-
-function getStoreDir(agentDir: string): string {
-  return path.join(agentDir, '.opena2a', 'credvault');
-}
-
-function initStore(agentDir: string): void {
-  const storeDir = getStoreDir(agentDir);
-  fs.mkdirSync(storeDir, { recursive: true });
-
-  // Use exclusive-create (wx) to atomically create-if-not-exists (avoids TOCTOU)
-  const metaPath = path.join(storeDir, STORE_META_FILE);
-  try {
-    const meta: SecretStoreMeta = { version: '1', entries: {} };
-    fs.writeFileSync(metaPath, JSON.stringify(meta, null, 2), { encoding: 'utf-8', flag: 'wx' });
-  } catch (e: any) {
-    if (e.code !== 'EEXIST') throw e;
-  }
-
-  const storePath = path.join(storeDir, STORE_FILE);
-  try {
-    // Generate encryption key and create empty store
-    const key = crypto.randomBytes(32);
-    const iv = crypto.randomBytes(12); // 12 bytes for GCM
-    const cipher = crypto.createCipheriv('aes-256-gcm', key, iv);
-    const encrypted = Buffer.concat([cipher.update('{}', 'utf-8'), cipher.final()]);
-    const authTag = cipher.getAuthTag();
-
-    // Store key alongside (in production, this would use OS keychain)
-    const keyPath = path.join(storeDir, 'store.key');
-    fs.writeFileSync(keyPath, key.toString('hex'), { encoding: 'utf-8', flag: 'wx' });
-    // Format: iv:authTag:ciphertext (all hex)
-    fs.writeFileSync(
-      storePath,
-      iv.toString('hex') + ':' + authTag.toString('hex') + ':' + encrypted.toString('hex'),
-      { encoding: 'utf-8', flag: 'wx' }
-    );
-    // Restrict key file permissions (owner read/write only)
-    try { fs.chmodSync(keyPath, 0o600); } catch { /* Windows */ }
-  } catch (e: any) {
-    if (e.code !== 'EEXIST') throw e;
-  }
-}
+// A credential store was created here until #431: an AES key written
+// beside a ciphertext that, in every shipped version, encrypted the literal
+// `{}` — nothing ever wrote an entry or read one back. A key that protects
+// nothing is liability without benefit, and it sat ungitignored in the tree
+// this plugin was asked to make safer. `fix-all` removes the credential from
+// the config file and stores it nowhere; the user recovers the value from
+// the provider or from history, and the output says so.
 
 // --- Scan helpers ---
 
@@ -371,9 +322,6 @@ export class CredVaultPlugin implements OpenA2APlugin {
         }));
     }
 
-    // Initialize encrypted store
-    initStore(agentDir);
-
     // Fix CRED-001: Replace hardcoded credentials with env var references
     const credFindings = findings.filter((f) => f.id === 'CRED-001');
     if (credFindings.length > 0) {
@@ -449,7 +397,7 @@ export class CredVaultPlugin implements OpenA2APlugin {
   }
 
   async uninstall(): Promise<void> {
-    // No persistent state beyond the store directory
+    // No persistent state
   }
 }
 

--- a/src/plugins/signcrypt.ts
+++ b/src/plugins/signcrypt.ts
@@ -10,6 +10,7 @@ import type {
   PluginInitOptions,
 } from './core';
 import type { AIMCore } from '@opena2a/aim-core';
+import { resolveProjectStore, type ProjectStore } from '../store/project-store';
 import * as fs from 'fs';
 import * as path from 'path';
 import * as crypto from 'crypto';
@@ -26,7 +27,6 @@ export interface SignatureRecord {
 }
 
 export interface SignCryptConfig {
-  dataDir?: string;
   maxHeartbeatAge?: number; // seconds, default 604800 (7 days)
 }
 
@@ -249,10 +249,12 @@ export const metadata: PluginMetadata = {
 export class SignCryptPlugin implements OpenA2APlugin {
   readonly metadata = metadata;
   private aimCore?: AIMCore;
+  private store?: ProjectStore;
   private config: SignCryptConfig = {};
 
   async init(options?: PluginInitOptions): Promise<void> {
     this.aimCore = options?.aimCore;
+    this.store = options?.store;
     this.config = (options?.config as SignCryptConfig) ?? {};
   }
 
@@ -311,7 +313,8 @@ export class SignCryptPlugin implements OpenA2APlugin {
       remediations.push({
         findingId: finding.id,
         description: `Signed ${finding.filePath} with SHA-256 hash pin and Ed25519 signature`,
-        filesModified: [finding.filePath],
+        // Both files this iteration wrote: the signed file and the record of it.
+        filesModified: [finding.filePath, path.join(SIGNATURE_DIR, SIGNATURES_FILE)],
         rollbackAvailable: false,
       });
     }
@@ -328,20 +331,27 @@ export class SignCryptPlugin implements OpenA2APlugin {
       this.aimCore.setTrustHints({ configSigned: true });
     }
 
-    // If files were signed without AIM identity, add a recommendation finding
+    // Files signed without an identity: say where one would come from. The
+    // identity lives in the user store (#534), so the check resolves through
+    // the same contract the writer uses — a probe of the old in-tree path
+    // would tell every user with an out-of-tree identity to create one forever.
     if (!this.aimCore && remediations.length > 0) {
-      // Check if an identity already exists on disk
-      const aimDir = path.join(agentDir, '.opena2a', 'aim', 'identity.json');
-      if (!fs.existsSync(aimDir)) {
-        remediations.push({
-          findingId: 'SIGN-TIP',
-          description: 'Files signed with hash pins only (no cryptographic identity). ' +
-            'Run with --with-aim to create an Ed25519 identity for automatic signature management, ' +
-            'audit logging, and trust scoring.',
-          filesModified: [],
-          rollbackAvailable: false,
-        });
-      }
+      // Resolving can refuse (store would sit inside the target); a tip is
+      // not worth failing the plugin over, so that case reads as "no identity".
+      let store: ProjectStore | undefined = this.store;
+      if (!store) { try { store = resolveProjectStore(agentDir); } catch { store = undefined; } }
+      const hasIdentity = store ? fs.existsSync(store.identityPath) : false;
+      remediations.push({
+        findingId: 'SIGN-TIP',
+        description: hasIdentity
+          ? `Files signed with hash pins only. An identity for this project exists at ${store!.identityPath}; ` +
+            'run with --with-aim to sign with it.'
+          : 'Files signed with hash pins only (no cryptographic identity). ' +
+            'Run with --with-aim to create an Ed25519 identity, stored outside the project, for automatic ' +
+            'signature management and audit logging.',
+        filesModified: [],
+        rollbackAvailable: false,
+      });
     }
 
     return remediations;

--- a/src/store/project-store.ts
+++ b/src/store/project-store.ts
@@ -1,0 +1,216 @@
+/**
+ * The user store: where hackmyagent keeps material it writes on a project's
+ * behalf that must never live inside the project itself (#534, #431).
+ *
+ * `fix-all --with-aim` used to write the Ed25519 signing identity — secret key
+ * included — to `<target>/.opena2a/aim/`, and `fix-all` wrote a vault key
+ * beside it. Both sat ungitignored in the tree the command had just been asked
+ * to make safer, one `git add -A` from a commit. Everything private now
+ * resolves under the user store; everything that stays in the tree is public
+ * material that is correct to commit.
+ *
+ * Layout: `$OPENA2A_HOME/projects/<key>/` (default root `~/.opena2a`, the
+ * same expression the config and pending-scan stores already use), where
+ * `key` is the first sixteen hex characters of sha256 over the project's
+ * real path. The real path is the one keying input the audited tree cannot
+ * influence: any in-tree signal (a git remote, a package name, a marker file)
+ * would let a hostile repository key itself onto another project's store and
+ * get its files signed with that project's key. `realpathSync.native` is
+ * required — on a case-insensitive filesystem the non-native variant returns
+ * two spellings, and two keys, for one directory.
+ *
+ * Conformance vector every implementation pins:
+ *   key("/srv/example-project") === "2550ea6e13e5f88a"
+ *
+ * This module is the ONLY place the private-material filenames and the
+ * `aim` / `credvault` directory names are spelled. Plugins receive a
+ * `ProjectStore` through `PluginInitOptions` and read paths from it; a path
+ * computed from `agentDir` anywhere else fails the repo tripwire test. A
+ * rename or move of the project yields a new key and a fresh store; there is
+ * no rename detection, by design.
+ */
+
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { createHash } from 'crypto';
+import { spawnSync, type SpawnSyncOptionsWithStringEncoding } from 'child_process';
+
+/** aim-core's file contract: `identity.json` at the root of its dataDir. */
+const IDENTITY_FILE = 'identity.json';
+/** The vault key the credvault plugin wrote next to its store, in-tree, before #431. */
+const LEGACY_VAULT_KEY_FILE = 'store.key';
+const LEGACY_IN_TREE_DIR = '.opena2a';
+
+export interface ProjectStore {
+  /** `$OPENA2A_HOME/projects/<key>` */
+  root: string;
+  /** sha256(realpath)[:16] */
+  key: string;
+  /** The project's real path — what `key` was derived from. */
+  projectPath: string;
+  /** aim-core `dataDir`: identity, audit log, policy. */
+  aimDir: string;
+  /** The identity file inside `aimDir` (aim-core's contract). */
+  identityPath: string;
+  /**
+   * Reserved for a credential store with a writer and a reader. No shipped
+   * version has either — every vault ever written encrypted the literal `{}`
+   * — so nothing is created here until one exists (CISO, 2026-08-24).
+   */
+  credvaultDir: string;
+  /** A directory for any other component, under the store root. */
+  dirFor(name: string): string;
+  /** Create the store root (0700) and its manifest if absent. Idempotent. */
+  ensure(): ProjectStore;
+}
+
+export interface LegacyKeyMaterial {
+  kind: 'identity' | 'vault';
+  /** Absolute path inside the target. */
+  path: string;
+  /** Target-relative, for citations. */
+  relativePath: string;
+  gitState: 'tracked' | 'untracked' | 'not-a-repo';
+}
+
+/** `$OPENA2A_HOME`, else `~/.opena2a` — the expression the rest of the CLI uses. */
+export function userStoreRoot(): string {
+  return process.env.OPENA2A_HOME || path.join(os.homedir(), '.opena2a');
+}
+
+export function projectKey(realPath: string): string {
+  return createHash('sha256').update(realPath, 'utf8').digest('hex').slice(0, 16);
+}
+
+/**
+ * The real path of `p`'s deepest existing ancestor, with the rest appended:
+ * the store root usually does not exist yet, and a symlinked prefix (macOS's
+ * `/var` -> `/private/var`) would otherwise make the inside-target comparison
+ * below compare two spellings of one directory.
+ */
+function realpathOfExistingPrefix(p: string): string {
+  let cur = path.resolve(p);
+  const tail: string[] = [];
+  while (!fs.existsSync(cur)) {
+    const parent = path.dirname(cur);
+    if (parent === cur) break;
+    tail.unshift(path.basename(cur));
+    cur = parent;
+  }
+  let real = cur;
+  try { real = fs.realpathSync.native(cur); } catch { /* unreadable prefix: compare as spelled */ }
+  return path.join(real, ...tail);
+}
+
+/**
+ * Resolve (without creating) the store for `target`. Throws when the store
+ * would sit inside the target — `fix-all ~`, or a target that contains
+ * `$OPENA2A_HOME` — because a store inside the audited tree is the defect this
+ * module exists to remove, and no flag may recreate it.
+ */
+export function resolveProjectStore(target: string, opts: { createdBy?: string } = {}): ProjectStore {
+  const projectPath = fs.realpathSync.native(target);
+  const root = realpathOfExistingPrefix(userStoreRoot());
+  const key = projectKey(projectPath);
+  const storeRoot = path.join(root, 'projects', key);
+
+  const rel = path.relative(projectPath, storeRoot);
+  // A component that merely BEGINS with `..` (`..hidden`) is inside; only the
+  // parent segment itself, alone or followed by a separator, is outside.
+  const outside = rel === '..' || rel.startsWith('..' + path.sep) || path.isAbsolute(rel);
+  const inside = rel === '' || !outside;
+  if (inside) {
+    throw new Error(
+      `The user store ${storeRoot} would sit inside the target ${projectPath}. ` +
+      'Set OPENA2A_HOME to a directory outside the tree being fixed.',
+    );
+  }
+
+  const dirFor = (name: string): string => path.join(storeRoot, name);
+  const aimDir = dirFor('aim');
+  const store: ProjectStore = {
+    root: storeRoot,
+    key,
+    projectPath,
+    aimDir,
+    identityPath: path.join(aimDir, IDENTITY_FILE),
+    credvaultDir: dirFor('credvault'),
+    dirFor,
+    ensure(): ProjectStore {
+      // Ancestors (`$OPENA2A_HOME`, `projects/`) keep the default mode; only
+      // the project's own store root is private.
+      fs.mkdirSync(path.dirname(storeRoot), { recursive: true });
+      if (!fs.existsSync(storeRoot)) fs.mkdirSync(storeRoot, { mode: 0o700 });
+      try { fs.chmodSync(storeRoot, 0o700); } catch { /* Windows: no mode bits */ }
+      const manifest = path.join(storeRoot, 'project.json');
+      if (!fs.existsSync(manifest)) {
+        const body = JSON.stringify(
+          { schemaVersion: 1, path: projectPath, createdAt: new Date().toISOString(), createdBy: opts.createdBy ?? 'hackmyagent' },
+          null,
+          2,
+        );
+        try {
+          fs.writeFileSync(manifest, body + '\n', { encoding: 'utf-8', flag: 'wx', mode: 0o600 });
+        } catch (e: any) {
+          if (e.code !== 'EEXIST') throw e;
+        }
+      }
+      return store;
+    },
+  };
+  return store;
+}
+
+/**
+ * Private key material an earlier hackmyagent wrote INTO the target. Reported,
+ * never read, moved or deleted: a key of unknown exposure gets regenerated in
+ * the user store, and what happens to the old file is the user's decision
+ * with the git state in front of them.
+ */
+export function findLegacyKeyMaterial(target: string): LegacyKeyMaterial[] {
+  const candidates: Array<{ kind: LegacyKeyMaterial['kind']; relativePath: string }> = [
+    { kind: 'identity', relativePath: path.join(LEGACY_IN_TREE_DIR, 'aim', IDENTITY_FILE) },
+    { kind: 'vault', relativePath: path.join(LEGACY_IN_TREE_DIR, 'credvault', LEGACY_VAULT_KEY_FILE) },
+  ];
+  const found: LegacyKeyMaterial[] = [];
+  let targetReal: string;
+  try { targetReal = fs.realpathSync.native(target); } catch { return found; }
+  for (const c of candidates) {
+    const abs = path.join(target, c.relativePath);
+    // Only a file that really lives under the target is "inside the project":
+    // a symlinked `.opena2a/` would otherwise name a file elsewhere and the
+    // advice "take it out of the tree" would act on the wrong file.
+    let real: string;
+    try { real = fs.realpathSync.native(abs); } catch { continue; }
+    const within = path.relative(targetReal, real);
+    if (within === '' || within.startsWith('..' + path.sep) || within === '..' || path.isAbsolute(within)) continue;
+    found.push({ kind: c.kind, path: abs, relativePath: c.relativePath, gitState: gitStateOf(target, c.relativePath) });
+  }
+  return found;
+}
+
+function gitStateOf(target: string, relativePath: string): LegacyKeyMaterial['gitState'] {
+  // Inside a git hook, git exports GIT_DIR / GIT_WORK_TREE / GIT_INDEX_FILE
+  // pointing at the hook's own repository; inherited, they make `cwd: target`
+  // answer for the wrong repository (the git-context.ts precedent, #348).
+  const env = { ...process.env };
+  delete env.GIT_DIR;
+  delete env.GIT_WORK_TREE;
+  delete env.GIT_INDEX_FILE;
+  const opts: SpawnSyncOptionsWithStringEncoding = {
+    cwd: target,
+    env,
+    encoding: 'utf-8',
+    stdio: ['ignore', 'pipe', 'pipe'],
+    timeout: 5000,
+  };
+  // The target may be a clone that ships a hostile .git/config; the two
+  // read-only queries run with the one config that would execute a command
+  // on their behalf switched off.
+  const quiet = ['-c', 'core.fsmonitor=false'];
+  const inRepo = spawnSync('git', [...quiet, 'rev-parse', '--is-inside-work-tree'], opts);
+  if (inRepo.error || inRepo.status !== 0 || inRepo.stdout.trim() !== 'true') return 'not-a-repo';
+  const tracked = spawnSync('git', [...quiet, 'ls-files', '--error-unmatch', '--', relativePath], opts);
+  return tracked.status === 0 ? 'tracked' : 'untracked';
+}

--- a/src/ui/verify-command.ts
+++ b/src/ui/verify-command.ts
@@ -105,6 +105,7 @@ function isUsableLine(line: number | undefined): line is number {
  *     Verify: cat <target>/.env
  *     CRITICAL  Private Key Files
  *     Verify: cat <target>/.opena2a/credvault/store.key
+ *     (the vault key `fix-all` wrote in-tree at the time — #431; it writes none now)
  *
  * — a security scanner instructing the reader to print an entire secret file to
  * a terminal, on findings whose flagged trigger (`.env` is not listed in


### PR DESCRIPTION
`fix-all --with-aim` wrote the agent's Ed25519 signing identity — secret key included — to `<target>/.opena2a/aim/identity.json`, and `fix-all` wrote an AES key to `<target>/.opena2a/credvault/store.key`: inside the project the command had just been asked to make safer, neither gitignored, one `git add -A` from a commit, and described in the output as "plugin data" (#534, #431). Measured on 0.32.0: seven files written into a fresh `git init` tree, all staged, `git check-ignore` exit 1 on both keys, no `.gitignore` written; our own `secure` then reported the vault key as CRITICAL.

**Where the identity lives now.** A user store, `$OPENA2A_HOME/projects/<key>/aim/` (default root `~/.opena2a`, the expression the config and pending-scan stores already use), with `key = sha256(realpath(project))[:16]` — the real path is the one keying input the audited tree cannot influence, so a hostile repository cannot key itself onto another project's store. One identity per project, not one per user. `src/store/project-store.ts` is the only module that spells the private filenames or the store directories; `fix-all` resolves it once, hands it to every plugin through `PluginInitOptions.store`, and refuses to run if the store would sit inside the target. A repository test fails on any plugin that joins `agentDir` with a private store name again.

**What the vault key became.** Nothing. In every shipped version the credvault store encrypted the literal `{}` and no code ever wrote an entry or read one back, so the key protected nothing. It is no longer generated; `fix-all` removes a hardcoded credential from the config file and stores it nowhere, and the output now says so instead of implying a vault holds it.

**What the output says.** The "Plugin data stored … rm -rf" pair is gone. Every writing run names the signing identity (created or reused), the private key's absolute path with "outside the project; do not copy it into the tree", the public key, the public files written into the tree (`.opena2a/signcrypt/signatures.json`, `.opena2a/skillguard/pins.json`, `.env.example` — correct to commit), and that `fix-all` keeps no backup. `--json` gains `privateKeyPaths`, `store`, and `legacyKeyMaterial`. `--dry-run` and `--scan-only` write nothing under the target and construct no identity (they used to write `audit.jsonl` into the tree). The `SIGN-TIP` remediation resolves the identity through the store — before, it probed the old in-tree path and would have told every user with an out-of-tree identity to create one forever.

**Existing users.** A key an earlier version left inside the tree is reported on every run and every channel, with its git state (`tracked` / `untracked`) and `git -C <target>` commands to verify it. For the identity the remedy is to regenerate — re-run `fix-all --with-aim`, then take the old file out of the tree; for the vault key there is nothing to regenerate — take `.opena2a/credvault/` out of the tree; either way a key that was ever committed or pushed is treated as public. The tool never reads, moves or deletes such files. (Whether it should remove them itself is under decision; this change deliberately does not.)

**Not in this change.** `secure` still has no check that sees `identity.json` (#577, scanner). `fix-all` still writes no backup (#579, split out of #431). The sibling in-tree writer in opena2a-cli's `mcp-audit`, aim-core's own 644-then-chmod identity write, and `OPENA2A_HOME` support in aim-core and `@opena2a/shared` are filed as opena2a-org/opena2a#295.

**Gate evidence.** The ten new assertions are red on the pre-fix build (0 of 10 pass on the `323d787` dist). Six mutations — identity written back into the tree, SIGN-TIP probing the old in-tree path, store root created world-readable, legacy material left unreported, dry-run constructing the identity, the inside-target invariant removed — each turn a named test red and restore byte-identically. Every `fix-all` spawn harness now isolates `HOME` and `OPENA2A_HOME` (a test run used to be able to write a real identity into the developer's own store), and every `git` the change spawns runs with `GIT_DIR`/`GIT_WORK_TREE`/`GIT_INDEX_FILE` scrubbed, so a run inside a git hook answers for the target rather than the hook's repository (#348). Full suite 4306 passed / 0 failed; lint clean; `secure --ci` on this tree 100/100 over 594 files. A new-user walkthrough covered `--help`, plain, `--with-aim`, `--dry-run`, `--scan-only`, `--json`, a seeded legacy vault key, and a missing target. An independent adversarial round on both trees (isolated HOME, hash snapshots of every file per mode) found no CRITICAL or HIGH regression and confirmed the headline measurements; it also found three MEDIUM defects in the new code, all fixed here with a test each: the inside-target predicate accepted a path component that merely began with `..` (`OPENA2A_HOME=<target>/..hidden` reached the tree), read-only modes refused a target that contained the store root where base scanned (the store is now resolved lazily and only a writing `--with-aim` refuses), and the "safe to commit" list was keyed on file existence rather than on what the run wrote (a pre-existing `.env.example` with a live value was labelled safe). Lower-severity items fixed in the same pass: symlinked `.opena2a/` containment, `core.fsmonitor=false` on the two read-only git queries inside a possibly hostile clone, ancestor directories keep their default mode, the label fallback when a path is unprintable, `aimEnabled` now documented as `false` in read-only modes, and `SKILL-001`'s `filesModified` lists the signatures file it writes. Pre-existing and recorded, not fixed: `secure --fix`/`harden-soul` still copy `.env` into `<target>/.hackmyagent-backup/` (#389, #376 — the CHANGELOG says so), credvault's config rewrite goes through a default-mode temp file, and aim-core writes the identity 644-then-chmod (opena2a#295).

Closes #534. Closes #431.
