### PR TITLE
Refuse secure --format asp outside an OASB-1 benchmark run

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -160,6 +160,15 @@ SARIF and HTML are byte-identical to before (they carry the configured value); `
 `scan-soul` and `detect --json`, ASFF, the MCP server and the Registry payload do not read the
 prefix.
 
+### `secure --format asp` outside a benchmark run is refused
+
+The Agent Security Profile is produced only by the OASB-1 benchmark arm (`-b oasb-1`; the
+OASB-2 composite has no profile format either), but the format validator accepted `asp` for any
+run and the ordinary report printed — a CI job that asked for a machine format got a human one,
+with nothing in the exit code to say so (#563). The flag is now refused on every other arm where
+the format errors are raised, exit 1, naming the flag it needs; `--help` lists `asp` with that
+condition. With `-b oasb-1` the ASP document is unchanged.
+
 ### Multi-part fix text renders on separate lines in the findings list
 
 The fix generator composes a remediation from several authored parts — the command, a

--- a/__tests__/cli/secure-format-asp-gating.test.ts
+++ b/__tests__/cli/secure-format-asp-gating.test.ts
@@ -1,0 +1,88 @@
+/**
+ * #563 — `secure --format asp` outside benchmark mode rendered the TEXT report.
+ *
+ * The Agent Security Profile is produced only by the OASB-1 benchmark arm (the
+ * OASB-2 composite has no profile renderer either), but the format validator
+ * accepted `asp` for any run, so a CI job that asked for a machine format got a
+ * human one — and nothing in the exit code said so. The flag is now refused
+ * where the other format errors are raised, with the flag it needs named; with
+ * `-b oasb-1` it still produces the ASP document.
+ */
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { spawnSync } from 'node:child_process';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { assertDistFreshIfPresent, BUILT_CLI as CLI } from '../helpers/dist-freshness';
+
+beforeAll(assertDistFreshIfPresent);
+
+let dir: string;
+
+beforeAll(() => {
+  dir = fs.mkdtempSync(path.join(os.tmpdir(), 'hma-563-'));
+  fs.writeFileSync(path.join(dir, 'package.json'), '{ "name": "fx563", "version": "1.0.0", "private": true }\n');
+  fs.writeFileSync(path.join(dir, '.gitignore'), 'node_modules/\n.env\n');
+  fs.writeFileSync(path.join(dir, 'index.js'), 'module.exports = () => 1;\n');
+});
+
+afterAll(() => {
+  try { fs.rmSync(dir, { recursive: true, force: true }); } catch { /* best effort */ }
+});
+
+function run(args: string[]) {
+  const r = spawnSync(process.execPath, [CLI, ...args], {
+    encoding: 'utf8',
+    timeout: 240_000,
+    maxBuffer: 64 * 1024 * 1024,
+    env: { ...process.env, NO_COLOR: '1', OPENA2A_TELEMETRY: 'off', HOME: fs.mkdtempSync(path.join(os.tmpdir(), 'hma-home-')) },
+  });
+  return { status: r.status, stdout: r.stdout ?? '', stderr: r.stderr ?? '' };
+}
+
+describe('#563 secure --format asp is a benchmark format', () => {
+  it('without -b it is refused with the flag it needs, and no report is printed', () => {
+    const r = run(['secure', dir, '--ci', '--format', 'asp']);
+    expect(r.status).toBe(1);
+    expect(r.stderr).toContain('--format asp');
+    expect(r.stderr).toContain('-b oasb-1');
+    // Neither the text report nor an ASP document reached stdout.
+    expect(r.stdout).not.toMatch(/Security\s+━/);
+    expect(r.stdout).not.toContain('"specVersion"');
+  });
+
+  it('with -b it still produces the Agent Security Profile document', () => {
+    const r = run(['secure', dir, '--ci', '-b', 'oasb-1', '--format', 'asp']);
+    const body = JSON.parse(r.stdout.slice(r.stdout.indexOf('{')));
+    expect(body.specVersion).toBe('1.0.0');
+    expect(body.generator?.name).toBe('HackMyAgent');
+    expect(body.securityPosture?.benchmark).toBe('OASB-1');
+    expect([0, 1, 2]).toContain(r.status);
+  });
+
+  it('with -b oasb-2 it is refused too: the composite arm has no profile renderer', () => {
+    const r = run(['secure', dir, '--ci', '-b', 'oasb-2', '--format', 'asp']);
+    expect(r.status).toBe(1);
+    expect(r.stderr).toContain('-b oasb-1');
+    expect(r.stdout).not.toContain('"specVersion"');
+    expect(r.stdout).not.toMatch(/Compliance/);
+  });
+
+  it('an unknown format is still refused by the same validator', () => {
+    const r = run(['secure', dir, '--ci', '--format', 'xyz']);
+    expect(r.status).toBe(1);
+    expect(r.stderr).toContain("Invalid format 'xyz'");
+  });
+
+  it('--help names asp with its condition, and the flag it cites is registered', () => {
+    const r = run(['secure', '--help']);
+    expect(r.status).toBe(0);
+    // Commander wraps option descriptions; compare on collapsed whitespace.
+    const flat = r.stdout.replace(/\s+/g, ' ');
+    expect(flat).toMatch(/asp with -b oasb-1/);
+    expect(flat).toMatch(/asp +Agent Security Profile \(with -b oasb-1\)/);
+    expect(flat).toMatch(/-b, --benchmark <name>/);
+    // Commander appends its own default; the description must not repeat it.
+    expect(flat).not.toMatch(/\(default: text\) \(default: "text"\)/);
+  });
+});

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -4638,6 +4638,8 @@ Output formats (--format):
   json   Machine-readable JSON
   sarif  GitHub Security tab / IDE integration
   html   Shareable compliance report
+  asff   AWS Security Hub findings
+  asp    Agent Security Profile (with -b oasb-1)
 
 Severities: critical, high, medium, low
 
@@ -4674,7 +4676,7 @@ Examples:
   // it is fixed the promise is scoped to where it holds.
   .option('--ignore <checks>', 'Comma-separated check IDs to leave out of the findings list (e.g., CRED-001,GIT-002). Suppressed checks are still scored and still set the exit code for this command; use --fail-below for a score floor. Not yet honoured by --benchmark')
   .option('--json', 'Output as JSON (deprecated: use --format json)')
-  .option('-f, --format <format>', 'Output format: text, json, sarif, html, asff (default: text)', 'text')
+  .option('-f, --format <format>', 'Output format: text, json, sarif, html, asff; asp with -b oasb-1', 'text')
   .option('--aws-account-id <id>', 'AWS account ID for ASFF format')
   .option('--aws-region <region>', 'AWS region for ASFF format')
   .option('-o, --output <file>', 'Write output to file instead of stdout')
@@ -4799,6 +4801,16 @@ Examples:
       const format = options.json ? 'json' : (options.format || 'text');
       if (!validFormats.includes(format)) {
         console.error(`Error: Invalid format '${escapeForDisplay(String(format))}'. Use: ${validFormats.join(', ')}`);
+        process.exit(1);
+      }
+      // #563 — the Agent Security Profile is rendered only by the OASB-1
+      // benchmark arm (the OASB-2 composite has no profile format either);
+      // outside it the format was accepted and the ordinary text report
+      // printed, so a CI job that asked for a machine format got a human one
+      // with nothing in the exit code to say so. Refuse it where the other
+      // format errors are raised, and name the flag it needs.
+      if (format === 'asp' && String(options.benchmark ?? '').toLowerCase() !== 'oasb-1') {
+        console.error('Error: --format asp is the Agent Security Profile of an OASB-1 benchmark run. Use it with -b oasb-1.');
         process.exit(1);
       }
 


### PR DESCRIPTION
The Agent Security Profile is produced only by the OASB-1 benchmark arm
(`-b oasb-1`; the OASB-2 composite has no profile renderer either — the one
`case 'asp'` sits in the OASB-1 output switch), but `secure`'s format validator
accepted `asp` for any run and the ordinary report printed — a CI job that
asked for a machine format got a human one, with nothing in the exit code to
say so (#563).

The flag is now refused where the other format errors are raised, exit 1, with
a message naming the flag it needs:

```
Error: --format asp is the Agent Security Profile of an OASB-1 benchmark run. Use it with -b oasb-1.
```

`secure --help` lists `asp with -b oasb-1` on the `-f, --format` line. With
`-b oasb-1` the ASP document is unchanged; `-b oasb-2 --format asp` is refused
with the same message (it printed the composite text report before).

Gating on the benchmark option rather than removing `asp` from the valid list
keeps the benchmark run's flag valid: removing it would have turned a correct
invocation into an "Invalid format" error.

**Measured against the build before this change:** `secure <dir> --format asp`
printed the text report and exited by findings; now exit 1 with the message and
nothing on stdout. `secure <dir> -b oasb-1 --format asp` produces the same
document on both builds apart from its timestamp.

**Red-proofed and mutated.** On the pre-change build the two refusal cells and
the help cell fail; the OASB-1 cell and the unknown-format cell pass on both
(they pin no-regression). With the gate removed, the refusal cells fail by name.

Direct flag-validation fix in the CPO's domain, under the recorded 2026-08-24
CPO ruling on #274/#563 (separate PR, same batch).

Closes #563.
