### PR TITLE
Report a benchmark level with no measured controls as null, not 100

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,78 @@ was named `scopedUnreadableInputs` although it counts every recorded unread
 input; the comment now describes the number that is produced and the method is
 named for what it does (#590).
 
+### Breaking: a benchmark level with no measured controls is `null`, not 100
+
+`secure -b oasb-1` set a level's compliance to 100 when no scored control at
+that level produced a result, and the overall figure to 0 in the same case.
+The two L3 controls (3.5, 8.4) have no automated check, so every `L3=100%`
+ever printed was that default, and the rating ladder read an unmeasured level
+as perfect. Measured on 0.32.0 over five repositories: at `-l L2` and `-l L3`,
+ai-trust, secretless and oasb printed `Certified` over L2 and L3 denominators
+of 0/0; `-l L1 -c "Identity & Provenance"` printed `Rating: Certified` beside
+`Compliance: 0% (0/0 verified controls)` on any tree at exit 0, and exit 1
+under `--fail-below 80` because `0 < 80`.
+
+A zero-denominator level is now `null` in `--json` and `--format asp`
+(`l1Compliance`, `l2Compliance`, `l3Compliance`; `compliance` when nothing
+was measured), renders `not assessed`, and never feeds the rating ladder: a
+rung that reads a null level is skipped, not failed, and the first available
+rung that holds is awarded. `Certified` cannot be awarded at a level whose
+denominator is null, so those three repositories now print
+`Rating: Passing (L2, L3 not assessed)` at `-l L3` and
+`Rating: Passing (L2 not assessed)` at `-l L2`, exit 0 as before, with one
+`Not assessed at Lx:` line per unmeasured level under the header, each
+carrying a Verify command that repeats the run's own flags (`--category`,
+`--scan-depth`, `--no-machine-posture`, `--ignore`, `--deep`,
+`--static-only`) and runs as printed; `--json` carries the bare word `Passing`. `Passing (L2, L3 not
+assessed)` means the L1 ladder holds and the higher levels were not
+measured; it is not an L2 or L3 pass. A bare `Passing` at L2 or L3 now says
+those levels were measured; in 0.32.0 the same bare word could stand over an
+unmeasured L2.
+A run in which no scored control produced a result prints
+`Rating: Not Assessed` and `Compliance: not measured (0/0 verified controls)`,
+exits 2, and does not evaluate `--fail-below`
+(`--fail-below N not evaluated: no compliance was measured`). A `--category`
+that has controls at L2 or L3 and none at L1 is also `Not Assessed` at
+exit 2; its compliance figure is measured over the controls it does have,
+and a `--fail-below` breach over that figure still exits 1, this arm's
+existing precedence. `-l L1` on a project tree keeps its rating word and
+exit code (none of the five repositories moved) and its non-verbose text
+output is identical apart from timestamps; at every level `--json` now
+carries `null` for `l2Compliance` and `l3Compliance` where 0.32.0 printed
+the 100 default, and `--verbose` lists the examined levels only. The L2
+footer no longer recommends `-l L3` while the catalogue has no automated L3
+check.
+Library consumers: `calculateRating` takes `number | null` and can return a
+sixth value, `Not Assessed` (the `BenchmarkResult['rating']` union widens the
+same way); the four compliance fields of `BenchmarkResult` are
+`number | null`. New exports beside it: `ratingsUnavailableWhenNull`,
+`automatedControlsAt`, `nextLevelFooter`, and the types `BenchmarkRating` and
+`LadderRating`. `formatPublishOutput` prints `compliance not measured` for a
+null figure.
+
+Not changed here: an empty directory at `--scan-depth quick -l L1` still
+prints `Certified 100% (2/2)`; its L1 denominator is 2, and the cell closes
+when absent-subject checks leave the denominator (#458). The MCP server's
+benchmark assessor is unchanged (#458). `-b oasb-2` still averages an
+unmeasured OASB-1 half as 0 (`Infrastructure Score (OASB-1): 0%`, the figure
+0.32.0 printed) above the OASB-1 report's `not measured`; the composite's own
+refusal is #458 step 4. A category whose verified denominator is 0 still
+reads `compliance: 0` at the category grain and `N/A (no controls at this
+level)` in text, as before. The rating design in #513 (a passing word while
+automatable controls at a measured level go unverified) stays open.
+
+Verify:
+
+```
+d=$(mktemp -d)
+hackmyagent secure "$d" -b oasb-1 -l L3 --scan-depth quick --no-machine-posture --format json | jq '{rating, l2Compliance, l3Compliance}'
+# 0.32.0: "Certified", 100, 100      now: "Passing", null, null
+hackmyagent secure "$d" -b oasb-1 -l L1 -c "Identity & Provenance" --no-machine-posture; echo "exit $?"
+# 0.32.0: Rating: Certified, Compliance: 0% (0/0 verified controls), exit 0
+# now:    Rating: Not Assessed, Compliance: not measured (0/0 verified controls), exit 2
+```
+
 ### UNICODE-STEGO-002 corroborates invisible payloads only on the classes a decoder reconstitutes
 
 The GlassWorm decoder finding is CRITICAL only when a corroborator is present in

--- a/__tests__/benchmarks/calculate-rating-null-levels.test.ts
+++ b/__tests__/benchmarks/calculate-rating-null-levels.test.ts
@@ -1,0 +1,176 @@
+/**
+ * #458 step 0 — `calculateRating` over `number | null` levels.
+ *
+ * A level with a zero scored denominator arrives as `null` (never 100, never
+ * 0). A rung of the ladder that reads a null level is UNAVAILABLE: skipped,
+ * not failed. The first available rung that holds is awarded. When every
+ * rung reads a null (L1 is null) the rating is `Not Assessed`.
+ *
+ * `0` is a measurement (0 of N passed) and keeps failing rungs exactly as
+ * before; the pins below hold that line.
+ *
+ * Cells tagged RED-ON-BASE fail on the 6d6685e build, where a null L1 fell
+ * through every comparison to `Not Passing` (JS: `null === 100`,
+ * `null >= 90`, `null >= 70` are all false), a null L2/L3 fell to `Passing`,
+ * and the ladder had no way to say "not measured".
+ */
+import { describe, it, expect } from 'vitest';
+import * as oasb from '../../src/benchmarks/oasb-1';
+import * as pkg from '../../src/index';
+import { hasDisplayHazard } from '../../src/ui/display-safe';
+
+const { calculateRating } = oasb;
+
+describe('calculateRating: null levels are skipped rungs, not failed ones', () => {
+  it('RED-ON-BASE L1 null is Not Assessed at every requested level (every rung reads L1)', () => {
+    expect(calculateRating(null, null, null, 'L1')).toBe('Not Assessed');
+    expect(calculateRating(null, null, null, 'L2')).toBe('Not Assessed');
+    expect(calculateRating(null, 100, 100, 'L3')).toBe('Not Assessed');
+  });
+
+  it('RED-ON-BASE a null L1 is never Not Passing', () => {
+    for (const level of ['L1', 'L2', 'L3'] as const) {
+      expect(calculateRating(null, 0, 0, level)).not.toBe('Not Passing');
+    }
+  });
+
+  it('L1 ladder never reads L2/L3: nulls there do not move an L1 rating', () => {
+    expect(calculateRating(100, null, null, 'L1')).toBe('Certified');
+    expect(calculateRating(90, null, null, 'L1')).toBe('Passing');
+    expect(calculateRating(70, null, null, 'L1')).toBe('Needs Improvement');
+    expect(calculateRating(69, null, null, 'L1')).toBe('Not Passing');
+  });
+
+  it('L2 requested, L2 null: Certified and Compliant are unavailable; Passing/Needs Improvement/Not Passing decide on L1', () => {
+    expect(calculateRating(100, null, null, 'L2')).toBe('Passing');
+    expect(calculateRating(90, null, null, 'L2')).toBe('Passing');
+    expect(calculateRating(75, null, null, 'L2')).toBe('Needs Improvement');
+    expect(calculateRating(69, null, null, 'L2')).toBe('Not Passing');
+  });
+
+  it('L2 requested, L2 measured: unchanged ladder', () => {
+    expect(calculateRating(100, 100, null, 'L2')).toBe('Certified');
+    expect(calculateRating(100, 90, null, 'L2')).toBe('Compliant');
+    expect(calculateRating(100, 50, null, 'L2')).toBe('Passing');
+  });
+
+  it('L3 requested: Certified needs a measured L3; Compliant needs a measured L2; the rest read L1', () => {
+    expect(calculateRating(100, 100, null, 'L3')).toBe('Compliant');
+    expect(calculateRating(100, null, null, 'L3')).toBe('Passing');
+    expect(calculateRating(94, 100, null, 'L3')).toBe('Passing');
+    expect(calculateRating(100, 100, 100, 'L3')).toBe('Certified');
+    expect(calculateRating(100, null, 100, 'L3')).toBe('Passing');
+  });
+
+  it('L3 requested with L2/L3 null: the fail words still decide on the measured L1 (pre-mortem 2)', () => {
+    expect(calculateRating(60, null, null, 'L3')).toBe('Not Passing');
+    expect(calculateRating(85, null, null, 'L3')).toBe('Needs Improvement');
+    expect(calculateRating(100, 50, null, 'L3')).toBe('Passing');
+  });
+
+  it('PIN: 0 is a measurement, not an absence — it still fails the rungs it always failed', () => {
+    expect(calculateRating(0, 0, 0, 'L1')).toBe('Not Passing');
+    expect(calculateRating(100, 0, 0, 'L2')).toBe('Passing');
+    expect(calculateRating(100, 100, 0, 'L3')).toBe('Compliant');
+  });
+});
+
+describe('ratingsUnavailableWhenNull: which words a null level takes off the table', () => {
+  // The render derives its "X and Y are not awardable" clause from the same
+  // rung table `calculateRating` walks, so the prose cannot drift from the
+  // arithmetic.
+  const unavailable = (level: oasb.BenchmarkLevel, nullLevel: oasb.BenchmarkLevel) =>
+    oasb.ratingsUnavailableWhenNull(level, nullLevel);
+
+  it('RED-ON-BASE at L3, a null L3 removes Certified only', () => {
+    expect(unavailable('L3', 'L3')).toEqual(['Certified']);
+  });
+
+  it('RED-ON-BASE at L3 or L2, a null L2 removes Certified and Compliant', () => {
+    expect(unavailable('L3', 'L2')).toEqual(['Certified', 'Compliant']);
+    expect(unavailable('L2', 'L2')).toEqual(['Certified', 'Compliant']);
+  });
+
+  it('RED-ON-BASE a null L1 removes every word at every level', () => {
+    for (const level of ['L1', 'L2', 'L3'] as const) {
+      const words = unavailable(level, 'L1');
+      expect(words).toContain('Certified');
+      expect(words).toContain('Passing');
+      expect(words).toContain('Needs Improvement');
+      expect(words).toContain('Not Passing');
+      expect(words).not.toContain('Not Assessed');
+    }
+  });
+
+  it('RED-ON-BASE a level the ladder does not read removes nothing', () => {
+    expect(unavailable('L1', 'L2')).toEqual([]);
+    expect(unavailable('L1', 'L3')).toEqual([]);
+    expect(unavailable('L2', 'L3')).toEqual([]);
+  });
+
+  it('PROPERTY: the ladder never awards a word that ratingsUnavailableWhenNull says a null level removes', () => {
+    // Derived from the same rung table both functions walk: with every
+    // measured level at 100 and exactly one level null, the awarded word
+    // must not be in the unavailable list, and must be the strongest word
+    // that is left.
+    const levels: oasb.BenchmarkLevel[] = ['L1', 'L2', 'L3'];
+    for (const level of levels) {
+      for (const nullLevel of levels) {
+        const v = (lv: oasb.BenchmarkLevel): number | null => (lv === nullLevel ? null : 100);
+        const word = calculateRating(v('L1'), v('L2'), v('L3'), level);
+        const removed = unavailable(level, nullLevel);
+        expect(removed, `${level} with ${nullLevel} null awarded ${word}`).not.toContain(word);
+        const all = unavailable(level, 'L1'); // the whole ladder at this level, strongest first
+        const left = all.filter((w) => !removed.includes(w));
+        expect(word).toBe(left.length === 0 ? 'Not Assessed' : left[0]);
+      }
+    }
+  });
+});
+
+describe('nextLevelFooter: derived from the catalogue, not from a literal', () => {
+  const control = (id: string, level: oasb.BenchmarkLevel, checkIds: string[]): oasb.BenchmarkControl => ({
+    id, name: `control ${id}`, category: 'Stub', level, scored: true, description: '',
+    checkIds, verification: checkIds.length > 0 ? 'automated' : 'forward',
+  });
+  const stub = (controls: oasb.BenchmarkControl[]): oasb.BenchmarkCategory[] => [{ id: 1, name: 'Stub', description: '', controls }];
+
+  it('cites the next level while an automated check there can change the rating', () => {
+    const cat = stub([control('1.1', 'L1', ['A']), control('1.2', 'L2', ['B']), control('1.3', 'L3', ['C'])]);
+    expect(oasb.nextLevelFooter('L1', 'hma', cat)).toBe("Run 'hma secure -b oasb-1 -l L2' for stricter checks.");
+    expect(oasb.nextLevelFooter('L2', 'hma', cat)).toBe("Run 'hma secure -b oasb-1 -l L3' for hardened requirements.");
+    expect(oasb.nextLevelFooter('L3', 'hma', cat)).toBeNull();
+  });
+
+  it('states the fact and cites no command while the next level has no automated check', () => {
+    const cat = stub([control('1.1', 'L1', ['A']), control('1.2', 'L2', []), control('1.3', 'L3', []), control('1.4', 'L3', [])]);
+    expect(oasb.nextLevelFooter('L1', 'hma', cat)).toBe('L2 adds 1 control (1.2); none has an automated check in this version, so -l L2 cannot raise this rating.');
+    expect(oasb.nextLevelFooter('L2', 'hma', cat)).toBe('L3 adds 2 controls (1.3, 1.4); none has an automated check in this version, so -l L3 cannot raise this rating.');
+    expect(oasb.nextLevelFooter('L2', 'hma', cat)).not.toContain('Run ');
+  });
+
+  it('RED-ON-BASE with the shipped catalogue: L1 -> cites -l L2; L2 -> states the L3 fact (3.5, 8.4)', () => {
+    expect(oasb.nextLevelFooter('L1', 'hackmyagent')).toContain("-l L2' for stricter checks");
+    expect(oasb.nextLevelFooter('L2', 'hackmyagent')).toBe('L3 adds 2 controls (3.5, 8.4); none has an automated check in this version, so -l L3 cannot raise this rating.');
+    expect(oasb.automatedControlsAt('L3').length).toBe(0);
+    expect(oasb.automatedControlsAt('L2').length).toBe(3);
+    // 23 L1 controls carry checkIds; one of them is not `verification: 'automated'`
+    // and so cannot settle on its own, which is the census this helper takes.
+    expect(oasb.automatedControlsAt('L1').length).toBe(22);
+  });
+});
+
+describe('#458 step 0 library surface', () => {
+  it('RED-ON-BASE the three helpers beside calculateRating are exported from the package root', () => {
+    for (const name of ['ratingsUnavailableWhenNull', 'automatedControlsAt', 'nextLevelFooter'] as const) {
+      expect(typeof (pkg as any)[name], name).toBe('function');
+    }
+    expect(pkg.calculateRating(null, null, null, 'L1')).toBe('Not Assessed');
+  });
+
+  it('PIN: no catalogue category name carries a display hazard (the cited -c value is one of these)', () => {
+    for (const c of oasb.OASB_1_CATEGORIES) {
+      expect(hasDisplayHazard(c.name), c.name).toBe(false);
+    }
+  });
+});

--- a/__tests__/cli/benchmark-empty-denominator.test.ts
+++ b/__tests__/cli/benchmark-empty-denominator.test.ts
@@ -1,0 +1,436 @@
+/**
+ * #458 step 0 (the sentence in #513's title) — a benchmark level whose scored
+ * denominator is 0 is `null`, renders "not assessed", and never feeds the
+ * rating ladder.
+ *
+ * Before: `generateBenchmarkReport` set `l1/l2/l3Compliance` to 100 when no
+ * scored control at that level produced a result, and `compliance` to 0 in
+ * the same case, five lines apart. The two L3 controls (3.5, 8.4) have no
+ * automated check, so every `L3=100%` ever printed was that default; an empty
+ * directory at `-l L3 --scan-depth quick` read `Certified` with two of
+ * forty-six controls measured; a category with no automatable control printed
+ * `Rating: Certified` beside `Compliance: 0% (0/0 verified controls)` at exit
+ * 0 — or exit 1 under `--fail-below 80`, because `0 < 80`.
+ *
+ * Ruling: CPO 2026-08-25 (COUNCIL_LEDGER, "#458 step 0"), on the CISO's
+ * 2026-08-11 direction: zero denominator => `null`, "not assessed at this
+ * level", never feeds the ladder, never `Not Passing`. A rung of the ladder
+ * that reads a null level is skipped, not failed; when every rung reads a
+ * null the rating is `Not Assessed` and the exit code is the unmeasured
+ * floor (2), never 1 (1 = measured and failed).
+ *
+ * Cells tagged RED-ON-BASE fail on the 6d6685e build; the others pin
+ * behaviour that must not move (a measured level still fails as before).
+ *
+ * Out of scope here, on purpose: the empty-dir-at-quick `-l L1` cell
+ * (`Certified 100% (2/2)`) closes when absent-subject checks leave the
+ * denominator (#458 steps 1-2, scanner-side); the MCP server's assessor
+ * (0.33.0 hold condition); #513's rating redesign (deferred).
+ */
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { spawnSync } from 'node:child_process';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { assertDistFreshIfPresent, BUILT_CLI as CLI } from '../helpers/dist-freshness';
+
+beforeAll(assertDistFreshIfPresent);
+
+let root: string;
+let empty: string;
+
+let home: string;
+
+function run(args: string[], env: Record<string, string> = {}) {
+  const res = spawnSync(process.execPath, [CLI, ...args], {
+    encoding: 'utf-8',
+    timeout: 240_000,
+    env: {
+      ...process.env,
+      NO_COLOR: '1',
+      OPENA2A_TELEMETRY: 'off',
+      HOME: home,
+      ...env,
+    },
+  });
+  return {
+    status: res.status,
+    out: `${res.stdout ?? ''}${res.stderr ?? ''}`,
+    stdout: res.stdout ?? '',
+    stderr: res.stderr ?? '',
+  };
+}
+
+function parseJson(stdout: string): any {
+  return JSON.parse(stdout.slice(stdout.indexOf('{')));
+}
+
+const NO_CONTROL_CATEGORY = 'Identity & Provenance'; // no automatable control at any level
+const L2_ONLY_CATEGORY = 'Agent-to-Agent Security'; // no L1 controls; 7.4 is automatable at L2
+
+let mcpTree: string;
+
+beforeAll(() => {
+  root = fs.mkdtempSync(path.join(os.tmpdir(), 'hma-458-'));
+  home = fs.mkdtempSync(path.join(os.tmpdir(), 'hma-home-'));
+  empty = path.join(root, 'empty');
+  fs.mkdirSync(empty);
+  // An MCP-shaped tree: types as `mcp`, so 7.4 (Agent-to-Agent, L2) gets a
+  // result while the category has no L1 control at all.
+  mcpTree = path.join(root, 'mcp tree'); // the space is deliberate: cited commands must quote it
+  fs.mkdirSync(path.join(mcpTree, 'src'), { recursive: true });
+  fs.writeFileSync(path.join(mcpTree, 'package.json'), '{"name":"mcp458","version":"1.0.0","dependencies":{"@modelcontextprotocol/sdk":"^1.0.0"}}\n');
+  fs.writeFileSync(path.join(mcpTree, 'package-lock.json'), '{"name":"mcp458","lockfileVersion":3,"packages":{}}\n');
+  fs.writeFileSync(path.join(mcpTree, '.gitignore'), 'node_modules\n');
+  fs.writeFileSync(path.join(mcpTree, 'src', 'index.js'), 'const { Server } = require("@modelcontextprotocol/sdk/server");\n');
+});
+
+/** The first `Verify:` command on the line that starts with `prefix`, as printed. */
+function citedCommand(out: string, prefix: string, label: 'Verify' | 'Fix'): string {
+  const at = out.indexOf(prefix);
+  expect(at).toBeGreaterThan(-1);
+  const line = out.slice(at, out.indexOf('\n', at));
+  const m = line.match(new RegExp(`${label}: (.*?)(?= Fix: |$)`));
+  expect(m, `${label} on: ${line}`).not.toBeNull();
+  return m![1];
+}
+
+function sh(command: string, cwd: string) {
+  const res = spawnSync('/bin/sh', ['-c', command], {
+    encoding: 'utf-8', cwd, timeout: 240_000,
+    env: { ...process.env, NO_COLOR: '1', OPENA2A_TELEMETRY: 'off', HOME: home, PATH: `${path.dirname(process.execPath)}:${process.env.PATH ?? ''}` },
+  });
+  return { status: res.status, stdout: res.stdout ?? '', stderr: res.stderr ?? '' };
+}
+
+const hasJq = spawnSync('jq', ['--version']).status === 0;
+
+afterAll(() => {
+  try { fs.rmSync(root, { recursive: true, force: true }); } catch { /* best effort */ }
+});
+
+describe('#458 step 0: an unmeasured benchmark level is null and never feeds the ladder', () => {
+  it('RED-ON-BASE json: -l L3 on an empty dir at quick depth carries null for L2/L3 and the ladder skips those rungs', () => {
+    const res = run(['secure', empty, '-b', 'oasb-1', '-l', 'L3', '--scan-depth', 'quick', '--no-machine-posture', '--format', 'json']);
+    const body = parseJson(res.stdout);
+    expect(body.l1Compliance).toBe(100);
+    expect(body.l2Compliance).toBeNull();
+    expect(body.l3Compliance).toBeNull();
+    // The overall figure is over what WAS measured (2/2), not a default.
+    expect(body.compliance).toBe(100);
+    // Certified reads L3 and Compliant reads L2: both unavailable. Passing
+    // reads L1 alone and holds. The text suffix never reaches json.
+    expect(body.rating).toBe('Passing');
+    expect(JSON.stringify(body)).not.toContain('not assessed)');
+    expect(res.status).toBe(0);
+  });
+
+  it('RED-ON-BASE text: -l L3 prints Passing, one "Not assessed at" line per unmeasured level under Unverified:, and says so in the verbose line', () => {
+    const res = run(['secure', empty, '-b', 'oasb-1', '-l', 'L3', '--scan-depth', 'quick', '--no-machine-posture', '--verbose']);
+    // The word never travels alone: the null scope rides in the same string.
+    expect(res.out).toContain('Rating: Passing (L2, L3 not assessed)');
+    expect(res.out).not.toContain('Rating: Certified');
+    expect(res.out).toContain('Compliance by level: L1=100% L2=not assessed L3=not assessed');
+    const unverifiedAt = res.out.indexOf('Unverified:');
+    const l2At = res.out.indexOf('Not assessed at L2:');
+    const l3At = res.out.indexOf('Not assessed at L3:');
+    expect(unverifiedAt).toBeGreaterThan(-1);
+    expect(l2At).toBeGreaterThan(unverifiedAt);
+    expect(l3At).toBeGreaterThan(l2At);
+    // The L3 catalogue has no automated control at all: the line says which
+    // rating word that makes unawardable, and names the controls.
+    const l3Line = res.out.slice(l3At, res.out.indexOf('\n', l3At));
+    expect(l3Line).toContain('3.5');
+    expect(l3Line).toContain('8.4');
+    expect(l3Line).toContain('Certified is not awardable at L3');
+    // The L2 line's Verify must not send the reader to `--verbose`, which
+    // skips categories with 0 verified controls; `--json` lists every control.
+    const l2Line = res.out.slice(l2At, res.out.indexOf('\n', l2At));
+    expect(l2Line).toContain('Compliant and Certified are not awardable.');
+    expect(l2Line).not.toContain('not awardable at L2');
+    // The line names the automated L2 controls that produced nothing.
+    // Catalogue pin, like the L3 IDs above: the three L2 controls with an automated check.
+    expect(l2Line).toContain('0 of 3 automated L2 controls (2.5, 7.4, 9.4) produced a result');
+    expect(l2Line).toMatch(/Verify: .*-l L2 --scan-depth quick --no-machine-posture --format json \| jq/);
+    expect(l2Line).not.toContain('--json ');
+    expect(res.status).toBe(0);
+  });
+
+  // skipIf, not a silent early return: a machine without jq shows the cell as skipped.
+  it.skipIf(!hasJq)('RED-ON-BASE text: the printed Verify runs as printed and reproduces the population the line counts', () => {
+    const res = run(['secure', empty, '-b', 'oasb-1', '-l', 'L3', '--scan-depth', 'quick', '--no-machine-posture']);
+    const verify = citedCommand(res.out, 'Not assessed at L2:', 'Verify');
+    // The cited command names the tool by its installed name; run it through the built CLI.
+    const cmd = verify.replace(/^\S+ secure /, `${JSON.stringify(process.execPath)} ${JSON.stringify(CLI)} secure `);
+    const ran = sh(cmd, root);
+    expect(ran.status, ran.stderr).toBe(0);
+    const controls = JSON.parse(ran.stdout);
+    expect(Array.isArray(controls)).toBe(true);
+    expect(controls.length).toBe(18); // every L2 control, as the line's population
+    expect(controls.every((c: any) => c.level === 'L2')).toBe(true);
+  });
+
+  it('RED-ON-BASE text (T2): default depth -l L3 is Not Passing with the null scope in the same string, exit 1', () => {
+    const res = run(['secure', empty, '-b', 'oasb-1', '-l', 'L3', '--no-machine-posture', '--verbose']);
+    expect(res.out).toContain('Rating: Not Passing (L2, L3 not assessed)');
+    expect(res.out).toContain('Compliance by level: L1=');
+    expect(res.out).toContain('L2=not assessed L3=not assessed');
+    expect(res.status).toBe(1);
+  });
+
+  it('RED-ON-BASE text: -l L2 prints the L2 line only — a level the run did not examine gets no line', () => {
+    const res = run(['secure', empty, '-b', 'oasb-1', '-l', 'L2', '--scan-depth', 'quick', '--no-machine-posture', '--verbose']);
+    expect(res.out).toContain('Rating: Passing (L2 not assessed)');
+    expect(res.out).toContain('Not assessed at L2:');
+    expect(res.out).not.toContain('Not assessed at L3:');
+    expect(res.out).toContain('L2=not assessed');
+    // The L2 footer used to cite `-l L3 for hardened requirements`, a command
+    // that cannot change the rating while no L3 control has an automated
+    // check. It now states the fact and cites no command.
+    expect(res.out).toContain("L3 adds 2 controls (3.5, 8.4); none has an automated check in this version, so -l L3 cannot raise this rating.");
+    expect(res.out).not.toContain("-l L3' for hardened requirements");
+    // The verbose line covers the examined levels only; the Spec link prints once.
+    expect(res.out).toContain('Compliance by level: L1=100% L2=not assessed\n');
+    expect(res.out.split('https://oasb.ai/oasb-1').length - 1).toBe(1);
+    expect(res.status).toBe(0);
+  });
+
+  it('RED-ON-BASE text: a run in which no control was measured is Not Assessed at exit 2, with a Verify and a Fix', () => {
+    const res = run(['secure', empty, '-b', 'oasb-1', '-l', 'L1', '-c', NO_CONTROL_CATEGORY, '--no-machine-posture']);
+    // The word already says it: no `(L1 not assessed)` suffix on Not Assessed.
+    expect(res.out).toContain('Rating: Not Assessed\n');
+    expect(res.out).not.toContain('Rating: Certified');
+    expect(res.out).toContain('Compliance: not measured (0/0 verified controls)');
+    expect(res.stderr).toContain('Benchmark rating is Not Assessed: no scored control produced a result.');
+    const l1At = res.out.indexOf('Not assessed at L1:');
+    expect(l1At).toBeGreaterThan(-1);
+    const l1Line = res.out.slice(l1At, res.out.indexOf('\n', l1At));
+    expect(l1Line).toContain('no rating is awardable at L1');
+    expect(l1Line).toContain('Verify:');
+    // A --category that selects no automatable control is fixed by dropping
+    // it; the Fix keeps the run's other flags and the requested level.
+    const fix = citedCommand(res.out, 'Not assessed at L1:', 'Fix');
+    // The target is quoted only when the shell needs it (#273 citationPath); this one has no space.
+    expect(fix).toMatch(/^drop --category: \S+ secure \S+ -b oasb-1 -l L1 --no-machine-posture$/);
+    expect(fix).not.toContain('-c ');
+    expect(res.status).toBe(2);
+  });
+
+  // The two checks that produce the only L1 results on an empty directory at
+  // quick depth (2.2 and 9.1). Ignoring them empties the L1 population — the
+  // Verify must say so, and the Fix must name the flag, not the target.
+  const QUICK_L1_CHECKS = 'PERM-001,PERM-002,SEM-PERM-001,SEM-PERM-002,SEM-MCP-001,PROC-001';
+
+  it('RED-ON-BASE text: --ignore shapes the population, so the cited Verify repeats it and the Fix drops it', () => {
+    const res = run(['secure', empty, '-b', 'oasb-1', '-l', 'L1', '--scan-depth', 'quick', '--no-machine-posture', '--ignore', QUICK_L1_CHECKS]);
+    // Guard: the fixture reaches the arm under test (L1 emptied by --ignore).
+    expect(res.out).toContain('Rating: Not Assessed\n');
+    expect(res.status).toBe(2);
+    const l1At = res.out.indexOf('Not assessed at L1:');
+    const l1Line = res.out.slice(l1At, res.out.indexOf('\n', l1At));
+    expect(l1Line).toMatch(/^Not assessed at L1: 0 of \d+ automated L1 controls \(/);
+    const verify = citedCommand(res.out, 'Not assessed at L1:', 'Verify');
+    expect(verify).toMatch(new RegExp(`--ignore '?${QUICK_L1_CHECKS}'?( |$)`));
+    const fix = citedCommand(res.out, 'Not assessed at L1:', 'Fix');
+    expect(fix).toMatch(/^drop --ignore: \S+ secure \S+ -b oasb-1 -l L1 --scan-depth quick --no-machine-posture$/);
+    expect(fix.slice('drop --ignore: '.length)).not.toContain('--ignore');
+  });
+
+  it.skipIf(!hasJq)('RED-ON-BASE text: the Verify cited beside an --ignore run reproduces the 0 the line counts', () => {
+    const res = run(['secure', empty, '-b', 'oasb-1', '-l', 'L1', '--scan-depth', 'quick', '--no-machine-posture', '--ignore', QUICK_L1_CHECKS]);
+    expect(res.out).toContain('Rating: Not Assessed\n');
+    const verify = citedCommand(res.out, 'Not assessed at L1:', 'Verify');
+    const cmd = verify.replace(/^\S+ secure /, `${JSON.stringify(process.execPath)} ${JSON.stringify(CLI)} secure `);
+    const ran = sh(cmd, root);
+    expect(ran.status, ran.stderr).toBe(0);
+    const controls = JSON.parse(ran.stdout);
+    expect(controls.length).toBeGreaterThan(0); // the population, not an empty array
+    expect(controls.filter((c: any) => c.status !== 'unverified').length).toBe(0);
+  });
+
+  it('RED-ON-BASE text: an --ignore that names no check of this population gets the project-root Fix, not "drop --ignore"', () => {
+    // 10.1 (Monitoring & Response, L1) is measured by LOG-001/AUDIT-001; FOO-999 cannot have emptied it.
+    const res = run(['secure', empty, '-b', 'oasb-1', '-l', 'L1', '-c', 'Monitoring & Response', '--no-machine-posture', '--ignore', 'FOO-999']);
+    expect(res.out).toContain('Rating: Not Assessed\n');
+    expect(res.status).toBe(2);
+    const verify = citedCommand(res.out, 'Not assessed at L1:', 'Verify');
+    expect(verify).toContain('--ignore FOO-999'); // the Verify still repeats the run
+    const fix = citedCommand(res.out, 'Not assessed at L1:', 'Fix');
+    expect(fix).toMatch(/^run against the project root/);
+    expect(fix).not.toContain('drop --ignore');
+  });
+
+  it('RED-ON-BASE text: the cited Verify repeats --deep and --static-only', () => {
+    const deep = run(['secure', empty, '-b', 'oasb-1', '-l', 'L3', '--scan-depth', 'quick', '--no-machine-posture', '--deep']);
+    expect(deep.out).toContain('Rating: Passing (L2, L3 not assessed)');
+    expect(citedCommand(deep.out, 'Not assessed at L2:', 'Verify')).toContain(' --deep ');
+    const stat = run(['secure', empty, '-b', 'oasb-1', '-l', 'L3', '--scan-depth', 'quick', '--no-machine-posture', '--static-only']);
+    expect(stat.out).toContain('Rating: Passing (L2, L3 not assessed)');
+    expect(citedCommand(stat.out, 'Not assessed at L2:', 'Verify')).toContain(' --static-only ');
+  });
+
+  it('PIN: a -c that names no category exits 1 at the unknown-category gate, before any citation line exists', () => {
+    // Why the cited `-c` value needs no display escaping: only a catalogue
+    // name (case-insensitively) gets past this gate, and no catalogue name
+    // carries a display hazard (pinned in calculate-rating-null-levels).
+    const res = run(['secure', empty, '-b', 'oasb-1', '-l', 'L1', '-c', 'No Such Category', '--no-machine-posture']);
+    expect(res.stderr).toContain("Error: Unknown category 'No Such Category'.");
+    expect(res.out).not.toContain('Not assessed at');
+    expect(res.status).toBe(1);
+  });
+
+  it('RED-ON-BASE text: a --category with no controls at an examined level says so instead of "none of the 0 controls ()"', () => {
+    const res = run(['secure', empty, '-b', 'oasb-1', '-l', 'L3', '-c', NO_CONTROL_CATEGORY, '--no-machine-posture']);
+    expect(res.out).toContain('Not assessed at L3: the selected category has no L3 controls;');
+    expect(res.out).not.toContain('none of the 0 ');
+    expect(res.out).not.toContain('()');
+    expect(res.status).toBe(2);
+  });
+
+  it('RED-ON-BASE text: a --category with L2 controls and no L1 controls is Not Assessed, and the reason counts the measured controls', () => {
+    const res = run(['secure', mcpTree, '-b', 'oasb-1', '-l', 'L2', '-c', L2_ONLY_CATEGORY, '--no-machine-posture']);
+    expect(res.out).toContain('Rating: Not Assessed\n');
+    // The figure IS measured (over the L2 controls that produced a result).
+    expect(res.out).toMatch(/Compliance: \d+% \(\d+\/[1-9]\d* verified controls\)/);
+    expect(res.stderr).toMatch(/Benchmark rating is Not Assessed: no scored L1 control produced a result in this selection, so the rating ladder cannot be read; \d+ scored controls? at a higher level produced a result and (is|are) not rated\./);
+    expect(res.stderr).not.toContain('no scored control produced a result.');
+    expect(res.status).toBe(2);
+  });
+
+  it('RED-ON-BASE (this arm\'s recorded precedence): a measured --fail-below breach still exits 1 beside a Not Assessed rating, with both reasons on stderr', () => {
+    const res = run(['secure', mcpTree, '-b', 'oasb-1', '-l', 'L2', '-c', L2_ONLY_CATEGORY, '--no-machine-posture', '--fail-below', '80']);
+    expect(res.stderr).toContain('Benchmark rating is Not Assessed');
+    // The printed reason must not misstate the precedence it applies.
+    expect(res.stderr).toMatch(/Compliance \d+% is below threshold 80% — a measured breach outranks the not-measured floor above: exit 1/);
+    expect(res.status).toBe(1);
+  });
+
+  it.skipIf(!hasJq)('RED-ON-BASE text: cited commands quote a target path that contains a space, and run', () => {
+    const res = run(['secure', mcpTree, '-b', 'oasb-1', '-l', 'L2', '-c', L2_ONLY_CATEGORY, '--no-machine-posture']);
+    const verify = citedCommand(res.out, 'Not assessed at L1:', 'Verify');
+    expect(verify).toContain(`'${mcpTree}'`);
+    expect(verify).toContain(`-c 'Agent-to-Agent Security'`);
+    const cmd = verify.replace(/^\S+ secure /, `${JSON.stringify(process.execPath)} ${JSON.stringify(CLI)} secure `);
+    const ran = sh(cmd, root);
+    expect(ran.status, ran.stderr).toBe(0);
+    const controls = JSON.parse(ran.stdout);
+    expect(Array.isArray(controls)).toBe(true);
+    expect(controls.length).toBe(0); // the category has no L1 controls: the line's own claim
+  });
+
+  it('RED-ON-BASE json: the Not Assessed run carries rating "Not Assessed" and null compliance at exit 2', () => {
+    const res = run(['secure', empty, '-b', 'oasb-1', '-l', 'L1', '-c', NO_CONTROL_CATEGORY, '--no-machine-posture', '--format', 'json']);
+    const body = parseJson(res.stdout);
+    expect(body.rating).toBe('Not Assessed');
+    expect(body.compliance).toBeNull();
+    expect(body.l1Compliance).toBeNull();
+    expect(body.passedControls).toBe(0);
+    expect(body.failedControls).toBe(0);
+    expect(res.status).toBe(2);
+  });
+
+  it('RED-ON-BASE --fail-below is not evaluated against a NULL compliance: the Not Assessed exit 2 stands', () => {
+    const res = run(['secure', empty, '-b', 'oasb-1', '-l', 'L1', '-c', NO_CONTROL_CATEGORY, '--no-machine-posture', '--fail-below', '80']);
+    expect(res.stderr).toContain('--fail-below 80 not evaluated: no compliance was measured (0 verified controls).');
+    expect(res.stderr).not.toContain('below threshold');
+    expect(res.status).toBe(2);
+  });
+
+  it('RED-ON-BASE html: the Not Assessed run prints no null% and carries the not-assessed line', () => {
+    const res = run(['secure', empty, '-b', 'oasb-1', '-l', 'L1', '-c', NO_CONTROL_CATEGORY, '--no-machine-posture', '--format', 'html']);
+    expect(res.stdout).not.toMatch(/null%|NaN|undefined/);
+    expect(res.stdout).toContain('not measured');
+    expect(res.stdout).toContain('Not assessed at L1:');
+    expect(res.stdout).toContain('>Not Assessed<');
+    // The grade tile has its own null branch (grey 'not assessed'); a null
+    // compliance must never fall through to the numeric ladder's bottom rung.
+    expect(res.stdout).toContain('>not assessed<');
+    expect(res.stdout).not.toContain('needs-attention');
+    expect(res.status).toBe(2);
+  });
+
+  it('RED-ON-BASE asp + sarif (T5): the Not Assessed run carries the same rating and nulls on asp, and sarif still parses, both at exit 2', () => {
+    const asp = run(['secure', empty, '-b', 'oasb-1', '-l', 'L1', '-c', NO_CONTROL_CATEGORY, '--no-machine-posture', '--format', 'asp']);
+    const body = parseJson(asp.stdout);
+    expect(body.securityPosture.rating).toBe('Not Assessed');
+    expect(body.securityPosture.compliance).toBeNull();
+    expect(body.securityPosture.l1Compliance).toBeNull();
+    expect(asp.stdout).not.toMatch(/null%|NaN|undefined/);
+    expect(asp.status).toBe(2);
+    const sarif = run(['secure', empty, '-b', 'oasb-1', '-l', 'L1', '-c', NO_CONTROL_CATEGORY, '--no-machine-posture', '--format', 'sarif']);
+    expect(Array.isArray(parseJson(sarif.stdout).runs)).toBe(true);
+    expect(sarif.status).toBe(2);
+  });
+
+  it('RED-ON-BASE html: the badge carries the null scope at -l L3', () => {
+    const res = run(['secure', empty, '-b', 'oasb-1', '-l', 'L3', '--scan-depth', 'quick', '--no-machine-posture', '--format', 'html']);
+    expect(res.stdout).toContain('Passing (L2, L3 not assessed)');
+    // The document's title carries the same scope as its badge.
+    expect(res.stdout).toContain('<title>OASB-1 Compliance Report | Passing (L2, L3 not assessed)</title>');
+    expect(res.stdout).not.toMatch(/null%|NaN|undefined/);
+    expect(res.status).toBe(0);
+  });
+
+  it('RED-ON-BASE asp: securityPosture carries the same null levels and rating as json', () => {
+    const res = run(['secure', empty, '-b', 'oasb-1', '-l', 'L3', '--scan-depth', 'quick', '--no-machine-posture', '--format', 'asp']);
+    const body = parseJson(res.stdout);
+    expect(body.securityPosture.l1Compliance).toBe(100);
+    expect(body.securityPosture.l2Compliance).toBeNull();
+    expect(body.securityPosture.l3Compliance).toBeNull();
+    expect(body.securityPosture.compliance).toBe(100);
+    expect(body.securityPosture.rating).toBe('Passing');
+    expect(res.status).toBe(0);
+  });
+
+  it('RED-ON-BASE json: an L1 failure still reads Not Passing at -l L3 when L2/L3 are unmeasured (null rungs are skipped, not failed)', () => {
+    const res = run(['secure', empty, '-b', 'oasb-1', '-l', 'L3', '--no-machine-posture', '--format', 'json']);
+    const body = parseJson(res.stdout);
+    expect(typeof body.l1Compliance).toBe('number');
+    expect(body.l1Compliance).toBeLessThan(70);
+    expect(body.l2Compliance).toBeNull();
+    expect(body.l3Compliance).toBeNull();
+    expect(body.rating).toBe('Not Passing');
+    expect(res.status).toBe(1);
+  });
+
+  it('PIN sarif: still parses; the SARIF writer reads neither compliance nor rating', () => {
+    const res = run(['secure', empty, '-b', 'oasb-1', '-l', 'L3', '--scan-depth', 'quick', '--no-machine-posture', '--format', 'sarif']);
+    const body = parseJson(res.stdout);
+    expect(Array.isArray(body.runs)).toBe(true);
+    expect(Array.isArray(body.runs[0].results)).toBe(true);
+    expect(res.status).toBe(0);
+  });
+
+  it('PIN: a measured level below threshold still fails as before (-l L1 at default depth is Not Passing, exit 1, numeric l1Compliance)', () => {
+    const res = run(['secure', empty, '-b', 'oasb-1', '-l', 'L1', '--no-machine-posture', '--format', 'json']);
+    const body = parseJson(res.stdout);
+    expect(typeof body.l1Compliance).toBe('number');
+    expect(typeof body.compliance).toBe('number');
+    expect(body.rating).toBe('Not Passing');
+    expect(res.status).toBe(1);
+  });
+
+  it('PIN: -l L1 on a measured tree prints the bare word and still cites -l L2 (L2 has automated controls)', () => {
+    const res = run(['secure', empty, '-b', 'oasb-1', '-l', 'L1', '--scan-depth', 'quick', '--no-machine-posture']);
+    expect(res.out).toContain('Rating: Certified\n');
+    expect(res.out).not.toContain('not assessed');
+    expect(res.out).toContain("secure -b oasb-1 -l L2' for stricter checks");
+    expect(res.status).toBe(0);
+  });
+
+  it('PIN (T4): --fail-below at -l L3 compares the measured figure; null L2/L3 do not enter it', () => {
+    const ok = run(['secure', empty, '-b', 'oasb-1', '-l', 'L3', '--scan-depth', 'quick', '--no-machine-posture', '--fail-below', '80']);
+    expect(ok.stderr).not.toContain('threshold');
+    expect(ok.status).toBe(0);
+    const low = run(['secure', empty, '-b', 'oasb-1', '-l', 'L3', '--no-machine-posture', '--fail-below', '80']);
+    expect(low.stderr).toMatch(/Compliance \d+% is below threshold 80%/);
+    expect(low.status).toBe(1);
+  });
+
+  it('PIN: --fail-below over a measured compliance still applies', () => {
+    const res = run(['secure', empty, '-b', 'oasb-1', '-l', 'L1', '--no-machine-posture', '--fail-below', '80']);
+    expect(res.stderr).toContain('below threshold 80%');
+    expect(res.stderr).not.toContain('not evaluated');
+    expect(res.status).toBe(1);
+  });
+});

--- a/__tests__/registry/publish-output-not-measured.test.ts
+++ b/__tests__/registry/publish-output-not-measured.test.ts
@@ -1,0 +1,23 @@
+/**
+ * #458 step 0 — a benchmark run that measured nothing carries `compliance:
+ * null`; the publish summary must say so rather than print `null% compliance`.
+ * Nothing populates `oasbResult` on a CLI path today, so this is the library
+ * surface pinned directly.
+ */
+import { describe, it, expect } from 'vitest';
+import { formatPublishOutput } from '../../src/registry/publish';
+
+const result = { success: true, scanId: 'scan-1', profileUrl: '', status: 'accepted', isCommunity: false };
+
+describe('formatPublishOutput over a null benchmark compliance', () => {
+  it('RED-ON-BASE prints "compliance not measured", never null%', () => {
+    const out = formatPublishOutput(result as any, { packageName: 'p', oasbResult: { compliance: null, rating: 'Not Assessed' } } as any, 'https://api.oa2a.org');
+    expect(out).toContain('OASB (compliance not measured)');
+    expect(out).not.toContain('null');
+  });
+
+  it('PIN: a measured compliance still prints its figure', () => {
+    const out = formatPublishOutput(result as any, { packageName: 'p', oasbResult: { compliance: 94, rating: 'Passing' } } as any, 'https://api.oa2a.org');
+    expect(out).toContain('OASB (94% compliance)');
+  });
+});

--- a/docs/use-cases/ci-pipeline.md
+++ b/docs/use-cases/ci-pipeline.md
@@ -56,7 +56,13 @@ conformance is `NONE`, exits 1 whether or not you pass the flag. Before 0.27.0
 Exit `2` means HMA could not look at the target, so it reports no score and no
 risk level. Causes: the path or package does not exist, the endpoint under
 `attack` was unreachable, no payload was answered, `attack --local` was used
-(which contacts no agent), or a scan plugin failed. It is non-zero on purpose --
+(which contacts no agent), or a scan plugin failed. For `secure -b oasb-1`,
+exit 2 also means the rating ladder could not be read: no scored L1 control
+produced a result, the rating prints as `Not Assessed`, and the category
+results are still printed. When nothing at all was measured there is no
+compliance figure and `--fail-below` is not evaluated; a `--category` whose
+L2 or L3 controls did produce results keeps its measured figure, and a
+`--fail-below` breach over it exits 1. It is non-zero on purpose --
 "I could not tell you" must not be read by a pipeline as "it is safe".
 
 ## JSON output format

--- a/src/benchmarks/index.ts
+++ b/src/benchmarks/index.ts
@@ -11,6 +11,9 @@ export {
   getControlsForCategory,
   getCheckIdsForLevel,
   calculateRating,
+  ratingsUnavailableWhenNull,
+  automatedControlsAt,
+  nextLevelFooter,
 } from './oasb-1';
 
 export type {
@@ -18,6 +21,8 @@ export type {
   BenchmarkControl,
   BenchmarkCategory,
   BenchmarkResult,
+  BenchmarkRating,
+  LadderRating,
   BenchmarkCategoryResult,
   BenchmarkControlResult,
 } from './oasb-1';

--- a/src/benchmarks/oasb-1.ts
+++ b/src/benchmarks/oasb-1.ts
@@ -63,16 +63,23 @@ export interface BenchmarkResult {
   version: string;
   level: BenchmarkLevel;
   timestamp: Date;
-  /** Overall compliance percentage */
-  compliance: number;
-  /** L1 compliance percentage */
-  l1Compliance: number;
-  /** L2 compliance percentage (includes L1) */
-  l2Compliance: number;
-  /** L3 compliance percentage (includes L1+L2) */
-  l3Compliance: number;
-  /** Rating based on compliance */
-  rating: 'Certified' | 'Compliant' | 'Passing' | 'Needs Improvement' | 'Not Passing';
+  /**
+   * Overall compliance percentage over the scored controls that produced a
+   * result; `null` when none did. A zero denominator is not a figure (#458
+   * step 0; CISO 2026-08-11: never 100, never 0).
+   */
+  compliance: number | null;
+  /** L1 compliance percentage over L1 scored controls; `null` when none produced a result */
+  l1Compliance: number | null;
+  /** L2 compliance percentage over L2 scored controls; `null` when none produced a result */
+  l2Compliance: number | null;
+  /** L3 compliance percentage over L3 scored controls; `null` when none produced a result */
+  l3Compliance: number | null;
+  /**
+   * Rating from the ladder in `calculateRating`. `Not Assessed` when no rung
+   * of the ladder could read a measured level (L1 is `null`).
+   */
+  rating: 'Certified' | 'Compliant' | 'Passing' | 'Needs Improvement' | 'Not Passing' | 'Not Assessed';
   categories: BenchmarkCategoryResult[];
   /** Total controls checked */
   totalControls: number;
@@ -1372,36 +1379,125 @@ export function getCheckIdsForLevel(level: BenchmarkLevel): string[] {
   return Array.from(checkIds);
 }
 
+export type BenchmarkRating = BenchmarkResult['rating'];
+/** The words the ladder can award; `Not Assessed` is what it says when it cannot. */
+export type LadderRating = Exclude<BenchmarkRating, 'Not Assessed'>;
+
+interface LadderRung {
+  rating: LadderRating;
+  /**
+   * The levels this rung's condition reads. A rung is UNAVAILABLE — skipped,
+   * not failed — when any of them is `null` (no scored control at that level
+   * produced a result).
+   */
+  reads: readonly BenchmarkLevel[];
+  holds: (l1: number, l2: number, l3: number) => boolean;
+}
+
 /**
- * Calculate compliance rating based on percentages
+ * The rating ladder, one rung list per requested level, walked top-down.
+ * The first available rung that holds is awarded.
+ *
+ * Kept as data so the render can say which words a null level takes off the
+ * table (`ratingsUnavailableWhenNull`) from the same source the arithmetic
+ * walks — the prose cannot drift from the rule.
+ */
+const RATING_LADDER: Record<BenchmarkLevel, readonly LadderRung[]> = {
+  L1: [
+    { rating: 'Certified', reads: ['L1'], holds: (l1) => l1 === 100 },
+    { rating: 'Passing', reads: ['L1'], holds: (l1) => l1 >= 90 },
+    { rating: 'Needs Improvement', reads: ['L1'], holds: (l1) => l1 >= 70 },
+    { rating: 'Not Passing', reads: ['L1'], holds: () => true },
+  ],
+  L2: [
+    { rating: 'Certified', reads: ['L1', 'L2'], holds: (l1, l2) => l1 === 100 && l2 === 100 },
+    { rating: 'Compliant', reads: ['L1', 'L2'], holds: (l1, l2) => l1 === 100 && l2 >= 90 },
+    { rating: 'Passing', reads: ['L1'], holds: (l1) => l1 >= 90 },
+    { rating: 'Needs Improvement', reads: ['L1'], holds: (l1) => l1 >= 70 },
+    { rating: 'Not Passing', reads: ['L1'], holds: () => true },
+  ],
+  L3: [
+    { rating: 'Certified', reads: ['L1', 'L2', 'L3'], holds: (l1, l2, l3) => l1 === 100 && l2 === 100 && l3 === 100 },
+    { rating: 'Compliant', reads: ['L1', 'L2'], holds: (l1, l2) => l1 === 100 && l2 >= 90 },
+    { rating: 'Passing', reads: ['L1'], holds: (l1) => l1 >= 90 },
+    { rating: 'Needs Improvement', reads: ['L1'], holds: (l1) => l1 >= 70 },
+    { rating: 'Not Passing', reads: ['L1'], holds: () => true },
+  ],
+};
+
+/**
+ * Calculate the compliance rating from per-level percentages.
+ *
+ * A level is `null` when no scored control at that level produced a result
+ * (#458 step 0). Such a level never feeds the ladder: every rung that reads
+ * it is skipped, and the first available rung that holds is awarded. `0` is a
+ * measurement (0 of N passed) and fails rungs exactly as before. When every
+ * rung reads a null — L1 is null — the ladder has nothing to say and returns
+ * `Not Assessed`.
+ *
+ * Before this, a null-denominator level defaulted to 100 and read as perfect
+ * (the sentence in #513's title); CISO 2026-08-11 / CPO 2026-08-25 rulings.
  */
 export function calculateRating(
-  l1Compliance: number,
-  l2Compliance: number,
-  l3Compliance: number,
+  l1Compliance: number | null,
+  l2Compliance: number | null,
+  l3Compliance: number | null,
   level: BenchmarkLevel
-): BenchmarkResult['rating'] {
-  if (level === 'L1') {
-    if (l1Compliance === 100) return 'Certified';
-    if (l1Compliance >= 90) return 'Passing';
-    if (l1Compliance >= 70) return 'Needs Improvement';
-    return 'Not Passing';
+): BenchmarkRating {
+  const byLevel: Record<BenchmarkLevel, number | null> = {
+    L1: l1Compliance,
+    L2: l2Compliance,
+    L3: l3Compliance,
+  };
+  // A null a rung did not declare it reads becomes NaN, so an undeclared read
+  // can never make the rung hold: every comparison against NaN is false.
+  const num = (v: number | null): number => (v === null ? Number.NaN : v);
+  for (const rung of RATING_LADDER[level]) {
+    if (rung.reads.some((lv) => byLevel[lv] === null)) continue;
+    if (rung.holds(num(l1Compliance), num(l2Compliance), num(l3Compliance))) return rung.rating;
   }
+  return 'Not Assessed';
+}
 
-  if (level === 'L2') {
-    if (l1Compliance === 100 && l2Compliance === 100) return 'Certified';
-    if (l1Compliance === 100 && l2Compliance >= 90) return 'Compliant';
-    if (l1Compliance >= 90) return 'Passing';
-    if (l1Compliance >= 70) return 'Needs Improvement';
-    return 'Not Passing';
+/**
+ * The rating words that a `null` at `nullLevel` takes off the table when the
+ * benchmark was requested at `level`, in ladder order (strongest first).
+ * Empty when the ladder at `level` never reads `nullLevel`.
+ */
+export function ratingsUnavailableWhenNull(level: BenchmarkLevel, nullLevel: BenchmarkLevel): LadderRating[] {
+  return RATING_LADDER[level].filter((r) => r.reads.includes(nullLevel)).map((r) => r.rating);
+}
+
+/** The own-level controls at `level` that an automated check can settle. */
+export function automatedControlsAt(level: BenchmarkLevel, catalogue: BenchmarkCategory[] = OASB_1_CATEGORIES): BenchmarkControl[] {
+  return catalogue
+    .flatMap((c) => c.controls)
+    .filter((c) => c.level === level && c.scored && c.verification === 'automated' && c.checkIds.length > 0);
+}
+
+/**
+ * The "next level" line printed under a benchmark report, or `null` at L3.
+ *
+ * A footer cites the next level's command only while an automated check
+ * there can change the rating; a cited command that cannot produce the
+ * outcome it promises is a dead end. Derived from the catalogue, never from
+ * a literal, so the day OASB-1 gains an automated L3 check the citation
+ * returns with no code change (#458 step 0, CPO 2026-08-25 R4).
+ */
+export function nextLevelFooter(
+  current: BenchmarkLevel,
+  cliPrefix: string,
+  catalogue: BenchmarkCategory[] = OASB_1_CATEGORIES,
+): string | null {
+  const next: BenchmarkLevel | null = current === 'L1' ? 'L2' : current === 'L2' ? 'L3' : null;
+  if (next === null) return null;
+  const purpose = next === 'L2' ? 'for stricter checks' : 'for hardened requirements';
+  if (automatedControlsAt(next, catalogue).length > 0) {
+    return `Run '${cliPrefix} secure -b oasb-1 -l ${next}' ${purpose}.`;
   }
-
-  // L3
-  if (l1Compliance === 100 && l2Compliance === 100 && l3Compliance === 100) return 'Certified';
-  if (l1Compliance === 100 && l2Compliance >= 90) return 'Compliant';
-  if (l1Compliance >= 90) return 'Passing';
-  if (l1Compliance >= 70) return 'Needs Improvement';
-  return 'Not Passing';
+  const own = catalogue.flatMap((c) => c.controls).filter((c) => c.level === next);
+  const ids = own.map((c) => c.id).join(', ');
+  return `${next} adds ${own.length} control${own.length === 1 ? '' : 's'} (${ids}); none has an automated check in this version, so -l ${next} cannot raise this rating.`;
 }
 
 export const OASB_1_VERSION = '1.0.0';

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -25,6 +25,8 @@ import {
   getControlsForCategory,
   getCheckIdsForLevel,
   calculateRating,
+  ratingsUnavailableWhenNull,
+  nextLevelFooter,
   AVAILABLE_BENCHMARKS,
   isValidBenchmark,
   type BenchmarkLevel,
@@ -3208,13 +3210,23 @@ function generateBenchmarkReport(
     controlResults.push({ control, status, findings: relatedFindings, remediation });
   }
 
-  // Calculate compliance percentages
-  const l1Compliance = l1Total > 0 ? Math.round((l1Passed / l1Total) * 100) : 100;
-  const l2Compliance = l2Total > 0 ? Math.round((l2Passed / l2Total) * 100) : 100;
-  const l3Compliance = l3Total > 0 ? Math.round((l3Passed / l3Total) * 100) : 100;
+  // Compliance percentages. #458 step 0 — a level with no scored control
+  // that produced a result has no figure: `null`, never a default. The two
+  // L3 controls (3.5, 8.4) have no automated check, so `l3Compliance` was the
+  // old `: 100` default on every target and the L3 ladder read it as perfect
+  // (the sentence in #513's title); a category with no scored control read
+  // `Rating: Certified` beside `Compliance: 0% (0/0)` because the overall
+  // figure defaulted to 0 five lines below — the opposite default for the
+  // same case. CISO 2026-08-11 / CPO 2026-08-25: zero denominator => null,
+  // renders "not assessed", never feeds the ladder, never Not Passing.
+  const pct = (passed: number, total: number): number | null =>
+    total > 0 ? Math.round((passed / total) * 100) : null;
+  const l1Compliance = pct(l1Passed, l1Total);
+  const l2Compliance = pct(l2Passed, l2Total);
+  const l3Compliance = pct(l3Passed, l3Total);
   const totalScored = l1Total + l2Total + l3Total;
   const totalPassed = l1Passed + l2Passed + l3Passed;
-  const overallCompliance = totalScored > 0 ? Math.round((totalPassed / totalScored) * 100) : 0;
+  const overallCompliance = pct(totalPassed, totalScored);
 
   // Group results by category
   const categoryResults: BenchmarkCategoryResult[] = [];
@@ -3366,7 +3378,7 @@ function generateSarifOutput(benchmarkResult: BenchmarkResult, findings: Securit
 }
 
 // HTML report for shareable compliance documentation
-function generateHtmlReport(result: BenchmarkResult): string {
+function generateHtmlReport(result: BenchmarkResult, targetDir: string, flags?: BenchmarkRunFlags): string {
   assertRedactionProvenance(result, 'html-benchmark');
   const ratingColor = {
     'Certified': '#22c55e',
@@ -3374,6 +3386,7 @@ function generateHtmlReport(result: BenchmarkResult): string {
     'Passing': '#eab308',
     'Needs Improvement': '#f97316',
     'Not Passing': '#ef4444',
+    'Not Assessed': '#94a3b8',
   }[result.rating] || '#94a3b8';
 
   const ratingBg = {
@@ -3382,14 +3395,18 @@ function generateHtmlReport(result: BenchmarkResult): string {
     'Passing': 'rgba(234, 179, 8, 0.15)',
     'Needs Improvement': 'rgba(249, 115, 22, 0.15)',
     'Not Passing': 'rgba(239, 68, 68, 0.15)',
+    'Not Assessed': 'rgba(148, 163, 184, 0.15)',
   }[result.rating] || 'rgba(148, 163, 184, 0.15)';
 
   // Generate donut chart SVG
   const donutRadius = 70;
   const donutStroke = 14;
   const donutCircumference = 2 * Math.PI * donutRadius;
-  const donutOffset = donutCircumference * (1 - result.compliance / 100);
-  const complianceColor = result.compliance >= 90 ? '#22c55e' : result.compliance >= 70 ? '#eab308' : '#ef4444';
+  // #458 step 0 — `compliance` is null when no control produced a result:
+  // an empty ring in the neutral colour, never `null%` under a red grade.
+  const donutOffset = donutCircumference * (1 - (result.compliance ?? 0) / 100);
+  const complianceColor = result.compliance === null ? '#94a3b8'
+    : result.compliance >= 90 ? '#22c55e' : result.compliance >= 70 ? '#eab308' : '#ef4444';
 
   // Generate radar chart data points
   const radarCategories = result.categories.slice(0, 10); // Max 10 for radar
@@ -3480,7 +3497,9 @@ function generateHtmlReport(result: BenchmarkResult): string {
     if (pct >= 60) return { letter: 'improving', color: '#f97316' };
     return { letter: 'needs-attention', color: '#ef4444' };
   };
-  const grade = getGrade(result.compliance);
+  const grade = result.compliance === null
+    ? { letter: 'not assessed', color: '#94a3b8' }
+    : getGrade(result.compliance);
 
   // Generate executive summary items
   const executiveSummary = failedControls.length === 0
@@ -3557,7 +3576,7 @@ function generateHtmlReport(result: BenchmarkResult): string {
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>OASB-1 Compliance Report | ${result.rating}</title>
+  <title>OASB-1 Compliance Report | ${escapeHtml(ratingWithScope(result))}</title>
   <style>
     :root {
       --bg-primary: #0a0f1a;
@@ -3946,7 +3965,8 @@ function generateHtmlReport(result: BenchmarkResult): string {
         <div class="meta">Version ${result.version} • Generated ${new Date(result.timestamp).toLocaleString()}</div>
       </div>
       <div class="header-right">
-        <div class="rating-badge">${result.rating}</div>
+        <div class="rating-badge">${escapeHtml(ratingWithScope(result))}</div>
+        ${notAssessedLines(result, targetDir, flags).map((line) => `<div style="margin-top: 8px; font-size: 13px; color: #94a3b8;">${escapeHtml(line)}</div>`).join('')}
         <div class="level-tag">${result.level} — ${result.level === 'L1' ? 'Essential' : result.level === 'L2' ? 'Standard' : 'Hardened'}</div>
       </div>
     </header>
@@ -3958,7 +3978,7 @@ function generateHtmlReport(result: BenchmarkResult): string {
             <span class="grade-letter" style="color: ${grade.color};">${grade.letter}</span>
           </div>
           <div class="score-main">
-            <div class="score-pct">${result.compliance}%</div>
+            <div class="score-pct">${result.compliance === null ? 'not measured' : `${result.compliance}%`}</div>
             <div class="score-label">Security Score</div>
           </div>
         </div>
@@ -4358,13 +4378,151 @@ function generateAspOutput(benchmarkResult: BenchmarkResult, scanResult: { findi
   return JSON.stringify(asp, null, 2);
 }
 
-function printBenchmarkReport(result: BenchmarkResult, verbose: boolean): void {
+/** The levels a `-l <level>` run examines, lowest first. */
+function examinedLevels(level: BenchmarkLevel): BenchmarkLevel[] {
+  return level === 'L1' ? ['L1'] : level === 'L2' ? ['L1', 'L2'] : ['L1', 'L2', 'L3'];
+}
+
+/** The examined levels whose compliance is `null` (no scored control produced a result). */
+function notAssessedLevels(result: BenchmarkResult): BenchmarkLevel[] {
+  const byLevel: Record<BenchmarkLevel, number | null> = {
+    L1: result.l1Compliance,
+    L2: result.l2Compliance,
+    L3: result.l3Compliance,
+  };
+  return examinedLevels(result.level).filter((lv) => byLevel[lv] === null);
+}
+
+/**
+ * #458 step 0 — the rating word never travels alone (CISO 2026-08-11, "no
+ * channel may render a rating word alone"): when a level at or below the
+ * requested one was not assessed, the text and html renderers say so in the
+ * same string. `--json` carries the bare word; the nulls sit beside it.
+ */
+function ratingWithScope(result: BenchmarkResult): string {
+  if (result.rating === 'Not Assessed') return result.rating;
+  const missing = notAssessedLevels(result);
+  return missing.length === 0 ? result.rating : `${result.rating} (${missing.join(', ')} not assessed)`;
+}
+
+/**
+ * The flags of this run that change what the scan runs, so a printed
+ * Verify/Fix command reproduces the figure it stands beside instead of
+ * measuring a different population: `--category`, `--scan-depth`,
+ * `--no-machine-posture`, `--ignore` (removes its checks from `allFindings`
+ * before the benchmark reads it), `--deep` and `--static-only` (turn the
+ * semantic and simulation layers on and off). Not carried: `--nanomind`
+ * (per-finding analysis by its help text, not a check) and `--fix` (mutates
+ * the target).
+ */
+interface BenchmarkRunFlags {
+  category?: string;
+  scanDepth?: string;
+  machinePosture?: boolean;
+  ignore?: string[];
+  deep?: boolean;
+  staticOnly?: boolean;
+}
+
+const plural = (n: number, word: string): string => `${n} ${word}${n === 1 ? '' : 's'}`;
+
+/**
+ * #458 step 0 — one line per level, at or below the requested one, whose
+ * compliance is `null`: what was not measured, why, which rating words that
+ * takes off the table, and how to verify it.
+ *
+ * Derived from the control statuses the run produced and the catalogue —
+ * never hardcoded, because #458 steps 1-2 change these counts (absent-subject
+ * controls become `not-applicable`, a different reason). The "not awardable"
+ * clause comes from the same rung table `calculateRating` walks. The cited
+ * Verify carries the run's own flags (category, depth, machine posture,
+ * `--ignore`, `--deep`, `--static-only`) so it reproduces the figure on the
+ * line, and is a runnable shell line.
+ */
+function notAssessedLines(result: BenchmarkResult, targetDir: string, flags?: BenchmarkRunFlags): string[] {
+  const examined = examinedLevels(result.level);
+  const byLevel: Record<BenchmarkLevel, number | null> = {
+    L1: result.l1Compliance,
+    L2: result.l2Compliance,
+    L3: result.l3Compliance,
+  };
+  const catalogue = new Map<string, BenchmarkControl>(
+    OASB_1_CATEGORIES.flatMap((c: BenchmarkCategory) => c.controls).map((c: BenchmarkControl) => [c.id, c]),
+  );
+  // #273 — the target is quoted only when the shell needs it, and a path the
+  // reader cannot be shown truthfully becomes the house `<dir>` placeholder.
+  const dir = citationTarget(targetDir);
+  const lines: string[] = [];
+  for (const lv of examined) {
+    if (byLevel[lv] !== null) continue;
+    const inScope = result.categories
+      .flatMap((c: BenchmarkCategoryResult) => c.controls)
+      .filter((c: BenchmarkControlResult) => c.level === lv);
+    const automated = inScope.filter((r: BenchmarkControlResult) => {
+      const c = catalogue.get(r.controlId);
+      return !!c && c.scored && c.verification === 'automated' && c.checkIds.length > 0;
+    });
+    const measured = inScope.filter((r: BenchmarkControlResult) => r.status !== 'unverified').length;
+    const manualForward = inScope.filter((r: BenchmarkControlResult) => {
+      const c = catalogue.get(r.controlId);
+      return !!c && (c.verification === 'manual' || c.verification === 'forward');
+    }).length;
+    // The words a null at `lv` takes off the table for the REQUESTED level's
+    // rating; "at Lx" is said only on the requested level's own line.
+    const off = ratingsUnavailableWhenNull(result.level, lv);
+    const ladderSize = ratingsUnavailableWhenNull(result.level, 'L1').length;
+    const where = lv === result.level ? ` at ${lv}` : '';
+    const offClause = off.length === 0 ? ''
+      : off.length >= ladderSize ? `no rating is awardable${where}`
+      : off.length === 1 ? `${off[0]} is not awardable${where}`
+      : `${[...off].reverse().join(' and ')} are not awardable${where}`;
+    const verify = `Verify: ${CLI_PREFIX} secure ${dir} -b oasb-1 -l ${lv}${runFlagsForCitation(flags)} --format json | jq '[.categories[].controls[] | select(.level == "${lv}")]'`;
+    // A Fix is owed only where the rating itself is withheld (L1 null =>
+    // `Not Assessed`). A --category that selects nothing automatable at this
+    // level is fixed by dropping the flag; an `--ignore` list naming a check
+    // that measures one of these automated controls is fixed by dropping
+    // that (a list naming nothing here cannot have emptied the population,
+    // so that Fix would change nothing); a selection whose automated controls
+    // produced nothing is fixed by pointing at the real project root.
+    const selectsNothingAutomatable = !!flags?.category && automated.length === 0;
+    const ignored = new Set((flags?.ignore ?? []).map((id) => id.toUpperCase()));
+    const suppressedByIgnore = ignored.size > 0 && automated.some((r: BenchmarkControlResult) =>
+      (catalogue.get(r.controlId)?.checkIds ?? []).some((id) => ignored.has(id.toUpperCase())));
+    const fix = lv !== 'L1' ? ''
+      : selectsNothingAutomatable
+        ? ` Fix: drop --category: ${CLI_PREFIX} secure ${dir} -b oasb-1 -l ${result.level}${runFlagsForCitation(flags, { category: true })}`
+        : suppressedByIgnore
+          ? ` Fix: drop --ignore: ${CLI_PREFIX} secure ${dir} -b oasb-1 -l ${result.level}${runFlagsForCitation(flags, { ignore: true })}`
+          : ` Fix: run against the project root that holds the artifacts OASB-1 examines (package manifest, agent or MCP config, source).`;
+    if (inScope.length === 0) {
+      lines.push(`Not assessed at ${lv}: the selected category has no ${lv} controls; ${offClause}. ${verify}${fix}`);
+      continue;
+    }
+    if (automated.length === 0) {
+      const ids = inScope.map((r: BenchmarkControlResult) => r.controlId).join(', ');
+      lines.push(
+        `Not assessed at ${lv}: none of the ${plural(inScope.length, `${lv} control`)} (${ids}) has an automated check in this version; ${offClause}. ${verify}${fix}`,
+      );
+      continue;
+    }
+    const ids = automated.map((r: BenchmarkControlResult) => r.controlId).join(', ');
+    const manual = manualForward > 0 ? ` (${manualForward} of ${plural(inScope.length, `${lv} control`)} are manual/forward)` : '';
+    lines.push(
+      `Not assessed at ${lv}: ${measured} of ${plural(automated.length, `automated ${lv} control`)} (${ids}) produced a result on this tree${manual}; ${offClause}. ${verify}${fix}`,
+    );
+  }
+  return lines;
+}
+
+function printBenchmarkReport(result: BenchmarkResult, verbose: boolean, targetDir: string, flags?: BenchmarkRunFlags): void {
   const ratingColors: Record<BenchmarkResult['rating'], string> = {
     'Certified': colors.green,
     'Compliant': colors.green,
     'Passing': colors.yellow,
     'Needs Improvement': colors.yellow,
     'Not Passing': colors.red,
+    // Neither green nor red: the ladder did not measure, so it does not say.
+    'Not Assessed': colors.dim,
   };
 
   // Header
@@ -4378,10 +4536,17 @@ function printBenchmarkReport(result: BenchmarkResult, verbose: boolean): void {
     'L3': 'Level 3 - Hardened',
   };
   console.log(`Level: ${levelNames[result.level]}`);
-  console.log(`Rating: ${ratingColors[result.rating]}${result.rating}${RESET()}`);
-  console.log(`Compliance: ${result.compliance}% (${result.passedControls}/${result.passedControls + result.failedControls} verified controls)`);
+  console.log(`Rating: ${ratingColors[result.rating]}${ratingWithScope(result)}${RESET()}`);
+  if (result.compliance === null) {
+    console.log(`Compliance: not measured (0/0 verified controls)`);
+  } else {
+    console.log(`Compliance: ${result.compliance}% (${result.passedControls}/${result.passedControls + result.failedControls} verified controls)`);
+  }
   if (result.unverifiedControls > 0) {
     console.log(`Unverified: ${result.unverifiedControls} controls require manual/forward verification`);
+  }
+  for (const line of notAssessedLines(result, targetDir, flags)) {
+    console.log(`${colors.dim}${line}${RESET()}`);
   }
   console.log();
 
@@ -4427,18 +4592,21 @@ function printBenchmarkReport(result: BenchmarkResult, verbose: boolean): void {
 
   // Compliance breakdown by level
   if (verbose) {
-    console.log(`\nCompliance by level: L1=${result.l1Compliance}% L2=${result.l2Compliance}% L3=${result.l3Compliance}%`);
+    // Examined levels only: a level the run was not asked for has no figure
+    // to report, and printing `L3=not assessed` on an -l L2 run reads as
+    // a gap rather than as scope.
+    const pctOrNot = (v: number | null): string => (v === null ? 'not assessed' : `${v}%`);
+    const byLevel: Record<BenchmarkLevel, number | null> = { L1: result.l1Compliance, L2: result.l2Compliance, L3: result.l3Compliance };
+    console.log(`\nCompliance by level: ${examinedLevels(result.level).map((lv) => `${lv}=${pctOrNot(byLevel[lv])}`).join(' ')}`);
     console.log(`Legend: [?] = Manual/Forward verification required`);
   }
 
   // Show appropriate next step based on current level
-  if (result.level === 'L1') {
-    console.log(`\nRun '${CLI_PREFIX} secure -b oasb-1 -l L2' for stricter checks.`);
-  } else if (result.level === 'L2') {
-    console.log(`\nRun '${CLI_PREFIX} secure -b oasb-1 -l L3' for hardened requirements.`);
-  } else {
-    console.log(`\nThis is the highest maturity level (L3 - Hardened).`);
-  }
+  // #458 step 0 — the next-level line is derived from the catalogue
+  // (`nextLevelFooter`): it cites a command only while an automated check
+  // at that level can change the rating.
+  const footer = nextLevelFooter(result.level, CLI_PREFIX);
+  console.log(footer === null ? `\nThis is the highest maturity level (L3 - Hardened).` : `\n${footer}`);
   console.log(`Spec: https://oasb.ai/oasb-1\n`);
 }
 
@@ -4648,9 +4816,11 @@ Exit codes:
   1  measured, and a critical/high issue was found
      (or non-compliant in benchmark mode, or a score below --fail-below)
   2  the run did not examine everything it found, so it reaches no pass:
-     an input was discovered and could not be read, or a --deep analysis
-     did not complete. What DID run is still reported and scored above,
-     and the score is an upper bound rather than a measurement of the tree.
+     an input was discovered and could not be read, a --deep analysis
+     did not complete, or (benchmark mode) no scored L1 control produced
+     a result and the rating is Not Assessed. What DID run is still
+     reported and scored above, and the score is an upper bound rather
+     than a measurement of the tree.
 
 Examples:
   $ ${CLI_PREFIX} secure                           Scan current directory
@@ -4674,13 +4844,13 @@ Examples:
   // unqualified claim in `--help` would make the tool assert something a user
   // can falsify in one command. The benchmark path is tracked separately; until
   // it is fixed the promise is scoped to where it holds.
-  .option('--ignore <checks>', 'Comma-separated check IDs to leave out of the findings list (e.g., CRED-001,GIT-002). Suppressed checks are still scored and still set the exit code for this command; use --fail-below for a score floor. Not yet honoured by --benchmark')
+  .option('--ignore <checks>', 'Comma-separated check IDs to leave out of the findings list (e.g., CRED-001,GIT-002). Suppressed checks are still scored and still set the exit code for this command; use --fail-below for a score floor. With --benchmark the ignored checks cannot report, so a control measured only by them stays unverified')
   .option('--json', 'Output as JSON (deprecated: use --format json)')
   .option('-f, --format <format>', 'Output format: text, json, sarif, html, asff; asp with -b oasb-1', 'text')
   .option('--aws-account-id <id>', 'AWS account ID for ASFF format')
   .option('--aws-region <region>', 'AWS region for ASFF format')
   .option('-o, --output <file>', 'Write output to file instead of stdout')
-  .option('--fail-below <percent>', 'ADDITIONALLY exit 1 if compliance is below this threshold (0-100). Does not disable the default non-compliance gate')
+  .option('--fail-below <percent>', 'ADDITIONALLY exit 1 if compliance is below this threshold (0-100). Does not disable the default non-compliance gate; not evaluated when no compliance was measured (0 verified controls: exit 2)')
   .option('-v, --verbose', 'Show all checks including passed ones')
   .option('-b, --benchmark <name>', 'Run benchmark compliance check (e.g., oasb-1)')
   .option('-l, --level <level>', 'Benchmark level: L1 (Essential), L2 (Standard), L3 (Hardened)', 'L1')
@@ -5247,7 +5417,14 @@ Examples:
           process.stdout.write('\n');
 
           // Show infra report then governance report
-          printBenchmarkReport(infraResult, options.verbose ?? false);
+          printBenchmarkReport(infraResult, options.verbose ?? false, targetDir, {
+            category: options.category,
+            scanDepth: options.scanDepth,
+            machinePosture: options.machinePosture,
+            ignore: ignoreList,
+            deep: options.deep === true,
+            staticOnly: isStaticOnly,
+          });
           printBenchmarkUnreadDisclosure(result);
 
           process.stdout.write('\nGovernance Domains (scan-soul):\n');
@@ -5294,12 +5471,24 @@ Examples:
 
       // Benchmark mode - output compliance report
       if (options.benchmark) {
-        // Use allFindings (unfiltered) for accurate benchmark evaluation
+        // allFindings: every finding regardless of the score threshold. It is
+        // not unfiltered: `--ignore` removed its checks above, so the controls
+        // they measure read as not assessed (the cited Verify repeats the flag).
         const benchmarkResult = generateBenchmarkReport(
           result.allFindings || result.findings,
           level,
           options.category
         );
+
+        // The run's own flags, for the Verify/Fix commands the report cites.
+        const benchmarkRunFlags: BenchmarkRunFlags = {
+          category: options.category,
+          scanDepth: options.scanDepth,
+          machinePosture: options.machinePosture,
+          ignore: ignoreList,
+          deep: options.deep === true,
+          staticOnly: isStaticOnly,
+        };
 
         // Output based on format
         let output: string;
@@ -5322,13 +5511,13 @@ Examples:
             output = generateSarifOutput(benchmarkResult, result.findings, targetDir);
             break;
           case 'html':
-            output = generateHtmlReport(benchmarkResult);
+            output = generateHtmlReport(benchmarkResult, targetDir, benchmarkRunFlags);
             break;
           case 'asp':
             output = generateAspOutput(benchmarkResult, result, targetDir);
             break;
           default: // text
-            printBenchmarkReport(benchmarkResult, options.verbose ?? false);
+            printBenchmarkReport(benchmarkResult, options.verbose ?? false, targetDir, benchmarkRunFlags);
             printBenchmarkUnreadDisclosure(result);
             output = '';
         }
@@ -5358,10 +5547,46 @@ Examples:
           console.error(`Benchmark rating is ${benchmarkResult.rating}. Exiting 1 per "non-compliant in benchmark mode".`);
         }
 
-        // Check fail threshold
-        if (failBelow !== undefined && benchmarkResult.compliance < failBelow) {
-          console.error(`Compliance ${benchmarkResult.compliance}% is below threshold ${failBelow}%`);
-          process.exit(1);
+        // #458 step 0 — `Not Assessed` means the rating ladder could not be
+        // read: no scored L1 control produced a result. That is "did not
+        // measure", so the unmeasured floor (2) is raised, raise-only, the
+        // same code this arm already uses for an unread input above.
+        //
+        // A --category can select controls at L2/L3 and none at L1; then the
+        // compliance figure IS measured (over those controls) while the
+        // rating is Not Assessed, and a `--fail-below` breach over it still
+        // exits 1 below. That is this arm's recorded precedence — measured-
+        // and-failed outranks not-measured ("both true -> 1"), which differs
+        // from the secure arm's #512 rule and is kept as is by the CPO
+        // ruling of 2026-08-25. The reason printed says which case it is.
+        if (benchmarkResult.rating === 'Not Assessed') {
+          const measuredElsewhere = benchmarkResult.passedControls + benchmarkResult.failedControls;
+          const why = measuredElsewhere > 0
+            ? `no scored L1 control produced a result in this selection, so the rating ladder cannot be read; ${plural(measuredElsewhere, 'scored control')} at a higher level produced a result and ${measuredElsewhere === 1 ? 'is' : 'are'} not rated`
+            : 'no scored control produced a result';
+          console.error(`Benchmark rating is Not Assessed: ${why}. Exit code raised to ${EXIT_UNMEASURED} (not measured).`);
+          raiseExitCode(EXIT_UNMEASURED);
+        }
+
+        // Check fail threshold — against a measured figure only. For any
+        // positive N, `null < N` is `true` in JS, so a bare comparison over a
+        // null compliance would exit 1 for a number that was never produced
+        // (0.32.0 defaulted the figure to 0 and printed `Compliance 0% is
+        // below threshold` over 0/0 controls — the same claim, one step
+        // earlier). A threshold is a claim about a measurement.
+        if (failBelow !== undefined) {
+          if (benchmarkResult.compliance === null) {
+            console.error(`--fail-below ${failBelow} not evaluated: no compliance was measured (0 verified controls).`);
+          } else if (benchmarkResult.compliance < failBelow) {
+            // Beside a Not Assessed rating this is the case the comment above
+            // describes: the breach is over a MEASURED figure, so it outranks
+            // the not-measured floor that was just raised. Say so.
+            const outranks = benchmarkResult.rating === 'Not Assessed'
+              ? ' — a measured breach outranks the not-measured floor above: exit 1'
+              : '';
+            console.error(`Compliance ${benchmarkResult.compliance}% is below threshold ${failBelow}%${outranks}`);
+            process.exit(1);
+          }
         }
 
         if (ratingFails) process.exit(1);
@@ -6202,6 +6427,36 @@ function detectAIInfrastructure(primaryTarget: string): Array<{ name: string; di
       return false;
     }
   });
+}
+
+/**
+ * The flags of the current run, rendered for a cited `secure` command
+ * (`omit` drops the flag a "drop --category" / "drop --ignore" Fix removes).
+ * The category and the ignore list go through `citationPath`: quoted when the
+ * shell needs it, the house placeholder when the bytes cannot be shown
+ * truthfully. The cited `-c` value is the run's own spelling (the gate in
+ * `generateBenchmarkReport` matches case-insensitively and exits 1 on any
+ * other string), so the placeholder arm is the helper's contract, not a
+ * defence this file relies on.
+ *
+ * Placed under the `secure` registration on purpose: the #372 walker
+ * attributes a flag that names no command to the enclosing `.command(`, and
+ * these are `secure` flags (`check` registers neither `--scan-depth` nor
+ * `--no-machine-posture`). Function declarations hoist, so the callers above
+ * are unaffected.
+ */
+function runFlagsForCitation(
+  flags: BenchmarkRunFlags | undefined,
+  omit: { category?: boolean; ignore?: boolean } = {},
+): string {
+  const parts: string[] = [];
+  if (flags?.category && !omit.category) parts.push(`-c ${citationPath(flags.category) ?? '<category>'}`);
+  if (flags?.scanDepth && flags.scanDepth !== 'standard') parts.push(`--scan-depth ${escapeForDisplay(flags.scanDepth)}`);
+  if (flags?.machinePosture === false) parts.push('--no-machine-posture');
+  if (flags?.ignore && flags.ignore.length > 0 && !omit.ignore) parts.push(`--ignore ${citationPath(flags.ignore.join(',')) ?? '<checks>'}`);
+  if (flags?.deep) parts.push('--deep');
+  if (flags?.staticOnly) parts.push('--static-only');
+  return parts.length > 0 ? ` ${parts.join(' ')}` : '';
 }
 
 program

--- a/src/index.ts
+++ b/src/index.ts
@@ -120,12 +120,17 @@ export {
   getControlsForCategory,
   getCheckIdsForLevel,
   calculateRating,
+  ratingsUnavailableWhenNull,
+  automatedControlsAt,
+  nextLevelFooter,
   AVAILABLE_BENCHMARKS,
   isValidBenchmark,
 } from './benchmarks';
 
 export type {
   BenchmarkLevel,
+  BenchmarkRating,
+  LadderRating,
   BenchmarkControl,
   BenchmarkCategory,
   BenchmarkResult,

--- a/src/registry/publish.ts
+++ b/src/registry/publish.ts
@@ -514,7 +514,10 @@ export function formatPublishOutput(
       parts.push(`hardening (${failed.length} finding${failed.length === 1 ? '' : 's'})`);
     }
     if (data.oasbResult) {
-      parts.push(`OASB (${data.oasbResult.compliance}% compliance)`);
+      // #458 step 0: a benchmark run that measured nothing carries `null`.
+      parts.push(data.oasbResult.compliance === null
+        ? 'OASB (compliance not measured)'
+        : `OASB (${data.oasbResult.compliance}% compliance)`);
     }
     if (data.soulResult) {
       parts.push(`SOUL (${data.soulResult.score}/100)`);


### PR DESCRIPTION
`secure -b oasb-1` set a level's compliance to 100 when no scored control at that level produced a result, and the overall figure to 0 in the same case, five lines apart. The two L3 controls (3.5, 8.4) have no automated check, so every `L3=100%` ever printed was that default and the L3 ladder read an unmeasured level as perfect; a category with no scored control printed `Rating: Certified` beside `Compliance: 0% (0/0 verified controls)` at exit 0, and exit 1 under `--fail-below 80` because `0 < 80`.

A zero-denominator level is now `null` in `--json`/`--format asp`, renders `not assessed`, and never feeds the ladder: a rung that reads a null level is skipped, not failed; the first available rung that holds is awarded; the text and html `Rating:` line names the levels that were not assessed (`Rating: Passing (L2, L3 not assessed)`), `--json` carries the bare word. When every rung reads a null the rating is `Not Assessed`, exit 2 (the unmeasured floor, raise-only), and `--fail-below` is not evaluated. One `Not assessed at Lx:` line per unmeasured level, derived from the control statuses and the catalogue, each with a Verify that repeats the run's flags and runs as printed; the L1 line carries a Fix keyed on whether `--category` selected nothing automatable. A `--category` with L2/L3 controls and no L1 controls is `Not Assessed` at exit 2 with the reason naming the measured controls; a `--fail-below` breach over its measured figure still exits 1 (this arm's recorded precedence, kept by the ruling). The L2 footer cites `-l L3` only while an automated L3 check exists (today: none, so it states the fact and cites no command).

Rulings: CISO 2026-08-11 (zero denominator ⇒ null, never feeds the ladder, never Not Passing), CA 2026-08-24 (step 0 lands first, alone), CPO 2026-08-25 ×3 (contract, reconciled Q2). COUNCIL_LEDGER entries 9a60c30, 976736e, 84724f9.

## Measured (0.32.0 at 6d6685e → this branch), `--no-machine-posture --json`, HOME-isolated

| target | level | before | after |
|---|---|---|---|
| empty dir, quick | L1 | Certified 100 (2/2), l2 100, l3 100, exit 0 | rating and exit unchanged (L1 denominator is 2 — closes with #458 steps 1-2); l2 null, l3 null |
| empty dir, quick | L2 / L3 | Certified, l2 100, l3 100, exit 0 | Passing, l2 null, l3 null, exit 0 |
| ai-trust, secretless, oasb | L1 | Certified, l2 100, l3 100, exit 0 | rating and exit unchanged; l2 null, l3 null |
| ai-trust, secretless, oasb | L2 / L3 | Certified, l2 100, l3 100, exit 0 | Passing (L2[, L3] not assessed), l2 null, l3 null, exit 0 |
| opena2a | L1 / L2 / L3 | Passing 94, exit 0 | word and exit unchanged; l2 null at L1, l3 null at every level; text at L3 reads `Passing (L3 not assessed)` |
| hackmyagent | L1 / L2 / L3 | Needs Improvement, exit 1 | word and exit unchanged; l3 null; text at L3 reads `Needs Improvement (L3 not assessed)` |
| empty dir, default depth | L1 / L3 | Not Passing 69% (9/13), exit 1 | word and exit unchanged (the L1 denominator is measured); at L3 the text line reads `Not Passing (L2, L3 not assessed)`, json l2/l3 null |
| empty dir, `-l L1 -c "Identity & Provenance"` | L1 | Certified, 0% (0/0), exit 0; exit 1 with `--fail-below 80` | Not Assessed, not measured (0/0), exit 2; exit 2 with `--fail-below 80`, `not evaluated` on stderr |

0 of 5 repositories change rating word or exit at `-l L1`; 3 of 5 go `Certified → Passing` at `-l L2`/`-l L3` with exit unchanged. Non-verbose `-l L1` text output on a measured tree is identical apart from timestamps; `--json` at every level now carries `null` where 0.32.0 printed the 100 default for an unmeasured level.

## Review

Independent round on e733697 (5 finders, 2 refuters per MEDIUM+ finding, on git-archive trees of head and base): 8 confirmed. Fixed in the amend: the cited Verify omitted `--ignore`/`--deep`, which shape the benchmark population (`--ignore` removes its checks from `allFindings` before the benchmark reads it), so it did not reproduce the figure and the L1 Fix blamed the target; `BenchmarkRunFlags` now carries both, the Fix says `drop --ignore`, and the `--ignore` help text no longer claims the flag is not honoured by `--benchmark`. The `-c` value is rendered through `citationPath` (an unknown name exits 1 at `generateBenchmarkReport`'s gate; no catalogue name carries a display hazard — both pinned). HTML `<title>` carries the scope. `formatPublishOutput` prints `compliance not measured` for null. Vacuity: L2 line IDs pinned, Not-Assessed anchor tightened, html tile and package exports pinned. Recorded, not fixed: the composite arm and the category grain (above).

A scoped re-review of that amend (3 finders, 2 refuters each) found 5 MEDIUMs inside it, all fixed in the final commit and none further reviewed by agents (two rounds of fixes-inside-fixes is the stopping rule): the `drop --ignore` Fix keyed on the flag's presence rather than its cause — now printed only when the list names a check that measures one of the population's automated controls, with a negative cell (`--ignore FOO-999` gets the project-root Fix and the Verify still repeats the flag); `--static-only` also shapes the population and is now carried in the citation beside `--deep`, both pinned; the `ci-pipeline.md` sentence was false for the L2-only `--category` arm (exit 2 with a measured figure, `--fail-below` evaluated) and now states both cases; the "bare Passing" CHANGELOG sentence dropped a misplaced threshold; the `--ignore` help text uses the output's own vocabulary (`unverified`).

## Tests

- `__tests__/cli/benchmark-empty-denominator.test.ts` (spawn, built CLI): RED-ON-BASE cells red on the 6d6685e dist, green here; PIN cells green on both.
- `__tests__/benchmarks/calculate-rating-null-levels.test.ts`: null-rung ladder + `ratingsUnavailableWhenNull`; the 23 numeric pins in `oasb-1.test.ts` stay green.
- `__tests__/registry/publish-output-not-measured.test.ts`: `formatPublishOutput` over a null compliance prints `compliance not measured`, never `null%`.
- Red-proof of the three files on the 43662a6 build: 27 of 27 `RED-ON-BASE` cells red, 9 of 9 `PIN` cells green, no inversion.
- Mutations, each applied to the branch source, built, run against the three suites above, then restored by copy and rebuilt (green after restore, tree identical to the worktree). Every mutation turns at least one named cell red; M1–M12 and M15–M18 were run on the tree before the round-2 fixes (their target lines are unchanged since), M13, M14 and M19–M21 on the final tree:

| mutation | site | red | a cell it turns red |
|---|---|---|---|
| M1 per-level `null` → `100` | cli.ts `generateBenchmarkReport` | 18 | json: -l L3 on an empty dir at quick depth carries null for L2/L3 and the ladder skips those rungs |
| M2 per-level `null` → `0` | same line | 18 | json: -l L3 on an empty dir at quick depth carries null for L2/L3 and the ladder skips those rungs |
| M3 `--fail-below` null guard removed | cli.ts oasb-1 arm | 1 | --fail-below is not evaluated against a NULL compliance: the Not Assessed exit 2 stands |
| M4 Not Assessed `raiseExitCode(EXIT_UNMEASURED)` dropped | cli.ts oasb-1 arm | 8 | text: a run in which no control was measured is Not Assessed at exit 2, with a Verify and a Fix |
| M5 rating scope suffix dropped | cli.ts `ratingWithScope` | 4 | text: -l L3 prints Passing, one "Not assessed at" line per unmeasured level under Unverified:, and says so in the verbos |
| M6 next-level footer census inverted | oasb-1.ts `nextLevelFooter` | 5 | cites the next level while an automated check there can change the rating |
| M7 category-keyed Fix never keyed | cli.ts `notAssessedLines` | 1 | text: a run in which no control was measured is Not Assessed at exit 2, with a Verify and a Fix |
| M8 suffix returned on Not Assessed | cli.ts `ratingWithScope` | 4 | text: a run in which no control was measured is Not Assessed at exit 2, with a Verify and a Fix |
| M9 empty-scope category branch dropped | cli.ts `notAssessedLines` | 1 | text: a --category with no controls at an examined level says so instead of "none of the 0 controls ()" |
| M10 null rung not skipped | oasb-1.ts `calculateRating` | 13 | L1 null is Not Assessed at every requested level (every rung reads L1) |
| M11 `-c` dropped from the cited Verify | cli.ts `runFlagsForCitation` | 1 | text: cited commands quote a target path that contains a space, and run |
| M12 html grade tile null branch removed | cli.ts `generateHtmlReport` | 1 | html: the Not Assessed run prints no null% and carries the not-assessed line |
| M13 `--ignore` dropped from the cited Verify | cli.ts `runFlagsForCitation` | 3 | text: --ignore shapes the population, so the cited Verify repeats it and the Fix drops it |
| M14 `drop --ignore` Fix never keyed | cli.ts `notAssessedLines` | 1 | text: --ignore shapes the population, so the cited Verify repeats it and the Fix drops it |
| M15 html `<title>` bare rating word | cli.ts `generateHtmlReport` | 1 | html: the badge carries the null scope at -l L3 |
| M16 L2 line prints wrong control IDs | cli.ts `notAssessedLines` | 1 | text: -l L3 prints Passing, one "Not assessed at" line per unmeasured level under Unverified:, and says so in the verbos |
| M17 publish null guard removed | publish.ts `formatPublishOutput` | 1 | prints "compliance not measured", never null% |
| M18 `automatedControlsAt` package export dropped | src/index.ts | 1 | the three helpers beside calculateRating are exported from the package root |
| M19 `drop --ignore` Fix keyed on presence, not cause | cli.ts `notAssessedLines` | 1 | text: an --ignore that names no check of this population gets the project-root Fix, not "drop --ignore" |
| M20 `--deep` dropped from the cited Verify | cli.ts `runFlagsForCitation` | 1 | text: the cited Verify repeats --deep and --static-only |
| M21 `--static-only` dropped from the cited Verify | cli.ts `runFlagsForCitation` | 1 | text: the cited Verify repeats --deep and --static-only |

  An earlier M11 variant (`&& false` on the condition) narrowed `flags` to `never`, failed the build (exit 2) and was discarded as invalid — a mutation whose build fails is not a kill.

## Not in scope (stated so nobody reads this as closing them)

- The empty-directory `--scan-depth quick -l L1` cell (`Certified 100% (2/2)`): #458 steps 1-2, scanner-side.
- `src/mcp-server.ts` benchmark assessor (absence read as PASS): #458 step 5, 0.33.0 hold condition.
- The `-b oasb-2` composite arm (`cli.ts` `infraResult.compliance ?? 0`): on an empty directory with `-l L1 -c "Identity & Provenance"` it prints `Infrastructure Score (OASB-1): 0%` and exits 1 on BOTH 43662a6 and this branch — the 0 is the figure 0.32.0 produced from its own zero default, not a change here — but this branch now prints `Compliance: not measured` directly beneath it, so the document contradicts itself on that path. That is the composite refusal ruled as #458 step 4; stated in the CHANGELOG's "Not changed here".
- Category-grain zero denominators (`compliance: 0` per category in `--json`/asp/html, `N/A (no controls at this level)` in text for a category whose controls were all unverified): same class one grain down, unchanged on both builds; filed as a follow-up issue at close-out.
- README `## Exit codes` row 2 needs one clause for the new benchmark `Not Assessed` exit-2 case; that row is being edited by the open directory-unread-input branch (#588), so the clause lands in this lane's follow-up PR right after it, before the 0.33.0 tag. `docs/use-cases/ci-pipeline.md` carries the clause in this PR.
- #513's rating design (a passing word while automatable controls at a measured level go unverified): deferred by Abdel 2026-08-11; this PR fixes the sentence in its title and nothing else there.
- Filed while measuring: #615 (`--verbose` lists 9 of 44 unverified controls), #616 (text benchmark mode exits 1 on a score-only `--fail-below` breach with no reason line).

Refs #458, refs #513.
