### PR TITLE
Count a fix on the MCP summary only when it is confirmed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -169,6 +169,24 @@ with nothing in the exit code to say so (#563). The flag is now refused on every
 the format errors are raised, exit 1, naming the flag it needs; `--help` lists `asp` with that
 condition. With `-b oasb-1` the ASP document is unchanged.
 
+### The MCP scan summary counts a fix only when it is confirmed
+
+The `hackmyagent_scan` MCP tool's summary line built its two counts from overlapping
+filters: outstanding issues via the scoring predicate, fixes via a bare `fixed` flag. A fix
+that was attempted and then disproved by the verification pass counted as both, so one finding
+read `1 issue found | 1 fixed` (#274). The HTML report and the Registry remediation report
+already counted a fix only when it is confirmed, and the text fix summary leads with what was
+confirmed; the MCP summary and the deprecated OpenClaw arm now count the same way. Those four
+surfaces — the HTML report, the Registry remediation report, the MCP summary and the OpenClaw
+arm — read one shared predicate; the text fix summary keeps its own attempted/verified split. For a disproved attempt the line reads `1 issue found` with no fix
+clause; a confirmed fix beside it reads `1 issue found | 1 fixed`. The body is unchanged: the
+disproved finding is listed under issues with its remedy. On the deprecated `secure-openclaw`
+arm the counts line and the `--json` `fixed` field follow the same rule (the per-finding
+`fixed`/`fixVerified` flags are unchanged), and on the text channel of a measured run the backup
+path and rollback command are keyed on the backup the scanner wrote rather than on the confirmed
+count, so a run whose only attempt was disproved still says where the backup is and how to roll
+back.
+
 ### Multi-part fix text renders on separate lines in the findings list
 
 The fix generator composes a remediation from several authored parts — the command, a

--- a/__tests__/cli/secure-openclaw-disproved-fix-disclosure.test.ts
+++ b/__tests__/cli/secure-openclaw-disproved-fix-disclosure.test.ts
@@ -1,0 +1,113 @@
+/**
+ * #274 — the deprecated `secure-openclaw` arm on a run whose ONLY attempted fix
+ * was disproved by the verification pass (`fixed: true, fixVerified: false`).
+ *
+ * Two properties, measured through the real CLI on a tree the run rewrites:
+ *
+ * 1. The counts line and `--json` count a fix only when it is confirmed, so the
+ *    disproved attempt reads `0 fixed` and is listed under Findings ("Auto-fix
+ *    did not resolve this"), never under Auto-Remediation Applied.
+ * 2. The recoverability disclosure keys on the WRITE, not on the confirmed
+ *    count: the run rewrote SKILL.md and created a backup, so "Backup created:"
+ *    and the rollback command print even though nothing was confirmed. The
+ *    first cut of the #274 change gated those lines on the confirmed count and
+ *    printed neither for exactly this run (the review round caught it).
+ *
+ * The fixture reaches the branch by construction: SKILL-004's auto-fix rewrites
+ * `filesystem: *` to `filesystem:./`, the re-scan still matches `/etc/passwd`
+ * on the same line, so the attempt is disproved; the guard comment is
+ * pre-signed with the hash of the post-fix body so the signature check does not
+ * add a second attempt. Both cells assert the rewrite and the backup exist
+ * BEFORE the property, so a fixture that stops reaching the branch fails loudly
+ * instead of passing on a run that attempted nothing.
+ */
+import { describe, it, expect, beforeAll } from 'vitest';
+import { spawnSync } from 'node:child_process';
+import { createHash } from 'node:crypto';
+import { existsSync, mkdtempSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { assertDistFreshIfPresent } from '../helpers/dist-freshness';
+
+beforeAll(assertDistFreshIfPresent);
+
+const REPO_ROOT = path.join(__dirname, '..', '..');
+const CLI = path.join(REPO_ROOT, 'dist', 'cli.js');
+
+const POST_FIX_BODY = '---\nname: demo\ndescription: demo skill\n---\n# Demo\n\nfilesystem:./ and filesystem: /etc/passwd\n\n';
+const PRE_FIX_LINE_7 = 'filesystem: * and filesystem: /etc/passwd';
+const POST_FIX_LINE_7 = 'filesystem:./ and filesystem: /etc/passwd';
+
+function fixture(): string {
+  const dir = mkdtempSync(path.join(tmpdir(), 'hma-274-openclaw-'));
+  mkdirSync(path.join(dir, 'skills', 'demo'), { recursive: true });
+  const hash = createHash('sha256').update(POST_FIX_BODY.replace(/\n$/, '')).digest('hex');
+  writeFileSync(
+    path.join(dir, 'skills', 'demo', 'SKILL.md'),
+    `---\nname: demo\ndescription: demo skill\n---\n# Demo\n\n${PRE_FIX_LINE_7}\n\n` +
+      `<!-- opena2a-guard hash="sha256:${hash}" signed="2026-08-20T00:00:00.000Z" -->`,
+  );
+  return dir;
+}
+
+function run(dir: string, extra: string[] = []) {
+  const home = mkdtempSync(path.join(tmpdir(), 'hma-274-home-'));
+  const r = spawnSync(process.execPath, [CLI, 'secure-openclaw', '--fix', dir, ...extra], {
+    encoding: 'utf8',
+    timeout: 120_000,
+    env: {
+      ...process.env,
+      HOME: home,
+      OPENA2A_HOME: path.join(home, '.opena2a'),
+      OPENA2A_TELEMETRY: 'off',
+      NO_COLOR: '1',
+      FORCE_COLOR: '0',
+    },
+  });
+  // eslint-disable-next-line no-control-regex
+  const strip = (s: string) => s.replace(/\x1b\[[0-9;]*m/g, '');
+  return { status: r.status, stdout: strip(r.stdout ?? ''), stderr: strip(r.stderr ?? '') };
+}
+
+/** The fixture must have reached the disproved-attempt branch, or nothing below measures anything. */
+function assertTreeWasRewritten(dir: string) {
+  const line7 = readFileSync(path.join(dir, 'skills', 'demo', 'SKILL.md'), 'utf8').split('\n')[6];
+  expect(line7, 'fixture no longer reaches the branch: SKILL-004 auto-fix did not rewrite line 7').toBe(POST_FIX_LINE_7);
+  expect(existsSync(path.join(dir, '.hackmyagent-backup')), 'fixture no longer reaches the branch: no backup was created').toBe(true);
+}
+
+describe('#274 secure-openclaw --fix on a run whose only attempt was disproved', () => {
+  it('counts the disproved attempt as an issue, not a fix, and still discloses the backup and the rollback command', () => {
+    const dir = fixture();
+    const r = run(dir);
+    assertTreeWasRewritten(dir);
+    expect(r.stdout, 'a CLI failure is not a measurement').not.toMatch(/at .*\.js:\d+:\d+/);
+
+    const counts = r.stdout.split('\n').find((l) => l.startsWith('Checks: '));
+    expect(counts, r.stdout).toBeDefined();
+    expect(counts).toMatch(/\| 0 fixed \|/);
+    expect(r.stdout).toContain('[SKILL-004]');
+    expect(r.stdout).not.toContain('Auto-Remediation Applied');
+
+    // Property 2 — the write is disclosed whatever the confirmed count.
+    expect(r.stdout).toContain('Backup created:');
+    expect(r.stdout).toMatch(/To rollback:.*rollback/);
+    expect(r.status).toBe(1);
+  }, 180_000);
+
+  it('--json reports fixed: 0 while the finding itself still carries the attempt', () => {
+    const dir = fixture();
+    const r = run(dir, ['--json']);
+    assertTreeWasRewritten(dir);
+    const json = JSON.parse(r.stdout);
+    const skill004 = (json.findings as Array<{ checkId: string; fixed?: boolean; fixVerified?: boolean }>)
+      .find((f) => f.checkId === 'SKILL-004');
+    expect(skill004, 'fixture no longer reaches the branch: SKILL-004 not in the findings').toBeDefined();
+    expect(skill004!.fixed, 'fixture no longer reaches the branch: SKILL-004 was not attempted').toBe(true);
+    expect(skill004!.fixVerified, 'fixture no longer reaches the branch: the attempt was not disproved').toBe(false);
+
+    expect(json.fixed).toBe(0);
+    expect(json.issues).toBeGreaterThanOrEqual(1);
+    expect(r.status).toBe(1);
+  }, 180_000);
+});

--- a/__tests__/mcp/mcp-scan-summary-partition.test.ts
+++ b/__tests__/mcp/mcp-scan-summary-partition.test.ts
@@ -1,0 +1,98 @@
+/**
+ * #274 — the MCP summary's two counts partition the findings.
+ *
+ * `Score: N/100 | 1 issue found | 1 fixed` was printed for ONE finding: an
+ * auto-fix that was attempted and then disproved by the verification pass
+ * counted as an outstanding issue AND as a completed fix. The HTML report and
+ * the Registry remediation report count a fix only when it is confirmed, and
+ * the text fix summary leads with what was confirmed; the MCP summary and the
+ * OpenClaw arm were the holdouts.
+ * `confirmedFix` is the complement of `countsAgainstScore` over the attempted
+ * ones. The partition and disproved-attempt cells are stated against
+ * `countsAgainstScore`, and the whole-space count cell checks the two printed
+ * counts SUM to the union of "counts against the score" and "was attempted" —
+ * an identity that does not mention the helper, so a helper reverted to bare
+ * `fixed` breaks the sum (an extra 3 on one side) instead of being copied to
+ * both sides of the assertion.
+ */
+import { describe, it, expect } from 'vitest';
+import { emitFinding } from '../../src/hardening/finding-emit';
+import type { SecurityFinding, SecurityFindingDraft } from '../../src/hardening/security-check';
+import { buildScanToolText } from '../../src/mcp-server';
+import { confirmedFix, countsAgainstScore } from '../../src/ui/verdict-band';
+
+/** Every combination of the three fields the predicates read. */
+const SPACE = (() => {
+  const tri = [true, false, undefined] as const;
+  const out: Array<{ passed?: boolean; fixed?: boolean; fixVerified?: boolean }> = [];
+  for (const passed of tri) for (const fixed of tri) for (const fixVerified of tri) {
+    out.push({ passed, fixed, fixVerified });
+  }
+  return out;
+})();
+
+function finding(shape: { passed?: boolean; fixed?: boolean; fixVerified?: boolean }, i = 0): SecurityFinding {
+  return emitFinding({
+    checkId: `T-${String(i).padStart(3, '0')}`,
+    name: 'Test finding',
+    category: 'test',
+    severity: 'medium',
+    message: 'm',
+    fixable: true,
+    ...shape,
+  } as unknown as SecurityFindingDraft) as SecurityFinding;
+}
+
+function counts(text: string): { issues: number; fixed: number | null } {
+  const issues = Number(/\| (\d+) issues? found/.exec(text)?.[1]);
+  const fixed = /\| (\d+) fixed/.exec(text);
+  return { issues, fixed: fixed ? Number(fixed[1]) : null };
+}
+
+describe('#274 MCP summary counts partition the findings', () => {
+  it('covers the whole input space', () => {
+    expect(SPACE).toHaveLength(27);
+  });
+
+  it('no finding is both an outstanding issue and a confirmed fix', () => {
+    for (const shape of SPACE) {
+      const f = finding(shape);
+      expect(countsAgainstScore(f) && confirmedFix(f), JSON.stringify(shape)).toBe(false);
+    }
+  });
+
+  it('every disproved attempt is an issue and never a fix', () => {
+    // A disproved attempt is `fixed: true, fixVerified: false` whatever the
+    // check did to `passed` (some flip it on fix, some leave it, some never
+    // set it) — all three shapes are issues.
+    for (const passed of [true, false, undefined]) {
+      const f = finding({ passed, fixed: true, fixVerified: false });
+      expect(countsAgainstScore(f), `passed=${String(passed)}`).toBe(true);
+      expect(confirmedFix(f), `passed=${String(passed)}`).toBe(false);
+    }
+  });
+
+  it('the summary line counts exactly the two classes, over the whole space at once', () => {
+    const all = SPACE.map((s, i) => finding(s, i));
+    const text = buildScanToolText({ score: 50, maxScore: 100, findings: all });
+    const c = counts(text);
+    expect(c.issues).toBe(all.filter(countsAgainstScore).length);
+    // The two counts partition the union of "counts against the score" and
+    // "was attempted": stated without the helper, so the helper cannot be on
+    // both sides. Over this space the union is 21; a bare-`fixed` helper would
+    // print 9 fixed and make the sum 24.
+    const union = all.filter((f) => countsAgainstScore(f) || f.fixed === true).length;
+    expect(c.issues + (c.fixed ?? 0)).toBe(union);
+    // Non-vacuity: both classes are populated by the space.
+    expect(c.issues).toBeGreaterThan(0);
+    expect(c.fixed ?? 0).toBeGreaterThan(0);
+  });
+
+  it('prints the ruled strings for the three shapes', () => {
+    const disproved = finding({ passed: true, fixed: true, fixVerified: false }, 1);
+    const verified = finding({ passed: true, fixed: true, fixVerified: true }, 2);
+    expect(buildScanToolText({ score: 40, maxScore: 100, findings: [disproved] })).toMatch(/^Score: 40\/100 \| 1 issue found(?! \| \d+ fixed)/);
+    expect(buildScanToolText({ score: 40, maxScore: 100, findings: [disproved, verified] })).toContain('| 1 issue found | 1 fixed');
+    expect(buildScanToolText({ score: 90, maxScore: 100, findings: [verified] })).toContain('| 0 issues found | 1 fixed');
+  });
+});

--- a/__tests__/mcp/mcp-server-unverified-fix.test.ts
+++ b/__tests__/mcp/mcp-server-unverified-fix.test.ts
@@ -80,10 +80,10 @@ describe('#285 MCP scan tool reports a disproved fix', () => {
     expect(text).not.toContain('No issues found.');
   });
 
-  it('still reports the fix was attempted, so the two statements do not contradict', () => {
+  it('does not count the disproved attempt as fixed: the counts partition the findings (#274)', () => {
     const text = buildScanToolText({ score: 40, maxScore: 100, findings: [disprovedFix] });
-    expect(text).toContain('1 fixed');
     expect(text).toContain('1 issue found');
+    expect(text).not.toContain('fixed');
   });
 });
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -350,7 +350,7 @@ import {
 import { reconcileArtifactIntents, rawIntentDisclosureLines } from './ui/artifact-intent';
 import { describeSemanticFamilyCoverage } from './ui/semantic-coverage-labels';
 import type { SemanticFamilyCoverage } from './nanomind-core/scanner-bridge.js';
-import { clampDisclosure, clampScoreToVerdictBand, countsAgainstScore, expandSuppressed, retainForVerdict, summarizeSuppressed } from './ui/verdict-band';
+import { clampDisclosure, clampScoreToVerdictBand, countsAgainstScore, confirmedFix, expandSuppressed, retainForVerdict, summarizeSuppressed } from './ui/verdict-band';
 import { shouldPrintVersionFooter } from './ui/version-footer';
 import { soulScopeDisclosureLines } from './ui/soul-scope-disclosure';
 import { fixSummaryLine } from './ui/fix-summary';
@@ -4142,7 +4142,7 @@ function generateScanHtmlReport(scanResult: { findings: SecurityFinding[]; score
   // header arithmetic adds up. A fix the verification pass could not confirm
   // is counted as an outstanding issue (it is still on disk), and listing it
   // in both tables made `issues + fixed + passed` exceed the check total.
-  const fixedFindings = scanResult.findings.filter(f => f.fixed && f.fixVerified !== false);
+  const fixedFindings = scanResult.findings.filter(f => confirmedFix(f));
   const score = scanResult.score;
   const scoreColor = score >= 90 ? '#22c55e' : score >= 70 ? '#eab308' : score >= 50 ? '#f97316' : '#ef4444';
   const gradeLetters = score >= 90 ? 'strong' : score >= 80 ? 'good' : score >= 70 ? 'moderate' : score >= 60 ? 'improving' : 'needs-attention';
@@ -6281,7 +6281,8 @@ Examples:
       // Filter to OpenClaw-specific findings
       const allOpenClawFindings = filterOpenClawFindings(result.findings);
       const issues = allOpenClawFindings.filter((f) => countsAgainstScore(f));
-      const fixedFindings = allOpenClawFindings.filter((f) => f.fixed);
+      // #274 — confirmed fixes only; a disproved attempt is counted in `issues`.
+      const fixedFindings = allOpenClawFindings.filter((f) => confirmedFix(f));
       const passedFindings = allOpenClawFindings.filter((f) => f.passed);
 
       // #373, same class as `check`. `--help` above promises "Exit code 1 if
@@ -6372,7 +6373,7 @@ Examples:
         console.log(`${colors.green}No OpenClaw-specific issues found.${RESET()}\n`);
       }
 
-      // Show fixed findings
+      // Show confirmed fixes
       if (fixedFindings.length > 0) {
         console.log(`${colors.green}Auto-Remediation Applied:${RESET()}\n`);
         for (const finding of fixedFindings) {
@@ -6382,14 +6383,25 @@ Examples:
           }
         }
         console.log();
+      }
 
-        if (result.backupPath) {
-          console.log(`${colors.yellow}Backup created:${RESET()} ${escapePathForDisplay(result.backupPath)}`);
-          console.log(`${colors.yellow}To rollback:${RESET()} ${CLI_PREFIX} rollback ${citationTarget(targetDir)}`);
-          console.log();
-          console.log(`${colors.cyan}Note:${RESET()} If you replaced tokens with env vars, set OPENCLAW_AUTH_TOKEN`);
-          console.log(`      in your environment before starting OpenClaw.\n`);
-        }
+      // #274 — the recoverability disclosure keys on the BACKUP the scanner
+      // wrote, not on the confirmed count. `backupPath` is set when `--fix`
+      // created the backup (before any check ran), and fix writes cannot
+      // happen without it — `createBackup` failing downgrades `shouldFix`. A
+      // run whose only attempt was disproved (`fixed: true, fixVerified:
+      // false`) rewrote the tree and has this backup all the same; gated on
+      // `fixedFindings` it printed neither the path nor the rollback command
+      // for exactly that run. The attempt itself is disclosed under Findings
+      // ("Auto-fix did not resolve this"). Known sibling gaps, recorded not
+      // fixed here: the unmeasured arm returns above before this line, and
+      // the hand-built `--json` document carries no `backupPath` (#610).
+      if (result.backupPath) {
+        console.log(`${colors.yellow}Backup created:${RESET()} ${escapePathForDisplay(result.backupPath)}`);
+        console.log(`${colors.yellow}To rollback:${RESET()} ${CLI_PREFIX} rollback ${citationTarget(targetDir)}`);
+        console.log();
+        console.log(`${colors.cyan}Note:${RESET()} If you replaced tokens with env vars, set OPENCLAW_AUTH_TOKEN`);
+        console.log(`      in your environment before starting OpenClaw.\n`);
       }
 
       // Show passed checks in verbose mode

--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -34,7 +34,7 @@ import {
 import { citationTarget } from './ui/shell-quote';
 import { assertRedactionProvenance } from './hardening/finding-emit';
 import { getCheckCounts } from './hardening/taxonomy';
-import { countsAgainstScore } from './ui/verdict-band';
+import { countsAgainstScore, confirmedFix } from './ui/verdict-band';
 import {
   resolveRoots,
   resolveWithinRoots,
@@ -152,7 +152,10 @@ export function buildScanToolText(result: {
 }): string {
   assertRedactionProvenance(result.findings, 'mcp-scan-text');
   const issues = result.findings.filter((f) => countsAgainstScore(f));
-  const fixed = result.findings.filter((f) => f.fixed);
+  // #274 — attempted-and-disproved is an issue above, not a fix here: the two
+  // counts partition the findings, as on the HTML report, the Registry
+  // remediation report and the OpenClaw arm's `fixed` count.
+  const fixed = result.findings.filter((f) => confirmedFix(f));
 
   let summary = `Score: ${result.score}/${result.maxScore} | ${issues.length} issue${issues.length !== 1 ? 's' : ''} found`;
   if (fixed.length > 0) {

--- a/src/registry/remediation.ts
+++ b/src/registry/remediation.ts
@@ -1,5 +1,5 @@
 import type { SecurityFinding } from '../hardening/security-check.js';
-import { countsAgainstScore } from '../ui/verdict-band';
+import { countsAgainstScore, confirmedFix } from '../ui/verdict-band';
 
 interface RemediationReport {
   findingId: string;
@@ -34,7 +34,7 @@ export async function reportRemediation(
   // the same finding to `/remediation/track` as still open — one call, two
   // contradictory claims about the same checkId. (`|| f.fixVerified` was also
   // dead: `fixed` is already true wherever `fixVerified` is set.)
-  const fixedFindings = findings.filter(f => f.fixed && !countsAgainstScore(f));
+  const fixedFindings = findings.filter(f => confirmedFix(f));
 
   if (fixedFindings.length === 0) {
     return;

--- a/src/ui/verdict-band.ts
+++ b/src/ui/verdict-band.ts
@@ -95,6 +95,19 @@ export function countsAgainstScore(f: {
 }
 
 /**
+ * #274 — a fix the count surfaces may call "fixed": attempted AND not
+ * disproved. The complement of `countsAgainstScore` over the fixed ones, so
+ * the two counts on a summary line partition the findings: a finding is an
+ * outstanding issue or a confirmed fix, never both. The HTML report and the
+ * Registry remediation report already drew this line inline, and the text
+ * fix summary leads with what was confirmed (`fixSummaryLine`); the MCP
+ * summary and the OpenClaw arm counted every attempt.
+ */
+export function confirmedFix(f: { passed?: boolean; fixed?: boolean; fixVerified?: boolean }): boolean {
+  return f.fixed === true && !countsAgainstScore(f);
+}
+
+/**
  * Whether a finding stays in the report list after a re-filter.
  *
  * The list this gates is the one `countsAgainstScore` is then applied to, so


### PR DESCRIPTION
The `hackmyagent_scan` MCP tool's summary line built its two counts from
overlapping filters: outstanding issues via the scoring predicate
(`countsAgainstScore`), fixes via a bare `fixed` flag. A fix that was attempted
and then disproved by the verification pass (`fixed: true, fixVerified: false`)
counted as both, so ONE finding read `Score: N/100 | 1 issue found | 1 fixed`
(#274).

**The contract, ruled by the CPO on 2026-08-24:** on every summary count
surface `fixed` means CONFIRMED — attempted and not disproved — and the two
counts partition the findings. The HTML report and the Registry remediation
report already drew this line inline, and the text fix summary leads with what
was confirmed (`Attempted 1 fix, none confirmed`); the MCP summary and the
deprecated OpenClaw arm counted every attempt. One helper beside
`countsAgainstScore`, `confirmedFix` (`f.fixed === true && !countsAgainstScore(f)`),
is adopted by the MCP summary, the OpenClaw arm's counts line and `--json`, the
Registry remediation report and the HTML report (the last two carried an equivalent
expression inline). The live MCP tool has no fix argument today (its fix path
was removed earlier; see `fixRequestedNote` in `src/mcp-server.ts`), so the
summary change is observable through the exported `buildScanToolText` and
guards the path's return.

**Strings.** Disproved only: `Score: 40/100 | 1 issue found` (the fix clause is
omitted at zero, as before). Mixed: `… | 1 issue found | 1 fixed`. Verified
only: `… | 0 issues found | 1 fixed`. No "attempted" vocabulary on the header —
a partition line carries counts; the attempt is a per-finding fact, and the body
is unchanged (the disproved finding is listed under issues with its remedy).

**OpenClaw arm.** The counts line and the `--json` `fixed` field follow the
same rule; the per-finding `fixed`/`fixVerified` flags are unchanged, so a
consumer of the deprecated arm's JSON that wants attempts still has them. The
backup path and the rollback command are keyed on the write itself: a run whose
only attempt was disproved rewrote the tree and has a backup all the same. The
first cut of this PR gated that disclosure on the confirmed count and printed
neither line for exactly that run; the review round caught it and an
independent refuter reproduced it on both trees, and a spawn test on a
SKILL.md whose only auto-fix is disproved pins both the count and the
disclosure. Pre-existing on that arm and NOT changed here: its third count,
`passed`, overlaps `fixed` for checks that flip `passed` on fix, so the three
printed numbers can exceed the check total (#609; the `atomicFix` flag of the same class is #608).

**Tests.** The #285 cell that pinned `1 issue found | 1 fixed` for the disproved
finding is rewritten, not kept — the CPO read that assertion against the same
0.25.2 release whose text channel prints `Attempted 1 fix, none confirmed`, and
found it contradicting its own batch. A property test over all 27
`passed/fixed/fixVerified` combinations asserts no finding is in both counts,
that the disproved attempt is an issue for each of the three `passed` values,
and pins the three strings above against `buildScanToolText`. The partition
cells are stated against `countsAgainstScore`, and the whole-space cell checks
that the two printed counts sum to the union of "counts against the score" and
"was attempted" — an identity that never mentions the helper, so a helper
reverted to bare `fixed` breaks the sum instead of being copied to both sides
(the review round caught a first version that compared the count to the helper
itself and survived that mutation). The new OpenClaw spawn test asserts the
rewrite and the backup exist BEFORE the property, so a fixture that stops
reaching the disproved-attempt branch fails loudly.

Red-proofed on the pre-change build: the rewritten #285 cell, the whole-space
cell, the strings cell and both OpenClaw cells fail there; the partition-space
cells throw (no `confirmedFix`). Mutations, measured: `confirmedFix` returning
`f.fixed === true` fails five cells by name; returning `false` fails two; the
MCP issue count dropping disproved attempts fails five; the fix clause printed
at zero fails two; the OpenClaw arm counting bare attempts fails both OpenClaw
cells; the remediation report reverting to a bare `f.fixed` filter is caught by the
existing `unverified-fix-must-count` suite (its base inline expression was
already equivalent to the helper; only the bare-attempt revert is a behaviour
change).

Separate PR from #563 by the same ruling (other file region, other class).

Closes #274.
