### PR TITLE
Record a harden-soul run that changed nothing as a failure in telemetry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -187,6 +187,17 @@ path and rollback command are keyed on the backup the scanner wrote rather than 
 count, so a run whose only attempt was disproved still says where the backup is and how to roll
 back.
 
+### Telemetry records a harden-soul run that changed nothing as a failure
+
+`harden-soul` exits 1 only when it did not do its job — the target directory is missing, no
+backup could be written, the target refused the write, or the run threw; it has no
+findings-style exit 1. The telemetry hook followed the security-tool convention (exit 0 and 1
+both count as success) for it, so the fleet metric read "governance hardened" for the refused
+runs it recorded — no backup could be written, or the target refused the write — while the
+missing-target and thrown paths hard-exit and emit no event at all (#362). The command joins `rollback` in the set whose exit 1 is a
+failure; the set is pinned by a test that has to be edited deliberately to grow. Nothing a user
+sees changes outside the telemetry payload.
+
 ### Multi-part fix text renders on separate lines in the findings list
 
 The fix generator composes a remediation from several authored parts — the command, a

--- a/__tests__/telemetry/command-success.test.ts
+++ b/__tests__/telemetry/command-success.test.ts
@@ -50,11 +50,12 @@ describe('commandSucceeded (#350)', () => {
     expect(commandSucceeded('secure', 2, conventional)).toBe(false);
   });
 
-  it('lists rollback, and does not quietly grow', () => {
+  it('lists rollback and harden-soul, and does not quietly grow', () => {
     // A guard on the exception surface itself. Adding a command here changes
     // what a published metric means, so it should be a deliberate edit that
-    // fails this assertion first.
-    expect([...EXIT1_IS_FAILURE].sort()).toEqual(['rollback']);
+    // fails this assertion first. harden-soul was added under #362: its exit 1
+    // is a refusal or an error on every path, never a result.
+    expect([...EXIT1_IS_FAILURE].sort()).toEqual(['harden-soul', 'rollback']);
   });
 });
 

--- a/__tests__/telemetry/harden-soul-exit1-is-failure.test.ts
+++ b/__tests__/telemetry/harden-soul-exit1-is-failure.test.ts
@@ -1,0 +1,40 @@
+/**
+ * #362 — telemetry recorded a harden-soul run that modified nothing as a success.
+ *
+ * `commandSucceeded` follows the security-tool convention — exit 0 and 1 are
+ * both success, only 2 and above is a crash — which is right for `secure`,
+ * where exit 1 means "findings were detected and the command did its job".
+ * harden-soul exits 1 only when it did NOT do its job — the target directory is
+ * missing, no backup could be written, the target refused the write, or the run
+ * threw. It has no findings-style exit 1.
+ *
+ * Measured with the REAL SDK helper, not a stand-in: the issue records that a
+ * probe with `c => c === 0` returns false for every command and makes the
+ * defect look absent. Only `successFromExitCode`'s `n <= 1` reproduces it.
+ */
+import { describe, it, expect } from 'vitest';
+import { successFromExitCode } from '@opena2a/telemetry';
+import { commandSucceeded, EXIT1_IS_FAILURE } from '../../src/telemetry/command-success';
+
+describe('#362 harden-soul exit 1 is a failure for telemetry', () => {
+  it('pins the premise: the SDK helper reads exit 1 as success', () => {
+    // Non-vacuity: if the helper ever changes, the cells below stop measuring
+    // the thing this file is about.
+    expect(successFromExitCode(0)).toBe(true);
+    expect(successFromExitCode(1)).toBe(true);
+    expect(successFromExitCode(2)).toBe(false);
+  });
+
+  it('harden-soul exit 1 is recorded as a failure, exit 0 as a success', () => {
+    expect(commandSucceeded('harden-soul', 1, successFromExitCode)).toBe(false);
+    expect(commandSucceeded('harden-soul', 0, successFromExitCode)).toBe(true);
+    expect(EXIT1_IS_FAILURE.has('harden-soul')).toBe(true);
+  });
+
+  it('the result-style commands still read exit 1 as a success', () => {
+    for (const name of ['secure', 'check', 'scan-soul', 'trust', 'wild']) {
+      expect(commandSucceeded(name, 1, successFromExitCode), name).toBe(true);
+    }
+    expect(commandSucceeded('rollback', 1, successFromExitCode)).toBe(false);
+  });
+});

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -13538,8 +13538,9 @@ async function checkNpmPackage(
     await tele.track(name, {
       // Exit 1 normally means "findings were detected and the command did its
       // job", which is the security-tool convention `successFromExitCode`
-      // encodes. `rollback` is the exception (#350): there exit 1 means the
-      // user's files did not all come back, so only 0 is a success.
+      // encodes. The exceptions are the commands whose exit 1 means "I did not
+      // do my job"; EXIT1_IS_FAILURE is the authoritative list (its entries
+      // carry the per-command reasoning — #350, #362).
       success: commandSucceeded(name, exitCode, tele.successFromExitCode),
       durationMs: Date.now() - startedAt,
     });

--- a/src/telemetry/command-success.ts
+++ b/src/telemetry/command-success.ts
@@ -33,7 +33,16 @@
  * (add it)? `secure` and `scan-soul` exit 1 for findings — the first case.
  * `rollback` exits 1 when files did not come back — the second.
  */
-export const EXIT1_IS_FAILURE: ReadonlySet<string> = new Set(['rollback']);
+export const EXIT1_IS_FAILURE: ReadonlySet<string> = new Set([
+  'rollback',
+  // #362 — every exit 1 in harden-soul is a refusal or an error (the target
+  // directory is missing, no backup could be written, the target refused the
+  // write, or the run threw); it has no findings-style exit 1. The fleet
+  // metric read "governance hardened" for the refused runs it recorded (no
+  // backup, write refused); the missing-target and thrown paths hard-exit
+  // through process.exit(1) and emit no event at all.
+  'harden-soul',
+]);
 
 /**
  * Commands whose exit 2 reports a RESULT rather than a crash.


### PR DESCRIPTION
`harden-soul` exits 1 only when it did not do its job — the target directory
is missing, no backup could be written, the target refused the write, or the
run threw; it has no findings-style exit 1. The
telemetry hook followed the security-tool convention for it (exit 0 and 1 both
count as success, only 2 and above is a crash), which is right for `secure`,
where exit 1 means findings were detected and the command did its job. So the
fleet metric read "governance hardened" for the refused runs it recorded — no
backup could be written, or the target refused the write. The missing-target
and thrown paths hard-exit through `process.exit(1)` before the telemetry hook
and emit no event on either build; recording those at all is #350's
reason-carrying settlement, not this PR (#362).

**Change.** `harden-soul` joins `rollback` in `EXIT1_IS_FAILURE`
(`src/telemetry/command-success.ts`). The set is pinned by a test that has to be
edited deliberately to grow; it is edited here. A new suite measures the property
against the real `@opena2a/telemetry` `successFromExitCode` — a stand-in that
reads exit 1 as failure for every command makes the defect look absent, which
is how the issue records it was first misread — with the premise pinned
(0 and 1 → success, 2 → failure).

**Measured on the built module with the real helper:** `harden-soul` exit 1 →
recorded failure, exit 0 → success; `rollback` exit 1 → failure; `secure` exit
1 → success (unchanged). Nothing a user sees changes outside the telemetry
payload (the `OPENA2A_TELEMETRY_DEBUG=print` echo now shows `success: false`
for a refused run).

**Red-proofed:** on the build before this change the harden-soul cell fails
(exit 1 recorded as success); the premise and result-style cells pass on both.

**Scope, stated honestly.** A name-keyed exception set is not the durable
design: the exit-code settlement carrying its reason, with telemetry deriving
`success` from the reason and a ratchet on bare `process.exitCode = 1`, is the
follow-up under #350. This closes one command whose exit-1 meaning is uniform
on every path — the claims audit enumerated its five exit-1 sites (missing
target, no backup, write refused twice, the catch block), all refusals or
errors, none a result.

Under the CISO ruling of 2026-08-24 (outcome fidelity on publish and
telemetry, part 3). Seat 3 gave the telemetry half an independent read before
auto-merge was armed.

Closes #362.
