### PR TITLE
Restore LICENSE to canonical Apache-2.0 text (#584)

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,3 +1,4 @@
+
                                  Apache License
                            Version 2.0, January 2004
                         http://www.apache.org/licenses/
@@ -48,7 +49,7 @@
       "Contribution" shall mean any work of authorship, including
       the original version of the Work and any modifications or additions
       to that Work or Derivative Works thereof, that is intentionally
-      submitted to the Licensor for inclusion in the Work by the copyright owner
+      submitted to Licensor for inclusion in the Work by the copyright owner
       or by an individual or Legal Entity authorized to submit on behalf of
       the copyright owner. For the purposes of this definition, "submitted"
       means any form of electronic, verbal, or written communication sent
@@ -150,18 +151,17 @@
       appropriateness of using or redistributing the Work and assume any
       risks associated with Your exercise of permissions under this License.
 
-   8. Limitation of Liability. In no event and under no theory of
-      liability, whether in contract, strict liability, or tort
-      (including negligence or otherwise) arising in any way out of
-      the use or inability to use the Work (even if such Holder or other
-      party has been advised of the possibility of such damages), shall
-      any Contributor be liable to You for damages, including any direct,
-      indirect, special, incidental, or consequential damages of any
-      character arising as a result of this License or out of the use or
-      inability to use the Work (including but not limited to damages for
-      loss of goodwill, work stoppage, computer failure or malfunction, or
-      any and all other commercial damages or losses), even if such
-      Contributor has been advised of the possibility of such damages.
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
 
    9. Accepting Warranty or Additional Liability. While redistributing
       the Work or Derivative Works thereof, You may choose to offer,
@@ -176,7 +176,18 @@
 
    END OF TERMS AND CONDITIONS
 
-   Copyright 2025 OpenA2A
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.


### PR DESCRIPTION
Closes #584.

The LICENSE file differed from the canonical Apache-2.0 text in two places — a paraphrased clause 8 and a "to the Licensor" wording change — which made GitHub's license detection classify the repository as **NOASSERTION** while `package.json` declares `Apache-2.0`. Every published tarball carried the rewritten clause.

The file now byte-matches https://www.apache.org/licenses/LICENSE-2.0.txt.

**Verify:**
```
diff <(curl -sL https://www.apache.org/licenses/LICENSE-2.0.txt) LICENSE | grep -c '^[<>]'   # -> 0
```

**Acceptance:** after merge, `gh api repos/opena2a-org/hackmyagent --jq .license.spdx_id` returns `Apache-2.0` (GitHub's classifier may lag the merge by a short window).

Found by the pre-push license-integrity gate row during an unrelated rebase. LICENSE-only change; no code, test, or count touched.