### PR TITLE
Record a listed file whose stat rejects as an unread input (#515)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,49 @@ All notable changes to HackMyAgent are documented in this file.
 
 ## [Unreleased]
 
+### A directory the scan can list but not enter no longer hides its files at `--scan-depth quick`
+
+`chmod 600 <dir>` (readable, not traversable) lets `readdir` list the directory's
+files while `stat` on each of them rejects `EACCES`. The semantic walker's size
+gate treated that rejection as "skip", so a file the scan had already discovered
+left the assessment with no record and no finding: a tree whose `cfg/secrets.js`
+held an API key scored 98/100 at exit 0 at quick depth with `cfg/` at mode 600,
+and 69/100 at exit 1 with `cfg/` traversable. The score went up because the
+evidence went away — the #438 shape through a different errno path than the
+`chmod 000 <file>` case closed in 0.31.0 (#515).
+
+The size gate now reports the rejection on the same channel a failed `readFile`
+uses, so the file is an input discovered but not read: `SCAN-UNREAD-001` names
+it with the errno remedy, `coverage.unreadableInputs` counts it, and the run
+exits 2 at every depth — the exit code `chmod 000` on the file itself already
+produced. The remedy names the directory when a directory
+the user cannot enter is the cause — `chmod u+r <file>` inside it fails with
+the same `EACCES` the scan did — and says `chmod u+x` or `chmod u+rx`
+according to which bits the directory denies. `check <local path>` reads the
+same coverage ledger, so it records the same loss on this case (exit 2, one
+`SCAN-UNREAD-001`) and prints the same directory remedy: the finding builder
+classifies the obstruction itself when its caller passes the raw ledger
+record. `check`'s own discovery gaps (a non-candidate file, a directory it
+cannot list) remain open and are tracked with #588. The file is still not compiled; this records
+the loss, it does not pretend to have read the bytes. `ENOENT`, `EISDIR` and `ENOTDIR` are still not
+counted (a file removed between the listing and the `stat` is not a lost
+input). Measured across ten real trees (about 4,500 directories and 37,000
+files): no directory whose listing fails and no listed file whose `stat` fails,
+so no readable repository changes exit code.
+
+Not closed here: a directory the scan cannot list at all (`chmod 000 <dir>`, or
+a non-searchable directory with the file one level further down) is lost by the
+walker on `readdir`, not on a child `stat`, and this change does not record it.
+The `GIT-001`/`GIT-002` severity escalation reaches output only when those
+checks fire, and never names the directory; on a tree whose `.gitignore` is
+complete the run can exit 0 with no disclosure. Tracked with #588.
+
+The `--json` comment on `coverage.unreadableInputs` cited a scoped list
+(`unreadableInScope`) that does not exist, and the method producing the number
+was named `scopedUnreadableInputs` although it counts every recorded unread
+input; the comment now describes the number that is produced and the method is
+named for what it does (#590).
+
 ### UNICODE-STEGO-002 corroborates invisible payloads only on the classes a decoder reconstitutes
 
 The GlassWorm decoder finding is CRITICAL only when a corroborator is present in

--- a/__tests__/cli/secure-unread-directory-gate.test.ts
+++ b/__tests__/cli/secure-unread-directory-gate.test.ts
@@ -1,0 +1,278 @@
+/**
+ * `secure` must not report a passing verdict over a directory it could list but
+ * not enter (#515) — the #438 gate, one `chmod` over from the file case #499
+ * closed.
+ *
+ * Measured on `0e0cecf` (0.32.0 plus the #499/#508 work), one fixture and one
+ * `chmod`. The tree holds a benign `util.js`, a `.gitignore`, a `package.json`
+ * and `cfg/secrets.js` containing an `sk-` API key:
+ *
+ *   cfg/ mode 755, quick     ->  69/100  exit 1   (the credential is found)
+ *   cfg/ mode 600, quick     ->  98/100  exit 0   (nothing about cfg/ at all)
+ *   cfg/ mode 600, standard  ->  93/100  exit 2   (a static check's readFile
+ *                                                   recorded it — quick has no
+ *                                                   such reader)
+ *
+ * Mode 600 on a directory is readable but not traversable: `readdir` lists
+ * `secrets.js`, then `stat` and `readFile` on it reject `EACCES`. The semantic
+ * walker's size gate swallowed that rejection, so a file the scan had already
+ * DISCOVERED left the assessment with no ledger record and no finding. The score
+ * went UP because coverage went DOWN.
+ *
+ * ## Why this suite is shaped the way it is
+ *
+ * Every gate assertion is paired with a control, because a gate that fires on
+ * everything is not a gate: the SAME tree traversable must keep exit 1, and the
+ * readable half is BENIGN on purpose — a readable half carrying a finding of its
+ * own would exit 1 either way and every exit-code assertion here would pass
+ * without the gate existing at all. The `.gitignore` is present so GIT-001's
+ * `walkComplete` escalation cannot supply the non-zero exit for us.
+ *
+ * `chmod` does not deny root, so the suite probes for real non-traversability
+ * and skips when it cannot get it. The ledger-level rule is pinned
+ * unconditionally in `__tests__/nanomind-core/discover-files-unread-record.test.ts`.
+ */
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import type { TestContext } from 'vitest';
+import { execSync, spawnSync } from 'node:child_process';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { assertDistFreshIfPresent } from '../helpers/dist-freshness';
+
+beforeAll(assertDistFreshIfPresent);
+
+const CLI = path.join(__dirname, '..', '..', 'dist', 'cli.js');
+
+/** Measured, and the result is one the command promises to fail on. */
+const EXIT_FAIL = 1;
+/** The run did not examine everything it found. */
+const EXIT_INCOMPLETE = 2;
+
+const SK_KEY = `sk-proj-${'A'.repeat(48)}`;
+
+let root: string;
+/** Paths whose modes must be restored before the tree can be removed. */
+const restore: Array<{ p: string; mode: number }> = [];
+
+function run(args: string[]) {
+  const res = spawnSync(process.execPath, [CLI, ...args], {
+    encoding: 'utf-8',
+    timeout: 240_000,
+    env: {
+      ...process.env,
+      NO_COLOR: '1',
+      OPENA2A_TELEMETRY: 'off',
+      HOME: fs.mkdtempSync(path.join(os.tmpdir(), 'hma-home-')),
+    },
+  });
+  return { status: res.status, out: `${res.stdout ?? ''}${res.stderr ?? ''}` };
+}
+
+/**
+ * The OS would not deny access to this process (root, or a filesystem without
+ * permission bits): there is nothing to test, and a silent green here reads as
+ * coverage that does not exist. Skip, loudly.
+ */
+function osDeclined(ctx: TestContext): never {
+  console.warn('[secure-unread-directory-gate] the OS declined to deny access to this process (root?): SKIPPING, not passing');
+  ctx.skip();
+  throw new Error('unreachable: ctx.skip() throws');
+}
+
+function json(args: string[]) {
+  const res = run([...args, '--json']);
+  try {
+    return { status: res.status, body: JSON.parse(res.out.slice(res.out.indexOf('{'))) as any };
+  } catch {
+    return { status: res.status, body: null as any };
+  }
+}
+
+/**
+ * Build the fixture. The readable half is BENIGN and carries a `.gitignore`;
+ * see the header for why both matter.
+ */
+function makeTree(name: string): string {
+  const dir = path.join(root, name);
+  fs.mkdirSync(path.join(dir, 'cfg'), { recursive: true });
+  fs.writeFileSync(path.join(dir, 'util.js'), 'function add(a,b){return a+b;}\nmodule.exports={add};\n');
+  fs.writeFileSync(path.join(dir, 'package.json'), '{"name":"fx515","version":"1.0.0"}\n');
+  fs.writeFileSync(path.join(dir, '.gitignore'), 'node_modules/\n.env\n*.pem\n*.key\n');
+  fs.writeFileSync(path.join(dir, 'cfg', 'secrets.js'), `const K = "${SK_KEY}";\nmodule.exports={K};\n`);
+  return dir;
+}
+
+/**
+ * Make a directory listable but not traversable, and PROVE it: the child must
+ * still be listed and its `stat` must reject. Returns false when the OS
+ * declined (root, or a filesystem without permission support).
+ */
+function makeNonTraversable(dir: string, child: string): boolean {
+  fs.chmodSync(dir, 0o600);
+  restore.push({ p: dir, mode: 0o755 });
+  try {
+    const listed = fs.readdirSync(dir).includes(child);
+    if (!listed) return false;
+    fs.statSync(path.join(dir, child));
+    return false; // stat succeeded: nothing is being denied
+  } catch {
+    return true;
+  }
+}
+
+/** Make a file unreadable and PROVE it. */
+function makeUnreadable(file: string): boolean {
+  fs.chmodSync(file, 0o000);
+  restore.push({ p: file, mode: 0o644 });
+  try {
+    fs.readFileSync(file);
+    return false;
+  } catch {
+    return true;
+  }
+}
+
+beforeAll(() => {
+  root = fs.mkdtempSync(path.join(os.tmpdir(), 'hma-515-'));
+});
+
+afterAll(() => {
+  // Restore BEFORE removing, or the tree cannot be removed. In afterAll rather
+  // than a try/finally in the test body: a vitest timeout skips a `finally`.
+  for (const { p, mode } of restore) {
+    try { fs.chmodSync(p, mode); } catch { /* already gone */ }
+  }
+  try { fs.rmSync(root, { recursive: true, force: true }); } catch { /* best effort */ }
+});
+
+describe('#515 secure over a directory it can list but not enter', () => {
+  it('control: the same tree traversable finds the credential and exits 1 at quick depth', () => {
+    const dir = makeTree('control');
+    const res = json(['secure', dir, '--scan-depth', 'quick']);
+    expect(res.body).not.toBeNull();
+    expect(res.status).toBe(EXIT_FAIL);
+    expect(res.body.coverage.unreadableInputs).toEqual({ count: 0, codes: {} });
+    expect(res.body.findings.some((f: any) => /^AST-CRED-/.test(f.checkId) && f.file === 'cfg/secrets.js')).toBe(true);
+  }, 300_000);
+
+  it('quick depth: a listed-but-unstattable file is an unread input — exit 2, counted, named', (ctx: TestContext) => {
+    const dir = makeTree('dir600-quick');
+    if (!makeNonTraversable(path.join(dir, 'cfg'), 'secrets.js')) osDeclined(ctx);
+
+    const res = json(['secure', dir, '--scan-depth', 'quick']);
+    expect(res.body).not.toBeNull();
+    expect(res.status).toBe(EXIT_INCOMPLETE);
+
+    // Counted on the same channel a failed readFile uses.
+    expect(res.body.coverage.unreadableInputs).toEqual({ count: 1, codes: { EACCES: 1 } });
+
+    // Named, with the file the walker discovered — not the directory, not a
+    // count. The path is what the user acts on.
+    const unread = res.body.findings.filter((f: any) => f.checkId === 'SCAN-UNREAD-001');
+    expect(unread.map((f: any) => f.file)).toEqual(['cfg/secrets.js']);
+
+    // The credential was NOT read, so no credential finding may claim it was.
+    expect(res.body.findings.some((f: any) => /^AST-CRED-/.test(f.checkId))).toBe(false);
+
+    // The remedy is on the DIRECTORY. `chmod u+r cfg/secrets.js` fails with
+    // the same EACCES the scan did (measured: "Permission denied"), so a
+    // finding printing it would be a dead end in exactly this case.
+    expect(unread[0].fix).toMatch(/^chmod u\+x cfg && /);
+    expect(unread[0].fix).not.toContain('u+r');
+    expect(unread[0].guidance).toContain('can be listed but not entered');
+  }, 300_000);
+
+  it('the printed remedy runs and clears the obstruction', (ctx: TestContext) => {
+    const dir = makeTree('dir600-remedy');
+    if (!makeNonTraversable(path.join(dir, 'cfg'), 'secrets.js')) osDeclined(ctx);
+
+    const res = json(['secure', dir, '--scan-depth', 'quick']);
+    expect(res.body).not.toBeNull();
+    const unread = res.body.findings.find((f: any) => f.checkId === 'SCAN-UNREAD-001');
+    expect(unread).toBeDefined();
+    // Run the chmod clause exactly as printed, from the target directory the
+    // citation is relative to. A remedy that cannot run is a dead end.
+    const clause = String(unread.fix).split(' && ')[0];
+    const m = /^chmod u\+x (\S+)$/.exec(clause);
+    expect(m).not.toBeNull();
+    const ran = spawnSync('chmod', ['u+x', m![1]], { cwd: dir, encoding: 'utf-8' });
+    expect(ran.status).toBe(0);
+    // The obstruction is gone: the child is now stat-able, and a re-run finds
+    // the credential the first run could not reach.
+    expect(() => fs.statSync(path.join(dir, 'cfg', 'secrets.js'))).not.toThrow();
+    const again = json(['secure', dir, '--scan-depth', 'quick']);
+    expect(again.status).toBe(EXIT_FAIL);
+    expect(again.body.coverage.unreadableInputs).toEqual({ count: 0, codes: {} });
+  }, 300_000);
+
+  it('the text channel leads with the unread input rather than a clean verdict', (ctx: TestContext) => {
+    const dir = makeTree('dir600-text');
+    if (!makeNonTraversable(path.join(dir, 'cfg'), 'secrets.js')) osDeclined(ctx);
+
+    const res = run(['secure', dir, '--scan-depth', 'quick']);
+    expect(res.status).toBe(EXIT_INCOMPLETE);
+    expect(res.out).toMatch(/cfg\/secrets\.js/);
+    // The verdict names the incompleteness; on the base build this line read
+    // "Usable with caveats" with no mention of the file.
+    expect(res.out).toMatch(/Not Read/);
+  }, 300_000);
+
+  it('standard depth still exits 2 (the static reader recorded it before; the walker now agrees)', (ctx: TestContext) => {
+    const dir = makeTree('dir600-standard');
+    if (!makeNonTraversable(path.join(dir, 'cfg'), 'secrets.js')) osDeclined(ctx);
+
+    const res = json(['secure', dir, '--scan-depth', 'standard']);
+    expect(res.body).not.toBeNull();
+    expect(res.status).toBe(EXIT_INCOMPLETE);
+    // ONE record for one file, although two readers (static readFile and the
+    // semantic walker's stat) both failed on it: the ledger dedups by path.
+    expect(res.body.coverage.unreadableInputs).toEqual({ count: 1, codes: { EACCES: 1 } });
+    expect(res.body.findings.filter((f: any) => f.checkId === 'SCAN-UNREAD-001')).toHaveLength(1);
+  }, 300_000);
+
+  it('parity: chmod 600 on the directory and chmod 000 on the file produce the same exit code at quick depth', (ctx: TestContext) => {
+    const viaDir = makeTree('parity-dir');
+    const viaFile = makeTree('parity-file');
+    if (!makeNonTraversable(path.join(viaDir, 'cfg'), 'secrets.js')) osDeclined(ctx);
+    if (!makeUnreadable(path.join(viaFile, 'cfg', 'secrets.js'))) osDeclined(ctx);
+
+    const a = json(['secure', viaDir, '--scan-depth', 'quick']);
+    const b = json(['secure', viaFile, '--scan-depth', 'quick']);
+    expect(a.body).not.toBeNull();
+    expect(b.body).not.toBeNull();
+    expect(a.status).toBe(EXIT_INCOMPLETE);
+    expect(a.status).toBe(b.status);
+    expect(a.body.coverage.unreadableInputs).toEqual(b.body.coverage.unreadableInputs);
+    // Same gate, different cause, different remedy: the directory case names
+    // the directory; the file case keeps `chmod u+r <file>`.
+    const fixOf = (r: any) => r.body.findings.find((f: any) => f.checkId === 'SCAN-UNREAD-001').fix;
+    expect(fixOf(a)).toMatch(/^chmod u\+x cfg && /);
+    expect(fixOf(b)).toMatch(/^chmod u\+r cfg\/secrets\.js && /);
+  }, 300_000);
+
+  it('check <local path>: the same record through the same builder, with the same directory remedy', (ctx: TestContext) => {
+    const dir = makeTree('via-check');
+    if (!makeNonTraversable(path.join(dir, 'cfg'), 'secrets.js')) osDeclined(ctx);
+
+    const res = json(['check', dir, '--offline']);
+    expect(res.body).not.toBeNull();
+    expect(res.status).toBe(EXIT_INCOMPLETE);
+    expect(res.body.coverage.unreadableInputs).toEqual({ count: 1, codes: { EACCES: 1 } });
+    const unread = (res.body.details ?? []).filter((f: any) => f.checkId === 'SCAN-UNREAD-001');
+    expect(unread.map((f: any) => f.file)).toEqual(['cfg/secrets.js']);
+    // The remedy names the DIRECTORY and re-runs the command the user ran —
+    // `chmod u+r cfg/secrets.js` is a dead end here (same EACCES the scan got),
+    // and until this cell existed the check arm printed exactly that.
+    expect(unread[0].fix).toMatch(/^chmod u\+x cfg && /);
+    expect(unread[0].fix).toContain(' check ');
+    expect(unread[0].fix).not.toContain('chmod u+r ');
+
+    // The printed clause runs, and the re-run no longer reports an unread input.
+    execSync(unread[0].fix.split(' && ')[0], { cwd: dir });
+    const after = json(['check', dir, '--offline']);
+    expect(after.body).not.toBeNull();
+    expect(after.body.coverage.unreadableInputs).toEqual({ count: 0, codes: {} });
+    expect(after.status).not.toBe(EXIT_INCOMPLETE);
+  }, 300_000);
+});

--- a/__tests__/hardening/build-unread-input-finding.test.ts
+++ b/__tests__/hardening/build-unread-input-finding.test.ts
@@ -8,6 +8,9 @@
  * parameter is the ONLY thing that changes when `check` reuses it.
  */
 import { describe, it, expect } from 'vitest';
+import * as fsn from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
 import { buildUnreadInputFinding } from '../../src/hardening/scanner';
 
 describe('buildUnreadInputFinding', () => {
@@ -34,6 +37,32 @@ describe('buildUnreadInputFinding', () => {
     expect({ ...check, fix: undefined }).toEqual({ ...secure, fix: undefined });
   });
 
+  it('names the directory the user cannot enter when that, not the file, is the obstruction (#515)', () => {
+    // `chmod 600 <dir>` lists its files and rejects every open inside it;
+    // `chmod u+r <file>` fails with the same EACCES the scan did.
+    const f = buildUnreadInputFinding(
+      { rel: 'cfg/secrets.js', code: 'EACCES', obstructedBy: 'cfg' },
+      { cliName: 'hackmyagent', targetDir: '/tmp/proj' },
+    );
+    expect(f.fix).toBe('chmod u+x cfg && hackmyagent secure /tmp/proj');
+    expect(f.file).toBe('cfg/secrets.js'); // the input is still the file
+    expect(f.message).toBe('cfg/secrets.js could not be read (EACCES)');
+    expect(f.guidance).toContain('`cfg` can be listed but not entered');
+    const check = buildUnreadInputFinding(
+      { rel: 'cfg/secrets.js', code: 'EACCES', obstructedBy: 'cfg' },
+      { cliName: 'hackmyagent', targetDir: '/tmp/proj', command: 'check' },
+    );
+    expect(check.fix).toBe('chmod u+x cfg && hackmyagent check /tmp/proj');
+  });
+
+  it('a non-permission errno ignores obstructedBy: no chmod can answer EIO', () => {
+    const f = buildUnreadInputFinding(
+      { rel: 'cfg/secrets.js', code: 'EIO', obstructedBy: 'cfg' },
+      { cliName: 'hackmyagent', targetDir: '/tmp/proj' },
+    );
+    expect(f.fix).not.toContain('chmod');
+  });
+
   it('derives the remedy from the errno: a non-permission code gets no chmod and no re-run verb', () => {
     const f = buildUnreadInputFinding({ rel: 'broken', code: 'ELOOP' }, { cliName: 'hackmyagent', targetDir: '/tmp/proj', command: 'check' });
     expect(f.fix).not.toContain('chmod');
@@ -44,5 +73,75 @@ describe('buildUnreadInputFinding', () => {
   it('names the errno in guidance, not only in message', () => {
     const f = buildUnreadInputFinding({ rel: 'x', code: 'EIO' }, { cliName: 'hackmyagent', targetDir: '.' });
     expect(f.guidance).toContain('EIO');
+  });
+
+  // ---- The caller that passes the raw ledger record (the `check` arm shape) ----
+  // Real obstructions, so the builder's own classification is what is under
+  // test — the earlier pins hand it a pre-classified record, which is a shape
+  // no shipped `check` caller produces. Under root (or a filesystem without
+  // permission support) the obstruction cannot exist; the test SKIPS loudly
+  // rather than passing over nothing.
+
+  function realTree(): { dir: string; locked: string } {
+    const dir = fsn.mkdtempSync(path.join(os.tmpdir(), 'hma-buif-'));
+    fsn.mkdirSync(path.join(dir, 'cfg'));
+    fsn.writeFileSync(path.join(dir, 'cfg', 'secrets.js'), 'x\n');
+    return { dir, locked: path.join(dir, 'cfg', 'secrets.js') };
+  }
+  function cleanup(dir: string) {
+    try { fsn.chmodSync(path.join(dir, 'cfg'), 0o700); } catch { /* already removable */ }
+    fsn.rmSync(dir, { recursive: true, force: true });
+  }
+  function denied(target: string, mode: number): boolean {
+    try { fsn.accessSync(target, mode); return false; } catch { return true; }
+  }
+
+  it('classifies the obstruction itself when the caller passes the raw ledger record (the check arm)', (ctx) => {
+    const { dir, locked } = realTree();
+    try {
+      fsn.chmodSync(path.join(dir, 'cfg'), 0o600);
+      if (!denied(path.join(dir, 'cfg'), fsn.constants.X_OK)) {
+        console.warn('[build-unread-input-finding] cannot deny search to this process (root?): SKIPPING, not passing');
+        ctx.skip();
+      }
+      const f = buildUnreadInputFinding(
+        { path: locked, rel: 'cfg/secrets.js', code: 'EACCES' },
+        { cliName: 'hackmyagent', targetDir: dir, command: 'check' },
+      );
+      expect(f.fix.startsWith('chmod u+x cfg && ')).toBe(true);
+      expect(f.fix).toContain('hackmyagent check');
+      expect(f.fix).not.toContain('chmod u+r ');
+      expect(f.guidance).toContain('can be listed but not entered');
+    } finally { cleanup(dir); }
+  });
+
+  it('a directory that denies read as well gets `u+rx` and wording that does not claim it lists', (ctx) => {
+    const { dir } = realTree();
+    try {
+      fsn.chmodSync(path.join(dir, 'cfg'), 0o000);
+      if (!denied(path.join(dir, 'cfg'), fsn.constants.R_OK)) {
+        console.warn('[build-unread-input-finding] cannot deny read to this process (root?): SKIPPING, not passing');
+        ctx.skip();
+      }
+      const f = buildUnreadInputFinding(
+        { rel: 'cfg/secrets.js', code: 'EACCES', obstructedBy: 'cfg' },
+        { cliName: 'hackmyagent', targetDir: dir },
+      );
+      expect(f.fix.startsWith('chmod u+rx cfg && ')).toBe(true);
+      expect(f.guidance).toContain('cannot be listed or entered');
+      expect(f.guidance).not.toContain('can be listed but not entered');
+    } finally { cleanup(dir); }
+  });
+
+  it('an absent obstruction directory degrades to the enterable-not-listable strings (probe ENOENT)', () => {
+    // `/tmp/proj` does not exist, so the read-bit probe cannot tell — and the
+    // pinned strings above stand. This is the compatibility contract the
+    // pre-classified pins in this file rely on.
+    const f = buildUnreadInputFinding(
+      { rel: 'cfg/secrets.js', code: 'EACCES', obstructedBy: 'cfg' },
+      { cliName: 'hackmyagent', targetDir: '/tmp/proj' },
+    );
+    expect(f.fix).toBe('chmod u+x cfg && hackmyagent secure /tmp/proj');
+    expect(f.guidance).toContain('can be listed but not entered');
   });
 });

--- a/__tests__/hardening/build-unread-input-finding.test.ts
+++ b/__tests__/hardening/build-unread-input-finding.test.ts
@@ -7,13 +7,28 @@
  * byte-for-byte the shape the loop produced before, and the `command`
  * parameter is the ONLY thing that changes when `check` reuses it.
  */
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, afterAll } from 'vitest';
 import * as fsn from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';
 import { buildUnreadInputFinding } from '../../src/hardening/scanner';
 
 describe('buildUnreadInputFinding', () => {
+  // A fresh target per probe-sensitive cell. The builder probes
+  // `<targetDir>/<obstructedBy>` for its read bit (#515), so a cell that pins
+  // `obstructedBy` against a shared literal such as `/tmp/proj` reads whatever
+  // the machine holds there — world-writable, plantable by any local user.
+  // The precondition the pinned strings rely on (no such directory) is
+  // asserted, not assumed.
+  const freshTargets: string[] = [];
+  const freshTarget = (): string => {
+    const dir = fsn.mkdtempSync(path.join(os.tmpdir(), 'hma-buif-target-'));
+    expect(fsn.existsSync(path.join(dir, 'cfg'))).toBe(false);
+    freshTargets.push(dir);
+    return dir;
+  };
+  afterAll(() => { for (const d of freshTargets) fsn.rmSync(d, { recursive: true, force: true }); });
+
   it('defaults command to `secure`, so the existing caller is unchanged', () => {
     const f = buildUnreadInputFinding(
       { rel: 'locked.txt', code: 'EACCES' },
@@ -40,19 +55,20 @@ describe('buildUnreadInputFinding', () => {
   it('names the directory the user cannot enter when that, not the file, is the obstruction (#515)', () => {
     // `chmod 600 <dir>` lists its files and rejects every open inside it;
     // `chmod u+r <file>` fails with the same EACCES the scan did.
+    const dir = freshTarget();
     const f = buildUnreadInputFinding(
       { rel: 'cfg/secrets.js', code: 'EACCES', obstructedBy: 'cfg' },
-      { cliName: 'hackmyagent', targetDir: '/tmp/proj' },
+      { cliName: 'hackmyagent', targetDir: dir },
     );
-    expect(f.fix).toBe('chmod u+x cfg && hackmyagent secure /tmp/proj');
+    expect(f.fix).toBe(`chmod u+x cfg && hackmyagent secure ${dir}`);
     expect(f.file).toBe('cfg/secrets.js'); // the input is still the file
     expect(f.message).toBe('cfg/secrets.js could not be read (EACCES)');
     expect(f.guidance).toContain('`cfg` can be listed but not entered');
     const check = buildUnreadInputFinding(
       { rel: 'cfg/secrets.js', code: 'EACCES', obstructedBy: 'cfg' },
-      { cliName: 'hackmyagent', targetDir: '/tmp/proj', command: 'check' },
+      { cliName: 'hackmyagent', targetDir: dir, command: 'check' },
     );
-    expect(check.fix).toBe('chmod u+x cfg && hackmyagent check /tmp/proj');
+    expect(check.fix).toBe(`chmod u+x cfg && hackmyagent check ${dir}`);
   });
 
   it('a non-permission errno ignores obstructedBy: no chmod can answer EIO', () => {
@@ -130,18 +146,29 @@ describe('buildUnreadInputFinding', () => {
       expect(f.fix.startsWith('chmod u+rx cfg && ')).toBe(true);
       expect(f.guidance).toContain('cannot be listed or entered');
       expect(f.guidance).not.toContain('can be listed but not entered');
+      // The `check` arm reaches this wording only through the builder's own
+      // classification (raw record, no `obstructedBy`); pin the shipped
+      // string with all three together: fallback + read denied + `check`.
+      const check = buildUnreadInputFinding(
+        { path: path.join(dir, 'cfg', 'secrets.js'), rel: 'cfg/secrets.js', code: 'EACCES' },
+        { cliName: 'hackmyagent', targetDir: dir, command: 'check' },
+      );
+      expect(check.fix.startsWith('chmod u+rx cfg && ')).toBe(true);
+      expect(check.fix).toContain('hackmyagent check');
+      expect(check.guidance).toContain('cannot be listed or entered');
     } finally { cleanup(dir); }
   });
 
   it('an absent obstruction directory degrades to the enterable-not-listable strings (probe ENOENT)', () => {
-    // `/tmp/proj` does not exist, so the read-bit probe cannot tell — and the
-    // pinned strings above stand. This is the compatibility contract the
-    // pre-classified pins in this file rely on.
+    // The fresh target has no `cfg` (asserted in `freshTarget`), so the
+    // read-bit probe cannot tell — and the pinned strings above stand. This is
+    // the compatibility contract the pre-classified pins in this file rely on.
+    const dir = freshTarget();
     const f = buildUnreadInputFinding(
       { rel: 'cfg/secrets.js', code: 'EACCES', obstructedBy: 'cfg' },
-      { cliName: 'hackmyagent', targetDir: '/tmp/proj' },
+      { cliName: 'hackmyagent', targetDir: dir },
     );
-    expect(f.fix).toBe('chmod u+x cfg && hackmyagent secure /tmp/proj');
+    expect(f.fix).toBe(`chmod u+x cfg && hackmyagent secure ${dir}`);
     expect(f.guidance).toContain('can be listed but not entered');
   });
 });

--- a/__tests__/nanomind-core/discover-files-unread-record.test.ts
+++ b/__tests__/nanomind-core/discover-files-unread-record.test.ts
@@ -1,0 +1,130 @@
+/**
+ * #515 — a file the semantic walker DISCOVERED (its directory listing named it)
+ * and then dropped because `stat` rejected is an input discovered but not read,
+ * and must reach the coverage ledger's failure channel.
+ *
+ * Measured on `0e0cecf`: `chmod 600 cfg/` (readable, not traversable) leaves
+ * `readdir` listing `cfg/secrets.js` while `stat` on it rejects `EACCES`. The
+ * walker's size gate returned `false` and the discovered file left the scan with
+ * no record. At `--scan-depth quick`, where this walker is the only reader of
+ * the tree, the tree scored 98/100 at exit 0; the same tree with `cfg/`
+ * traversable scored 69/100 at exit 1. The score went UP because a discovered
+ * credential file left the assessment — #438's shape through a different errno
+ * path than the `chmod 000 <file>` case #499 closed.
+ *
+ * This layer is unconditional on purpose: the rejection is injected through the
+ * tracked `fs` namespace, so it holds under root (where `chmod` denies nothing)
+ * and pins the ledger contract regardless of who runs it. The end-to-end half —
+ * a real mode-600 directory, exit codes, the `SCAN-UNREAD-001` finding — lives in
+ * `__tests__/cli/secure-unread-directory-gate.test.ts` and skips when the OS
+ * declines to deny.
+ *
+ * The walker runs OUTSIDE any `coverage.run()` frame, so the record lands under
+ * `(unattributed)` — the failure channel's documented asymmetry (a failure is
+ * recorded whoever raised it; an unattributable success is dropped).
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import * as path from 'node:path';
+import * as os from 'node:os';
+import { mkdtemp, mkdir, writeFile, rm } from 'node:fs/promises';
+
+/**
+ * Which directory's children reject `stat`, and with what errno. Mutated per
+ * test; `null` means the real `stat` runs untouched (the control).
+ */
+const reject = vi.hoisted((): { under: string | null; code: string } => ({ under: null, code: 'EACCES' }));
+
+vi.mock('../../src/hardening/tracked-fs', async () => {
+  const actual = await vi.importActual<typeof import('../../src/hardening/tracked-fs')>(
+    '../../src/hardening/tracked-fs',
+  );
+  const realStat = actual.fs.stat;
+  const stat = async (target: unknown, ...rest: unknown[]) => {
+    if (
+      reject.under &&
+      typeof target === 'string' &&
+      target.startsWith(reject.under + path.sep)
+    ) {
+      const err = new Error(`${reject.code}: permission denied, stat '${target}'`) as NodeJS.ErrnoException;
+      err.code = reject.code;
+      err.syscall = 'stat';
+      err.path = target;
+      throw err;
+    }
+    return (realStat as (...a: unknown[]) => Promise<unknown>)(target, ...rest);
+  };
+  return { ...actual, fs: { ...actual.fs, stat } };
+});
+
+import { runNanoMindScan } from '../../src/nanomind-core/scanner-bridge';
+import { CoverageLedger, withActiveLedger } from '../../src/hardening/coverage-ledger';
+
+let dir: string;
+
+/**
+ * A benign readable half and one JS file inside `cfg/`. The content of the
+ * dropped file is irrelevant to the ledger — the record is about the read that
+ * never happened — but it is a compile candidate (`.js` is in the walker's
+ * extension set), so in the control it is compiled and in the failure case it
+ * is the file that leaves.
+ */
+beforeEach(async () => {
+  dir = await mkdtemp(path.join(os.tmpdir(), 'hma-515-'));
+  await mkdir(path.join(dir, 'cfg'));
+  await writeFile(path.join(dir, 'util.js'), 'function add(a, b) { return a + b; }\nmodule.exports = { add };\n');
+  await writeFile(path.join(dir, 'cfg', 'secrets.js'), 'const K = process.env.API_KEY;\nmodule.exports = { K };\n');
+  reject.under = null;
+  reject.code = 'EACCES';
+});
+
+afterEach(async () => {
+  reject.under = null;
+  await rm(dir, { recursive: true, force: true });
+});
+
+async function scanWithLedger(): Promise<{ ledger: CoverageLedger; compiled: number }> {
+  const ledger = new CoverageLedger(dir);
+  const result = await withActiveLedger(ledger, () => runNanoMindScan(dir, [], 'library'));
+  return { ledger, compiled: result.compiledArtifacts };
+}
+
+describe('#515 discovered file whose stat rejects is an unread input', () => {
+  it('control: with stat working, nothing is unread and cfg/secrets.js compiles', async () => {
+    const { ledger, compiled } = await scanWithLedger();
+    // Presence first, then content: `expect(x?.count)` would pass against a
+    // ledger that lost the field.
+    expect(ledger.unreadableInputs).toBeDefined();
+    expect(ledger.unreadableInputs).toEqual({ count: 0, codes: {} });
+    expect(compiled).toBeGreaterThanOrEqual(2);
+  });
+
+  it('records EACCES on a listed child as one unread input, on the readFile channel', async () => {
+    reject.under = path.join(dir, 'cfg');
+    const { ledger, compiled } = await scanWithLedger();
+
+    expect(ledger.unreadableInputs).toEqual({ count: 1, codes: { EACCES: 1 } });
+    expect(ledger.unreadablePaths()).toEqual([
+      { path: path.resolve(dir, 'cfg', 'secrets.js'), code: 'EACCES' },
+    ]);
+    // The readable half is still analyzed: recording the loss must not blank
+    // the run (the #438 "withholding" alternative was rejected for that).
+    expect(compiled).toBeGreaterThanOrEqual(1);
+  });
+
+  it('EPERM is recorded too — the ledger admits every code it did not name as "not there"', async () => {
+    reject.under = path.join(dir, 'cfg');
+    reject.code = 'EPERM';
+    const { ledger } = await scanWithLedger();
+    expect(ledger.unreadableInputs).toEqual({ count: 1, codes: { EPERM: 1 } });
+  });
+
+  it('ENOENT on a listed child is NOT a lost input — a file removed between the listing and the stat', async () => {
+    reject.under = path.join(dir, 'cfg');
+    reject.code = 'ENOENT';
+    const { ledger } = await scanWithLedger();
+    // The record is made and the ledger's errno discrimination drops it — the
+    // same rule `readFile` failures already follow, not a second one.
+    expect(ledger.unreadableInputs).toEqual({ count: 0, codes: {} });
+    expect(ledger.unreadablePaths()).toEqual([]);
+  });
+});

--- a/src/hardening/scanner.ts
+++ b/src/hardening/scanner.ts
@@ -99,6 +99,30 @@ const BACKUP_MANIFEST_VERSION = 2;
 export const JS_FAMILY_EXTENSIONS = ['.ts', '.js', '.mjs', '.cjs', '.tsx', '.jsx'] as const;
 
 /**
+ * Sync twin of `HardeningScanner.unsearchableAncestor`, at module scope so
+ * `buildUnreadInputFinding` can classify an obstruction its caller did not
+ * (the `check` arm passes the ledger record through unmodified). Same bounds,
+ * kept textually in step with the async method — change the two together: the
+ * shallowest ancestor STRICTLY inside the target that this process cannot
+ * enter; the target root is never named. `accessSync` here is an inspection
+ * of a path already known to exist, not a discovery read.
+ */
+export function unsearchableAncestorSync(absPath: string, targetDir: string): string | undefined {
+  const root = path.resolve(targetDir);
+  let dir = path.dirname(absPath);
+  let shallowest: string | undefined;
+  while (dir.startsWith(root + path.sep)) {
+    try {
+      fsSync.accessSync(dir, fsSync.constants.X_OK);
+    } catch {
+      shallowest = dir;
+    }
+    dir = path.dirname(dir);
+  }
+  return shallowest ? path.relative(targetDir, shallowest) : undefined;
+}
+
+/**
  * Build the per-path `SCAN-UNREAD-001` finding for one discovered-but-unread
  * input. Module-level and pure so a second command (`check` on a local path,
  * #508) can emit the identical finding through the same errno->remedy logic
@@ -113,15 +137,50 @@ export const JS_FAMILY_EXTENSIONS = ['.ts', '.js', '.mjs', '.cjs', '.tsx', '.jsx
  *
  * `command` names the CLI verb the remedy re-runs; it defaults to `secure`, so
  * the `HardeningScanner.secure` caller is byte-for-byte unchanged.
+ *
+ * Not pure: when the caller did not classify the obstruction and the record
+ * carries its absolute path, this builder probes the tree itself
+ * (`unsearchableAncestorSync`, plus one read-bit probe on the obstruction) so
+ * both arms print the same remedy for the same obstruction. The probes are
+ * inspections of paths already known to exist and report to no channel.
  */
 export function buildUnreadInputFinding(
-  u: { rel: string; code: string },
+  u: { rel: string; code: string; obstructedBy?: string; path?: string },
   opts: { cliName: string; targetDir: string; command?: string },
 ): SecurityFinding {
-  const { rel, code } = u;
+  const { rel, code, obstructedBy } = u;
   const { cliName, targetDir, command = 'secure' } = opts;
   const permission = code === 'EACCES' || code === 'EPERM';
   const cited = citationPath(rel);
+  // The directory this user cannot enter, when that — not the file's own mode —
+  // is why the read failed (#515). `chmod u+r <file>` inside it fails with the
+  // same EACCES the scan did, so the remedy names the directory instead.
+  //
+  // Classified HERE when the caller did not: the `check` arm hands the ledger
+  // record straight to this builder and computes no ancestor of its own, and
+  // without this fallback it printed exactly the dead-end remedy this branch
+  // exists to remove — on the same input, in the same run (#515 adversarial
+  // round). Probe only for a permission denial, only when the record carries
+  // its absolute path.
+  const obstruction = obstructedBy
+    ?? (permission && u.path ? unsearchableAncestorSync(u.path, targetDir) : undefined);
+  const citedDir = obstruction ? citationPath(obstruction) : null;
+  // `chmod u+x` answers a directory that can be LISTED but not entered. One
+  // that denies read as well needs `u+rx`, and the guidance must not claim it
+  // "can be listed" (mode 000: nothing lists it). When the probe cannot tell
+  // — the directory vanished between the record and this render, or the
+  // caller pinned a path that never existed — the enterable-not-listable
+  // wording stands, which is what every earlier pin in the unit suite relies
+  // on.
+  let dirDeniesRead = false;
+  if (obstruction && permission) {
+    try {
+      fsSync.accessSync(path.resolve(targetDir, obstruction), fsSync.constants.R_OK);
+    } catch (e) {
+      const c = (e as NodeJS.ErrnoException).code;
+      dirDeniesRead = c === 'EACCES' || c === 'EPERM';
+    }
+  }
   const target = citationTarget(targetDir);
   // The re-run verb is a string LITERAL per branch, never a raw `${command}`
   // interpolation: a bare identifier in a runnable command string is what the
@@ -130,11 +189,19 @@ export function buildUnreadInputFinding(
   // unchanged. `${cited}`/`${target}` are citation-bound and `${cliName}` is a
   // known non-path operand, exactly as before.
   const fix = permission
-    ? (cited
+    ? (citedDir
       ? (command === 'check'
-        ? `chmod u+r ${cited} && ${cliName} check ${target}`
-        : `chmod u+r ${cited} && ${cliName} secure ${target}`)
-      : 'Make the file named above readable, then re-run this scan.')
+        ? (dirDeniesRead
+          ? `chmod u+rx ${citedDir} && ${cliName} check ${target}`
+          : `chmod u+x ${citedDir} && ${cliName} check ${target}`)
+        : (dirDeniesRead
+          ? `chmod u+rx ${citedDir} && ${cliName} secure ${target}`
+          : `chmod u+x ${citedDir} && ${cliName} secure ${target}`))
+      : cited
+        ? (command === 'check'
+          ? `chmod u+r ${cited} && ${cliName} check ${target}`
+          : `chmod u+r ${cited} && ${cliName} secure ${target}`)
+        : 'Make the file named above readable, then re-run this scan.')
     : `Resolve the ${code} on this path (a broken symlink, an I/O error or an `
       + `unreadable mount are the usual causes), then re-run this scan.`;
   return {
@@ -156,7 +223,16 @@ export function buildUnreadInputFinding(
     // reaches no reader — and the errno is the input that decides which
     // remedy applies.
     guidance:
-      `This file was discovered inside the target and the read failed with ${code}, so its `
+      (obstruction
+        ? (dirDeniesRead
+          ? `\`${obstruction}\` cannot be listed or entered by this user (no read or execute bit `
+            + `on the directory), which is why ${rel} could not be read: the remedy is on the `
+            + 'directory, not on the file. '
+          : `\`${obstruction}\` can be listed but not entered by this user (no execute bit on the `
+            + `directory), which is why ${rel} could not be opened: the remedy is on the directory, `
+            + 'not on the file. ')
+        : '')
+      + `This file was discovered inside the target and the read failed with ${code}, so its `
       + 'contents never reached a check. The score above is an upper bound, not a measurement '
       + 'of this tree: nothing was ruled out about this file, and a credential or an injected '
       + 'instruction in it would be invisible to this scan — leaving the score HIGHER than if '
@@ -2279,19 +2355,65 @@ export class HardeningScanner {
    * Check if a file path matches any .hmaignore pattern.
    */
   /** Every unreadable input this run recorded, before scope filtering. */
-  private unreadableAll: { path: string; code: string; rel: string }[] = [];
+  private unreadableAll: { path: string; code: string; rel: string; obstructedBy?: string }[] = [];
 
   /**
-   * The `{count, codes}` shape the exit code is settled on, counted over the
-   * inputs that were NOT scoped out by an `.hmaignore` path rule.
+   * For a permission-denied read, the shallowest ancestor inside the target
+   * that this process cannot ENTER. `chmod 600 <dir>` is listable and not
+   * traversable, so every `stat`/`open` on its children fails with `EACCES`
+   * whatever the children's own modes are (#515) — and the remedy the finding
+   * used to print, `chmod u+r <file>`, fails with the same `EACCES` the scan
+   * did. The remedy belongs on the directory.
    *
-   * `excludedRels` comes from the same `pathExcluded` set that produces the
-   * `Scope` disclosure, so the number and the sentence are two readings of one
-   * fact. A scoped-out file is named on screen AND absent from the gate; an
-   * `--ignore`d check is neither, because suppressing a check is not narrowing
-   * the scanned scope (#450).
+   * Shallowest, because a deeper directory cannot even be inspected until the
+   * one above it is searchable; naming it is the one step the user can take
+   * now. For a file a walker LISTED, only its parent can be unsearchable (the
+   * listing itself needed every directory above the parent); the walk matters
+   * for fixed-path probes, which reach several levels down without listing.
+   * Returns the path relative to the target, or undefined when every ancestor
+   * is searchable (the file itself is the obstruction). The target root is
+   * never named: a root the scan could not enter would have listed nothing to
+   * lose.
+   *
+   * `access(X_OK)` is an inspection of a path already known to exist, not a
+   * discovery read: a rejection here is the probe's answer, and the tracked
+   * namespace deliberately reports nothing for it.
+   *
+   * Bounds are mirrored by the module-level `unsearchableAncestorSync` (the
+   * finding builder's fallback for a caller that passes the raw ledger
+   * record); change the two together.
    */
-  private scopedUnreadableInputs(): { count: number; codes: Record<string, number> } {
+  private async unsearchableAncestor(absPath: string, targetDir: string): Promise<string | undefined> {
+    const root = path.resolve(targetDir);
+    let dir = path.dirname(absPath);
+    let shallowest: string | undefined;
+    while (dir.startsWith(root + path.sep)) {
+      try {
+        await fs.access(dir, fs.constants.X_OK);
+      } catch {
+        shallowest = dir;
+      }
+      dir = path.dirname(dir);
+    }
+    return shallowest ? path.relative(targetDir, shallowest) : undefined;
+  }
+
+  /**
+   * The `{count, codes}` shape `cli.ts` settles the exit code on, counted over
+   * EVERY unread input this run recorded — deliberately not narrowed by an
+   * `.hmaignore` path rule.
+   *
+   * A path rule scopes what is REPORTED about a file's contents; it cannot make
+   * an unread file read, and `retainAfterPathSuppression` keeps
+   * `SCAN-UNREAD-001` out of path suppression for exactly that reason. So the
+   * count, the finding and the exit code are three readings of one unscoped
+   * fact (#438, #590). An earlier shape narrowed this number to an in-scope
+   * list; that inverted the disclosure — a file the scan could not read AND
+   * had scoped out went silent, on the channels where `outOfScope` does not
+   * render at all — and was removed. A method named for that shape survived
+   * it (#590).
+   */
+  private allUnreadableInputs(): { count: number; codes: Record<string, number> } {
     const codes: Record<string, number> = {};
     for (const u of this.unreadableAll) codes[u.code] = (codes[u.code] ?? 0) + 1;
     return { count: this.unreadableAll.length, codes };
@@ -2969,10 +3091,12 @@ export class HardeningScanner {
     // pushes people to bypass a gate. The verdict channel says the true thing
     // instead — this run did not examine everything it found — through the exit
     // code, which `cli.ts` settles once, above every output channel.
-    // Every unreadable path gets a finding, and the `.hmaignore` path rules are
-    // then applied to it by the SAME machinery that applies them to every other
-    // finding — so a scoped-out file lands on `outOfScope` and the `Scope` line
-    // names it, exactly as a scoped-out readable finding is named today.
+    // Every unreadable path gets a finding, and `retainAfterPathSuppression`
+    // keeps that finding OUT of `.hmaignore` path suppression: a path rule
+    // scopes what is reported about a file's contents and cannot make an
+    // unread file read, and `outOfScope` renders as a bare count on two
+    // channels and not at all on three, so scoping it out was "exit 0 with
+    // nothing said" on the channels CI reads (#438, #591).
     //
     // Filtering the finding out here instead was the first attempt and it was
     // worse than the defect it fixed: it turned "exit 2 with nothing named" into
@@ -2982,13 +3106,18 @@ export class HardeningScanner {
     // warning. This repo's own `.hmaignore` scopes `src/hardening/` and
     // `src/nanomind-core/`, so that silence reached real trees.
     //
-    // The exit-code unit is then derived from the same marking below, which is
-    // what makes the `Scope` line's "not scored and not in the exit code" a true
-    // statement rather than a contradiction.
-    const unreadable = this.coverage.unreadablePaths().map((u) => ({
-      ...u,
-      rel: path.relative(targetDir, u.path) || path.basename(u.path),
-    }));
+    // The exit-code unit (`allUnreadableInputs`) is then counted over this same
+    // list, unscoped, so the finding, the count and the exit code cannot
+    // disagree about a file (#590).
+    const unreadable: { path: string; code: string; rel: string; obstructedBy?: string }[] = [];
+    for (const u of this.coverage.unreadablePaths()) {
+      const rel = path.relative(targetDir, u.path) || path.basename(u.path);
+      // A permission denial on a file inside a directory this user cannot
+      // ENTER is the directory's fault, and the remedy has to say so (#515).
+      const permission = u.code === 'EACCES' || u.code === 'EPERM';
+      const obstructedBy = permission ? await this.unsearchableAncestor(u.path, targetDir) : undefined;
+      unreadable.push({ ...u, rel, ...(obstructedBy ? { obstructedBy } : {}) });
+    }
     this.unreadableAll = unreadable;
     for (const u of unreadable) {
       // ONE finding per path, not one naming the first of N — see
@@ -3627,10 +3756,11 @@ export class HardeningScanner {
         suppressedFailures,
         unevidencedFailures,
         // Counts and errno codes, never paths — same rule as the line above.
-        // Derived from the SCOPED list, not the raw ledger — see where
-        // `unreadableInScope` is built. This is the number `cli.ts` settles the
-        // exit code on.
-        unreadableInputs: this.scopedUnreadableInputs(),
+        // Every recorded unread input, deliberately unscoped: a path rule
+        // cannot make an unread file read, and `retainAfterPathSuppression`
+        // keeps the matching finding visible for the same reason. This is the
+        // number `cli.ts` settles the exit code on (#590).
+        unreadableInputs: this.allUnreadableInputs(),
       },
     };
   }

--- a/src/hardening/scanner.ts
+++ b/src/hardening/scanner.ts
@@ -124,7 +124,7 @@ export function unsearchableAncestorSync(absPath: string, targetDir: string): st
 
 /**
  * Build the per-path `SCAN-UNREAD-001` finding for one discovered-but-unread
- * input. Module-level and pure so a second command (`check` on a local path,
+ * input. Module-level, shared by both arms, so a second command (`check` on a local path,
  * #508) can emit the identical finding through the same errno->remedy logic
  * instead of carrying a second copy of it — the per-channel-copy class #494
  * was the receipt for.
@@ -136,7 +136,7 @@ export function unsearchableAncestorSync(absPath: string, targetDir: string): st
  * and is a dead end for `EIO`/`ELOOP`, which the predicate deliberately admits.
  *
  * `command` names the CLI verb the remedy re-runs; it defaults to `secure`, so
- * the `HardeningScanner.secure` caller is byte-for-byte unchanged.
+ * the `HardeningScanner.secure` caller's re-run verb is unchanged.
  *
  * Not pure: when the caller did not classify the obstruction and the record
  * carries its absolute path, this builder probes the tree itself
@@ -185,9 +185,13 @@ export function buildUnreadInputFinding(
   // The re-run verb is a string LITERAL per branch, never a raw `${command}`
   // interpolation: a bare identifier in a runnable command string is what the
   // render-source gate (#273) forbids, and `command` is a fixed internal verb,
-  // not a path operand. `secure` is the default so this caller is byte-for-byte
-  // unchanged. `${cited}`/`${target}` are citation-bound and `${cliName}` is a
-  // known non-path operand, exactly as before.
+  // not a path operand. `secure` is the default so the `secure` caller's re-run
+  // verb is unchanged. `${cited}`/`${citedDir}`/`${target}` are citation-bound
+  // (`citationPath` quotes shell-significant names and returns null for a
+  // display hazard, which falls through to the generic remedy) and `${cliName}`
+  // is a known non-path operand. The gate itself does not inspect `chmod` sites
+  // — its operand class has no `+` (#618) — so the binding, not the gate, is
+  // what protects these strings.
   const fix = permission
     ? (citedDir
       ? (command === 'check'
@@ -2372,8 +2376,9 @@ export class HardeningScanner {
    * for fixed-path probes, which reach several levels down without listing.
    * Returns the path relative to the target, or undefined when every ancestor
    * is searchable (the file itself is the obstruction). The target root is
-   * never named: a root the scan could not enter would have listed nothing to
-   * lose.
+   * never named: the walk stops strictly inside the target, so a root that
+   * lists but cannot be entered leaves each child with the per-file remedy
+   * (recorded as #617).
    *
    * `access(X_OK)` is an inspection of a path already known to exist, not a
    * discovery read: a rejection here is the probe's answer, and the tracked

--- a/src/hardening/tracked-fs.ts
+++ b/src/hardening/tracked-fs.ts
@@ -99,11 +99,18 @@ for (const name of CONTENT_READS) {
 }
 
 // Failures are NOT reported on this channel. `access` is an existence probe by
-// definition and `stat` is used the same way, so their rejections are the
-// normal case rather than a lost input. An unreadable DIRECTORY is already
-// caught where it matters: `scanner.ts` catches the `readdir` rejection, sets
-// `complete = false` and emits a HIGH. Reporting it here as well would count
-// one obstruction twice, in two units.
+// definition and `stat` is mostly used the same way, so their rejections are
+// the normal case rather than a lost input — at PROBE sites. A `stat` on a
+// path a walker has already listed is a discovery read, and a rejection there
+// IS a lost input: `chmod 600 <dir>` lists the directory's files and rejects
+// every `stat` on them (#515). That case is recorded by the discovery site
+// itself (`scanner-bridge.ts` `isWithinSizeLimit`), the only place that knows
+// the path was discovered rather than probed; this wrapper cannot tell the two
+// apart and must not guess. An unreadable DIRECTORY is disclosed by
+// `scanner.ts`, whose sensitive-file walk sets `walkComplete = false` on the
+// `readdir` rejection and escalates GIT-001/GIT-002 to HIGH; reporting
+// `readdir` rejections here as well would count one obstruction twice, in two
+// units.
 for (const name of PATH_INSPECTIONS) {
   const fn = (realFs as unknown as Record<string, unknown>)[name];
   if (typeof fn === 'function') wrapped[name] = attribute(fn as AnyFn, noteInspect);

--- a/src/nanomind-core/scanner-bridge.ts
+++ b/src/nanomind-core/scanner-bridge.ts
@@ -22,6 +22,7 @@
 // below is a read OF THE SCAN TARGET and therefore coverage evidence; HMA's own
 // state (models, integrity manifest, LLM cache) is read elsewhere and stays raw.
 import { fs as trackedFs } from '../hardening/tracked-fs';
+import { noteReadFailure } from '../hardening/coverage-ledger';
 const { readFile, readdir, stat } = trackedFs;
 // DELIBERATELY RAW, and the reason is not an oversight (#499).
 //
@@ -827,11 +828,33 @@ async function walkDir(
   }
 }
 
+/**
+ * Size/empty gate on a path the walker has ALREADY discovered.
+ *
+ * A rejection here is not "nothing there": `readdir` listed this entry a
+ * moment ago. `chmod 600 <dir>` (readable, not traversable) is the measured
+ * case — the directory lists its files and every `stat` on them rejects
+ * `EACCES`. Returning `false` silently dropped a discovered credential file
+ * from the compile set, and at `--scan-depth quick`, where this walker is the
+ * only reader of the tree, the tree scored 98/100 at exit 0 against 69/100 at
+ * exit 1 with the directory traversable (#515) — #438's shape, one errno path
+ * over from the `chmod 000 <file>` case #499 closed.
+ *
+ * So the rejection is reported on the ledger's failure channel, the one the
+ * tracked `readFile` already uses, and the ledger decides which codes count
+ * (`ENOENT`/`EISDIR`/`ENOTDIR` do not: a file removed between the listing and
+ * this call is not a lost input). The file is still excluded from the compile
+ * set — this records the loss, it does not pretend to have read the bytes.
+ * The tracked namespace deliberately does not report `stat` failures in
+ * general, because probe sites expect them; this is the discovery-side
+ * exception, recorded at the site that knows the path was discovered.
+ */
 async function isWithinSizeLimit(filePath: string): Promise<boolean> {
   try {
     const s = await stat(filePath);
     return s.size <= MAX_FILE_SIZE && s.size > 0;
-  } catch {
+  } catch (err) {
+    noteReadFailure(filePath, (err as NodeJS.ErrnoException | null)?.code);
     return false;
   }
 }


### PR DESCRIPTION
Closes #515. Closes #590.

## What was wrong

`chmod 600 <dir>` (readable, not traversable) lets `readdir` list the directory's files while `stat` on each of them rejects `EACCES`. At `--scan-depth quick` the semantic walker is the only reader of the tree, and its size gate (`isWithinSizeLimit`) treated the rejection as "skip" — so a file the scan had already discovered left the assessment with no ledger record and no finding.

Measured on `0e0cecf`, fixture `util.js` + `package.json` + `.gitignore` + `cfg/secrets.js` holding an `sk-` key, isolated `HOME`:

| `cfg/` mode | depth | exit | score | `coverage.unreadableInputs` | disclosure |
|---|---|---|---|---|---|
| 755 | quick | 1 | 69 | 0 | AST-CRED-003 critical |
| 600 | quick | **0** | **98** | **0** | none |
| 600 | standard | 2 | 93 | EACCES 1 | SCAN-UNREAD-001 `cfg/secrets.js` |
| file `chmod 000`, dir 755 | quick | 2 | 93 | EACCES 1 | SCAN-UNREAD-001 |

The score went up because the evidence went away — #438's shape through a different errno path than the `chmod 000 <file>` case #499 closed.

## What changed

- `src/nanomind-core/scanner-bridge.ts` — `isWithinSizeLimit` reports its `stat` rejection through `noteReadFailure`, the channel the tracked `readFile` already uses. This is a size gate on a path the walker already listed, i.e. a discovery read, not an existence probe; the ledger's errno rule (`ENOENT`/`EISDIR`/`ENOTDIR` are not lost inputs) still applies at read time. The file is still excluded from the compile set: the change records the loss, it does not pretend to have read the bytes.
- `src/hardening/scanner.ts` — the finding's remedy matches the cause. With the record in place the finding printed `chmod u+r cfg/secrets.js`, which fails with the same `EACCES` the scan did (measured: `Permission denied`) — a dead end in exactly the case this change detects. The caller now probes for the shallowest directory inside the target that this user cannot enter (`unsearchableAncestor`) and `buildUnreadInputFinding` accepts an optional `obstructedBy`, rendering `chmod u+x <dir>` with guidance naming the directory — or `chmod u+rx <dir>` with wording that does not claim the directory lists, when it also denies read. The builder classifies the obstruction itself when its caller passes the raw ledger record (`unsearchableAncestorSync`, same bounds): `check <local path>` reads the same coverage ledger, so it records the same loss on this case — exit 0 → 2 on a mode-600 directory, one `SCAN-UNREAD-001` through the same builder — and, with the fallback, prints the same directory remedy. An adversarial review round caught the first cut of this PR shipping the old dead-end `chmod u+r <file>` string on the `check` arm while removing it from `secure`; the fallback is that fix, and a new e2e cell runs `check`'s printed clause and asserts the re-run clears. `check`'s own discovery gaps (a non-candidate file, a directory it cannot list) remain #588.
- `src/hardening/tracked-fs.ts` — comment: the "stat is a probe" rationale holds at probe sites and not at this discovery site; the wrapper itself is unchanged (it cannot tell the two apart).
- `src/hardening/scanner.ts` (#590) — the `--json` comment cited a scoped list (`unreadableInScope`) that does not exist and the method was named `scopedUnreadableInputs` while counting every recorded unread input. The docblock now describes the count as it ships (unscoped, by design — `retainAfterPathSuppression` keeps `SCAN-UNREAD-001` out of path suppression for the same reason), two stale sentences in the design comment are corrected, and the method is `allUnreadableInputs`. No behaviour change.

After, same fixture, rebuilt binary:

| `cfg/` mode | depth | exit | score | `coverage.unreadableInputs` | disclosure / remedy |
|---|---|---|---|---|---|
| 755 | quick | 1 | 69 | 0 | AST-CRED-003 critical (unchanged) |
| 600 | quick | **2** | **93** | **EACCES 1** | SCAN-UNREAD-001 `cfg/secrets.js`, fix `chmod u+x cfg && hackmyagent secure <target>` — the chmod clause runs (exit 0) and the re-run finds the credential at exit 1 |
| 600 | standard | 2 | 93 | EACCES 1 | one record — the static `readFile` and the walker's `stat` both failed on it and the ledger dedups by path |
| file `chmod 000`, dir 755 | quick | 2 | 93 | EACCES 1 | same exit as the directory case; fix stays `chmod u+r cfg/secrets.js` |

Real trees (`secretless`, `ai-trust`) unchanged at exit 0 / 0 unread. Base rate measured across ten real trees (~4,500 directories, ~37,000 files, skipping `node_modules`/`.git`/`dist`/`build`): zero directories whose listing fails, zero listed files whose `stat` fails. Corpus release-smoke: 12 passed, 0 failed, 2 skipped, no golden drift.

## Not closed here

A directory the scan cannot list at all (`chmod 000 <dir>`, or a non-searchable directory with the file one level further down) is lost by the walker on `readdir`, not on a child `stat`, and this change does not record it. The `walkComplete = false` severity escalation reaches output only when `GIT-001`/`GIT-002` fires, and never names the directory; on a tree whose `.gitignore` is complete the run can exit 0 with no disclosure. Recording the directory itself as an unread input is a separate change — tracked with #588.

The remedy probe classifies by mode bits only. The obstruction kinds it cannot name — an ACL `deny search` on a 755 directory, the target root itself being unsearchable, a directory-600-plus-file-000 pair, a hazard-carrying directory name, an obstruction that vanished before the render — print a remedy or a guidance sentence that does not fit the cause. Measured identical on this branch's parent and on both arms; recorded as #617 rather than widened here.

The #273 render-source gate does not inspect `chmod` remedy sites at all (its operand class has no `+`), so the three new `${citedDir}` interpolations are protected by `citationPath`'s binding, not by the gate — the same footing as the pre-existing `chmod u+r ${cited}`. Recorded as #618.

## Tests

- `__tests__/nanomind-core/discover-files-unread-record.test.ts` (new, unconditional): injects the `stat` rejection through the tracked namespace so it holds under root; pins EACCES and EPERM recorded, ENOENT not, the readable half still compiled.
- `__tests__/cli/secure-unread-directory-gate.test.ts` (new, end-to-end): a real mode-600 directory, proven non-traversable or skipped; control at exit 1; quick and standard at exit 2 with one record; the text channel names the file; the printed remedy is run as printed and clears the obstruction; `chmod 600 <dir>` and `chmod 000 <file>` produce the same exit code with different remedies.
- `__tests__/hardening/build-unread-input-finding.test.ts`: the `obstructedBy` remedy for `secure` and `check`, that a non-permission errno ignores it, and — against real obstructions, loudly skipped under root rather than silently green — that the builder classifies a raw ledger record itself (the `check` arm shape, which the earlier pre-classified pins could not exercise) and says `chmod u+rx` with honest wording for a directory that denies read as well, on both verbs. Because the builder now probes `<targetDir>/<obstructedBy>`, the probe-sensitive cells use a fresh `mkdtemp` target and assert the precondition they rely on instead of the shared literal `/tmp/proj` (measured: a planted `/tmp/proj/cfg` at mode 000 turned two cells red; with the fresh target they stay green with the plant in place).
- The e2e suite's OS-declined guards skip loudly (`ctx.skip()` + a warning) instead of returning silently green — a run without real obstructions now shows as skipped, not passed.
- Red-proof (both new suites against base `scanner-bridge.ts`, fix removed): 7 of 11 cells red on base — the six behaviour cells (`records EACCES`, `EPERM is recorded`, `quick depth … exit 2, counted, named`, `the printed remedy runs`, `the text channel leads with the unread input`, `parity dir-600 == file-000`) plus the new `check`-arm cell; the 4 green cells are the labelled controls. 11/11 green on HEAD.
- Full suite at the final SHA: 320 files, 4501 passed, 4 skipped, 10 todo, exit 0 (252 s, exclusive vitest window); lint/typecheck 0; corpus release-smoke 12 passed / 0 failed / 2 skipped; self-scan 100/100 with 618 files examined and 62 of 62 check executions completed.
