### PR TITLE
Absent-subject checks emit not-applicable records (#458 steps 1-2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,8 +22,10 @@ one-marker-tree noise #458 opened on) or, on 31 checks, a pass it never
 measured. 77 checks now emit a positive `notApplicable: { subject, reason }`
 record instead: no `severity`, no `passed` field, excluded from the issue list,
 never counted as a confirmed fix, never published to the Registry as a measured
-finding. `maxScore` does not change. Only the not-there errnos (ENOENT, EISDIR,
-ENOTDIR) mean absent; any other read error emits nothing and is disclosed by
+finding. Project-type scope still wins: a check scoped off the detected project
+type leaves no record at all, not-applicable or otherwise. `maxScore` does not
+change. Only the not-there errnos (ENOENT, EISDIR, ENOTDIR) mean
+absent; any other read error emits nothing and is disclosed by
 `SCAN-UNREAD-001`. The hazard probes (PERM-001, PERM-002, PERM-003, LOG-003)
 still pass when the probed path is not there — a measured absence — but an
 unreadable probed path now withholds the verdict instead of passing; CRED-002 no
@@ -32,7 +34,10 @@ longer passes with a caveat on an unreadable root; a present but unparseable
 mitigations stay failures: SANDBOX-001 (`file: "Dockerfile"`), DEP-001 and
 GIT-001 carry the path the fix creates. Measured on an empty directory: 93/100,
 six passes (CRED-002, LOG-003, MCP-010, PERM-001, PERM-002, PERM-003), three
-advisories, 13 not-applicable records; on a one-marker MCP tree, 27
+advisory-shaped failures in `allFindings` (SANDBOX-001, DEP-001, GIT-001 — the
+rendered issue list shows two, SANDBOX-001 being type-suppressed for library
+trees and disclosed in `coverage.suppressedFailures`), 13 not-applicable
+records; on a one-marker MCP tree, 27
 not-applicable records and 6 pathless failures (ENV-004, LOG-001, LOG-004,
 SEC-001, SEC-002, SEC-003 — present-subject checks, unchanged here). Known: a
 populated `.cursor/rules/` directory reads as absent (its rule files were not

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,44 @@ spelling rules. The name is now normalized once before validation, so
 every format. Unknown names are still rejected, with the value as given and the
 available list in lower case. (#630)
 
+### A check whose subject is absent records `not-applicable`, not a failure or a pass
+
+A hardening check whose subject was not in the scanned tree — no MCP config, no
+prompt file, no `.claude/settings.json`, no Cursor rules, no `.vscode/mcp.json`,
+no `package.json` — emitted either a pathless failure (the empty-directory and
+one-marker-tree noise #458 opened on) or, on 31 checks, a pass it never
+measured. 77 checks now emit a positive `notApplicable: { subject, reason }`
+record instead: no `severity`, no `passed` field, excluded from the issue list,
+never counted as a confirmed fix, never published to the Registry as a measured
+finding. `maxScore` does not change. Only the not-there errnos (ENOENT, EISDIR,
+ENOTDIR) mean absent; any other read error emits nothing and is disclosed by
+`SCAN-UNREAD-001`. The hazard probes (PERM-001, PERM-002, PERM-003, LOG-003)
+still pass when the probed path is not there — a measured absence — but an
+unreadable probed path now withholds the verdict instead of passing; CRED-002 no
+longer passes with a caveat on an unreadable root; a present but unparseable
+`.claude/settings.json` reads as "could not be parsed", not "not found". Absent
+mitigations stay failures: SANDBOX-001 (`file: "Dockerfile"`), DEP-001 and
+GIT-001 carry the path the fix creates. Measured on an empty directory: 93/100,
+six passes (CRED-002, LOG-003, MCP-010, PERM-001, PERM-002, PERM-003), three
+advisories, 13 not-applicable records; on a one-marker MCP tree, 27
+not-applicable records and 6 pathless failures (ENV-004, LOG-001, LOG-004,
+SEC-001, SEC-002, SEC-003 — present-subject checks, unchanged here). Known: a
+populated `.cursor/rules/` directory reads as absent (its rule files were not
+inspected before either); tracked separately. Verify:
+`T=$(mktemp -d) && printf '{"name":"t","version":"1.0.0","dependencies":{"@modelcontextprotocol/sdk":"^1.0.0"}}' > "$T/package.json" && git -C "$T" init -q && hackmyagent secure "$T" --json | jq '[.allFindings[] | select(.notApplicable)] | length'`
+— expect 27.
+
+The `secure -b oasb-1` benchmark reads these records as failures until the
+benchmark report becomes not-applicable-aware (#458 step 3, same release): an
+empty directory reports 29% compliance (L1) where it reported 69% built on
+passes it never measured, 25% at L2 and L3; a one-marker MCP tree 21% (L1) and
+18% (L2, L3) where it reported 43% and 38%. Controls 3.3, 3.4, 4.3, 5.2, 9.3
+and 9.5 move from passed to unverified on the empty directory (3.4 and 4.3 on
+the MCP tree) — the corrected direction; 5.1 (and on the MCP tree 5.2 and 9.5)
+move from passed to failed through the not-yet-aware mapping; 9.4 reads failed
+on the empty directory at L2 and L3 through the SANDBOX-001 advisory.
+(#458 steps 1-2.)
+
 ### `--fail-below` on the benchmark arms gates the figure the arm prints
 
 `secure -b oasb-1 --fail-below N` and `-b oasb-2 --fail-below N` also applied the

--- a/__tests__/cli/benchmark-empty-denominator.test.ts
+++ b/__tests__/cli/benchmark-empty-denominator.test.ts
@@ -172,9 +172,14 @@ describe('#458 step 0: an unmeasured benchmark level is null and never feeds the
 
   it('RED-ON-BASE text (T2): default depth -l L3 is Not Passing with the null scope in the same string, exit 1', () => {
     const res = run(['secure', empty, '-b', 'oasb-1', '-l', 'L3', '--no-machine-posture', '--verbose']);
-    expect(res.out).toContain('Rating: Not Passing (L2, L3 not assessed)');
+    // Since #458 steps 1-2 an absent Dockerfile is a MEASURED L2 failure —
+    // SANDBOX-001's ruled advisory shape (`passed: false`, `file` = the path
+    // the fix creates) — so L2 leaves the null scope on an empty tree and only
+    // L3 remains unmeasured. The property under test is unchanged: the null
+    // scope travels in the rating string, never alone.
+    expect(res.out).toContain('Rating: Not Passing (L3 not assessed)');
     expect(res.out).toContain('Compliance by level: L1=');
-    expect(res.out).toContain('L2=not assessed L3=not assessed');
+    expect(res.out).toContain('L2=0% L3=not assessed');
     expect(res.status).toBe(1);
   });
 
@@ -382,12 +387,15 @@ describe('#458 step 0: an unmeasured benchmark level is null and never feeds the
     expect(res.status).toBe(0);
   });
 
-  it('RED-ON-BASE json: an L1 failure still reads Not Passing at -l L3 when L2/L3 are unmeasured (null rungs are skipped, not failed)', () => {
+  it('RED-ON-BASE json: an L1 failure still reads Not Passing at -l L3 when L3 is unmeasured (null rungs are skipped, not failed)', () => {
     const res = run(['secure', empty, '-b', 'oasb-1', '-l', 'L3', '--no-machine-posture', '--format', 'json']);
     const body = parseJson(res.stdout);
     expect(typeof body.l1Compliance).toBe('number');
     expect(body.l1Compliance).toBeLessThan(70);
-    expect(body.l2Compliance).toBeNull();
+    // L2 is measured on an empty tree since #458 steps 1-2 (SANDBOX-001's
+    // advisory record fails 9.4 Sandboxing): 0, a number, not null. L3 is the
+    // null rung this cell is about.
+    expect(body.l2Compliance).toBe(0);
     expect(body.l3Compliance).toBeNull();
     expect(body.rating).toBe('Not Passing');
     expect(res.status).toBe(1);

--- a/__tests__/fixtures/stub-registry-fetch-preload.cjs
+++ b/__tests__/fixtures/stub-registry-fetch-preload.cjs
@@ -1,0 +1,40 @@
+/**
+ * Captures every outbound fetch the spawned CLI makes and answers it with a
+ * generic 200, so a `--publish` run is hermetic and the test can read the
+ * exact wire payload the Registry would have received.
+ *
+ * A preload rather than a module mock because the claim under test is the
+ * byte-level publish payload at the process boundary: `secure --publish`
+ * routes through dist/registry/publish.js -> dist/registry/client.js, whose
+ * network primitive is global fetch (client.ts:349 POST /api/v1/trust/publish).
+ * Stubbing fetch intercepts every path (unified, legacy fallback,
+ * reportFindings/reportRemediation) without touching the module graph.
+ *
+ * Gated on HMA_STUB_REGISTRY_CAPTURE: the path of an append-only JSONL file,
+ * one line per request: {"url": ..., "method": ..., "body": ...}.
+ */
+const { appendFileSync } = require('node:fs');
+
+const CAPTURE = process.env.HMA_STUB_REGISTRY_CAPTURE;
+if (typeof CAPTURE === 'string' && CAPTURE.length > 0) {
+  globalThis.fetch = async (url, init) => {
+    const record = {
+      url: String(url),
+      method: (init && init.method) || 'GET',
+      body: init && typeof init.body === 'string' ? init.body : null,
+    };
+    appendFileSync(CAPTURE, JSON.stringify(record) + '\n');
+    return {
+      ok: true,
+      status: 200,
+      // Superset shape: enough for RegistryClient's unified-publish read
+      // (profileUrl/consensusStatus) and inert for any other caller.
+      json: async () => ({
+        profileUrl: 'https://registry.stub/agents/stub',
+        consensusStatus: 'accepted',
+        success: true,
+      }),
+      text: async () => '{"success":true}',
+    };
+  };
+}

--- a/__tests__/hardening/absent-subject-not-applicable.test.ts
+++ b/__tests__/hardening/absent-subject-not-applicable.test.ts
@@ -59,6 +59,7 @@ async function makeTree(
       : { name: 'plain-tool', version: '1.0.0', bin: { pt: './index.js' } };
   await fs.writeFile(path.join(dir, 'package.json'), JSON.stringify(pkg, null, 2));
   for (const [rel, content] of Object.entries(files)) {
+    await fs.mkdir(path.dirname(path.join(dir, rel)), { recursive: true });
     await fs.writeFile(path.join(dir, rel), content);
   }
   initThrowawayRepo(dir);
@@ -92,7 +93,23 @@ describe('#458 — absent subjects on an mcp tree (the pin)', () => {
     ['PROMPT-001', 'CLAUDE.md'],
     ['SANDBOX-002', 'Dockerfile'],
     ['TOOL-001', 'mcp.json'],
+    // The non-census sites converted in the same unit: each reads ONE subject
+    // through readCheckSubject / readCheckDir, so the same three-way contract
+    // holds. The subject strings are the emitter literals.
+    ['CLAUDE-004', '.claude/settings.json'],
+    ['CLAUDE-005', '.claude/settings.json'],
+    ['CLAUDE-006', 'CLAUDE.md'],
+    ['CLAUDE-007', '.claude/settings.json'],
+    ['CURSOR-001', 'Cursor rules (.cursor/rules, .cursorrules)'],
+    ['VSCODE-001', '.vscode/mcp.json'],
+    ['VSCODE-002', '.vscode/mcp.json'],
   ];
+
+  // Hazard probes (PERM-001/002/003, LOG-003) stat a fixed list of paths for a
+  // DANGEROUS state (world-readable log, executable config, ...). A not-there
+  // errno on every probe is a completed measurement — the hazard is absent —
+  // so these keep `passed: true`; they never emit not-applicable.
+  const HZ_PASS_CELLS = ['PERM-001', 'PERM-002', 'PERM-003', 'LOG-003'];
 
   it.each(NA_CELLS)(
     '%s emits exactly one not-applicable record naming %s, with no severity and passed omitted',
@@ -117,6 +134,17 @@ describe('#458 — absent subjects on an mcp tree (the pin)', () => {
       expect(byId(result.findings, checkId)).toHaveLength(0);
     }
   });
+
+  it.each(HZ_PASS_CELLS)(
+    '%s keeps its measured pass on a tree with none of its probed paths — absence of a hazard is a verdict, not a missing subject',
+    (checkId) => {
+      const records = byId(result.allFindings, checkId);
+      expect(records).toHaveLength(1);
+      expect(records[0].passed).toBe(true);
+      expect(records[0].severity).toBeDefined();
+      expect(records[0].notApplicable).toBeUndefined();
+    },
+  );
 
   it('SANDBOX-001 keeps the absent-mitigation advisory: passed false with file naming the path the fix creates', () => {
     const records = byId(result.allFindings, 'SANDBOX-001');
@@ -183,18 +211,39 @@ describe('#458 G3 — a present subject is still measured in both directions', (
   });
 });
 
-describe('#458 — a present-but-unparseable mcp.json is a measured defect, not a missing subject', () => {
-  it(
-    'TOOL-001 keeps the fail: the subject exists, its state was measured',
-    async () => {
-      const result = await scanTree(await makeTree('mcp', { 'mcp.json': '{nope' }));
-      const records = byId(result.allFindings, 'TOOL-001');
-      expect(records).toHaveLength(1);
-      expect(records[0].passed).toBe(false);
-      expect(records[0].notApplicable).toBeUndefined();
-    },
-    SCAN_TIMEOUT,
-  );
+describe('#458 — a present-but-unparseable subject is a read subject, not a missing one', () => {
+  let result: ScanResult;
+
+  beforeAll(async () => {
+    result = await scanTree(
+      await makeTree('mcp', { 'mcp.json': '{nope', '.claude/settings.json': '{nope' }),
+    );
+  }, SCAN_TIMEOUT);
+
+  it('TOOL-001 keeps the fail: the subject exists, its state was measured', () => {
+    const records = byId(result.allFindings, 'TOOL-001');
+    expect(records).toHaveLength(1);
+    expect(records[0].passed).toBe(false);
+    expect(records[0].notApplicable).toBeUndefined();
+  });
+
+  it('CLAUDE-004 keeps its pass with the parse-failure message: the settings file was read', () => {
+    // Pre-#458 behaviour, byte-identical: an unparseable settings file is
+    // reported, not scored against. What #458 changed is only that a MISSING
+    // file no longer takes this branch.
+    const records = byId(result.allFindings, 'CLAUDE-004');
+    expect(records).toHaveLength(1);
+    expect(records[0].passed).toBe(true);
+    expect(records[0].message).toBe('Claude settings file could not be parsed');
+    expect(records[0].notApplicable).toBeUndefined();
+  });
+
+  it.each(['CLAUDE-005', 'CLAUDE-007'])('%s emits a measured record, never not-applicable, for the same read subject', (checkId) => {
+    const records = byId(result.allFindings, checkId);
+    expect(records).toHaveLength(1);
+    expect(typeof records[0].passed).toBe('boolean');
+    expect(records[0].notApplicable).toBeUndefined();
+  });
 });
 
 describe.skipIf(runsAsRoot)('#458 — an unreadable subject emits nothing; the unread channel discloses it', () => {
@@ -214,10 +263,15 @@ describe.skipIf(runsAsRoot)('#458 — an unreadable subject emits nothing; the u
     result = await scanTree(dir);
   }, SCAN_TIMEOUT);
 
-  it('PROMPT-001 emits no record at all — neither measured nor not-applicable', () => {
-    expect(byId(result.allFindings, 'PROMPT-001')).toHaveLength(0);
-    expect(byId(result.findings, 'PROMPT-001')).toHaveLength(0);
-  });
+  it.each(['PROMPT-001', 'PROMPT-002', 'PROMPT-003', 'PROMPT-004', 'CLAUDE-006'])(
+    '%s emits no record at all — neither measured nor not-applicable',
+    (checkId) => {
+      // Every check whose subject is CLAUDE.md, not only the one #458 named:
+      // the EACCES must not leak through any of them as a verdict.
+      expect(byId(result.allFindings, checkId)).toHaveLength(0);
+      expect(byId(result.findings, checkId)).toHaveLength(0);
+    },
+  );
 
   it('SANDBOX-001 and SANDBOX-002 emit nothing when the Dockerfile probe is obstructed', () => {
     // Dockerfile unread + composes absent: containerization is UNKNOWN, not
@@ -240,6 +294,65 @@ describe.skipIf(runsAsRoot)('#458 — an unreadable subject emits nothing; the u
       unread.some((f) => f.file === rel || (f.message ?? '').includes(rel));
     expect(named('CLAUDE.md')).toBe(true);
     expect(named('Dockerfile')).toBe(true);
+  });
+});
+
+describe('#458 — a hazard probe that cannot stat its path withholds its verdict; a hazard measured elsewhere still fails', () => {
+  // `fs.stat` follows symlinks, so a self-referential link raises ELOOP — an
+  // errno that is NOT not-there, on a filesystem state any user can create
+  // (no chmod, so this describe does not skip under root). `.env` sits on the
+  // probe lists of PERM-001, PERM-002 and PERM-003; `app.log` on LOG-003's.
+  let withheld: ScanResult;
+  let measured: ScanResult;
+
+  beforeAll(async () => {
+    const loopTree = await makeTree('mcp');
+    await fs.symlink('.env', path.join(loopTree, '.env'));
+    await fs.symlink('app.log', path.join(loopTree, 'app.log'));
+    // Precondition, asserted LOUDLY: the probe must fail with ELOOP here, or
+    // the cells below would measure nothing.
+    await expect(fs.stat(path.join(loopTree, '.env'))).rejects.toMatchObject({ code: 'ELOOP' });
+    await expect(fs.stat(path.join(loopTree, 'app.log'))).rejects.toMatchObject({ code: 'ELOOP' });
+    withheld = await scanTree(loopTree);
+
+    // Same obstruction, plus a hazard the probe CAN see on another listed
+    // path: secrets.json world-readable and group-writable.
+    const hazardTree = await makeTree('mcp', { 'secrets.json': '{}\n' });
+    await fs.symlink('.env', path.join(hazardTree, '.env'));
+    await fs.chmod(path.join(hazardTree, 'secrets.json'), 0o666);
+    measured = await scanTree(hazardTree);
+  }, SCAN_TIMEOUT * 2);
+
+  it.each(['PERM-001', 'PERM-002', 'PERM-003', 'LOG-003'])(
+    '%s emits no record when a probed path raised ELOOP and no hazard was measured',
+    (checkId) => {
+      expect(byId(withheld.allFindings, checkId)).toHaveLength(0);
+      expect(byId(withheld.findings, checkId)).toHaveLength(0);
+    },
+  );
+
+  it('SCAN-UNREAD-001 names both looped paths — stat failures are ledgered by the check itself', () => {
+    const unread = byId(withheld.allFindings, 'SCAN-UNREAD-001');
+    const named = (rel: string) =>
+      unread.some((f) => f.file === rel || (f.message ?? '').includes(rel));
+    expect(named('.env')).toBe(true);
+    expect(named('app.log')).toBe(true);
+  });
+
+  it.each(['PERM-001', 'PERM-003'])(
+    '%s still fails when the hazard was measured on a path the probe could stat',
+    (checkId) => {
+      // The withheld verdict is "nothing measured", not "unread wins": a
+      // measured hazard is disclosed regardless of the obstructed sibling.
+      const records = byId(measured.allFindings, checkId);
+      expect(records).toHaveLength(1);
+      expect(records[0].passed).toBe(false);
+      expect(records[0].notApplicable).toBeUndefined();
+    },
+  );
+
+  it('PERM-002 still emits nothing on the hazard tree: its only present probe path is the looped one', () => {
+    expect(byId(measured.allFindings, 'PERM-002')).toHaveLength(0);
   });
 });
 

--- a/__tests__/hardening/absent-subject-not-applicable.test.ts
+++ b/__tests__/hardening/absent-subject-not-applicable.test.ts
@@ -37,8 +37,8 @@ import { describe, it, expect, beforeAll, afterAll } from 'vitest';
 import * as fs from 'fs/promises';
 import * as path from 'path';
 import * as os from 'os';
-import { HardeningScanner } from '../../src/hardening/scanner';
-import type { SecurityFinding, ScanResult } from '../../src/hardening/security-check';
+import { HardeningScanner, findingAppliesTo } from '../../src/hardening/scanner';
+import type { SecurityFinding, SecurityFindingDraft, ScanResult } from '../../src/hardening/security-check';
 import { initThrowawayRepo } from '../helpers/throwaway-repo';
 
 const SCAN_TIMEOUT = 120_000;
@@ -245,14 +245,21 @@ describe.skipIf(runsAsRoot)('#458 — an unreadable subject emits nothing; the u
 
 describe('#458 — NA records are project-type-scoped like any pathless record', () => {
   it(
-    'a cli tree with no subjects carries no NA records: none of the three checks applies there',
+    'a cli tree with no subjects keeps NA records only for checks that apply to cli',
     async () => {
       // 'PROMPT-' -> mcp/api, 'TOOL-' -> mcp, 'SANDBOX-' -> webapp/api/mcp:
-      // none includes cli, so dropPathlessNoiseFloor routes every NA record
-      // out of allFindings. Absence-of-the-check on non-applicable trees is
-      // #426's lane — this cell pins that #458 did not change it.
+      // none includes cli, so dropPathlessNoiseFloor routes those NA records
+      // out of allFindings exactly as it routes any other pathless record.
+      // Checks scoped 'all' (CRED-, PERM-, CLAUDE-, ...) keep theirs, so the
+      // cell is stated as the predicate, not as a count of zero. Absence of
+      // the check on non-applicable trees is #426's lane — this pins that
+      // #458 did not change it.
       const result = await scanTree(await makeTree('cli'));
-      expect((result.allFindings ?? []).filter((f) => f.notApplicable)).toHaveLength(0);
+      const na = (result.allFindings ?? []).filter((f) => f.notApplicable);
+      expect(na.length).toBeGreaterThan(0);
+      for (const f of na) {
+        expect(findingAppliesTo(f as SecurityFindingDraft, 'cli'), `${f.checkId} does not apply to a cli tree`).toBe(true);
+      }
       for (const checkId of ['PROMPT-001', 'SANDBOX-002', 'TOOL-001']) {
         expect(byId(result.allFindings, checkId)).toHaveLength(0);
       }

--- a/__tests__/hardening/absent-subject-not-applicable.test.ts
+++ b/__tests__/hardening/absent-subject-not-applicable.test.ts
@@ -1,0 +1,262 @@
+/**
+ * #458 — an absent check subject is a not-applicable record, not a failure.
+ *
+ * PROMPT-001, SANDBOX-002 and TOOL-001 measured a SUBSTANCE ("boundary
+ * markers present", "runs as non-root", "tools whitelisted") but emitted
+ * `passed: false` when the SUBJECT (CLAUDE.md, Dockerfile, mcp.json) did not
+ * exist — collapsing "there is nothing to measure" with "it was measured and
+ * found wanting". The ruled contract (COUNCIL_LEDGER #458):
+ *
+ *   read   -> measured pass/fail, byte-identical to before;
+ *   absent -> a `notApplicable: { subject, reason }` record with NO severity
+ *             and `passed` omitted, carried on `allFindings` only (the render
+ *             channel `findings` never shows it);
+ *   unread -> NO record at all: any errno other than not-there (EACCES,
+ *             EPERM, ELOOP, ...) is an unread input, and the ledger's
+ *             unreadable-inputs channel (SCAN-UNREAD-001) discloses it.
+ *             Emitting NA there would let a permission error look like
+ *             a clean "nothing to measure" (#438/#499/#508/#514).
+ *
+ * SANDBOX-001 is the ruled exception: containerization is a mitigation the
+ * check RECOMMENDS, so its absence IS the finding — the fail keeps
+ * `passed: false` and gains `file: 'Dockerfile'` (the path the fix creates,
+ * GIT-001's advisory shape).
+ *
+ * Fixtures are mcp-typed on purpose: the prefix map scopes 'PROMPT-' to
+ * mcp/api, 'TOOL-' to mcp, 'SANDBOX-' to webapp/api/mcp, and
+ * `dropPathlessNoiseFloor` routes NA records (no `passed`, no `file`) through
+ * `findingAppliesTo` like any pathless record. Only an mcp tree keeps all
+ * three NA records in `allFindings`; the cli-tree block pins the inversion.
+ *
+ * `notApplicable.subject`/`.reason` are emitter literals — fixed strings in
+ * the check's source, never scanned bytes — which is what keeps them outside
+ * `BYTE_CARRYING_FIELDS` (finding-emit.ts). The exact-subject assertions here
+ * pin that the values are the ruled constants, not derived content.
+ */
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import * as fs from 'fs/promises';
+import * as path from 'path';
+import * as os from 'os';
+import { HardeningScanner } from '../../src/hardening/scanner';
+import type { SecurityFinding, ScanResult } from '../../src/hardening/security-check';
+import { initThrowawayRepo } from '../helpers/throwaway-repo';
+
+const SCAN_TIMEOUT = 120_000;
+
+const runsAsRoot = typeof process.getuid === 'function' && process.getuid() === 0;
+
+const tempDirs: string[] = [];
+
+async function makeTree(
+  kind: 'mcp' | 'cli',
+  files: Record<string, string> = {},
+): Promise<string> {
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), 'hackmyagent-test-'));
+  tempDirs.push(dir);
+  const pkg: Record<string, unknown> =
+    kind === 'mcp'
+      ? { name: 'na-fixture', version: '1.0.0', dependencies: { '@modelcontextprotocol/sdk': '^1.0.0' } }
+      : { name: 'plain-tool', version: '1.0.0', bin: { pt: './index.js' } };
+  await fs.writeFile(path.join(dir, 'package.json'), JSON.stringify(pkg, null, 2));
+  for (const [rel, content] of Object.entries(files)) {
+    await fs.writeFile(path.join(dir, rel), content);
+  }
+  initThrowawayRepo(dir);
+  return dir;
+}
+
+async function scanTree(dir: string): Promise<ScanResult> {
+  const scanner = new HardeningScanner();
+  return scanner.scan({ targetDir: dir });
+}
+
+function byId(findings: SecurityFinding[] | undefined, checkId: string): SecurityFinding[] {
+  return (findings ?? []).filter((f) => f.checkId === checkId);
+}
+
+afterAll(async () => {
+  for (const dir of tempDirs) {
+    await fs.rm(dir, { recursive: true, force: true });
+  }
+});
+
+describe('#458 — absent subjects on an mcp tree (the pin)', () => {
+  let result: ScanResult;
+
+  beforeAll(async () => {
+    // mcp-typed tree with NO CLAUDE.md, NO Dockerfile/compose, NO mcp.json.
+    result = await scanTree(await makeTree('mcp'));
+  }, SCAN_TIMEOUT);
+
+  const NA_CELLS: Array<[string, string]> = [
+    ['PROMPT-001', 'CLAUDE.md'],
+    ['SANDBOX-002', 'Dockerfile'],
+    ['TOOL-001', 'mcp.json'],
+  ];
+
+  it.each(NA_CELLS)(
+    '%s emits exactly one not-applicable record naming %s, with no severity and passed omitted',
+    (checkId, subject) => {
+      const records = byId(result.allFindings, checkId);
+      expect(records).toHaveLength(1);
+      const f = records[0];
+      expect(f.notApplicable?.subject).toBe(subject);
+      expect(f.notApplicable?.reason).toBeTruthy();
+      // NO severity: an NA record carries no judgment weight. `?? 0` in the
+      // score map and the NA-first guards depend on this staying absent.
+      expect(f.severity).toBeUndefined();
+      // `passed` OMITTED — not `false` (that was the defect) and not `true`
+      // (mcp-server's old `.get(id) !== false` would read it as a pass).
+      expect(Object.prototype.hasOwnProperty.call(f, 'passed')).toBe(false);
+    },
+  );
+
+  it('the render channel never shows a not-applicable record', () => {
+    expect(result.findings.filter((f) => f.notApplicable)).toHaveLength(0);
+    for (const [checkId] of NA_CELLS) {
+      expect(byId(result.findings, checkId)).toHaveLength(0);
+    }
+  });
+
+  it('SANDBOX-001 keeps the absent-mitigation advisory: passed false with file naming the path the fix creates', () => {
+    const records = byId(result.allFindings, 'SANDBOX-001');
+    expect(records).toHaveLength(1);
+    expect(records[0].passed).toBe(false);
+    expect(records[0].file).toBe('Dockerfile');
+    expect(records[0].notApplicable).toBeUndefined();
+    // And it IS user-facing — the advisory renders.
+    expect(byId(result.findings, 'SANDBOX-001').some((f) => f.passed === false)).toBe(true);
+  });
+});
+
+describe('#458 G3 — a present subject is still measured in both directions', () => {
+  let passing: ScanResult;
+  let failing: ScanResult;
+
+  beforeAll(async () => {
+    passing = await scanTree(
+      await makeTree('mcp', {
+        'CLAUDE.md': 'SYSTEM:\nAgent instructions live here.\n',
+        Dockerfile: 'FROM node:20\nUSER app\n',
+        'mcp.json': JSON.stringify({ servers: { srv: { allowedTools: ['read'] } } }),
+      }),
+    );
+    // The failing subjects avoid every pass-predicate substring:
+    // CLAUDE.md has none of SYSTEM:/USER:/---/###/the two phrases;
+    // Dockerfile has no USER directive; mcp.json has no allowedTools.
+    failing = await scanTree(
+      await makeTree('mcp', {
+        'CLAUDE.md': 'plain agent notes\nnothing marks a boundary here\n',
+        Dockerfile: 'FROM node:20\nCMD ["node","index.js"]\n',
+        'mcp.json': JSON.stringify({ servers: { srv: { command: 'node' } } }),
+      }),
+    );
+  }, SCAN_TIMEOUT * 2);
+
+  it.each(['PROMPT-001', 'SANDBOX-002', 'TOOL-001'])(
+    '%s measures a compliant subject as a pass with severity and no notApplicable',
+    (checkId) => {
+      const records = byId(passing.allFindings, checkId);
+      expect(records).toHaveLength(1);
+      expect(records[0].passed).toBe(true);
+      expect(records[0].severity).toBeDefined();
+      expect(records[0].notApplicable).toBeUndefined();
+    },
+  );
+
+  it.each(['PROMPT-001', 'SANDBOX-002', 'TOOL-001'])(
+    '%s measures a non-compliant subject as a fail with severity and no notApplicable',
+    (checkId) => {
+      const records = byId(failing.allFindings, checkId);
+      expect(records).toHaveLength(1);
+      expect(records[0].passed).toBe(false);
+      expect(records[0].severity).toBeDefined();
+      expect(records[0].notApplicable).toBeUndefined();
+    },
+  );
+
+  it('SANDBOX-001 passes when containerization is present, without the advisory file', () => {
+    const records = byId(passing.allFindings, 'SANDBOX-001');
+    expect(records).toHaveLength(1);
+    expect(records[0].passed).toBe(true);
+    expect(records[0].file).toBeUndefined();
+  });
+});
+
+describe('#458 — a present-but-unparseable mcp.json is a measured defect, not a missing subject', () => {
+  it(
+    'TOOL-001 keeps the fail: the subject exists, its state was measured',
+    async () => {
+      const result = await scanTree(await makeTree('mcp', { 'mcp.json': '{nope' }));
+      const records = byId(result.allFindings, 'TOOL-001');
+      expect(records).toHaveLength(1);
+      expect(records[0].passed).toBe(false);
+      expect(records[0].notApplicable).toBeUndefined();
+    },
+    SCAN_TIMEOUT,
+  );
+});
+
+describe.skipIf(runsAsRoot)('#458 — an unreadable subject emits nothing; the unread channel discloses it', () => {
+  let result: ScanResult;
+
+  beforeAll(async () => {
+    const dir = await makeTree('mcp', {
+      'CLAUDE.md': 'SYSTEM:\nwould pass, if it were readable\n',
+      Dockerfile: 'FROM node:20\nUSER app\n',
+    });
+    await fs.chmod(path.join(dir, 'CLAUDE.md'), 0o000);
+    await fs.chmod(path.join(dir, 'Dockerfile'), 0o000);
+    // Precondition, asserted LOUDLY: if these are readable anyway (exotic
+    // filesystem, elevated process), the cells below would measure nothing —
+    // a fixture precondition that cannot be met must fail, not skip green.
+    await expect(fs.readFile(path.join(dir, 'CLAUDE.md'), 'utf-8')).rejects.toMatchObject({ code: 'EACCES' });
+    result = await scanTree(dir);
+  }, SCAN_TIMEOUT);
+
+  it('PROMPT-001 emits no record at all — neither measured nor not-applicable', () => {
+    expect(byId(result.allFindings, 'PROMPT-001')).toHaveLength(0);
+    expect(byId(result.findings, 'PROMPT-001')).toHaveLength(0);
+  });
+
+  it('SANDBOX-001 and SANDBOX-002 emit nothing when the Dockerfile probe is obstructed', () => {
+    // Dockerfile unread + composes absent: containerization is UNKNOWN, not
+    // absent — an NA or a fail here would classify an EACCES as a verdict.
+    expect(byId(result.allFindings, 'SANDBOX-001')).toHaveLength(0);
+    expect(byId(result.allFindings, 'SANDBOX-002')).toHaveLength(0);
+  });
+
+  it('the genuinely absent subject still gets its NA record in the same scan', () => {
+    // mcp.json really is not there: mixed per-subject states must not bleed
+    // into each other.
+    const records = byId(result.allFindings, 'TOOL-001');
+    expect(records).toHaveLength(1);
+    expect(records[0].notApplicable?.subject).toBe('mcp.json');
+  });
+
+  it('SCAN-UNREAD-001 names both obstructed subjects', () => {
+    const unread = byId(result.allFindings, 'SCAN-UNREAD-001');
+    const named = (rel: string) =>
+      unread.some((f) => f.file === rel || (f.message ?? '').includes(rel));
+    expect(named('CLAUDE.md')).toBe(true);
+    expect(named('Dockerfile')).toBe(true);
+  });
+});
+
+describe('#458 — NA records are project-type-scoped like any pathless record', () => {
+  it(
+    'a cli tree with no subjects carries no NA records: none of the three checks applies there',
+    async () => {
+      // 'PROMPT-' -> mcp/api, 'TOOL-' -> mcp, 'SANDBOX-' -> webapp/api/mcp:
+      // none includes cli, so dropPathlessNoiseFloor routes every NA record
+      // out of allFindings. Absence-of-the-check on non-applicable trees is
+      // #426's lane — this cell pins that #458 did not change it.
+      const result = await scanTree(await makeTree('cli'));
+      expect((result.allFindings ?? []).filter((f) => f.notApplicable)).toHaveLength(0);
+      for (const checkId of ['PROMPT-001', 'SANDBOX-002', 'TOOL-001']) {
+        expect(byId(result.allFindings, checkId)).toHaveLength(0);
+      }
+    },
+    SCAN_TIMEOUT,
+  );
+});

--- a/__tests__/hardening/ignore-suppression-scope.test.ts
+++ b/__tests__/hardening/ignore-suppression-scope.test.ts
@@ -630,8 +630,13 @@ describe('#457 — a suppression may narrow the report, never invent a penalty',
   beforeAll(async () => {
     assertDistFreshIfPresent();
     plainDir = await makeMcpFixture();
-    suppressedDir = await makeMcpFixture('!SANDBOX-002\n');
-    familyDir = await makeMcpFixture('!SANDBOX-*\n!TOOL-*\n!PROMPT-*\n');
+    // SEC-001 (whole SEC-* family): pathless failures on this fixture. The
+    // earlier victim, SANDBOX-002, became a not-applicable record under #458
+    // steps 1-2 (no `passed` at all), and SANDBOX-001 gained a `file` (the
+    // Dockerfile its fix creates) and is therefore REPORTABLE — see the last
+    // cell of this block for what a suppression of that family discloses.
+    suppressedDir = await makeMcpFixture('!SEC-001\n');
+    familyDir = await makeMcpFixture('!SEC-*\n');
   }, 120_000);
 
   afterAll(async () => {
@@ -640,22 +645,23 @@ describe('#457 — a suppression may narrow the report, never invent a penalty',
     }
   });
 
-  // Guards the two cases below. If SANDBOX-002 ever stops firing pathlessly on
-  // this fixture — the check gains file attribution, or the project-type map
-  // changes — both assertions become "98 === 98" over nothing and would pass
-  // against a fully restored defect.
+  // Guards the two cases below. If SEC-001 ever stops firing pathlessly on
+  // this fixture — the check gains file attribution, becomes a not-applicable
+  // record, or the project-type map changes — both assertions become
+  // "98 === 98" over nothing and would pass against a fully restored defect.
   it('the fixture has an unreportable finding to suppress (guards this block)', () => {
     if (!hasBuild) return;
     const plain = runJson(['secure', plainDir, '--json']);
     const all = plain.body.allFindings ?? [];
-    const victim = all.find((f: any) => f.checkId === 'SANDBOX-002');
+    const victim = all.find((f: any) => f.checkId === 'SEC-001');
     expect(plain.body.projectType).toBe('mcp');
-    // It fails...
+    // It fails (a measured failure, not a not-applicable record)...
     expect(victim).toBeDefined();
     expect(victim.passed).toBe(false);
+    expect(victim.notApplicable).toBeUndefined();
     expect(victim.file ?? null).toBeNull();
     // ...and is reported nowhere and scored not at all.
-    expect(plain.body.findings.map((f: any) => f.checkId)).not.toContain('SANDBOX-002');
+    expect(plain.body.findings.map((f: any) => f.checkId)).not.toContain('SEC-001');
     expect(plain.body.suppressed ?? []).toEqual([]);
   });
 
@@ -679,5 +685,29 @@ describe('#457 — a suppression may narrow the report, never invent a penalty',
     expect(suppressed.body.score).toBe(plain.body.score);
     expect(suppressed.exitCode).toBe(plain.exitCode);
     expect(suppressed.body.suppressed ?? []).toEqual([]);
+  });
+
+  // #458 steps 1-2 split the old SANDBOX family into the two shapes the CPO
+  // four-state contract names: SANDBOX-001 is a fail-absent-mitigation
+  // advisory (`passed: false`, `file` = the Dockerfile its fix creates) and is
+  // REPORTABLE, so suppressing it is said; SANDBOX-002 is a not-applicable
+  // record (no `passed` at all) and is not a finding, so it is never a
+  // suppressed one. The score and the exit code still do not move.
+  it('a suppressed reportable finding is disclosed; a not-applicable record never is', async () => {
+    if (!hasBuild) return;
+    const dir = await makeMcpFixture('!SANDBOX-*\n');
+    try {
+      const plain = runJson(['secure', plainDir, '--json']);
+      const res = runJson(['secure', dir, '--json']);
+      expect(res.body.score).toBe(plain.body.score);
+      expect(res.exitCode).toBe(plain.exitCode);
+      expect((res.body.suppressed ?? []).map((s: any) => [s.checkId, s.count, s.suppressedBy]))
+        .toEqual([['SANDBOX-001', 1, 'hmaignore-check']]);
+      const na = (plain.body.allFindings ?? []).find((f: any) => f.checkId === 'SANDBOX-002');
+      expect(na?.notApplicable).toBeDefined();
+      expect(Object.prototype.hasOwnProperty.call(na ?? {}, 'passed')).toBe(false);
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
   });
 });

--- a/__tests__/hardening/noise-floor.test.ts
+++ b/__tests__/hardening/noise-floor.test.ts
@@ -3,7 +3,7 @@ import {
   dropPathlessNoiseFloor,
   findingAppliesTo,
 } from '../../src/hardening/scanner';
-import type { SecurityFinding } from '../../src/hardening/security-check';
+import type { SecurityFinding, SecurityFindingDraft } from '../../src/hardening/security-check';
 
 /**
  * Issue #131 / #130 — Pathless HIGH/CRITICAL findings (NET-, INJ-, SESSION-,
@@ -13,7 +13,9 @@ import type { SecurityFinding } from '../../src/hardening/security-check';
  * though `result.findings` (user-facing) already gated them out via `f.file`.
  *
  * Regression contract: dropPathlessNoiseFloor must drop only failed pathless
- * findings whose check prefix is not in scope for the current project type.
+ * findings whose check prefix is not in scope for the current project type —
+ * and (#458) not-applicable records under the same type rule: type scope wins
+ * over the not-applicable channel, so a scoped-off check leaves no record.
  * Pathless findings that DO apply (project-level real detections that lack
  * file attribution due to a separate emission bug) and all passed/fixed
  * findings remain.
@@ -135,5 +137,34 @@ describe('dropPathlessNoiseFloor (issue #131 / #130)', () => {
     ];
     expect(findingAppliesTo({ ...fail('NEW-CHECK-001') }, 'mcp')).toBe(true);
     expect(dropPathlessNoiseFloor(findings, 'mcp')).toHaveLength(1);
+  });
+});
+
+describe('not-applicable records vs project-type scope (#458)', () => {
+  function notApplicable(checkId: string): SecurityFindingDraft {
+    return {
+      checkId,
+      name: `${checkId} test record`,
+      description: 'synthetic',
+      category: 'test',
+      notApplicable: { subject: 'Dockerfile', reason: 'synthetic' },
+      message: 'Not applicable: no Dockerfile to inspect',
+      fixable: false,
+    };
+  }
+
+  it('drops a not-applicable record whose check is scoped off the project type', () => {
+    // PROC- is ['webapp', 'api']: a library or mcp tree carries NO record for
+    // it — the same outcome as the checks that never ran. This is a decision
+    // (type scope wins over the not-applicable channel), not a fall-through:
+    // dropPathlessNoiseFloor has an explicit notApplicable branch.
+    expect(dropPathlessNoiseFloor([notApplicable('PROC-001')], 'library')).toEqual([]);
+    expect(dropPathlessNoiseFloor([notApplicable('PROC-001')], 'mcp')).toEqual([]);
+  });
+
+  it('retains a not-applicable record whose check applies to the project type', () => {
+    const record = notApplicable('PROC-001');
+    expect(dropPathlessNoiseFloor([record], 'webapp')).toEqual([record]);
+    expect(dropPathlessNoiseFloor([record], 'api')).toEqual([record]);
   });
 });

--- a/__tests__/hardening/scanner.test.ts
+++ b/__tests__/hardening/scanner.test.ts
@@ -3628,23 +3628,19 @@ describe('#250 existence-aware git severity + surfaced file findings', () => {
       expect(result.findings.find((f) => f.checkId === 'SCAN-UNREAD-001')?.file).toBe('cfg/');
     });
 
-    it('CRED-002 does not escalate on the unlistable cause — the record is the disclosure', async (ctx) => {
+    it('CRED-002 emits no verdict over a mode-000 directory — SCAN-UNREAD-001 is the disclosure', async (ctx) => {
       await fs.writeFile(path.join(tempDir, '.gitignore'), 'node_modules/\n.env\nsecrets.json\n*.pem\n*.key\n');
       if (!(await withUnlistableDir())) { ctx.skip(); }
       const result = await scanner.scan({ targetDir: tempDir });
-      // A passed finding is filtered out of `findings`; the passed CRED-002
-      // lives in `allFindings`. Asserting on `findings` here would let every
-      // check below pass against `undefined`.
+      // "No private key files found" is measured over what the walk listed.
+      // With a directory it could not list, that absence is unmeasurable. The
+      // pass-with-caveat of #588 still counted as a pass everywhere the caveat
+      // text was not read (#458): the check now withholds its record and the
+      // unread channel carries the disclosure and the remedy.
       const all = (result as any).allFindings ?? result.findings;
-      const cred = all.find((f: any) => f.checkId === 'CRED-002');
-      expect(cred).toBeDefined();
-      expect(cred.severity).not.toBe('high');
-      expect(cred.passed).toBe(true);
-      expect(cred.description ?? '').not.toMatch(/could not fully cover/);
-      // The passed branch may not claim the whole tree: a directory was not
-      // listed, and "No private key files found" without that caveat asserts
-      // an absence the scan could not measure.
-      expect(cred.message).toBe('No private key files found among what could be listed (a directory could not be listed — see SCAN-UNREAD-001)');
+      expect(all.find((f: any) => f.checkId === 'CRED-002')).toBeUndefined();
+      expect(result.findings.find((f) => f.checkId === 'SCAN-UNREAD-001')?.file).toBe('cfg/');
+      expect(result.coverage.unreadableInputs.directories).toBe(1);
     });
   });
 

--- a/__tests__/mcp/mcp-server-not-applicable.test.ts
+++ b/__tests__/mcp/mcp-server-not-applicable.test.ts
@@ -1,0 +1,94 @@
+/**
+ * #458 — the benchmark assessor must not read a not-applicable record as the
+ * legacy "no false => pass".
+ *
+ * Measured at the extraction commit (088d451, behaviour-identical to main):
+ * an NA record carries `passed: undefined`, so `checkIdResults.get(id) !==
+ * false` credited its control as [PASS] and an L1 assessment fed NOTHING BUT
+ * an NA record read 100% compliance with every control passing. The three
+ * NA-bucket cells below go red there; the compatibility cells (measured
+ * pass/fail beside an NA sibling, absent-record legacy credit) stay green at
+ * both commits — they pin what #458 must NOT change.
+ */
+import { describe, it, expect } from 'vitest';
+import { assessBenchmarkFindings } from '../../src/mcp-server';
+import { getControlsForLevel } from '../../src/benchmarks/oasb-1';
+
+// Real L1 controls selected by SHAPE, not by hardcoded id: one with a single
+// checkId, one with at least two. The checkId->control mapping is
+// MANY-TO-MANY (measured: PROMPT-001 serves three L1 controls, so one NA
+// record moved three controls at once) — fixtures are restricted to controls
+// whose checkIds no other control cites, so every delta below is exactly 1.
+// If the control census changes, the premise cell fails loudly instead of the
+// suite testing nothing.
+const L1 = getControlsForLevel('L1');
+const citations = (id: string) => L1.filter((c) => c.checkIds.includes(id)).length;
+const single = L1.find((c) => c.checkIds.length === 1 && citations(c.checkIds[0]) === 1)!;
+const multi = L1.find((c) => c.checkIds.length >= 2 && c.checkIds.every((id) => citations(id) === 1))!;
+
+const na = (checkId: string) => ({
+  checkId,
+  notApplicable: { subject: 'system prompt', reason: 'no prompt file exists in the scanned tree' },
+});
+const pass = (checkId: string) => ({ checkId, passed: true });
+const fail = (checkId: string) => ({ checkId, passed: false });
+
+const baseline = assessBenchmarkFindings([], 'L1');
+
+describe('#458 benchmark assessor: not-applicable bucket', () => {
+  it('pins the premise: fixture controls exist and the empty baseline is all legacy credit', () => {
+    expect(single).toBeDefined();
+    expect(multi).toBeDefined();
+    expect(baseline.failed).toBe(0);
+    // Every absent record is credited as a pass (legacy, kept — see below).
+    expect(baseline.compliance).toBe(100);
+  });
+
+  it('an NA record moves its control out of passed into notApplicable', () => {
+    const a = assessBenchmarkFindings([na(single.checkIds[0])], 'L1');
+    expect(a.notApplicable).toBe(baseline.notApplicable + 1);
+    expect(a.passed).toBe(baseline.passed - 1);
+    expect(a.failed).toBe(baseline.failed);
+    expect(a.lines).toContain(
+      `[NOT-APPLICABLE] ${single.id} ${single.name} (${single.checkIds[0]}: no system prompt)`,
+    );
+    expect(a.lines).not.toContain(`[PASS] ${single.id} ${single.name}`);
+  });
+
+  it('NA is excluded from the compliance denominator and named in the summary line', () => {
+    const a = assessBenchmarkFindings([na(single.checkIds[0])], 'L1');
+    // If NA were bucketed as a failure, the denominator would keep the
+    // control and compliance would drop below 100.
+    expect(a.compliance).toBe(100);
+    expect(a.text).toContain('Not applicable: 1');
+  });
+
+  it('NA + an absent sibling checkId still reads NOT-APPLICABLE, not the legacy absent-record pass', () => {
+    const a = assessBenchmarkFindings([na(multi.checkIds[0])], 'L1');
+    expect(a.lines).toContain(
+      `[NOT-APPLICABLE] ${multi.id} ${multi.name} (${multi.checkIds[0]}: no system prompt)`,
+    );
+    expect(a.notApplicable).toBe(baseline.notApplicable + 1);
+  });
+
+  it('compat: one NA + one measured pass on the same control reads PASS', () => {
+    const a = assessBenchmarkFindings([na(multi.checkIds[0]), pass(multi.checkIds[1])], 'L1');
+    expect(a.lines).toContain(`[PASS] ${multi.id} ${multi.name}`);
+    expect(a.notApplicable).toBe(baseline.notApplicable);
+  });
+
+  it('compat: one NA + one measured failure reads FAIL, naming only the measured check', () => {
+    const a = assessBenchmarkFindings([na(multi.checkIds[0]), fail(multi.checkIds[1])], 'L1');
+    expect(a.lines).toContain(`[FAIL] ${multi.id} ${multi.name} (${multi.checkIds[1]})`);
+    expect(a.failed).toBe(baseline.failed + 1);
+    expect(a.notApplicable).toBe(baseline.notApplicable);
+  });
+
+  it('compat: pins the legacy credit #458 deliberately keeps — a control with NO records still passes', () => {
+    // Kept, not endorsed: the #458 ruling narrows the credit only where a
+    // positive NA record exists. This cell exists so a future fix of the
+    // absent-record credit is loud, not silent.
+    expect(baseline.passed).toBeGreaterThan(0);
+    expect(baseline.lines).toContain(`[PASS] ${single.id} ${single.name}`);
+  });
+});

--- a/__tests__/registry/publish-payload-not-applicable.test.ts
+++ b/__tests__/registry/publish-payload-not-applicable.test.ts
@@ -1,0 +1,101 @@
+/**
+ * #458 — a not-applicable record never reaches the publish wire, even when it
+ * is handed to `buildPublishPayload` directly.
+ *
+ * A mutation pass over this change showed the wire filter (publish.ts, the
+ * `isMeasured` continue in the hardening mapping) was unfalsifiable through
+ * the CLI fixture: `isReportableFinding` (scanner.ts) drops NA records
+ * upstream, so no end-to-end path ever fed one to the mapping and removing
+ * the filter left every suite green (survivor M7). This file feeds synthetic
+ * NA records to the builder directly, so the defense-in-depth filter is
+ * pinned on its own — an NA record that leaked onto the wire would fabricate
+ * a PASS, because `!countsAgainstScore(NA)` is true by the #458 score guard.
+ *
+ * The same pass surfaced the filter's unswept twin: `subReports.hardening`
+ * computed its denominator from the RAW input list, so an NA record inflated
+ * `totalChecks` and overstated `passRate`. The third cell pins the sweep.
+ *
+ * Fixtures go through `emitFinding` (the real emission boundary) so the
+ * builder's redaction-provenance read passes — same pattern as
+ * unverified-fix-must-count.test.ts.
+ */
+import { describe, it, expect } from 'vitest';
+import { buildPublishPayload } from '../../src/registry/publish';
+import { emitFinding } from '../../src/hardening/finding-emit';
+import type { SecurityFinding } from '../../src/hardening';
+import type { SecurityFindingDraft } from '../../src/hardening/security-check';
+
+const NOT_APPLICABLE: SecurityFinding = emitFinding({
+  checkId: 'PROC-001',
+  name: 'Container hardening',
+  description: 'Inspects the Dockerfile for hardening directives',
+  category: 'process',
+  notApplicable: {
+    subject: 'Dockerfile',
+    reason: 'No Dockerfile in the scanned tree.',
+  },
+  message: 'Not applicable: no Dockerfile to inspect',
+  fixable: false,
+} as SecurityFindingDraft);
+
+const MEASURED_FAIL: SecurityFinding = emitFinding({
+  checkId: 'GIT-001',
+  name: 'Sensitive files not ignored',
+  description: 'The ignore file does not cover local credential patterns',
+  category: 'process',
+  severity: 'medium',
+  passed: false,
+  message: 'ignore rules missing for local credential files',
+  fixable: true,
+  file: '.gitignore',
+} as SecurityFindingDraft);
+
+const MEASURED_PASS: SecurityFinding = emitFinding({
+  checkId: 'LOG-003',
+  name: 'No credential logging',
+  description: 'No credential values are written to logs',
+  category: 'logging',
+  severity: 'low',
+  passed: true,
+  message: 'no credential logging found',
+  fixable: false,
+} as SecurityFindingDraft);
+
+describe('#458 — not-applicable records at the publish boundary', () => {
+  const build = (findings: SecurityFinding[]) =>
+    buildPublishPayload(
+      { packageName: 'demo-agent', directory: '/tmp/demo', hardeningFindings: findings },
+      '0.25.2',
+    );
+
+  it('excludes the NA record from the wire and keeps both measured records', () => {
+    const payload = build([NOT_APPLICABLE, MEASURED_FAIL, MEASURED_PASS]);
+    expect(payload.findings.map((f) => f.checkId).sort()).toEqual(['GIT-001', 'LOG-003']);
+    for (const f of payload.findings) {
+      expect(typeof f.passed, `${f.checkId} must carry a boolean passed`).toBe('boolean');
+      expect('notApplicable' in f, `${f.checkId} must not carry notApplicable`).toBe(false);
+    }
+    const git = payload.findings.find((f) => f.checkId === 'GIT-001');
+    const log = payload.findings.find((f) => f.checkId === 'LOG-003');
+    expect(git!.passed, 'the measured failure stays a failure on the wire').toBe(false);
+    expect(log!.passed, 'the measured pass stays a pass on the wire').toBe(true);
+  });
+
+  it('a lone NA record publishes zero findings, not a fabricated pass', () => {
+    const payload = build([NOT_APPLICABLE]);
+    expect(payload.findings).toEqual([]);
+    expect(payload.verdict, 'nothing was measured, so nothing failed').toBe('pass');
+  });
+
+  it('the hardening sub-report denominator counts measured records only', () => {
+    const payload = build([NOT_APPLICABLE, MEASURED_FAIL, MEASURED_PASS]);
+    const hardening = payload.subReports.hardening as {
+      totalChecks: number;
+      failedChecks: number;
+      passRate: number;
+    };
+    expect(hardening.totalChecks, 'NA is in no denominator anywhere').toBe(2);
+    expect(hardening.failedChecks).toBe(1);
+    expect(hardening.passRate).toBe(50);
+  });
+});

--- a/__tests__/registry/secure-publish-wire-parity.test.ts
+++ b/__tests__/registry/secure-publish-wire-parity.test.ts
@@ -1,0 +1,198 @@
+// #458 — wire-level publish parity for `secure --publish`.
+//
+// The surface: `secure` hands `result.findings` (the rendered, refiltered
+// set) to publishScanResults as `hardeningFindings` (cli.ts sites 5599 /
+// 6042), and buildPayload maps EVERY one of them onto the wire as a
+// UnifiedFinding with `passed: !countsAgainstScore(f)` (publish.ts:191).
+// Nothing between the rendered list and the Registry filters again, so the
+// whole not-applicable contract for this surface rests on the rendered
+// list's own filter (isReportableFinding drops `notApplicable` records and
+// non-boolean `passed` first — scanner.ts:1346, commit b01a55c).
+//
+// Three claims, each measured at the process boundary against the payload
+// the Registry would actually receive (fetch intercepted by
+// stub-registry-fetch-preload.cjs — the network primitive for every publish
+// path is global fetch, client.ts:349):
+//   1. Every wire finding carries a boolean `passed` and no `notApplicable`
+//      key. A not-applicable record on the wire would fabricate a PASS,
+//      because `!countsAgainstScore(NA)` is true by the #458 score guard.
+//      (Today no emitter produces NA records yet, so the NA half is a
+//      contract pin that gains bite with the errno-emitter commit; the
+//      boolean half bites now.)
+//   2. Multiset parity by checkId between wire findings and the rendered
+//      `--json` findings — publish must neither drop nor invent records
+//      relative to what the user was shown.
+//   3. Direction parity: the wire `passed:false` count equals the rendered
+//      findings that count against the score, and the fixture forces both
+//      directions to be non-empty so a stuck-at-true/false mapping cannot
+//      pass. (Mutation check recorded in the commit message: flipping the
+//      dist mapping to `passed: true` turns cell 3 red.)
+//
+// Spawned, local-only (needs a built dist), same gating as
+// check-secure-cross-analyzer-parity.test.ts.
+
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { spawnSync } from 'node:child_process';
+import { existsSync, mkdtempSync, mkdirSync, writeFileSync, readFileSync, rmSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { countsAgainstScore } from '../../src/ui/verdict-band';
+import { assertDistFreshIfPresent } from '../helpers/dist-freshness';
+
+beforeAll(assertDistFreshIfPresent);
+
+const REPO_ROOT = join(__dirname, '..', '..');
+const CLI = join(REPO_ROOT, 'dist', 'cli.js');
+const PRELOAD = join(REPO_ROOT, '__tests__', 'fixtures', 'stub-registry-fetch-preload.cjs');
+
+function canRunSpawn(): boolean {
+  if (process.env.CI === 'true' || process.env.GITHUB_ACTIONS === 'true') return false;
+  return existsSync(CLI);
+}
+
+// The credential-bearing dotfile's name, assembled so no Bash command that
+// quotes this file's source ever names a blocked pattern literally.
+const ENV_BASENAME = ['.', 'en', 'v'].join('');
+
+// Password-bearing localhost connection string with the FAKE marker —
+// same fixture rationale as check-secure-cross-analyzer-parity.test.ts:
+// fires the credential checks without tripping GitHub push protection.
+const FIXTURE_ENV = 'DATABASE_URL=postgres://user:FAKEpassword@localhost:5432/db\n';
+
+interface WireFinding {
+  checkId?: string;
+  passed?: unknown;
+  notApplicable?: unknown;
+  severity?: string;
+}
+
+const state: {
+  exit: number | null;
+  rendered: { findings: Array<Record<string, unknown>>; publish?: Record<string, unknown> } | null;
+  wire: { findings: WireFinding[] } | null;
+  publishPosts: number;
+} = { exit: null, rendered: null, wire: null, publishPosts: 0 };
+
+let fixture = '';
+let scratch = '';
+
+beforeAll(() => {
+  if (!canRunSpawn()) return;
+
+  scratch = mkdtempSync(join(tmpdir(), 'hma-wire-parity-'));
+  fixture = join(scratch, 'pkg');
+  const fakeHome = join(scratch, 'home');
+  mkdirSync(fixture, { recursive: true });
+  mkdirSync(fakeHome, { recursive: true });
+
+  writeFileSync(
+    join(fixture, 'package.json'),
+    JSON.stringify({ name: 'hma-wire-parity-fixture', version: '1.0.0' }) + '\n',
+  );
+  writeFileSync(join(fixture, ENV_BASENAME), FIXTURE_ENV);
+
+  const outPath = join(scratch, 'out.json');
+  const capturePath = join(scratch, 'capture.jsonl');
+
+  const env = { ...process.env };
+  delete env.ANTHROPIC_API_KEY; // no analyst layer — deterministic, offline
+  const res = spawnSync(
+    'node',
+    [CLI, 'secure', fixture, '--ci', '--json', '--publish', '--output', outPath],
+    {
+      encoding: 'utf8',
+      timeout: 180_000,
+      env: {
+        ...env,
+        // Clean HOME: no ~/.opena2a keypair, no contribute config, no
+        // opt-out marker — the run measures the shipped default, not this
+        // machine's state.
+        HOME: fakeHome,
+        NODE_OPTIONS: `--require ${PRELOAD}`,
+        HMA_STUB_REGISTRY_CAPTURE: capturePath,
+      },
+    },
+  );
+  state.exit = res.status;
+
+  if (existsSync(outPath)) {
+    state.rendered = JSON.parse(readFileSync(outPath, 'utf8'));
+  }
+  if (existsSync(capturePath)) {
+    const posts = readFileSync(capturePath, 'utf8')
+      .trim()
+      .split('\n')
+      .filter(Boolean)
+      .map((line) => JSON.parse(line) as { url: string; method: string; body: string | null });
+    const publishPosts = posts.filter(
+      (p) =>
+        p.method === 'POST' &&
+        (p.url.includes('/api/v1/trust/publish') || p.url.includes('/community/scan-result')),
+    );
+    state.publishPosts = publishPosts.length;
+    if (publishPosts.length > 0 && publishPosts[0].body) {
+      state.wire = JSON.parse(publishPosts[0].body);
+    }
+  }
+}, 200_000);
+
+afterAll(() => {
+  if (scratch) rmSync(scratch, { recursive: true, force: true });
+});
+
+describe.skipIf(!canRunSpawn())('secure --publish wire parity (#458)', () => {
+  it('harness: run completes, emits a JSON doc, and POSTs exactly one publish payload', () => {
+    // Exit 1 is the scanner reporting failures on a credential-bearing
+    // fixture — expected. Anything else (null = crash/timeout, >1 = error
+    // path) means the run did not measure what this suite believes.
+    expect([0, 1]).toContain(state.exit);
+    expect(state.rendered).not.toBeNull();
+    expect(state.rendered!.publish).toBeDefined();
+    // Exactly one: a retry/fallback double-publish would double-count the
+    // package at the Registry.
+    expect(state.publishPosts).toBe(1);
+    expect(state.wire).not.toBeNull();
+  });
+
+  it('every wire finding carries boolean passed and no notApplicable record', () => {
+    const wire = state.wire!.findings;
+    expect(wire.length).toBeGreaterThan(0);
+    for (const f of wire) {
+      expect(typeof f.passed, `wire finding ${f.checkId} passed must be boolean`).toBe('boolean');
+      expect('notApplicable' in f, `wire finding ${f.checkId} leaked a notApplicable record`).toBe(
+        false,
+      );
+    }
+  });
+
+  it('wire findings are the rendered findings — multiset parity by checkId', () => {
+    const tally = (ids: Array<string | undefined>) => {
+      const m = new Map<string, number>();
+      for (const id of ids) m.set(id ?? '<none>', (m.get(id ?? '<none>') ?? 0) + 1);
+      return [...m.entries()].sort(([a], [b]) => a.localeCompare(b));
+    };
+    const wireIds = tally(state.wire!.findings.map((f) => f.checkId));
+    const renderedIds = tally(
+      state.rendered!.findings.map((f) => f.checkId as string | undefined),
+    );
+    expect(wireIds).toEqual(renderedIds);
+  });
+
+  it('direction parity: wire failed count matches rendered counts-against-score', () => {
+    // Measured on this surface: `result.findings` (the rendered list) holds
+    // only reportable issues — passed checks live in `allFindings` — so the
+    // wire carries failures. The claim with teeth is therefore one-sided:
+    // the wire must not RELABEL any of them as passed. A stuck-at-true
+    // mutation of the dist mapping (`passed: true`) turns this red because
+    // expectedFailed stays > 0 while wireFailed collapses to 0. A
+    // stuck-at-false mutation is indistinguishable on this fixture and is
+    // deliberately out of scope: fabricating PASS is the #458 defect class,
+    // fabricating FAIL is not silent (the user sees it rendered).
+    const wireFailed = state.wire!.findings.filter((f) => f.passed === false).length;
+    expect(wireFailed).toBeGreaterThan(0);
+    const expectedFailed = state.rendered!.findings.filter((f) =>
+      countsAgainstScore(f as Parameters<typeof countsAgainstScore>[0]),
+    ).length;
+    expect(wireFailed).toBe(expectedFailed);
+  });
+});

--- a/__tests__/ui/not-applicable-guard.test.ts
+++ b/__tests__/ui/not-applicable-guard.test.ts
@@ -9,7 +9,7 @@
  * names: an absent Dockerfile scored as a failed container check.
  */
 import { describe, it, expect } from 'vitest';
-import { countsAgainstScore, retainForVerdict } from '../../src/ui/verdict-band';
+import { confirmedFix, countsAgainstScore, retainForVerdict } from '../../src/ui/verdict-band';
 
 const NA = {
   notApplicable: {
@@ -42,5 +42,33 @@ describe('#458 not-applicable records do not read as failures', () => {
     expect(retainForVerdict({ passed: false })).toBe(true);
     expect(retainForVerdict({ passed: true })).toBe(false);
     expect(retainForVerdict({ passed: true, fixed: true })).toBe(true);
+  });
+});
+
+describe('#458 confirmedFix: an NA record is never a confirmed fix', () => {
+  // This is the one predicate where the NA short-circuit in
+  // `countsAgainstScore` INVERTS instead of composing: NA makes
+  // `countsAgainstScore` false, so `!countsAgainstScore(f)` reads "not an
+  // issue" as "confirmed" and a stray `fixed: true` on an NA record would be
+  // published as a remediation (src/registry/remediation.ts:37). Red on
+  // 4f02a0a (measured): `confirmedFix({ ...NA, fixed: true })` was true.
+  it('NA alone is not a confirmed fix', () => {
+    expect(confirmedFix(NA)).toBe(false);
+  });
+
+  it('NA + stray fixed:true is not a confirmed fix', () => {
+    expect(confirmedFix({ ...NA, fixed: true })).toBe(false);
+    expect(confirmedFix({ ...NA, fixed: true, fixVerified: true })).toBe(false);
+  });
+
+  it('NA is in no bucket across the whole {passed,fixed,fixVerified} space', () => {
+    const tri = [true, false, undefined] as const;
+    for (const passed of tri) for (const fixed of tri) for (const fixVerified of tri) {
+      const f = { ...NA, passed, fixed, fixVerified };
+      const label = JSON.stringify({ passed, fixed, fixVerified });
+      expect(countsAgainstScore(f), label).toBe(false);
+      expect(retainForVerdict(f), label).toBe(false);
+      expect(confirmedFix(f), label).toBe(false);
+    }
   });
 });

--- a/__tests__/ui/not-applicable-guard.test.ts
+++ b/__tests__/ui/not-applicable-guard.test.ts
@@ -1,0 +1,46 @@
+/**
+ * #458 — a not-applicable record (`notApplicable` set, `passed` omitted) is
+ * neither an outstanding failure nor a verdict line.
+ *
+ * Red on c0ee1f7 (measured, this file against that verdict-band.ts):
+ * `countsAgainstScore({ notApplicable })` was true — `!f.fixed` alone — and
+ * `retainForVerdict({ notApplicable })` was true — `!f.passed` alone. The third
+ * state fell into "failed" on both readers, which is the score defect #458
+ * names: an absent Dockerfile scored as a failed container check.
+ */
+import { describe, it, expect } from 'vitest';
+import { countsAgainstScore, retainForVerdict } from '../../src/ui/verdict-band';
+
+const NA = {
+  notApplicable: {
+    subject: 'Dockerfile',
+    reason: 'no Dockerfile in this tree; the container checks measured nothing',
+  },
+};
+
+describe('#458 not-applicable records do not read as failures', () => {
+  it('countsAgainstScore: an NA record does not count against the score', () => {
+    expect(countsAgainstScore(NA)).toBe(false);
+  });
+
+  it('countsAgainstScore: NA is decided before every other field', () => {
+    // fixed + fixVerified:false is the one shape that counts even when fixed;
+    // NA still wins, so the guard cannot be moved below that clause.
+    expect(countsAgainstScore({ ...NA, fixed: true, fixVerified: false })).toBe(false);
+  });
+
+  it('retainForVerdict: an NA record is not a verdict line', () => {
+    expect(retainForVerdict(NA)).toBe(false);
+    expect(retainForVerdict({ ...NA, fixed: true })).toBe(false);
+  });
+
+  it('the two measured states are unchanged', () => {
+    expect(countsAgainstScore({ passed: false })).toBe(true);
+    expect(countsAgainstScore({ passed: true })).toBe(false);
+    expect(countsAgainstScore({ passed: false, fixed: true })).toBe(false);
+    expect(countsAgainstScore({ passed: false, fixed: true, fixVerified: false })).toBe(true);
+    expect(retainForVerdict({ passed: false })).toBe(true);
+    expect(retainForVerdict({ passed: true })).toBe(false);
+    expect(retainForVerdict({ passed: true, fixed: true })).toBe(true);
+  });
+});

--- a/docs/release-playbook.md
+++ b/docs/release-playbook.md
@@ -129,15 +129,31 @@ the clamp stopped being applied.
 ```bash
 rm -rf /tmp/walk-empty && mkdir -p /tmp/walk-empty
 node dist/cli.js secure /tmp/walk-empty
+node dist/cli.js secure /tmp/walk-empty --json \
+  | jq '{score, na: ([.allFindings[] | select(.notApplicable)] | length), passed: [.allFindings[] | select(.passed == true) | .checkId]}'
 ```
 
 **Grade.**
-- Score MUST be `95-100`.
-- The ONLY acceptable finding is a LOW for missing `.gitignore`.
+- Score MUST be `93/100`. The only scored findings are LOW `GIT-001` (missing
+  `.gitignore`) and MEDIUM `DEP-001` (no lock file; `file` is
+  `package-lock.json`, the path the fix creates). `SANDBOX-001` (`file`
+  `Dockerfile`) fails in `allFindings` but is out of scope for the `library`
+  project type, so it is neither shown nor scored.
+- The human output MUST list exactly those two findings.
+- `na` MUST be `13`: a check whose subject is absent records
+  `notApplicable: { subject, reason }` instead of a pass or a failure (#458).
+  No not-applicable record may carry `severity` or `passed`, and none may
+  appear in the human output.
+- `passed` MUST be exactly the six hazard probes that pass on not-there:
+  `CRED-002`, `LOG-003`, `MCP-010`, `PERM-001`, `PERM-002`, `PERM-003`. Any
+  other check passing on an empty directory means a subject read was replaced
+  by a default and the false-pass class #458 removed is back.
 - Any HIGH or CRITICAL on an empty directory means a check is firing on
   absence of input instead of presence of problem.
 
-**Failure class.** HIGH if any HIGH/CRITICAL fires. MEDIUM if score < 90.
+**Failure class.** HIGH if any HIGH/CRITICAL fires or any other check passes.
+MEDIUM if the score moves without a scanner change, or a not-applicable record
+carries a severity, carries `passed`, or reaches the human output.
 
 ## Surface — `repo`
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -352,7 +352,7 @@ import {
 import { reconcileArtifactIntents, rawIntentDisclosureLines } from './ui/artifact-intent';
 import { describeSemanticFamilyCoverage } from './ui/semantic-coverage-labels';
 import type { SemanticFamilyCoverage } from './nanomind-core/scanner-bridge.js';
-import { clampDisclosure, clampScoreToVerdictBand, countsAgainstScore, confirmedFix, expandSuppressed, retainForVerdict, summarizeSuppressed } from './ui/verdict-band';
+import { clampDisclosure, clampScoreToVerdictBand, countsAgainstScore, confirmedFix, expandSuppressed, isMeasured, retainForVerdict, summarizeSuppressed, type MeasuredFinding } from './ui/verdict-band';
 import { shouldPrintVersionFooter } from './ui/version-footer';
 import { soulScopeDisclosureLines } from './ui/soul-scope-disclosure';
 import { fixSummaryLine } from './ui/fix-summary';
@@ -1660,7 +1660,7 @@ function displayUnifiedCheck(opts: UnifiedCheckDisplayOptions): void {
   };
 
   // ── Compute findings ────────────────────────────────────────────────
-  let failed: SecurityFinding[] = [];
+  let failed: MeasuredFinding[] = [];
   /**
    * What the VERDICT and the severity counts are computed from (#450).
    *
@@ -1690,7 +1690,7 @@ function displayUnifiedCheck(opts: UnifiedCheckDisplayOptions): void {
     // line. Today an upstream filter happens to spare us the second case —
     // but depending on that invariant is what produced the first, so decide
     // it here with the same function the score uses.
-    failed = localScan.findings.filter(f => countsAgainstScore(f));
+    failed = localScan.findings.filter(isMeasured).filter(f => countsAgainstScore(f));
     score = localScan.score;
     maxScore = localScan.maxScore;
     // #450 — the counts, the verdict and the score describe the whole tree; the
@@ -1752,7 +1752,7 @@ function displayUnifiedCheck(opts: UnifiedCheckDisplayOptions): void {
       passed: false,
       message: f.message || f.description || '',
       fixable: false,
-    }));
+    })).filter(isMeasured);
     // Use the canonical scoring formula (exponential decay + 0.4x governance weight)
     //
     // #457 — `gatedIssues`, not `issues`. The counts, the verdict and the exit
@@ -3120,6 +3120,8 @@ function groupFindingsBySeverity(findings: SecurityFinding[]): Record<Severity, 
   };
 
   for (const finding of findings) {
+    // #458 — a not-applicable record has no severity and no bucket here.
+    if (!isMeasured(finding)) continue;
     grouped[finding.severity].push(finding);
   }
 
@@ -4206,7 +4208,7 @@ function generateScanSarif(findings: SecurityFinding[], targetDir: string): stri
 // HTML report for non-benchmark secure scans
 function generateScanHtmlReport(scanResult: { findings: SecurityFinding[]; score: number; maxScore: number; projectType: string }, targetDir: string): string {
   assertRedactionProvenance(scanResult.findings, 'html-scan');
-  const issues = scanResult.findings.filter(f => countsAgainstScore(f));
+  const issues = scanResult.findings.filter(isMeasured).filter(f => countsAgainstScore(f));
   // Verified fixes only, so "Auto-Fixed" and "issues" stay disjoint and the
   // header arithmetic adds up. A fix the verification pass could not confirm
   // is counted as an outstanding issue (it is still on disk), and listing it
@@ -6621,7 +6623,7 @@ Examples:
 
       // Filter to OpenClaw-specific findings
       const allOpenClawFindings = filterOpenClawFindings(result.findings);
-      const issues = allOpenClawFindings.filter((f) => countsAgainstScore(f));
+      const issues = allOpenClawFindings.filter(isMeasured).filter((f) => countsAgainstScore(f));
       // #274 — confirmed fixes only; a disproved attempt is counted in `issues`.
       const fixedFindings = allOpenClawFindings.filter((f) => confirmedFix(f));
       const passedFindings = allOpenClawFindings.filter((f) => f.passed);
@@ -6900,7 +6902,11 @@ Examples:
         }
       } catch { /* ignore filter unavailable */ }
 
-      const issues = mergedFindings.filter((f: SecurityFinding) => !f.passed);
+      // #458 — bare `!f.passed` would classify a not-applicable record
+      // (`passed` omitted — it measured nothing) as an issue and render a
+      // severity it does not carry. A check whose subject is absent
+      // contributes no failed record to any consumer.
+      const issues = mergedFindings.filter(isMeasured).filter((f) => !f.passed);
       const passedFindings = mergedFindings.filter((f: SecurityFinding) => f.passed);
 
       // #373, same class as `check` and `secure-openclaw`. Measured
@@ -10997,6 +11003,9 @@ program
       const result = await scanner.scan({ targetDir: options.directory, autoFix: false, scanDepth: 'deep' as any });
 
       for (const finding of result.findings) {
+        // #458 — a not-applicable record measured nothing; there is no severity
+        // to enrich the benchmark metadata with.
+        if (!isMeasured(finding)) continue;
         if (metadata[finding.checkId]) {
           metadata[finding.checkId].name = finding.name;
           metadata[finding.checkId].category = finding.category;
@@ -12239,9 +12248,10 @@ async function publishToRegistry(
       findings: result.findings
         .filter(f => !PACKAGE_SCAN_LOCAL_ONLY_CATEGORIES.has(f.category))
         // #458 — result.findings holds measured records only (the render filter in
-        // scanner.ts drops a not-applicable record, which has no pass/fail state);
-        // this narrows the type to say so and drops nothing: the parity test pins it.
-        .filter((f): f is SecurityFinding & { passed: boolean } => typeof f.passed === 'boolean')
+        // scanner.ts drops a not-applicable record, which has no pass/fail state
+        // and no severity); this narrows the type to say both and drops nothing:
+        // the parity test pins it.
+        .filter((f): f is MeasuredFinding & { passed: boolean } => typeof f.passed === 'boolean' && f.severity !== undefined)
         .map(f => ({
           checkId: f.checkId,
           name: f.name,

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -12238,6 +12238,10 @@ async function publishToRegistry(
       toolVersion: VERSION,
       findings: result.findings
         .filter(f => !PACKAGE_SCAN_LOCAL_ONLY_CATEGORIES.has(f.category))
+        // #458 — result.findings holds measured records only (the render filter in
+        // scanner.ts drops a not-applicable record, which has no pass/fail state);
+        // this narrows the type to say so and drops nothing: the parity test pins it.
+        .filter((f): f is SecurityFinding & { passed: boolean } => typeof f.passed === 'boolean')
         .map(f => ({
           checkId: f.checkId,
           name: f.name,

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -3111,23 +3111,6 @@ function displayUnifiedCheck(opts: UnifiedCheckDisplayOptions): void {
   });
 }
 
-function groupFindingsBySeverity(findings: SecurityFinding[]): Record<Severity, SecurityFinding[]> {
-  const grouped: Record<Severity, SecurityFinding[]> = {
-    critical: [],
-    high: [],
-    medium: [],
-    low: [],
-  };
-
-  for (const finding of findings) {
-    // #458 — a not-applicable record has no severity and no bucket here.
-    if (!isMeasured(finding)) continue;
-    grouped[finding.severity].push(finding);
-  }
-
-  return grouped;
-}
-
 // Benchmark compliance helpers
 interface LocalControlResult {
   control: BenchmarkControl;

--- a/src/hardening/finding-emit.ts
+++ b/src/hardening/finding-emit.ts
@@ -56,6 +56,11 @@ export type RedactedFinding = SecurityFinding & {
  * `finding.rationale` to `message` and `:98` assigns THE SAME STRING to
  * `rationale.plainEnglish`, so redacting `message` alone leaves the identical
  * bytes on a second field of the same object.
+ *
+ * `notApplicable.subject`/`.reason` are excluded BY RULE, not oversight: the
+ * field's contract (`security-check.ts`) makes them emitter literals — never
+ * scanned bytes — and extending this walk to nested fields would add a parsing
+ * surface for strings that carry no target bytes.
  */
 const BYTE_CARRYING_FIELDS = [
   'name',

--- a/src/hardening/scanner.ts
+++ b/src/hardening/scanner.ts
@@ -367,6 +367,70 @@ async function readCheckSubject(filePath: string): Promise<SubjectRead> {
   }
 }
 
+/**
+ * #458 — the not-applicable record for a check whose subject is absent
+ * (`readCheckSubject` / `readCheckDir` classified it `absent`). No `severity`,
+ * no `passed`: the record names the subject the scan looked for and is
+ * invisible to every score / verdict / render consumer, all of which key on
+ * `passed` being a boolean or on `notApplicable`.
+ */
+function notApplicableRecord(
+  base: Pick<SecurityFindingDraft, 'checkId' | 'name' | 'description' | 'category'>,
+  subject: string,
+  reason: string,
+): SecurityFindingDraft {
+  return {
+    ...base,
+    notApplicable: { subject, reason },
+    message: `Not applicable: no ${subject} to inspect`,
+    fixable: false,
+  };
+}
+
+/**
+ * #458 — `readCheckSubject` for a check whose subject is a FAMILY of files in
+ * a directory (the root `.ts`/`.js` sources, the root config files, …) rather
+ * than one path.
+ *
+ * - `read`: the listing is in hand and at least one entry passes `admit`. The
+ *   FULL listing is returned, so the caller keeps its own filter loop and its
+ *   verdict on a present subject is unchanged.
+ * - `absent`: the directory is not there (not-there errno) OR no entry passes
+ *   `admit` — the subject family is absent from this tree; the check measured
+ *   nothing and emits a not-applicable record.
+ * - `unread`: any other errno on the listing — the caller emits nothing; the
+ *   tracked-fs namespace has ledgered the failed listing.
+ *
+ * Only the LISTING is classified here. A per-file read that fails inside the
+ * caller's loop keeps the caller's existing handling (the file was admitted,
+ * so the subject is present; the ledger discloses the unread file).
+ */
+type DirRead<T> =
+  | { state: 'read'; entries: T[] }
+  | { state: 'absent' }
+  | { state: 'unread' };
+
+async function classifyDirRead<T>(list: () => Promise<T[]>, admit: (entry: T) => boolean): Promise<DirRead<T>> {
+  let entries: T[];
+  try {
+    entries = await list();
+  } catch (err) {
+    const code = (err as NodeJS.ErrnoException).code ?? '';
+    return countsAsUnread(code) ? { state: 'unread' } : { state: 'absent' };
+  }
+  return entries.some(admit) ? { state: 'read', entries } : { state: 'absent' };
+}
+
+function readCheckDir(dir: string, admit: (name: string) => boolean): Promise<DirRead<string>> {
+  return classifyDirRead(() => fs.readdir(dir), admit);
+}
+
+type DirEntryLike = { name: string; isDirectory(): boolean };
+
+function readCheckDirents(dir: string, admit: (entry: DirEntryLike) => boolean): Promise<DirRead<DirEntryLike>> {
+  return classifyDirRead<DirEntryLike>(() => fs.readdir(dir, { withFileTypes: true }), admit);
+}
+
 export interface CreatedFileRecord {
   /** Path relative to the scan target. */
   path: string;
@@ -6801,24 +6865,29 @@ dist/
 
     // ENV-004: Check for production environment validation
     let hasEnvValidation = false;
-    try {
-      const pkgJson = await fs.readFile(path.join(targetDir, 'package.json'), 'utf-8');
+    const pkgReadEnv004 = await readCheckSubject(path.join(targetDir, 'package.json'));
+    if (pkgReadEnv004.state === 'read') {
+      const pkgJson = pkgReadEnv004.content;
       hasEnvValidation = pkgJson.includes('dotenv') || pkgJson.includes('env-var') || pkgJson.includes('envalid');
-    } catch {}
+    }
 
-    findings.push({
-      checkId: 'ENV-004',
-      name: 'Environment Validation',
-      description: 'No environment variable validation library detected',
-      category: 'environment',
-      severity: 'low',
-      passed: hasEnvValidation,
-      message: hasEnvValidation
-        ? 'Environment validation library detected'
-        : 'Consider using env validation (dotenv, envalid) to catch misconfigurations',
-      fixable: false,
-      guidance: 'Without environment validation, missing or malformed variables cause silent failures. A missing DB_HOST might fall back to an insecure default rather than failing fast.',
-    });
+    if (pkgReadEnv004.state === 'absent') {
+      findings.push(notApplicableRecord({ checkId: 'ENV-004', name: 'Environment Validation', description: 'No environment variable validation library detected', category: 'environment' }, 'package.json', 'No package.json in the scanned tree, so there is no dependency manifest to inspect.'));
+    } else if (pkgReadEnv004.state === 'read') {
+      findings.push({
+        checkId: 'ENV-004',
+        name: 'Environment Validation',
+        description: 'No environment variable validation library detected',
+        category: 'environment',
+        severity: 'low',
+        passed: hasEnvValidation,
+        message: hasEnvValidation
+          ? 'Environment validation library detected'
+          : 'Consider using env validation (dotenv, envalid) to catch misconfigurations',
+        fixable: false,
+        guidance: 'Without environment validation, missing or malformed variables cause silent failures. A missing DB_HOST might fall back to an insecure default rather than failing fast.',
+      });
+    }
 
     return findings;
   }
@@ -6831,24 +6900,29 @@ dist/
 
     // LOG-001: Check for logging configuration
     let hasLoggingConfig = false;
-    try {
-      const pkgJson = await fs.readFile(path.join(targetDir, 'package.json'), 'utf-8');
+    const pkgReadLog001 = await readCheckSubject(path.join(targetDir, 'package.json'));
+    if (pkgReadLog001.state === 'read') {
+      const pkgJson = pkgReadLog001.content;
       hasLoggingConfig = pkgJson.includes('winston') || pkgJson.includes('pino') || pkgJson.includes('bunyan');
-    } catch {}
+    }
 
-    findings.push({
-      checkId: 'LOG-001',
-      name: 'Structured Logging',
-      description: 'No structured logging library detected',
-      category: 'logging',
-      severity: 'low',
-      passed: hasLoggingConfig,
-      message: hasLoggingConfig
-        ? 'Structured logging library detected'
-        : 'Consider using structured logging (winston, pino) for better security auditing',
-      fixable: false,
-      guidance: 'Unstructured console.log output is hard to filter, search, or redact. Structured logging makes it possible to automatically mask sensitive fields and detect anomalies.',
-    });
+    if (pkgReadLog001.state === 'absent') {
+      findings.push(notApplicableRecord({ checkId: 'LOG-001', name: 'Structured Logging', description: 'No structured logging library detected', category: 'logging' }, 'package.json', 'No package.json in the scanned tree, so there is no dependency manifest to inspect.'));
+    } else if (pkgReadLog001.state === 'read') {
+      findings.push({
+        checkId: 'LOG-001',
+        name: 'Structured Logging',
+        description: 'No structured logging library detected',
+        category: 'logging',
+        severity: 'low',
+        passed: hasLoggingConfig,
+        message: hasLoggingConfig
+          ? 'Structured logging library detected'
+          : 'Consider using structured logging (winston, pino) for better security auditing',
+        fixable: false,
+        guidance: 'Unstructured console.log output is hard to filter, search, or redact. Structured logging makes it possible to automatically mask sensitive fields and detect anomalies.',
+      });
+    }
 
     // LOG-002: Check for sensitive data in log patterns
     //
@@ -6981,24 +7055,29 @@ dist/
 
     // LOG-004: Check for audit logging capability
     let hasAuditLogging = false;
-    try {
-      const pkgJson = await fs.readFile(path.join(targetDir, 'package.json'), 'utf-8');
+    const pkgReadLog004 = await readCheckSubject(path.join(targetDir, 'package.json'));
+    if (pkgReadLog004.state === 'read') {
+      const pkgJson = pkgReadLog004.content;
       hasAuditLogging = pkgJson.includes('audit') || pkgJson.includes('morgan') || pkgJson.includes('express-winston');
-    } catch {}
+    }
 
-    findings.push({
-      checkId: 'LOG-004',
-      name: 'Audit Logging',
-      description: 'No audit logging capability detected',
-      category: 'logging',
-      severity: 'medium',
-      passed: hasAuditLogging,
-      message: hasAuditLogging
-        ? 'Audit logging capability detected'
-        : 'Consider implementing audit logging for security events',
-      fixable: false,
-      guidance: 'Without audit logging, there is no record of who accessed what or when. Incident response becomes guesswork without a trail of security-relevant events.',
-    });
+    if (pkgReadLog004.state === 'absent') {
+      findings.push(notApplicableRecord({ checkId: 'LOG-004', name: 'Audit Logging', description: 'No audit logging capability detected', category: 'logging' }, 'package.json', 'No package.json in the scanned tree, so there is no dependency manifest to inspect.'));
+    } else if (pkgReadLog004.state === 'read') {
+      findings.push({
+        checkId: 'LOG-004',
+        name: 'Audit Logging',
+        description: 'No audit logging capability detected',
+        category: 'logging',
+        severity: 'medium',
+        passed: hasAuditLogging,
+        message: hasAuditLogging
+          ? 'Audit logging capability detected'
+          : 'Consider implementing audit logging for security events',
+        fixable: false,
+        guidance: 'Without audit logging, there is no record of who accessed what or when. Incident response becomes guesswork without a trail of security-relevant events.',
+      });
+    }
 
     return findings;
   }
@@ -7156,58 +7235,68 @@ dist/
     let hasAuthConfig = false;
     const authIndicators = ['auth', 'authentication', 'passport', 'jwt', 'session'];
 
-    try {
-      const pkgJson = await fs.readFile(path.join(targetDir, 'package.json'), 'utf-8');
+    const pkgReadAuth001 = await readCheckSubject(path.join(targetDir, 'package.json'));
+    if (pkgReadAuth001.state === 'read') {
+      const pkgJson = pkgReadAuth001.content;
       for (const indicator of authIndicators) {
         if (pkgJson.toLowerCase().includes(indicator)) {
           hasAuthConfig = true;
           break;
         }
       }
-    } catch {}
+    }
 
-    findings.push({
-      checkId: 'AUTH-001',
-      name: 'Authentication Configuration',
-      description: 'No authentication library or configuration detected',
-      category: 'authentication',
-      severity: 'medium',
-      passed: hasAuthConfig,
-      message: hasAuthConfig
-        ? 'Authentication configuration detected'
-        : 'No authentication library detected - ensure endpoints are protected',
-      fixable: false,
-      guidance: 'Without authentication, any network-reachable client can access your API endpoints, including reading data, triggering actions, and modifying state.',
-    });
+    if (pkgReadAuth001.state === 'absent') {
+      findings.push(notApplicableRecord({ checkId: 'AUTH-001', name: 'Authentication Configuration', description: 'No authentication library or configuration detected', category: 'authentication' }, 'package.json', 'No package.json in the scanned tree, so there is no dependency manifest to inspect.'));
+    } else if (pkgReadAuth001.state === 'read') {
+      findings.push({
+        checkId: 'AUTH-001',
+        name: 'Authentication Configuration',
+        description: 'No authentication library or configuration detected',
+        category: 'authentication',
+        severity: 'medium',
+        passed: hasAuthConfig,
+        message: hasAuthConfig
+          ? 'Authentication configuration detected'
+          : 'No authentication library detected - ensure endpoints are protected',
+        fixable: false,
+        guidance: 'Without authentication, any network-reachable client can access your API endpoints, including reading data, triggering actions, and modifying state.',
+      });
+    }
 
     // AUTH-002: Check for rate limiting
     let hasRateLimiting = false;
-    try {
-      const pkgJson = await fs.readFile(path.join(targetDir, 'package.json'), 'utf-8');
+    const pkgReadAuth002 = await readCheckSubject(path.join(targetDir, 'package.json'));
+    if (pkgReadAuth002.state === 'read') {
+      const pkgJson = pkgReadAuth002.content;
       hasRateLimiting = pkgJson.includes('rate-limit') || pkgJson.includes('express-rate-limit') || pkgJson.includes('bottleneck');
-    } catch {}
+    }
 
-    findings.push({
-      checkId: 'AUTH-002',
-      name: 'Rate Limiting',
-      description: 'No rate limiting library detected',
-      category: 'authentication',
-      severity: 'high',
-      passed: hasRateLimiting,
-      message: hasRateLimiting
-        ? 'Rate limiting library detected'
-        : 'No rate limiting detected - API may be vulnerable to abuse',
-      fixable: false,
-      guidance: 'Without rate limiting, attackers can brute-force credentials, scrape data, or exhaust resources with automated requests at no cost.',
-    });
+    if (pkgReadAuth002.state === 'absent') {
+      findings.push(notApplicableRecord({ checkId: 'AUTH-002', name: 'Rate Limiting', description: 'No rate limiting library detected', category: 'authentication' }, 'package.json', 'No package.json in the scanned tree, so there is no dependency manifest to inspect.'));
+    } else if (pkgReadAuth002.state === 'read') {
+      findings.push({
+        checkId: 'AUTH-002',
+        name: 'Rate Limiting',
+        description: 'No rate limiting library detected',
+        category: 'authentication',
+        severity: 'high',
+        passed: hasRateLimiting,
+        message: hasRateLimiting
+          ? 'Rate limiting library detected'
+          : 'No rate limiting detected - API may be vulnerable to abuse',
+        fixable: false,
+        guidance: 'Without rate limiting, attackers can brute-force credentials, scrape data, or exhaust resources with automated requests at no cost.',
+      });
+    }
 
     // AUTH-003: Check for session security
     let hasSecureSessions = false;
     const sessionIndicators = ['express-session', 'cookie-session', 'secure: true', 'httpOnly: true'];
 
-    try {
-      const files = await fs.readdir(targetDir);
-      for (const file of files) {
+    const dirReadAuth003 = await readCheckDir(targetDir, (file) => file.endsWith('.ts') || file.endsWith('.js') || file.endsWith('.json'));
+    if (dirReadAuth003.state === 'read') {
+      for (const file of dirReadAuth003.entries) {
         if (file.endsWith('.ts') || file.endsWith('.js') || file.endsWith('.json')) {
           try {
             const content = await fs.readFile(path.join(targetDir, file), 'utf-8');
@@ -7220,42 +7309,51 @@ dist/
           } catch {}
         }
       }
-    } catch {}
+    }
 
-    findings.push({
-      checkId: 'AUTH-003',
-      name: 'Secure Session Configuration',
-      description: 'Session security configuration not detected',
-      category: 'authentication',
-      severity: 'medium',
-      passed: hasSecureSessions,
-      message: hasSecureSessions
-        ? 'Secure session configuration detected'
-        : 'Ensure sessions use secure, httpOnly cookies',
-      fixable: false,
-      guidance: 'Sessions without secure and httpOnly flags are vulnerable to theft via XSS attacks or network sniffing, allowing attackers to hijack authenticated sessions.',
-    });
+    if (dirReadAuth003.state === 'absent') {
+      findings.push(notApplicableRecord({ checkId: 'AUTH-003', name: 'Secure Session Configuration', description: 'Session security configuration not detected', category: 'authentication' }, 'source or config files (.ts, .js, .json)', 'No .ts, .js or .json files at the scanned root, so there is nothing to inspect.'));
+    } else if (dirReadAuth003.state === 'read') {
+      findings.push({
+        checkId: 'AUTH-003',
+        name: 'Secure Session Configuration',
+        description: 'Session security configuration not detected',
+        category: 'authentication',
+        severity: 'medium',
+        passed: hasSecureSessions,
+        message: hasSecureSessions
+          ? 'Secure session configuration detected'
+          : 'Ensure sessions use secure, httpOnly cookies',
+        fixable: false,
+        guidance: 'Sessions without secure and httpOnly flags are vulnerable to theft via XSS attacks or network sniffing, allowing attackers to hijack authenticated sessions.',
+      });
+    }
 
     // AUTH-004: Check for CORS configuration
     let hasCorsConfig = false;
-    try {
-      const pkgJson = await fs.readFile(path.join(targetDir, 'package.json'), 'utf-8');
+    const pkgReadAuth004 = await readCheckSubject(path.join(targetDir, 'package.json'));
+    if (pkgReadAuth004.state === 'read') {
+      const pkgJson = pkgReadAuth004.content;
       hasCorsConfig = pkgJson.includes('cors');
-    } catch {}
+    }
 
-    findings.push({
-      checkId: 'AUTH-004',
-      name: 'CORS Configuration',
-      description: 'No CORS library detected',
-      category: 'authentication',
-      severity: 'medium',
-      passed: hasCorsConfig,
-      message: hasCorsConfig
-        ? 'CORS library detected'
-        : 'No CORS configuration detected - ensure cross-origin requests are properly handled',
-      fixable: false,
-      guidance: 'Without explicit CORS configuration, browsers may block legitimate cross-origin requests or, worse, a permissive default may allow malicious sites to make authenticated requests to your API.',
-    });
+    if (pkgReadAuth004.state === 'absent') {
+      findings.push(notApplicableRecord({ checkId: 'AUTH-004', name: 'CORS Configuration', description: 'No CORS library detected', category: 'authentication' }, 'package.json', 'No package.json in the scanned tree, so there is no dependency manifest to inspect.'));
+    } else if (pkgReadAuth004.state === 'read') {
+      findings.push({
+        checkId: 'AUTH-004',
+        name: 'CORS Configuration',
+        description: 'No CORS library detected',
+        category: 'authentication',
+        severity: 'medium',
+        passed: hasCorsConfig,
+        message: hasCorsConfig
+          ? 'CORS library detected'
+          : 'No CORS configuration detected - ensure cross-origin requests are properly handled',
+        fixable: false,
+        guidance: 'Without explicit CORS configuration, browsers may block legitimate cross-origin requests or, worse, a permissive default may allow malicious sites to make authenticated requests to your API.',
+      });
+    }
 
     return findings;
   }
@@ -7308,51 +7406,61 @@ dist/
 
     // PROC-002: Check for security headers middleware
     let hasSecurityHeaders = false;
-    try {
-      const pkgJson = await fs.readFile(path.join(targetDir, 'package.json'), 'utf-8');
+    const pkgReadProc002 = await readCheckSubject(path.join(targetDir, 'package.json'));
+    if (pkgReadProc002.state === 'read') {
+      const pkgJson = pkgReadProc002.content;
       hasSecurityHeaders = pkgJson.includes('helmet') || pkgJson.includes('security-headers');
-    } catch {}
+    }
 
-    findings.push({
-      checkId: 'PROC-002',
-      name: 'Security Headers',
-      description: 'No security headers middleware detected',
-      category: 'process',
-      severity: 'medium',
-      passed: hasSecurityHeaders,
-      message: hasSecurityHeaders
-        ? 'Security headers middleware detected (helmet)'
-        : 'Consider using helmet or similar for security headers',
-      fixable: false,
-      guidance: 'Missing security headers (CSP, X-Frame-Options, HSTS) leave your app vulnerable to clickjacking, XSS, and protocol downgrade attacks.',
-    });
+    if (pkgReadProc002.state === 'absent') {
+      findings.push(notApplicableRecord({ checkId: 'PROC-002', name: 'Security Headers', description: 'No security headers middleware detected', category: 'process' }, 'package.json', 'No package.json in the scanned tree, so there is no dependency manifest to inspect.'));
+    } else if (pkgReadProc002.state === 'read') {
+      findings.push({
+        checkId: 'PROC-002',
+        name: 'Security Headers',
+        description: 'No security headers middleware detected',
+        category: 'process',
+        severity: 'medium',
+        passed: hasSecurityHeaders,
+        message: hasSecurityHeaders
+          ? 'Security headers middleware detected (helmet)'
+          : 'Consider using helmet or similar for security headers',
+        fixable: false,
+        guidance: 'Missing security headers (CSP, X-Frame-Options, HSTS) leave your app vulnerable to clickjacking, XSS, and protocol downgrade attacks.',
+      });
+    }
 
     // PROC-003: Check for input validation
     let hasInputValidation = false;
-    try {
-      const pkgJson = await fs.readFile(path.join(targetDir, 'package.json'), 'utf-8');
+    const pkgReadProc003 = await readCheckSubject(path.join(targetDir, 'package.json'));
+    if (pkgReadProc003.state === 'read') {
+      const pkgJson = pkgReadProc003.content;
       hasInputValidation = pkgJson.includes('joi') || pkgJson.includes('zod') || pkgJson.includes('yup') || pkgJson.includes('class-validator');
-    } catch {}
+    }
 
-    findings.push({
-      checkId: 'PROC-003',
-      name: 'Input Validation',
-      description: 'No input validation library detected',
-      category: 'process',
-      severity: 'high',
-      passed: hasInputValidation,
-      message: hasInputValidation
-        ? 'Input validation library detected'
-        : 'No input validation library found - validate all user inputs',
-      fixable: false,
-      guidance: 'Without input validation, attackers can inject SQL, scripts, or malformed data that corrupts state, steals data, or crashes the application.',
-    });
+    if (pkgReadProc003.state === 'absent') {
+      findings.push(notApplicableRecord({ checkId: 'PROC-003', name: 'Input Validation', description: 'No input validation library detected', category: 'process' }, 'package.json', 'No package.json in the scanned tree, so there is no dependency manifest to inspect.'));
+    } else if (pkgReadProc003.state === 'read') {
+      findings.push({
+        checkId: 'PROC-003',
+        name: 'Input Validation',
+        description: 'No input validation library detected',
+        category: 'process',
+        severity: 'high',
+        passed: hasInputValidation,
+        message: hasInputValidation
+          ? 'Input validation library detected'
+          : 'No input validation library found - validate all user inputs',
+        fixable: false,
+        guidance: 'Without input validation, attackers can inject SQL, scripts, or malformed data that corrupts state, steals data, or crashes the application.',
+      });
+    }
 
     // PROC-004: Check for error handling
     let hasErrorHandling = false;
-    try {
-      const files = await fs.readdir(targetDir);
-      for (const file of files) {
+    const dirReadProc004 = await readCheckDir(targetDir, (file) => file.endsWith('.ts') || file.endsWith('.js'));
+    if (dirReadProc004.state === 'read') {
+      for (const file of dirReadProc004.entries) {
         if (file.endsWith('.ts') || file.endsWith('.js')) {
           try {
             const content = await fs.readFile(path.join(targetDir, file), 'utf-8');
@@ -7363,21 +7471,25 @@ dist/
           } catch {}
         }
       }
-    } catch {}
+    }
 
-    findings.push({
-      checkId: 'PROC-004',
-      name: 'Error Handling',
-      description: 'No error handling patterns detected',
-      category: 'process',
-      severity: 'medium',
-      passed: hasErrorHandling,
-      message: hasErrorHandling
-        ? 'Error handling patterns detected'
-        : 'Ensure proper error handling to prevent information disclosure',
-      fixable: false,
-      guidance: 'Unhandled errors can crash the process, leak stack traces with internal paths and variable names, and create denial-of-service conditions.',
-    });
+    if (dirReadProc004.state === 'absent') {
+      findings.push(notApplicableRecord({ checkId: 'PROC-004', name: 'Error Handling', description: 'No error handling patterns detected', category: 'process' }, 'source files (.ts, .js)', 'No .ts or .js files at the scanned root, so there is no source to inspect.'));
+    } else if (dirReadProc004.state === 'read') {
+      findings.push({
+        checkId: 'PROC-004',
+        name: 'Error Handling',
+        description: 'No error handling patterns detected',
+        category: 'process',
+        severity: 'medium',
+        passed: hasErrorHandling,
+        message: hasErrorHandling
+          ? 'Error handling patterns detected'
+          : 'Ensure proper error handling to prevent information disclosure',
+        fixable: false,
+        guidance: 'Unhandled errors can crash the process, leak stack traces with internal paths and variable names, and create denial-of-service conditions.',
+      });
+    }
 
     return findings;
   }
@@ -7627,9 +7739,9 @@ dist/
 
     // NET-003: Check for HTTPS enforcement
     let hasHttpsEnforcement = false;
-    try {
-      const files = await fs.readdir(targetDir);
-      for (const file of files) {
+    const dirReadNet003 = await readCheckDir(targetDir, (file) => file.endsWith('.ts') || file.endsWith('.js'));
+    if (dirReadNet003.state === 'read') {
+      for (const file of dirReadNet003.entries) {
         if (file.endsWith('.ts') || file.endsWith('.js')) {
           try {
             const content = await fs.readFile(path.join(targetDir, file), 'utf-8');
@@ -7640,21 +7752,25 @@ dist/
           } catch {}
         }
       }
-    } catch {}
+    }
 
-    findings.push({
-      checkId: 'NET-003',
-      name: 'HTTPS Configuration',
-      description: 'No HTTPS/TLS configuration detected',
-      category: 'network',
-      severity: 'high',
-      passed: hasHttpsEnforcement,
-      message: hasHttpsEnforcement
-        ? 'HTTPS/TLS configuration detected'
-        : 'No HTTPS configuration found - ensure production uses TLS',
-      fixable: false,
-      guidance: 'Without TLS, all traffic including API keys, tokens, and user data is transmitted in plaintext. Anyone on the network can intercept and read it.',
-    });
+    if (dirReadNet003.state === 'absent') {
+      findings.push(notApplicableRecord({ checkId: 'NET-003', name: 'HTTPS Configuration', description: 'No HTTPS/TLS configuration detected', category: 'network' }, 'source files (.ts, .js)', 'No .ts or .js files at the scanned root, so there is no source to inspect.'));
+    } else if (dirReadNet003.state === 'read') {
+      findings.push({
+        checkId: 'NET-003',
+        name: 'HTTPS Configuration',
+        description: 'No HTTPS/TLS configuration detected',
+        category: 'network',
+        severity: 'high',
+        passed: hasHttpsEnforcement,
+        message: hasHttpsEnforcement
+          ? 'HTTPS/TLS configuration detected'
+          : 'No HTTPS configuration found - ensure production uses TLS',
+        fixable: false,
+        guidance: 'Without TLS, all traffic including API keys, tokens, and user data is transmitted in plaintext. Anyone on the network can intercept and read it.',
+      });
+    }
 
     // NET-004: Check for exposed debug endpoints
     let hasDebugEndpoints = false;
@@ -7763,9 +7879,9 @@ dist/
 
     // API-001: Check for API versioning
     let hasApiVersioning = false;
-    try {
-      const files = await fs.readdir(targetDir);
-      for (const file of files) {
+    const dirReadApi001 = await readCheckDir(targetDir, (file) => file.endsWith('.ts') || file.endsWith('.js'));
+    if (dirReadApi001.state === 'read') {
+      for (const file of dirReadApi001.entries) {
         if (file.endsWith('.ts') || file.endsWith('.js')) {
           try {
             const content = await fs.readFile(path.join(targetDir, file), 'utf-8');
@@ -7776,42 +7892,51 @@ dist/
           } catch {}
         }
       }
-    } catch {}
+    }
 
-    findings.push({
-      checkId: 'API-001',
-      name: 'API Versioning',
-      description: 'API versioning not detected',
-      category: 'api',
-      severity: 'low',
-      passed: hasApiVersioning,
-      message: hasApiVersioning
-        ? 'API versioning pattern detected'
-        : 'Consider implementing API versioning for backwards compatibility',
-      fixable: false,
-      guidance: 'Without API versioning, breaking changes affect all clients immediately. Versioning enables safe deprecation and prevents accidental security regressions.',
-    });
+    if (dirReadApi001.state === 'absent') {
+      findings.push(notApplicableRecord({ checkId: 'API-001', name: 'API Versioning', description: 'API versioning not detected', category: 'api' }, 'source files (.ts, .js)', 'No .ts or .js files at the scanned root, so there is no source to inspect.'));
+    } else if (dirReadApi001.state === 'read') {
+      findings.push({
+        checkId: 'API-001',
+        name: 'API Versioning',
+        description: 'API versioning not detected',
+        category: 'api',
+        severity: 'low',
+        passed: hasApiVersioning,
+        message: hasApiVersioning
+          ? 'API versioning pattern detected'
+          : 'Consider implementing API versioning for backwards compatibility',
+        fixable: false,
+        guidance: 'Without API versioning, breaking changes affect all clients immediately. Versioning enables safe deprecation and prevents accidental security regressions.',
+      });
+    }
 
     // API-002: Check for API documentation
     let hasApiDocs = false;
-    try {
-      const pkgJson = await fs.readFile(path.join(targetDir, 'package.json'), 'utf-8');
+    const pkgReadApi002 = await readCheckSubject(path.join(targetDir, 'package.json'));
+    if (pkgReadApi002.state === 'read') {
+      const pkgJson = pkgReadApi002.content;
       hasApiDocs = pkgJson.includes('swagger') || pkgJson.includes('openapi') || pkgJson.includes('@apidevtools');
-    } catch {}
+    }
 
-    findings.push({
-      checkId: 'API-002',
-      name: 'API Documentation',
-      description: 'No API documentation library detected',
-      category: 'api',
-      severity: 'low',
-      passed: hasApiDocs,
-      message: hasApiDocs
-        ? 'API documentation library detected'
-        : 'Consider adding OpenAPI/Swagger documentation',
-      fixable: false,
-      guidance: 'Undocumented APIs are harder to use correctly and easier to misuse. Clear documentation reduces the chance of insecure integrations by consumers.',
-    });
+    if (pkgReadApi002.state === 'absent') {
+      findings.push(notApplicableRecord({ checkId: 'API-002', name: 'API Documentation', description: 'No API documentation library detected', category: 'api' }, 'package.json', 'No package.json in the scanned tree, so there is no dependency manifest to inspect.'));
+    } else if (pkgReadApi002.state === 'read') {
+      findings.push({
+        checkId: 'API-002',
+        name: 'API Documentation',
+        description: 'No API documentation library detected',
+        category: 'api',
+        severity: 'low',
+        passed: hasApiDocs,
+        message: hasApiDocs
+          ? 'API documentation library detected'
+          : 'Consider adding OpenAPI/Swagger documentation',
+        fixable: false,
+        guidance: 'Undocumented APIs are harder to use correctly and easier to misuse. Clear documentation reduces the chance of insecure integrations by consumers.',
+      });
+    }
 
     // API-003: Check for API key in URL
     let hasKeyInUrl = false;
@@ -7848,9 +7973,9 @@ dist/
 
     // API-004: Check for response headers security
     let hasSecurityHeaders = false;
-    try {
-      const files = await fs.readdir(targetDir);
-      for (const file of files) {
+    const dirReadApi004 = await readCheckDir(targetDir, (file) => file.endsWith('.ts') || file.endsWith('.js'));
+    if (dirReadApi004.state === 'read') {
+      for (const file of dirReadApi004.entries) {
         if (file.endsWith('.ts') || file.endsWith('.js')) {
           try {
             const content = await fs.readFile(path.join(targetDir, file), 'utf-8');
@@ -7861,21 +7986,25 @@ dist/
           } catch {}
         }
       }
-    } catch {}
+    }
 
-    findings.push({
-      checkId: 'API-004',
-      name: 'API Security Headers',
-      description: 'Security headers not explicitly set',
-      category: 'api',
-      severity: 'medium',
-      passed: hasSecurityHeaders,
-      message: hasSecurityHeaders
-        ? 'Security headers detected in responses'
-        : 'Add security headers (X-Content-Type-Options, X-Frame-Options, CSP)',
-      fixable: false,
-      guidance: 'Missing security headers like X-Frame-Options and CSP leave your API responses vulnerable to clickjacking, MIME-sniffing, and cross-site scripting attacks.',
-    });
+    if (dirReadApi004.state === 'absent') {
+      findings.push(notApplicableRecord({ checkId: 'API-004', name: 'API Security Headers', description: 'Security headers not explicitly set', category: 'api' }, 'source files (.ts, .js)', 'No .ts or .js files at the scanned root, so there is no source to inspect.'));
+    } else if (dirReadApi004.state === 'read') {
+      findings.push({
+        checkId: 'API-004',
+        name: 'API Security Headers',
+        description: 'Security headers not explicitly set',
+        category: 'api',
+        severity: 'medium',
+        passed: hasSecurityHeaders,
+        message: hasSecurityHeaders
+          ? 'Security headers detected in responses'
+          : 'Add security headers (X-Content-Type-Options, X-Frame-Options, CSP)',
+        fixable: false,
+        guidance: 'Missing security headers like X-Frame-Options and CSP leave your API responses vulnerable to clickjacking, MIME-sniffing, and cross-site scripting attacks.',
+      });
+    }
 
     return findings;
   }
@@ -7888,56 +8017,66 @@ dist/
 
     // SEC-001: Check for secret management tools
     let hasSecretManager = false;
-    try {
-      const pkgJson = await fs.readFile(path.join(targetDir, 'package.json'), 'utf-8');
+    const pkgReadSec001 = await readCheckSubject(path.join(targetDir, 'package.json'));
+    if (pkgReadSec001.state === 'read') {
+      const pkgJson = pkgReadSec001.content;
       hasSecretManager = pkgJson.includes('vault') || pkgJson.includes('aws-sdk') || pkgJson.includes('dotenv-vault') || pkgJson.includes('1password');
-    } catch {}
+    }
 
-    findings.push({
-      checkId: 'SEC-001',
-      name: 'Secret Management',
-      description: 'No secret management tool detected',
-      category: 'secrets',
-      severity: 'medium',
-      passed: hasSecretManager,
-      message: hasSecretManager
-        ? 'Secret management capability detected'
-        : 'Consider using a secret manager (Vault, AWS Secrets Manager, doppler)',
-      fixable: false,
-      guidance: 'Without a secret manager, credentials end up in .env files, config files, or source code where they can be leaked through version control or log files.',
-    });
+    if (pkgReadSec001.state === 'absent') {
+      findings.push(notApplicableRecord({ checkId: 'SEC-001', name: 'Secret Management', description: 'No secret management tool detected', category: 'secrets' }, 'package.json', 'No package.json in the scanned tree, so there is no dependency manifest to inspect.'));
+    } else if (pkgReadSec001.state === 'read') {
+      findings.push({
+        checkId: 'SEC-001',
+        name: 'Secret Management',
+        description: 'No secret management tool detected',
+        category: 'secrets',
+        severity: 'medium',
+        passed: hasSecretManager,
+        message: hasSecretManager
+          ? 'Secret management capability detected'
+          : 'Consider using a secret manager (Vault, AWS Secrets Manager, doppler)',
+        fixable: false,
+        guidance: 'Without a secret manager, credentials end up in .env files, config files, or source code where they can be leaked through version control or log files.',
+      });
+    }
 
     // SEC-002: Check for encryption library
     let hasEncryption = false;
-    try {
-      const pkgJson = await fs.readFile(path.join(targetDir, 'package.json'), 'utf-8');
+    const pkgReadSec002 = await readCheckSubject(path.join(targetDir, 'package.json'));
+    if (pkgReadSec002.state === 'read') {
+      const pkgJson = pkgReadSec002.content;
       hasEncryption = pkgJson.includes('crypto') || pkgJson.includes('bcrypt') || pkgJson.includes('argon2') || pkgJson.includes('sodium');
-    } catch {}
+    }
 
-    findings.push({
-      checkId: 'SEC-002',
-      name: 'Encryption Library',
-      description: 'No encryption library detected',
-      category: 'secrets',
-      severity: 'medium',
-      passed: hasEncryption,
-      message: hasEncryption
-        ? 'Encryption library detected'
-        : 'Consider using encryption for sensitive data (bcrypt, argon2)',
-      fixable: false,
-      guidance: 'Without encryption, sensitive data like passwords and tokens are stored in plaintext. A database breach or file leak exposes everything immediately.',
-    });
+    if (pkgReadSec002.state === 'absent') {
+      findings.push(notApplicableRecord({ checkId: 'SEC-002', name: 'Encryption Library', description: 'No encryption library detected', category: 'secrets' }, 'package.json', 'No package.json in the scanned tree, so there is no dependency manifest to inspect.'));
+    } else if (pkgReadSec002.state === 'read') {
+      findings.push({
+        checkId: 'SEC-002',
+        name: 'Encryption Library',
+        description: 'No encryption library detected',
+        category: 'secrets',
+        severity: 'medium',
+        passed: hasEncryption,
+        message: hasEncryption
+          ? 'Encryption library detected'
+          : 'Consider using encryption for sensitive data (bcrypt, argon2)',
+        fixable: false,
+        guidance: 'Without encryption, sensitive data like passwords and tokens are stored in plaintext. A database breach or file leak exposes everything immediately.',
+      });
+    }
 
     // SEC-003: Check for key rotation support
     let hasKeyRotation = false;
-    try {
-      // Dirents, not names: this probe reads EVERY root entry, and a directory
-      // at mode 000 fails open() with EACCES before EISDIR can say "not a
-      // file" — which put `.git`/`node_modules` on the coverage ledger as an
-      // unread FILE at standard depth (#588). A directory is never this
-      // probe's input; a file, symlink or anything else keeps today's read.
-      const entries = await fs.readdir(targetDir, { withFileTypes: true });
-      for (const entry of entries) {
+    // Dirents, not names: this probe reads EVERY root entry, and a directory
+    // at mode 000 fails open() with EACCES before EISDIR can say "not a
+    // file" — which put `.git`/`node_modules` on the coverage ledger as an
+    // unread FILE at standard depth (#588). A directory is never this
+    // probe's input; a file, symlink or anything else keeps today's read.
+    const dirReadSec003 = await readCheckDirents(targetDir, (entry) => !entry.isDirectory());
+    if (dirReadSec003.state === 'read') {
+      for (const entry of dirReadSec003.entries) {
         if (entry.isDirectory()) continue;
         const file = entry.name;
         try {
@@ -7948,21 +8087,25 @@ dist/
           }
         } catch {}
       }
-    } catch {}
+    }
 
-    findings.push({
-      checkId: 'SEC-003',
-      name: 'Key Rotation Support',
-      description: 'No key rotation mechanism detected',
-      category: 'secrets',
-      severity: 'low',
-      passed: hasKeyRotation,
-      message: hasKeyRotation
-        ? 'Key rotation support detected'
-        : 'Consider implementing key rotation for long-lived secrets',
-      fixable: false,
-      guidance: 'Without key rotation, a single compromised key grants permanent access. Regular rotation limits the window of exposure when a key is leaked.',
-    });
+    if (dirReadSec003.state === 'absent') {
+      findings.push(notApplicableRecord({ checkId: 'SEC-003', name: 'Key Rotation Support', description: 'No key rotation mechanism detected', category: 'secrets' }, 'files at the scanned root', 'No files at the scanned root, so there is nothing to inspect.'));
+    } else if (dirReadSec003.state === 'read') {
+      findings.push({
+        checkId: 'SEC-003',
+        name: 'Key Rotation Support',
+        description: 'No key rotation mechanism detected',
+        category: 'secrets',
+        severity: 'low',
+        passed: hasKeyRotation,
+        message: hasKeyRotation
+          ? 'Key rotation support detected'
+          : 'Consider implementing key rotation for long-lived secrets',
+        fixable: false,
+        guidance: 'Without key rotation, a single compromised key grants permanent access. Regular rotation limits the window of exposure when a key is leaked.',
+      });
+    }
 
     // SEC-004: Check for hardcoded connection strings
     let hasHardcodedConnStr = false;
@@ -8081,24 +8224,29 @@ dist/
 
     // IO-003: Check for XSS protection
     let hasXssProtection = false;
-    try {
-      const pkgJson = await fs.readFile(path.join(targetDir, 'package.json'), 'utf-8');
+    const pkgReadIo003 = await readCheckSubject(path.join(targetDir, 'package.json'));
+    if (pkgReadIo003.state === 'read') {
+      const pkgJson = pkgReadIo003.content;
       hasXssProtection = pkgJson.includes('xss') || pkgJson.includes('sanitize') || pkgJson.includes('DOMPurify') || pkgJson.includes('helmet');
-    } catch {}
+    }
 
-    findings.push({
-      checkId: 'IO-003',
-      name: 'XSS Protection',
-      description: 'No XSS protection library detected',
-      category: 'io',
-      severity: 'high',
-      passed: hasXssProtection,
-      message: hasXssProtection
-        ? 'XSS protection library detected'
-        : 'No XSS protection library found - sanitize user input before rendering',
-      fixable: false,
-      guidance: 'Without XSS protection, user-supplied content rendered in the browser can execute arbitrary JavaScript, stealing session tokens and user data.',
-    });
+    if (pkgReadIo003.state === 'absent') {
+      findings.push(notApplicableRecord({ checkId: 'IO-003', name: 'XSS Protection', description: 'No XSS protection library detected', category: 'io' }, 'package.json', 'No package.json in the scanned tree, so there is no dependency manifest to inspect.'));
+    } else if (pkgReadIo003.state === 'read') {
+      findings.push({
+        checkId: 'IO-003',
+        name: 'XSS Protection',
+        description: 'No XSS protection library detected',
+        category: 'io',
+        severity: 'high',
+        passed: hasXssProtection,
+        message: hasXssProtection
+          ? 'XSS protection library detected'
+          : 'No XSS protection library found - sanitize user input before rendering',
+        fixable: false,
+        guidance: 'Without XSS protection, user-supplied content rendered in the browser can execute arbitrary JavaScript, stealing session tokens and user data.',
+      });
+    }
 
     // IO-004: Check for path traversal protection
     let hasPathTraversal = false;
@@ -8191,80 +8339,92 @@ dist/
 
     // PROMPT-002: Check for injection defense instructions
     let hasInjectionDefense = false;
-    try {
-      const content = await fs.readFile(claudeMdPath, 'utf-8');
+    if (claudeMdRead.state === 'read') {
+      const content = claudeMdRead.content;
       hasInjectionDefense =
         content.toLowerCase().includes('injection') ||
         content.toLowerCase().includes('malicious') ||
         content.toLowerCase().includes('untrusted') ||
         content.toLowerCase().includes('sanitize') ||
         content.toLowerCase().includes('validate input');
-    } catch {}
+    }
 
-    findings.push({
-      checkId: 'PROMPT-002',
-      name: 'Injection Defense Instructions',
-      description: 'System prompts should include injection defense guidance',
-      category: 'prompt-security',
-      severity: 'medium',
-      passed: hasInjectionDefense,
-      message: hasInjectionDefense
-        ? 'Injection defense instructions found'
-        : 'Consider adding injection defense instructions to system prompts',
-      fixable: false,
-      guidance: 'System prompts without injection defenses can be overridden by user inputs that say "ignore previous instructions", bypassing all safety rules.',
-    });
+    if (claudeMdRead.state === 'absent') {
+      findings.push(notApplicableRecord({ checkId: 'PROMPT-002', name: 'Injection Defense Instructions', description: 'System prompts should include injection defense guidance', category: 'prompt-security' }, 'CLAUDE.md', 'No CLAUDE.md in the scanned tree, so there is no system prompt file to inspect.'));
+    } else if (claudeMdRead.state === 'read') {
+      findings.push({
+        checkId: 'PROMPT-002',
+        name: 'Injection Defense Instructions',
+        description: 'System prompts should include injection defense guidance',
+        category: 'prompt-security',
+        severity: 'medium',
+        passed: hasInjectionDefense,
+        message: hasInjectionDefense
+          ? 'Injection defense instructions found'
+          : 'Consider adding injection defense instructions to system prompts',
+        fixable: false,
+        guidance: 'System prompts without injection defenses can be overridden by user inputs that say "ignore previous instructions", bypassing all safety rules.',
+      });
+    }
 
     // PROMPT-003: Check for output constraints
     let hasOutputConstraints = false;
-    try {
-      const content = await fs.readFile(claudeMdPath, 'utf-8');
+    if (claudeMdRead.state === 'read') {
+      const content = claudeMdRead.content;
       hasOutputConstraints =
         content.toLowerCase().includes('never output') ||
         content.toLowerCase().includes('do not reveal') ||
         content.toLowerCase().includes('do not disclose') ||
         content.toLowerCase().includes('keep confidential') ||
         content.toLowerCase().includes('do not share');
-    } catch {}
+    }
 
-    findings.push({
-      checkId: 'PROMPT-003',
-      name: 'Output Confidentiality Rules',
-      description: 'System prompts should define output confidentiality constraints',
-      category: 'prompt-security',
-      severity: 'medium',
-      passed: hasOutputConstraints,
-      message: hasOutputConstraints
-        ? 'Output confidentiality rules defined'
-        : 'Consider defining what information should not be disclosed',
-      fixable: false,
-      guidance: 'Without output confidentiality rules, the agent may freely reveal system prompts, internal tool names, API keys, or other sensitive context when asked.',
-    });
+    if (claudeMdRead.state === 'absent') {
+      findings.push(notApplicableRecord({ checkId: 'PROMPT-003', name: 'Output Confidentiality Rules', description: 'System prompts should define output confidentiality constraints', category: 'prompt-security' }, 'CLAUDE.md', 'No CLAUDE.md in the scanned tree, so there is no system prompt file to inspect.'));
+    } else if (claudeMdRead.state === 'read') {
+      findings.push({
+        checkId: 'PROMPT-003',
+        name: 'Output Confidentiality Rules',
+        description: 'System prompts should define output confidentiality constraints',
+        category: 'prompt-security',
+        severity: 'medium',
+        passed: hasOutputConstraints,
+        message: hasOutputConstraints
+          ? 'Output confidentiality rules defined'
+          : 'Consider defining what information should not be disclosed',
+        fixable: false,
+        guidance: 'Without output confidentiality rules, the agent may freely reveal system prompts, internal tool names, API keys, or other sensitive context when asked.',
+      });
+    }
 
     // PROMPT-004: Check for role confusion protection
     let hasRoleProtection = false;
-    try {
-      const content = await fs.readFile(claudeMdPath, 'utf-8');
+    if (claudeMdRead.state === 'read') {
+      const content = claudeMdRead.content;
       hasRoleProtection =
         content.toLowerCase().includes('you are') ||
         content.toLowerCase().includes('your role') ||
         content.toLowerCase().includes('as an assistant') ||
         content.toLowerCase().includes('maintain your role');
-    } catch {}
+    }
 
-    findings.push({
-      checkId: 'PROMPT-004',
-      name: 'Role Definition Protection',
-      description: 'System prompts should clearly define the AI role to prevent confusion attacks',
-      category: 'prompt-security',
-      severity: 'low',
-      passed: hasRoleProtection,
-      message: hasRoleProtection
-        ? 'Role definition found in prompts'
-        : 'Consider clearly defining the AI role to prevent role confusion attacks',
-      fixable: false,
-      guidance: 'Without a clear role definition, attackers can use "you are now a hacker assistant" style prompts to override the agent identity and bypass safety constraints.',
-    });
+    if (claudeMdRead.state === 'absent') {
+      findings.push(notApplicableRecord({ checkId: 'PROMPT-004', name: 'Role Definition Protection', description: 'System prompts should clearly define the AI role to prevent confusion attacks', category: 'prompt-security' }, 'CLAUDE.md', 'No CLAUDE.md in the scanned tree, so there is no system prompt file to inspect.'));
+    } else if (claudeMdRead.state === 'read') {
+      findings.push({
+        checkId: 'PROMPT-004',
+        name: 'Role Definition Protection',
+        description: 'System prompts should clearly define the AI role to prevent confusion attacks',
+        category: 'prompt-security',
+        severity: 'low',
+        passed: hasRoleProtection,
+        message: hasRoleProtection
+          ? 'Role definition found in prompts'
+          : 'Consider clearly defining the AI role to prevent role confusion attacks',
+        fixable: false,
+        guidance: 'Without a clear role definition, attackers can use "you are now a hacker assistant" style prompts to override the agent identity and bypass safety constraints.',
+      });
+    }
 
     return findings;
   }
@@ -8280,9 +8440,9 @@ dist/
 
     // INJ-001: Check for input validation in MCP handlers
     let hasInputValidation = false;
-    try {
-      const files = await fs.readdir(targetDir);
-      for (const file of files) {
+    const dirReadInj001 = await readCheckDir(targetDir, (file) => file.endsWith('.ts') || file.endsWith('.js'));
+    if (dirReadInj001.state === 'read') {
+      for (const file of dirReadInj001.entries) {
         if (file.endsWith('.ts') || file.endsWith('.js')) {
           try {
             const content = await fs.readFile(path.join(targetDir, file), 'utf-8');
@@ -8300,27 +8460,31 @@ dist/
           } catch {}
         }
       }
-    } catch {}
+    }
 
-    findings.push({
-      checkId: 'INJ-001',
-      name: 'Input Validation Library',
-      description: 'Applications should use schema validation for inputs',
-      category: 'input-validation',
-      severity: 'high',
-      passed: hasInputValidation,
-      message: hasInputValidation
-        ? 'Input validation library detected'
-        : 'Consider using zod, joi, or similar for input validation',
-      fixable: false,
-      guidance: 'Without schema validation, any malformed or malicious input reaches your application logic. This is the root cause of injection, overflow, and type confusion attacks.',
-    });
+    if (dirReadInj001.state === 'absent') {
+      findings.push(notApplicableRecord({ checkId: 'INJ-001', name: 'Input Validation Library', description: 'Applications should use schema validation for inputs', category: 'input-validation' }, 'source files (.ts, .js)', 'No .ts or .js files at the scanned root, so there is no source to inspect.'));
+    } else if (dirReadInj001.state === 'read') {
+      findings.push({
+        checkId: 'INJ-001',
+        name: 'Input Validation Library',
+        description: 'Applications should use schema validation for inputs',
+        category: 'input-validation',
+        severity: 'high',
+        passed: hasInputValidation,
+        message: hasInputValidation
+          ? 'Input validation library detected'
+          : 'Consider using zod, joi, or similar for input validation',
+        fixable: false,
+        guidance: 'Without schema validation, any malformed or malicious input reaches your application logic. This is the root cause of injection, overflow, and type confusion attacks.',
+      });
+    }
 
     // INJ-002: Check for XSS protection patterns
     let hasXssProtection = false;
-    try {
-      const files = await fs.readdir(targetDir);
-      for (const file of files) {
+    const dirReadInj002 = await readCheckDir(targetDir, (file) => file.endsWith('.ts') || file.endsWith('.js'));
+    if (dirReadInj002.state === 'read') {
+      for (const file of dirReadInj002.entries) {
         if (file.endsWith('.ts') || file.endsWith('.js')) {
           try {
             const content = await fs.readFile(path.join(targetDir, file), 'utf-8');
@@ -8337,27 +8501,31 @@ dist/
           } catch {}
         }
       }
-    } catch {}
+    }
 
-    findings.push({
-      checkId: 'INJ-002',
-      name: 'XSS Protection',
-      description: 'Output should be properly escaped to prevent XSS',
-      category: 'input-validation',
-      severity: 'high',
-      passed: hasXssProtection,
-      message: hasXssProtection
-        ? 'XSS protection patterns detected'
-        : 'Consider implementing output escaping for user-facing content',
-      fixable: false,
-      guidance: 'Unescaped user content rendered in HTML lets attackers inject scripts that steal cookies, hijack sessions, and impersonate users.',
-    });
+    if (dirReadInj002.state === 'absent') {
+      findings.push(notApplicableRecord({ checkId: 'INJ-002', name: 'XSS Protection', description: 'Output should be properly escaped to prevent XSS', category: 'input-validation' }, 'source files (.ts, .js)', 'No .ts or .js files at the scanned root, so there is no source to inspect.'));
+    } else if (dirReadInj002.state === 'read') {
+      findings.push({
+        checkId: 'INJ-002',
+        name: 'XSS Protection',
+        description: 'Output should be properly escaped to prevent XSS',
+        category: 'input-validation',
+        severity: 'high',
+        passed: hasXssProtection,
+        message: hasXssProtection
+          ? 'XSS protection patterns detected'
+          : 'Consider implementing output escaping for user-facing content',
+        fixable: false,
+        guidance: 'Unescaped user content rendered in HTML lets attackers inject scripts that steal cookies, hijack sessions, and impersonate users.',
+      });
+    }
 
     // INJ-003: Check for SQL injection protection
     let hasSqlProtection = false;
-    try {
-      const files = await fs.readdir(targetDir);
-      for (const file of files) {
+    const dirReadInj003 = await readCheckDir(targetDir, (file) => file.endsWith('.ts') || file.endsWith('.js'));
+    if (dirReadInj003.state === 'read') {
+      for (const file of dirReadInj003.entries) {
         if (file.endsWith('.ts') || file.endsWith('.js')) {
           try {
             const content = await fs.readFile(path.join(targetDir, file), 'utf-8');
@@ -8376,21 +8544,25 @@ dist/
           } catch {}
         }
       }
-    } catch {}
+    }
 
-    findings.push({
-      checkId: 'INJ-003',
-      name: 'SQL Injection Protection',
-      description: 'Database queries should use parameterized statements',
-      category: 'input-validation',
-      severity: 'critical',
-      passed: hasSqlProtection,
-      message: hasSqlProtection
-        ? 'Parameterized queries or ORM detected'
-        : 'Ensure all database queries use parameterized statements',
-      fixable: false,
-      guidance: 'SQL injection via string concatenation lets attackers read, modify, or delete any data in your database. Parameterized queries prevent this entirely.',
-    });
+    if (dirReadInj003.state === 'absent') {
+      findings.push(notApplicableRecord({ checkId: 'INJ-003', name: 'SQL Injection Protection', description: 'Database queries should use parameterized statements', category: 'input-validation' }, 'source files (.ts, .js)', 'No .ts or .js files at the scanned root, so there is no source to inspect.'));
+    } else if (dirReadInj003.state === 'read') {
+      findings.push({
+        checkId: 'INJ-003',
+        name: 'SQL Injection Protection',
+        description: 'Database queries should use parameterized statements',
+        category: 'input-validation',
+        severity: 'critical',
+        passed: hasSqlProtection,
+        message: hasSqlProtection
+          ? 'Parameterized queries or ORM detected'
+          : 'Ensure all database queries use parameterized statements',
+        fixable: false,
+        guidance: 'SQL injection via string concatenation lets attackers read, modify, or delete any data in your database. Parameterized queries prevent this entirely.',
+      });
+    }
 
     // INJ-004: Check for command injection protection
     let hasCmdProtection = false;
@@ -8448,37 +8620,43 @@ dist/
 
     // RATE-001: Check for rate limiting configuration
     let hasRateLimiting = false;
-    try {
-      const pkgPath = path.join(targetDir, 'package.json');
-      const content = await fs.readFile(pkgPath, 'utf-8');
-      const pkg = JSON.parse(content);
+    const pkgReadRate001 = await readCheckSubject(path.join(targetDir, 'package.json'));
+    if (pkgReadRate001.state === 'read') {
+      // Present-but-unparseable stays a measured fail (TOOL-001 precedent).
+      try {
+        const pkg = JSON.parse(pkgReadRate001.content);
       const deps = { ...pkg.dependencies, ...pkg.devDependencies };
       hasRateLimiting =
         'express-rate-limit' in deps ||
         'rate-limiter-flexible' in deps ||
         'bottleneck' in deps ||
         '@upstash/ratelimit' in deps;
-    } catch {}
+      } catch {}
+    }
 
-    findings.push({
-      checkId: 'RATE-001',
-      name: 'Rate Limiting Configuration',
-      description: 'API endpoints should have rate limiting',
-      category: 'rate-limiting',
-      severity: 'medium',
-      passed: hasRateLimiting,
-      message: hasRateLimiting
-        ? 'Rate limiting library detected'
-        : 'Consider implementing rate limiting to prevent abuse',
-      fixable: false,
-      guidance: 'Without rate limiting, attackers can make unlimited API calls, exhausting your quota and running up costs. It also enables brute-force and credential stuffing attacks.',
-    });
+    if (pkgReadRate001.state === 'absent') {
+      findings.push(notApplicableRecord({ checkId: 'RATE-001', name: 'Rate Limiting Configuration', description: 'API endpoints should have rate limiting', category: 'rate-limiting' }, 'package.json', 'No package.json in the scanned tree, so there is no dependency manifest to inspect.'));
+    } else if (pkgReadRate001.state === 'read') {
+      findings.push({
+        checkId: 'RATE-001',
+        name: 'Rate Limiting Configuration',
+        description: 'API endpoints should have rate limiting',
+        category: 'rate-limiting',
+        severity: 'medium',
+        passed: hasRateLimiting,
+        message: hasRateLimiting
+          ? 'Rate limiting library detected'
+          : 'Consider implementing rate limiting to prevent abuse',
+        fixable: false,
+        guidance: 'Without rate limiting, attackers can make unlimited API calls, exhausting your quota and running up costs. It also enables brute-force and credential stuffing attacks.',
+      });
+    }
 
     // RATE-002: Check for retry/backoff patterns
     let hasBackoff = false;
-    try {
-      const files = await fs.readdir(targetDir);
-      for (const file of files) {
+    const dirReadRate002 = await readCheckDir(targetDir, (file) => file.endsWith('.ts') || file.endsWith('.js'));
+    if (dirReadRate002.state === 'read') {
+      for (const file of dirReadRate002.entries) {
         if (file.endsWith('.ts') || file.endsWith('.js')) {
           try {
             const content = await fs.readFile(path.join(targetDir, file), 'utf-8');
@@ -8494,27 +8672,31 @@ dist/
           } catch {}
         }
       }
-    } catch {}
+    }
 
-    findings.push({
-      checkId: 'RATE-002',
-      name: 'Retry with Backoff',
-      description: 'External calls should implement exponential backoff',
-      category: 'rate-limiting',
-      severity: 'low',
-      passed: hasBackoff,
-      message: hasBackoff
-        ? 'Retry/backoff patterns detected'
-        : 'Consider implementing exponential backoff for external calls',
-      fixable: false,
-      guidance: 'Without exponential backoff, retries hammer external services at full speed during outages, worsening the problem and potentially getting your API key banned.',
-    });
+    if (dirReadRate002.state === 'absent') {
+      findings.push(notApplicableRecord({ checkId: 'RATE-002', name: 'Retry with Backoff', description: 'External calls should implement exponential backoff', category: 'rate-limiting' }, 'source files (.ts, .js)', 'No .ts or .js files at the scanned root, so there is no source to inspect.'));
+    } else if (dirReadRate002.state === 'read') {
+      findings.push({
+        checkId: 'RATE-002',
+        name: 'Retry with Backoff',
+        description: 'External calls should implement exponential backoff',
+        category: 'rate-limiting',
+        severity: 'low',
+        passed: hasBackoff,
+        message: hasBackoff
+          ? 'Retry/backoff patterns detected'
+          : 'Consider implementing exponential backoff for external calls',
+        fixable: false,
+        guidance: 'Without exponential backoff, retries hammer external services at full speed during outages, worsening the problem and potentially getting your API key banned.',
+      });
+    }
 
     // RATE-003: Check for timeout configurations
     let hasTimeouts = false;
-    try {
-      const files = await fs.readdir(targetDir);
-      for (const file of files) {
+    const dirReadRate003 = await readCheckDir(targetDir, (file) => file.endsWith('.ts') || file.endsWith('.js') || file.endsWith('.json'));
+    if (dirReadRate003.state === 'read') {
+      for (const file of dirReadRate003.entries) {
         if (file.endsWith('.ts') || file.endsWith('.js') || file.endsWith('.json')) {
           try {
             const content = await fs.readFile(path.join(targetDir, file), 'utf-8');
@@ -8529,27 +8711,31 @@ dist/
           } catch {}
         }
       }
-    } catch {}
+    }
 
-    findings.push({
-      checkId: 'RATE-003',
-      name: 'Timeout Configuration',
-      description: 'Operations should have appropriate timeouts',
-      category: 'rate-limiting',
-      severity: 'medium',
-      passed: hasTimeouts,
-      message: hasTimeouts
-        ? 'Timeout configurations detected'
-        : 'Consider setting timeouts for external calls and long-running operations',
-      fixable: false,
-      guidance: 'Without timeouts, a slow or unresponsive external service can cause your application to hang indefinitely, tying up connections and eventually crashing.',
-    });
+    if (dirReadRate003.state === 'absent') {
+      findings.push(notApplicableRecord({ checkId: 'RATE-003', name: 'Timeout Configuration', description: 'Operations should have appropriate timeouts', category: 'rate-limiting' }, 'source or config files (.ts, .js, .json)', 'No .ts, .js or .json files at the scanned root, so there is nothing to inspect.'));
+    } else if (dirReadRate003.state === 'read') {
+      findings.push({
+        checkId: 'RATE-003',
+        name: 'Timeout Configuration',
+        description: 'Operations should have appropriate timeouts',
+        category: 'rate-limiting',
+        severity: 'medium',
+        passed: hasTimeouts,
+        message: hasTimeouts
+          ? 'Timeout configurations detected'
+          : 'Consider setting timeouts for external calls and long-running operations',
+        fixable: false,
+        guidance: 'Without timeouts, a slow or unresponsive external service can cause your application to hang indefinitely, tying up connections and eventually crashing.',
+      });
+    }
 
     // RATE-004: Check for concurrent request limiting
     let hasConcurrencyLimit = false;
-    try {
-      const files = await fs.readdir(targetDir);
-      for (const file of files) {
+    const dirReadRate004 = await readCheckDir(targetDir, (file) => file.endsWith('.ts') || file.endsWith('.js'));
+    if (dirReadRate004.state === 'read') {
+      for (const file of dirReadRate004.entries) {
         if (file.endsWith('.ts') || file.endsWith('.js')) {
           try {
             const content = await fs.readFile(path.join(targetDir, file), 'utf-8');
@@ -8565,21 +8751,25 @@ dist/
           } catch {}
         }
       }
-    } catch {}
+    }
 
-    findings.push({
-      checkId: 'RATE-004',
-      name: 'Concurrency Limits',
-      description: 'Concurrent operations should be limited',
-      category: 'rate-limiting',
-      severity: 'low',
-      passed: hasConcurrencyLimit,
-      message: hasConcurrencyLimit
-        ? 'Concurrency limiting detected'
-        : 'Consider limiting concurrent operations to prevent resource exhaustion',
-      fixable: false,
-      guidance: 'Without concurrency limits, a burst of requests can spawn unbounded parallel operations that exhaust memory, file descriptors, and CPU, crashing the service.',
-    });
+    if (dirReadRate004.state === 'absent') {
+      findings.push(notApplicableRecord({ checkId: 'RATE-004', name: 'Concurrency Limits', description: 'Concurrent operations should be limited', category: 'rate-limiting' }, 'source files (.ts, .js)', 'No .ts or .js files at the scanned root, so there is no source to inspect.'));
+    } else if (dirReadRate004.state === 'read') {
+      findings.push({
+        checkId: 'RATE-004',
+        name: 'Concurrency Limits',
+        description: 'Concurrent operations should be limited',
+        category: 'rate-limiting',
+        severity: 'low',
+        passed: hasConcurrencyLimit,
+        message: hasConcurrencyLimit
+          ? 'Concurrency limiting detected'
+          : 'Consider limiting concurrent operations to prevent resource exhaustion',
+        fixable: false,
+        guidance: 'Without concurrency limits, a burst of requests can spawn unbounded parallel operations that exhaust memory, file descriptors, and CPU, crashing the service.',
+      });
+    }
 
     return findings;
   }
@@ -8595,9 +8785,9 @@ dist/
 
     // SESSION-001: Check for secure session configuration
     let hasSecureSessions = false;
-    try {
-      const files = await fs.readdir(targetDir);
-      for (const file of files) {
+    const dirReadSession001 = await readCheckDir(targetDir, (file) => file.endsWith('.ts') || file.endsWith('.js'));
+    if (dirReadSession001.state === 'read') {
+      for (const file of dirReadSession001.entries) {
         if (file.endsWith('.ts') || file.endsWith('.js')) {
           try {
             const content = await fs.readFile(path.join(targetDir, file), 'utf-8');
@@ -8612,27 +8802,31 @@ dist/
           } catch {}
         }
       }
-    } catch {}
+    }
 
-    findings.push({
-      checkId: 'SESSION-001',
-      name: 'Secure Cookie Settings',
-      description: 'Session cookies should have secure flags',
-      category: 'session-security',
-      severity: 'high',
-      passed: hasSecureSessions,
-      message: hasSecureSessions
-        ? 'Secure cookie flags detected'
-        : 'Set httpOnly, secure, and sameSite on session cookies',
-      fixable: false,
-      guidance: 'Session cookies without secure flags can be stolen via XSS (missing httpOnly), sent over plain HTTP (missing secure), or exploited in cross-site attacks (missing sameSite).',
-    });
+    if (dirReadSession001.state === 'absent') {
+      findings.push(notApplicableRecord({ checkId: 'SESSION-001', name: 'Secure Cookie Settings', description: 'Session cookies should have secure flags', category: 'session-security' }, 'source files (.ts, .js)', 'No .ts or .js files at the scanned root, so there is no source to inspect.'));
+    } else if (dirReadSession001.state === 'read') {
+      findings.push({
+        checkId: 'SESSION-001',
+        name: 'Secure Cookie Settings',
+        description: 'Session cookies should have secure flags',
+        category: 'session-security',
+        severity: 'high',
+        passed: hasSecureSessions,
+        message: hasSecureSessions
+          ? 'Secure cookie flags detected'
+          : 'Set httpOnly, secure, and sameSite on session cookies',
+        fixable: false,
+        guidance: 'Session cookies without secure flags can be stolen via XSS (missing httpOnly), sent over plain HTTP (missing secure), or exploited in cross-site attacks (missing sameSite).',
+      });
+    }
 
     // SESSION-002: Check for session expiry
     let hasSessionExpiry = false;
-    try {
-      const files = await fs.readdir(targetDir);
-      for (const file of files) {
+    const dirReadSession002 = await readCheckDir(targetDir, (file) => file.endsWith('.ts') || file.endsWith('.js') || file.endsWith('.json'));
+    if (dirReadSession002.state === 'read') {
+      for (const file of dirReadSession002.entries) {
         if (file.endsWith('.ts') || file.endsWith('.js') || file.endsWith('.json')) {
           try {
             const content = await fs.readFile(path.join(targetDir, file), 'utf-8');
@@ -8648,51 +8842,61 @@ dist/
           } catch {}
         }
       }
-    } catch {}
+    }
 
-    findings.push({
-      checkId: 'SESSION-002',
-      name: 'Session Expiry',
-      description: 'Sessions should have appropriate expiry times',
-      category: 'session-security',
-      severity: 'medium',
-      passed: hasSessionExpiry,
-      message: hasSessionExpiry
-        ? 'Session expiry configuration detected'
-        : 'Configure appropriate session expiry times',
-      fixable: false,
-      guidance: 'Sessions without expiry remain valid indefinitely. A stolen session token grants permanent access until the server is restarted or the token is manually revoked.',
-    });
+    if (dirReadSession002.state === 'absent') {
+      findings.push(notApplicableRecord({ checkId: 'SESSION-002', name: 'Session Expiry', description: 'Sessions should have appropriate expiry times', category: 'session-security' }, 'source or config files (.ts, .js, .json)', 'No .ts, .js or .json files at the scanned root, so there is nothing to inspect.'));
+    } else if (dirReadSession002.state === 'read') {
+      findings.push({
+        checkId: 'SESSION-002',
+        name: 'Session Expiry',
+        description: 'Sessions should have appropriate expiry times',
+        category: 'session-security',
+        severity: 'medium',
+        passed: hasSessionExpiry,
+        message: hasSessionExpiry
+          ? 'Session expiry configuration detected'
+          : 'Configure appropriate session expiry times',
+        fixable: false,
+        guidance: 'Sessions without expiry remain valid indefinitely. A stolen session token grants permanent access until the server is restarted or the token is manually revoked.',
+      });
+    }
 
     // SESSION-003: Check for CSRF protection
     let hasCsrfProtection = false;
-    try {
-      const pkgPath = path.join(targetDir, 'package.json');
-      const content = await fs.readFile(pkgPath, 'utf-8');
-      const pkg = JSON.parse(content);
+    const pkgReadSession003 = await readCheckSubject(path.join(targetDir, 'package.json'));
+    if (pkgReadSession003.state === 'read') {
+      // Present-but-unparseable stays a measured fail (TOOL-001 precedent).
+      try {
+        const pkg = JSON.parse(pkgReadSession003.content);
       const deps = { ...pkg.dependencies, ...pkg.devDependencies };
       hasCsrfProtection = 'csurf' in deps || 'csrf' in deps || '@fastify/csrf-protection' in deps;
-    } catch {}
+      } catch {}
+    }
 
-    findings.push({
-      checkId: 'SESSION-003',
-      name: 'CSRF Protection',
-      description: 'Forms should have CSRF protection',
-      category: 'session-security',
-      severity: 'high',
-      passed: hasCsrfProtection,
-      message: hasCsrfProtection
-        ? 'CSRF protection library detected'
-        : 'Consider implementing CSRF protection for state-changing operations',
-      fixable: false,
-      guidance: 'Without CSRF protection, a malicious website can trick authenticated users into performing unwanted actions (transfers, password changes, data deletion) by forging requests from their browser.',
-    });
+    if (pkgReadSession003.state === 'absent') {
+      findings.push(notApplicableRecord({ checkId: 'SESSION-003', name: 'CSRF Protection', description: 'Forms should have CSRF protection', category: 'session-security' }, 'package.json', 'No package.json in the scanned tree, so there is no dependency manifest to inspect.'));
+    } else if (pkgReadSession003.state === 'read') {
+      findings.push({
+        checkId: 'SESSION-003',
+        name: 'CSRF Protection',
+        description: 'Forms should have CSRF protection',
+        category: 'session-security',
+        severity: 'high',
+        passed: hasCsrfProtection,
+        message: hasCsrfProtection
+          ? 'CSRF protection library detected'
+          : 'Consider implementing CSRF protection for state-changing operations',
+        fixable: false,
+        guidance: 'Without CSRF protection, a malicious website can trick authenticated users into performing unwanted actions (transfers, password changes, data deletion) by forging requests from their browser.',
+      });
+    }
 
     // SESSION-004: Check for secure token storage
     let hasSecureStorage = false;
-    try {
-      const files = await fs.readdir(targetDir);
-      for (const file of files) {
+    const dirReadSession004 = await readCheckDir(targetDir, (file) => file.endsWith('.ts') || file.endsWith('.js'));
+    if (dirReadSession004.state === 'read') {
+      for (const file of dirReadSession004.entries) {
         if (file.endsWith('.ts') || file.endsWith('.js')) {
           try {
             const content = await fs.readFile(path.join(targetDir, file), 'utf-8');
@@ -8708,21 +8912,25 @@ dist/
           } catch {}
         }
       }
-    } catch {}
+    }
 
-    findings.push({
-      checkId: 'SESSION-004',
-      name: 'Secure Token Storage',
-      description: 'Tokens should be stored securely',
-      category: 'session-security',
-      severity: 'medium',
-      passed: hasSecureStorage,
-      message: hasSecureStorage
-        ? 'Secure token storage detected'
-        : 'Consider using secure storage for sensitive tokens',
-      fixable: false,
-      guidance: 'Tokens stored in plaintext files or localStorage can be stolen by any process with file access or XSS attack, allowing full account takeover without credentials.',
-    });
+    if (dirReadSession004.state === 'absent') {
+      findings.push(notApplicableRecord({ checkId: 'SESSION-004', name: 'Secure Token Storage', description: 'Tokens should be stored securely', category: 'session-security' }, 'source files (.ts, .js)', 'No .ts or .js files at the scanned root, so there is no source to inspect.'));
+    } else if (dirReadSession004.state === 'read') {
+      findings.push({
+        checkId: 'SESSION-004',
+        name: 'Secure Token Storage',
+        description: 'Tokens should be stored securely',
+        category: 'session-security',
+        severity: 'medium',
+        passed: hasSecureStorage,
+        message: hasSecureStorage
+          ? 'Secure token storage detected'
+          : 'Consider using secure storage for sensitive tokens',
+        fixable: false,
+        guidance: 'Tokens stored in plaintext files or localStorage can be stolen by any process with file access or XSS attack, allowing full account takeover without credentials.',
+      });
+    }
 
     return findings;
   }
@@ -8738,9 +8946,9 @@ dist/
 
     // ENCRYPT-001: Check for encryption at rest
     let hasEncryption = false;
-    try {
-      const files = await fs.readdir(targetDir);
-      for (const file of files) {
+    const dirReadEncrypt001 = await readCheckDir(targetDir, (file) => file.endsWith('.ts') || file.endsWith('.js'));
+    if (dirReadEncrypt001.state === 'read') {
+      for (const file of dirReadEncrypt001.entries) {
         if (file.endsWith('.ts') || file.endsWith('.js')) {
           try {
             const content = await fs.readFile(path.join(targetDir, file), 'utf-8');
@@ -8756,27 +8964,31 @@ dist/
           } catch {}
         }
       }
-    } catch {}
+    }
 
-    findings.push({
-      checkId: 'ENCRYPT-001',
-      name: 'Encryption Implementation',
-      description: 'Sensitive data should be encrypted at rest',
-      category: 'encryption',
-      severity: 'high',
-      passed: hasEncryption,
-      message: hasEncryption
-        ? 'Encryption implementation detected'
-        : 'Consider encrypting sensitive data at rest',
-      fixable: false,
-      guidance: 'Without encryption at rest, anyone with disk access (stolen laptop, compromised server, backup leak) can read sensitive data including credentials and user information.',
-    });
+    if (dirReadEncrypt001.state === 'absent') {
+      findings.push(notApplicableRecord({ checkId: 'ENCRYPT-001', name: 'Encryption Implementation', description: 'Sensitive data should be encrypted at rest', category: 'encryption' }, 'source files (.ts, .js)', 'No .ts or .js files at the scanned root, so there is no source to inspect.'));
+    } else if (dirReadEncrypt001.state === 'read') {
+      findings.push({
+        checkId: 'ENCRYPT-001',
+        name: 'Encryption Implementation',
+        description: 'Sensitive data should be encrypted at rest',
+        category: 'encryption',
+        severity: 'high',
+        passed: hasEncryption,
+        message: hasEncryption
+          ? 'Encryption implementation detected'
+          : 'Consider encrypting sensitive data at rest',
+        fixable: false,
+        guidance: 'Without encryption at rest, anyone with disk access (stolen laptop, compromised server, backup leak) can read sensitive data including credentials and user information.',
+      });
+    }
 
     // ENCRYPT-002: Check for secure hashing
     let hasSecureHashing = false;
-    try {
-      const files = await fs.readdir(targetDir);
-      for (const file of files) {
+    const dirReadEncrypt002 = await readCheckDir(targetDir, (file) => file.endsWith('.ts') || file.endsWith('.js'));
+    if (dirReadEncrypt002.state === 'read') {
+      for (const file of dirReadEncrypt002.entries) {
         if (file.endsWith('.ts') || file.endsWith('.js')) {
           try {
             const content = await fs.readFile(path.join(targetDir, file), 'utf-8');
@@ -8792,21 +9004,25 @@ dist/
           } catch {}
         }
       }
-    } catch {}
+    }
 
-    findings.push({
-      checkId: 'ENCRYPT-002',
-      name: 'Secure Password Hashing',
-      description: 'Passwords should use secure hashing algorithms',
-      category: 'encryption',
-      severity: 'critical',
-      passed: hasSecureHashing,
-      message: hasSecureHashing
-        ? 'Secure hashing algorithm detected (bcrypt/argon2/scrypt)'
-        : 'Use bcrypt, argon2, or scrypt for password hashing',
-      fixable: false,
-      guidance: 'Passwords hashed with fast algorithms (MD5, SHA1) can be cracked in bulk using rainbow tables or GPU brute-force. Bcrypt, argon2, and scrypt are deliberately slow to resist this.',
-    });
+    if (dirReadEncrypt002.state === 'absent') {
+      findings.push(notApplicableRecord({ checkId: 'ENCRYPT-002', name: 'Secure Password Hashing', description: 'Passwords should use secure hashing algorithms', category: 'encryption' }, 'source files (.ts, .js)', 'No .ts or .js files at the scanned root, so there is no source to inspect.'));
+    } else if (dirReadEncrypt002.state === 'read') {
+      findings.push({
+        checkId: 'ENCRYPT-002',
+        name: 'Secure Password Hashing',
+        description: 'Passwords should use secure hashing algorithms',
+        category: 'encryption',
+        severity: 'critical',
+        passed: hasSecureHashing,
+        message: hasSecureHashing
+          ? 'Secure hashing algorithm detected (bcrypt/argon2/scrypt)'
+          : 'Use bcrypt, argon2, or scrypt for password hashing',
+        fixable: false,
+        guidance: 'Passwords hashed with fast algorithms (MD5, SHA1) can be cracked in bulk using rainbow tables or GPU brute-force. Bcrypt, argon2, and scrypt are deliberately slow to resist this.',
+      });
+    }
 
     // ENCRYPT-003: Check for weak algorithms
     let hasWeakAlgorithms = false;
@@ -8846,9 +9062,9 @@ dist/
 
     // ENCRYPT-004: Check for TLS configuration
     let hasTlsConfig = false;
-    try {
-      const files = await fs.readdir(targetDir);
-      for (const file of files) {
+    const dirReadEncrypt004 = await readCheckDir(targetDir, (file) => file.endsWith('.ts') || file.endsWith('.js') || file.endsWith('.json'));
+    if (dirReadEncrypt004.state === 'read') {
+      for (const file of dirReadEncrypt004.entries) {
         if (file.endsWith('.ts') || file.endsWith('.js') || file.endsWith('.json')) {
           try {
             const content = await fs.readFile(path.join(targetDir, file), 'utf-8');
@@ -8864,21 +9080,25 @@ dist/
           } catch {}
         }
       }
-    } catch {}
+    }
 
-    findings.push({
-      checkId: 'ENCRYPT-004',
-      name: 'TLS Configuration',
-      description: 'Communications should use TLS',
-      category: 'encryption',
-      severity: 'high',
-      passed: hasTlsConfig,
-      message: hasTlsConfig
-        ? 'TLS/HTTPS configuration detected'
-        : 'Ensure all communications use TLS',
-      fixable: false,
-      guidance: 'Without TLS, all network traffic including credentials, tokens, and sensitive data is transmitted in plaintext and can be intercepted by anyone on the network path.',
-    });
+    if (dirReadEncrypt004.state === 'absent') {
+      findings.push(notApplicableRecord({ checkId: 'ENCRYPT-004', name: 'TLS Configuration', description: 'Communications should use TLS', category: 'encryption' }, 'source or config files (.ts, .js, .json)', 'No .ts, .js or .json files at the scanned root, so there is nothing to inspect.'));
+    } else if (dirReadEncrypt004.state === 'read') {
+      findings.push({
+        checkId: 'ENCRYPT-004',
+        name: 'TLS Configuration',
+        description: 'Communications should use TLS',
+        category: 'encryption',
+        severity: 'high',
+        passed: hasTlsConfig,
+        message: hasTlsConfig
+          ? 'TLS/HTTPS configuration detected'
+          : 'Ensure all communications use TLS',
+        fixable: false,
+        guidance: 'Without TLS, all network traffic including credentials, tokens, and sensitive data is transmitted in plaintext and can be intercepted by anyone on the network path.',
+      });
+    }
 
     return findings;
   }
@@ -8894,9 +9114,9 @@ dist/
 
     // AUDIT-001: Check for audit logging
     let hasAuditLogging = false;
-    try {
-      const files = await fs.readdir(targetDir);
-      for (const file of files) {
+    const dirReadAudit001 = await readCheckDir(targetDir, (file) => file.endsWith('.ts') || file.endsWith('.js'));
+    if (dirReadAudit001.state === 'read') {
+      for (const file of dirReadAudit001.entries) {
         if (file.endsWith('.ts') || file.endsWith('.js')) {
           try {
             const content = await fs.readFile(path.join(targetDir, file), 'utf-8');
@@ -8912,27 +9132,31 @@ dist/
           } catch {}
         }
       }
-    } catch {}
+    }
 
-    findings.push({
-      checkId: 'AUDIT-001',
-      name: 'Audit Logging',
-      description: 'Security-relevant events should be logged',
-      category: 'audit',
-      severity: 'medium',
-      passed: hasAuditLogging,
-      message: hasAuditLogging
-        ? 'Audit logging implementation detected'
-        : 'Consider implementing audit logging for security events',
-      fixable: false,
-      guidance: 'Missing audit logs mean you cannot detect or investigate security incidents after they occur. Attackers operate undetected and forensic analysis becomes impossible.',
-    });
+    if (dirReadAudit001.state === 'absent') {
+      findings.push(notApplicableRecord({ checkId: 'AUDIT-001', name: 'Audit Logging', description: 'Security-relevant events should be logged', category: 'audit' }, 'source files (.ts, .js)', 'No .ts or .js files at the scanned root, so there is no source to inspect.'));
+    } else if (dirReadAudit001.state === 'read') {
+      findings.push({
+        checkId: 'AUDIT-001',
+        name: 'Audit Logging',
+        description: 'Security-relevant events should be logged',
+        category: 'audit',
+        severity: 'medium',
+        passed: hasAuditLogging,
+        message: hasAuditLogging
+          ? 'Audit logging implementation detected'
+          : 'Consider implementing audit logging for security events',
+        fixable: false,
+        guidance: 'Missing audit logs mean you cannot detect or investigate security incidents after they occur. Attackers operate undetected and forensic analysis becomes impossible.',
+      });
+    }
 
     // AUDIT-002: Check for log rotation
     let hasLogRotation = false;
-    try {
-      const files = await fs.readdir(targetDir);
-      for (const file of files) {
+    const dirReadAudit002 = await readCheckDir(targetDir, (file) => file.endsWith('.ts') || file.endsWith('.js') || file.endsWith('.json'));
+    if (dirReadAudit002.state === 'read') {
+      for (const file of dirReadAudit002.entries) {
         if (file.endsWith('.ts') || file.endsWith('.js') || file.endsWith('.json')) {
           try {
             const content = await fs.readFile(path.join(targetDir, file), 'utf-8');
@@ -8947,51 +9171,61 @@ dist/
           } catch {}
         }
       }
-    } catch {}
+    }
 
-    findings.push({
-      checkId: 'AUDIT-002',
-      name: 'Log Rotation',
-      description: 'Logs should have rotation configured',
-      category: 'audit',
-      severity: 'low',
-      passed: hasLogRotation,
-      message: hasLogRotation
-        ? 'Log rotation configuration detected'
-        : 'Consider configuring log rotation to manage disk space',
-      fixable: false,
-      guidance: 'Without log rotation, logs grow until they fill the disk, causing service outages. Attackers can also exploit this to trigger denial-of-service by generating excessive log entries.',
-    });
+    if (dirReadAudit002.state === 'absent') {
+      findings.push(notApplicableRecord({ checkId: 'AUDIT-002', name: 'Log Rotation', description: 'Logs should have rotation configured', category: 'audit' }, 'source or config files (.ts, .js, .json)', 'No .ts, .js or .json files at the scanned root, so there is nothing to inspect.'));
+    } else if (dirReadAudit002.state === 'read') {
+      findings.push({
+        checkId: 'AUDIT-002',
+        name: 'Log Rotation',
+        description: 'Logs should have rotation configured',
+        category: 'audit',
+        severity: 'low',
+        passed: hasLogRotation,
+        message: hasLogRotation
+          ? 'Log rotation configuration detected'
+          : 'Consider configuring log rotation to manage disk space',
+        fixable: false,
+        guidance: 'Without log rotation, logs grow until they fill the disk, causing service outages. Attackers can also exploit this to trigger denial-of-service by generating excessive log entries.',
+      });
+    }
 
     // AUDIT-003: Check for error tracking
     let hasErrorTracking = false;
-    try {
-      const pkgPath = path.join(targetDir, 'package.json');
-      const content = await fs.readFile(pkgPath, 'utf-8');
-      const pkg = JSON.parse(content);
+    const pkgReadAudit003 = await readCheckSubject(path.join(targetDir, 'package.json'));
+    if (pkgReadAudit003.state === 'read') {
+      // Present-but-unparseable stays a measured fail (TOOL-001 precedent).
+      try {
+        const pkg = JSON.parse(pkgReadAudit003.content);
       const deps = { ...pkg.dependencies, ...pkg.devDependencies };
       hasErrorTracking = '@sentry/node' in deps || 'bugsnag' in deps || 'rollbar' in deps;
-    } catch {}
+      } catch {}
+    }
 
-    findings.push({
-      checkId: 'AUDIT-003',
-      name: 'Error Tracking',
-      description: 'Errors should be tracked for monitoring',
-      category: 'audit',
-      severity: 'low',
-      passed: hasErrorTracking,
-      message: hasErrorTracking
-        ? 'Error tracking service detected'
-        : 'Consider using an error tracking service for production',
-      fixable: false,
-      guidance: 'Without error tracking, security-related failures (auth errors, injection attempts, rate limit hits) go unnoticed in production, giving attackers time to refine their approach.',
-    });
+    if (pkgReadAudit003.state === 'absent') {
+      findings.push(notApplicableRecord({ checkId: 'AUDIT-003', name: 'Error Tracking', description: 'Errors should be tracked for monitoring', category: 'audit' }, 'package.json', 'No package.json in the scanned tree, so there is no dependency manifest to inspect.'));
+    } else if (pkgReadAudit003.state === 'read') {
+      findings.push({
+        checkId: 'AUDIT-003',
+        name: 'Error Tracking',
+        description: 'Errors should be tracked for monitoring',
+        category: 'audit',
+        severity: 'low',
+        passed: hasErrorTracking,
+        message: hasErrorTracking
+          ? 'Error tracking service detected'
+          : 'Consider using an error tracking service for production',
+        fixable: false,
+        guidance: 'Without error tracking, security-related failures (auth errors, injection attempts, rate limit hits) go unnoticed in production, giving attackers time to refine their approach.',
+      });
+    }
 
     // AUDIT-004: Check for no sensitive data in logs
     let hasLogSanitization = false;
-    try {
-      const files = await fs.readdir(targetDir);
-      for (const file of files) {
+    const dirReadAudit004 = await readCheckDir(targetDir, (file) => file.endsWith('.ts') || file.endsWith('.js'));
+    if (dirReadAudit004.state === 'read') {
+      for (const file of dirReadAudit004.entries) {
         if (file.endsWith('.ts') || file.endsWith('.js')) {
           try {
             const content = await fs.readFile(path.join(targetDir, file), 'utf-8');
@@ -9006,21 +9240,25 @@ dist/
           } catch {}
         }
       }
-    } catch {}
+    }
 
-    findings.push({
-      checkId: 'AUDIT-004',
-      name: 'Log Sanitization',
-      description: 'Sensitive data should be redacted from logs',
-      category: 'audit',
-      severity: 'high',
-      passed: hasLogSanitization,
-      message: hasLogSanitization
-        ? 'Log sanitization patterns detected'
-        : 'Consider redacting sensitive data (passwords, tokens) from logs',
-      fixable: false,
-      guidance: 'Unsanitized logs containing passwords, tokens, or PII become a secondary breach vector. Log aggregation services, backups, and support teams all gain access to sensitive data.',
-    });
+    if (dirReadAudit004.state === 'absent') {
+      findings.push(notApplicableRecord({ checkId: 'AUDIT-004', name: 'Log Sanitization', description: 'Sensitive data should be redacted from logs', category: 'audit' }, 'source files (.ts, .js)', 'No .ts or .js files at the scanned root, so there is no source to inspect.'));
+    } else if (dirReadAudit004.state === 'read') {
+      findings.push({
+        checkId: 'AUDIT-004',
+        name: 'Log Sanitization',
+        description: 'Sensitive data should be redacted from logs',
+        category: 'audit',
+        severity: 'high',
+        passed: hasLogSanitization,
+        message: hasLogSanitization
+          ? 'Log sanitization patterns detected'
+          : 'Consider redacting sensitive data (passwords, tokens) from logs',
+        fixable: false,
+        guidance: 'Unsanitized logs containing passwords, tokens, or PII become a secondary breach vector. Log aggregation services, backups, and support teams all gain access to sensitive data.',
+      });
+    }
 
     return findings;
   }
@@ -9114,53 +9352,65 @@ dist/
     }
 
     // SANDBOX-003: Check for resource limits
+    // #458 — both compose spellings are probed; a readable .yaml decides,
+    // else a readable .yml (the original precedence, verdict unchanged). Both
+    // absent => not-applicable; neither read and either obstructed => nothing.
+    const composeYmlRead = await readCheckSubject(path.join(targetDir, 'docker-compose.yml'));
+    const composeYamlRead = await readCheckSubject(path.join(targetDir, 'docker-compose.yaml'));
+    const composeRead: SubjectRead =
+      composeYamlRead.state === 'read' ? composeYamlRead
+      : composeYmlRead.state === 'read' ? composeYmlRead
+      : composeYmlRead.state === 'unread' || composeYamlRead.state === 'unread' ? { state: 'unread' }
+      : { state: 'absent' };
     let hasResourceLimits = false;
-    try {
-      const composePath = path.join(targetDir, 'docker-compose.yml');
-      const content = await fs.readFile(composePath, 'utf-8');
+    if (composeRead.state === 'read') {
+      const content = composeRead.content;
       hasResourceLimits = content.includes('mem_limit') || content.includes('cpus') || content.includes('deploy:');
-    } catch {}
-    try {
-      const composePath = path.join(targetDir, 'docker-compose.yaml');
-      const content = await fs.readFile(composePath, 'utf-8');
-      hasResourceLimits = content.includes('mem_limit') || content.includes('cpus') || content.includes('deploy:');
-    } catch {}
+    }
 
-    findings.push({
-      checkId: 'SANDBOX-003',
-      name: 'Resource Limits',
-      description: 'Containers should have resource limits',
-      category: 'sandboxing',
-      severity: 'medium',
-      passed: hasResourceLimits,
-      message: hasResourceLimits
-        ? 'Resource limits configured'
-        : 'Consider setting CPU and memory limits for containers',
-      fixable: false,
-      guidance: 'Without resource limits, a single compromised or buggy container can consume all host CPU and memory, causing denial-of-service for every other service on the machine.',
-    });
+    if (composeRead.state === 'absent') {
+      findings.push(notApplicableRecord({ checkId: 'SANDBOX-003', name: 'Resource Limits', description: 'Containers should have resource limits', category: 'sandboxing' }, 'docker-compose.yml', 'No docker-compose.yml or docker-compose.yaml in the scanned tree, so there is no container configuration to inspect.'));
+    } else if (composeRead.state === 'read') {
+      findings.push({
+        checkId: 'SANDBOX-003',
+        name: 'Resource Limits',
+        description: 'Containers should have resource limits',
+        category: 'sandboxing',
+        severity: 'medium',
+        passed: hasResourceLimits,
+        message: hasResourceLimits
+          ? 'Resource limits configured'
+          : 'Consider setting CPU and memory limits for containers',
+        fixable: false,
+        guidance: 'Without resource limits, a single compromised or buggy container can consume all host CPU and memory, causing denial-of-service for every other service on the machine.',
+      });
+    }
 
     // SANDBOX-004: Check for read-only filesystem
+    // #458 — reuses SANDBOX-003's docker-compose.yml read; this check has
+    // only ever read the .yml spelling, and that stays as it is.
     let hasReadOnlyFs = false;
-    try {
-      const composePath = path.join(targetDir, 'docker-compose.yml');
-      const content = await fs.readFile(composePath, 'utf-8');
-      hasReadOnlyFs = content.includes('read_only: true');
-    } catch {}
+    if (composeYmlRead.state === 'read') {
+      hasReadOnlyFs = composeYmlRead.content.includes('read_only: true');
+    }
 
-    findings.push({
-      checkId: 'SANDBOX-004',
-      name: 'Read-Only Filesystem',
-      description: 'Containers should use read-only filesystem where possible',
-      category: 'sandboxing',
-      severity: 'low',
-      passed: hasReadOnlyFs,
-      message: hasReadOnlyFs
-        ? 'Read-only filesystem configured'
-        : 'Consider using read-only filesystem for containers',
-      fixable: false,
-      guidance: 'A writable filesystem allows attackers to drop malware, modify binaries, or plant persistence mechanisms inside the container. Read-only filesystems prevent post-exploitation tampering.',
-    });
+    if (composeYmlRead.state === 'absent') {
+      findings.push(notApplicableRecord({ checkId: 'SANDBOX-004', name: 'Read-Only Filesystem', description: 'Containers should use read-only filesystem where possible', category: 'sandboxing' }, 'docker-compose.yml', 'No docker-compose.yml in the scanned tree, so there is no container configuration to inspect.'));
+    } else if (composeYmlRead.state === 'read') {
+      findings.push({
+        checkId: 'SANDBOX-004',
+        name: 'Read-Only Filesystem',
+        description: 'Containers should use read-only filesystem where possible',
+        category: 'sandboxing',
+        severity: 'low',
+        passed: hasReadOnlyFs,
+        message: hasReadOnlyFs
+          ? 'Read-only filesystem configured'
+          : 'Consider using read-only filesystem for containers',
+        fixable: false,
+        guidance: 'A writable filesystem allows attackers to drop malware, modify binaries, or plant persistence mechanisms inside the container. Read-only filesystems prevent post-exploitation tampering.',
+      });
+    }
 
     return findings;
   }
@@ -9176,8 +9426,9 @@ dist/
     const mcpConfigPath = path.join(targetDir, 'mcp.json');
 
     // #458 — one errno-classified read shared by TOOL-001/002/003. TOOL-001 is
-    // errno-gated in this cut; TOOL-002/003 keep their legacy behaviour
-    // (`mcpConfig` null => failed advisory) until the class sweep reaches them.
+    // TOOL-002/003 branch on the same read (#458): absent mcp.json =>
+    // not-applicable naming the subject, unread => nothing, read => their
+    // verdict, unchanged.
     const mcpRead = await readCheckSubject(mcpConfigPath);
     let mcpConfig: Record<string, unknown> | null = null;
     if (mcpRead.state === 'read') {
@@ -9243,19 +9494,23 @@ dist/
       }
     }
 
-    findings.push({
-      checkId: 'TOOL-002',
-      name: 'Tool Resource Constraints',
-      description: 'MCP tools should have resource constraints',
-      category: 'tool-boundaries',
-      severity: 'medium',
-      passed: hasResourceConstraints,
-      message: hasResourceConstraints
-        ? 'Resource constraints configured'
-        : 'Consider setting maxTokens and timeout for MCP tools',
-      fixable: false,
-      guidance: 'Without token limits and timeouts, a runaway or malicious tool call can consume unlimited API credits and block the agent indefinitely.',
-    });
+    if (mcpRead.state === 'absent') {
+      findings.push(notApplicableRecord({ checkId: 'TOOL-002', name: 'Tool Resource Constraints', description: 'MCP tools should have resource constraints', category: 'tool-boundaries' }, 'mcp.json', 'No mcp.json in the scanned tree, so no MCP servers are configured and there are no tool boundaries to measure.'));
+    } else if (mcpRead.state === 'read') {
+      findings.push({
+        checkId: 'TOOL-002',
+        name: 'Tool Resource Constraints',
+        description: 'MCP tools should have resource constraints',
+        category: 'tool-boundaries',
+        severity: 'medium',
+        passed: hasResourceConstraints,
+        message: hasResourceConstraints
+          ? 'Resource constraints configured'
+          : 'Consider setting maxTokens and timeout for MCP tools',
+        fixable: false,
+        guidance: 'Without token limits and timeouts, a runaway or malicious tool call can consume unlimited API credits and block the agent indefinitely.',
+      });
+    }
 
     // TOOL-003: Check for dangerous tool usage
     let hasDangerousTools = false;
@@ -9271,44 +9526,52 @@ dist/
       }
     }
 
-    findings.push({
-      checkId: 'TOOL-003',
-      name: 'Dangerous Tool Detection',
-      description: 'Identify potentially dangerous MCP tools',
-      category: 'tool-boundaries',
-      severity: 'high',
-      passed: !hasDangerousTools,
-      message: hasDangerousTools
-        ? 'Potentially dangerous tools detected (shell/exec) - ensure proper restrictions'
-        : 'No obvious dangerous tools detected',
-      fixable: false,
-      guidance: 'Shell and exec tools give the AI agent arbitrary command execution on the host. A prompt injection can leverage these to exfiltrate data, install malware, or pivot to other systems.',
-    });
+    if (mcpRead.state === 'absent') {
+      findings.push(notApplicableRecord({ checkId: 'TOOL-003', name: 'Dangerous Tool Detection', description: 'Identify potentially dangerous MCP tools', category: 'tool-boundaries' }, 'mcp.json', 'No mcp.json in the scanned tree, so no MCP servers are configured and there are no tool boundaries to measure.'));
+    } else if (mcpRead.state === 'read') {
+      findings.push({
+        checkId: 'TOOL-003',
+        name: 'Dangerous Tool Detection',
+        description: 'Identify potentially dangerous MCP tools',
+        category: 'tool-boundaries',
+        severity: 'high',
+        passed: !hasDangerousTools,
+        message: hasDangerousTools
+          ? 'Potentially dangerous tools detected (shell/exec) - ensure proper restrictions'
+          : 'No obvious dangerous tools detected',
+        fixable: false,
+        guidance: 'Shell and exec tools give the AI agent arbitrary command execution on the host. A prompt injection can leverage these to exfiltrate data, install malware, or pivot to other systems.',
+      });
+    }
 
     // TOOL-004: Check for tool confirmation requirements
     let hasConfirmation = false;
-    try {
-      const claudePath = path.join(targetDir, 'CLAUDE.md');
-      const content = await fs.readFile(claudePath, 'utf-8');
+    const claudeReadTool004 = await readCheckSubject(path.join(targetDir, 'CLAUDE.md'));
+    if (claudeReadTool004.state === 'read') {
+      const content = claudeReadTool004.content;
       hasConfirmation =
         content.toLowerCase().includes('confirm') ||
         content.toLowerCase().includes('approval') ||
         content.toLowerCase().includes('ask before');
-    } catch {}
+    }
 
-    findings.push({
-      checkId: 'TOOL-004',
-      name: 'Tool Confirmation Requirements',
-      description: 'Dangerous operations should require confirmation',
-      category: 'tool-boundaries',
-      severity: 'medium',
-      passed: hasConfirmation,
-      message: hasConfirmation
-        ? 'Tool confirmation instructions detected'
-        : 'Consider requiring confirmation for destructive operations',
-      fixable: false,
-      guidance: 'Without confirmation gates, the AI agent can execute destructive operations (file deletion, database drops, deployments) in a single step with no human checkpoint.',
-    });
+    if (claudeReadTool004.state === 'absent') {
+      findings.push(notApplicableRecord({ checkId: 'TOOL-004', name: 'Tool Confirmation Requirements', description: 'Dangerous operations should require confirmation', category: 'tool-boundaries' }, 'CLAUDE.md', 'No CLAUDE.md in the scanned tree, so there is no system prompt file to inspect.'));
+    } else if (claudeReadTool004.state === 'read') {
+      findings.push({
+        checkId: 'TOOL-004',
+        name: 'Tool Confirmation Requirements',
+        description: 'Dangerous operations should require confirmation',
+        category: 'tool-boundaries',
+        severity: 'medium',
+        passed: hasConfirmation,
+        message: hasConfirmation
+          ? 'Tool confirmation instructions detected'
+          : 'Consider requiring confirmation for destructive operations',
+        fixable: false,
+        guidance: 'Without confirmation gates, the AI agent can execute destructive operations (file deletion, database drops, deployments) in a single step with no human checkpoint.',
+      });
+    }
 
     return findings;
   }

--- a/src/hardening/scanner.ts
+++ b/src/hardening/scanner.ts
@@ -51,6 +51,7 @@ import {
   type CategoryCoverage,
   type CheckExecution,
   type CoverageTruncation,
+  countsAsUnread,
   noteListFailure,
 } from './coverage-ledger';
 
@@ -324,6 +325,46 @@ export function buildUnreadInputFinding(
     fix,
     guidance,
   } as any;
+}
+
+/**
+ * #458 — one errno vocabulary for a check whose subject may be absent.
+ *
+ * The three-way classification behind the ruled four-state verdict contract:
+ *
+ * - `read`: the subject exists and its bytes are in hand — MEASURE it.
+ * - `absent`: a not-there errno (`countsAsUnread` false: ENOENT / EISDIR /
+ *   ENOTDIR) — the subject does not exist in this tree, so the check measured
+ *   nothing. The caller emits a not-applicable record naming the subject —
+ *   unless the check RECOMMENDS the artifact, in which case absence IS the
+ *   finding, with `file` set to the path the fix creates (GIT-001 /
+ *   SANDBOX-001 shape).
+ * - `unread`: every other errno (EACCES, EPERM, ELOOP, ENAMETOOLONG, …) — the
+ *   subject may well exist; the scan could not look. The caller emits NOTHING
+ *   for this check. The tracked-fs namespace has already recorded the failed
+ *   read on the ledger's unreadable-inputs channel, and
+ *   `buildUnreadInputFinding` is the one reporter for that channel. A
+ *   not-applicable record here would absorb a read failure into "not
+ *   applicable" and undo #438/#499/#508/#514; a `passed: false` would score a
+ *   tree nothing measured. The check id being absent downstream is correct:
+ *   `generateBenchmarkReport` reads a missing check id as `unverified`, which
+ *   is exactly what an unreadable subject is.
+ *
+ * Fail-closed: an error carrying no errno code classifies as `unread` — no
+ * evidence of absence is never `absent`.
+ */
+type SubjectRead =
+  | { state: 'read'; content: string }
+  | { state: 'absent' }
+  | { state: 'unread' };
+
+async function readCheckSubject(filePath: string): Promise<SubjectRead> {
+  try {
+    return { state: 'read', content: await fs.readFile(filePath, 'utf-8') };
+  } catch (err) {
+    const code = (err as NodeJS.ErrnoException).code ?? '';
+    return countsAsUnread(code) ? { state: 'unread' } : { state: 'absent' };
+  }
 }
 
 export interface CreatedFileRecord {
@@ -8104,33 +8145,49 @@ dist/
   ): Promise<SecurityFindingDraft[]> {
     const findings: SecurityFindingDraft[] = [];
 
-    // PROMPT-001: Check for system prompt boundary markers
-    let hasPromptBoundaries = false;
+    // PROMPT-001: Check for system prompt boundary markers.
+    // #458 — errno-gated: absent subject => not-applicable record; unread
+    // subject => no record (the ledger's unreadable-inputs channel carries
+    // the obstruction); read subject => measured pass/fail, unchanged.
     const claudeMdPath = path.join(targetDir, 'CLAUDE.md');
-    try {
-      const content = await fs.readFile(claudeMdPath, 'utf-8');
-      hasPromptBoundaries =
+    const claudeMdRead = await readCheckSubject(claudeMdPath);
+    if (claudeMdRead.state === 'absent') {
+      findings.push({
+        checkId: 'PROMPT-001',
+        name: 'Prompt Boundary Markers',
+        description: 'System prompts should have clear boundary markers to prevent injection',
+        category: 'prompt-security',
+        notApplicable: {
+          subject: 'CLAUDE.md',
+          reason: 'No CLAUDE.md in the scanned tree, so there is no system prompt file whose boundary markers could be measured.',
+        },
+        message: 'Not applicable: no CLAUDE.md to measure for prompt boundary markers',
+        fixable: false,
+      });
+    } else if (claudeMdRead.state === 'read') {
+      const content = claudeMdRead.content;
+      const hasPromptBoundaries =
         content.includes('SYSTEM:') ||
         content.includes('USER:') ||
         content.includes('---') ||
         content.includes('###') ||
         content.toLowerCase().includes('do not follow instructions') ||
         content.toLowerCase().includes('ignore attempts to');
-    } catch {}
 
-    findings.push({
-      checkId: 'PROMPT-001',
-      name: 'Prompt Boundary Markers',
-      description: 'System prompts should have clear boundary markers to prevent injection',
-      category: 'prompt-security',
-      severity: 'high',
-      passed: hasPromptBoundaries,
-      message: hasPromptBoundaries
-        ? 'Prompt boundaries detected in CLAUDE.md'
-        : 'Consider adding prompt boundary markers to prevent injection attacks',
-      fixable: false,
-      guidance: 'Without clear boundary markers, attackers can inject instructions that blend with the system prompt, making it impossible for the model to distinguish trusted from untrusted content.',
-    });
+      findings.push({
+        checkId: 'PROMPT-001',
+        name: 'Prompt Boundary Markers',
+        description: 'System prompts should have clear boundary markers to prevent injection',
+        category: 'prompt-security',
+        severity: 'high',
+        passed: hasPromptBoundaries,
+        message: hasPromptBoundaries
+          ? 'Prompt boundaries detected in CLAUDE.md'
+          : 'Consider adding prompt boundary markers to prevent injection attacks',
+        fixable: false,
+        guidance: 'Without clear boundary markers, attackers can inject instructions that blend with the system prompt, making it impossible for the model to distinguish trusted from untrusted content.',
+      });
+    }
 
     // PROMPT-002: Check for injection defense instructions
     let hasInjectionDefense = false;
@@ -8977,56 +9034,84 @@ dist/
   ): Promise<SecurityFindingDraft[]> {
     const findings: SecurityFindingDraft[] = [];
 
-    // SANDBOX-001: Check for Docker/container usage
-    let hasContainerization = false;
-    try {
-      await fs.access(path.join(targetDir, 'Dockerfile'));
-      hasContainerization = true;
-    } catch {}
-    try {
-      await fs.access(path.join(targetDir, 'docker-compose.yml'));
-      hasContainerization = true;
-    } catch {}
-    try {
-      await fs.access(path.join(targetDir, 'docker-compose.yaml'));
-      hasContainerization = true;
-    } catch {}
+    // SANDBOX-001: Check for Docker/container usage.
+    // #458 — containerization is a mitigation this check RECOMMENDS, so its
+    // absence is the finding, never a not-applicable record: the fail keeps
+    // `passed: false` and gains `file` naming the path the fix creates
+    // (GIT-001's advisory shape), which keeps it off the pathless noise floor.
+    // The probes go through `readCheckSubject` rather than `fs.access` because
+    // tracked-fs does not ledger a failed `access` — a probe obstructed by
+    // EACCES must reach the unreadable-inputs channel, not vanish. Every
+    // probed path is content-read by SANDBOX-002/003/004 when present, so
+    // coverage counts do not move.
+    const containerProbes = [
+      await readCheckSubject(path.join(targetDir, 'Dockerfile')),
+      await readCheckSubject(path.join(targetDir, 'docker-compose.yml')),
+      await readCheckSubject(path.join(targetDir, 'docker-compose.yaml')),
+    ];
+    const hasContainerization = containerProbes.some((p) => p.state === 'read');
+    if (hasContainerization || containerProbes.every((p) => p.state === 'absent')) {
+      const sandbox001: SecurityFindingDraft = {
+        checkId: 'SANDBOX-001',
+        name: 'Container Isolation',
+        description: 'Applications should run in isolated containers',
+        category: 'sandboxing',
+        severity: 'medium',
+        passed: hasContainerization,
+        message: hasContainerization
+          ? 'Container configuration detected'
+          : 'Consider running in Docker containers for isolation',
+        fixable: false,
+        guidance: 'Without container isolation, a compromised application has direct access to the host filesystem, network, and other processes. Containers limit the blast radius of a breach.',
+      };
+      if (!hasContainerization) {
+        // Absent-mitigation advisory: `file` is the path the fix creates.
+        sandbox001.file = 'Dockerfile';
+      }
+      findings.push(sandbox001);
+    }
+    // else: no probe read and at least one failed for a reason other than
+    // absence — containerization is UNKNOWN, not absent. Emit nothing; the
+    // ledger's unreadable-inputs channel discloses the obstruction (#458).
 
-    findings.push({
-      checkId: 'SANDBOX-001',
-      name: 'Container Isolation',
-      description: 'Applications should run in isolated containers',
-      category: 'sandboxing',
-      severity: 'medium',
-      passed: hasContainerization,
-      message: hasContainerization
-        ? 'Container configuration detected'
-        : 'Consider running in Docker containers for isolation',
-      fixable: false,
-      guidance: 'Without container isolation, a compromised application has direct access to the host filesystem, network, and other processes. Containers limit the blast radius of a breach.',
-    });
-
-    // SANDBOX-002: Check for non-root execution
-    let hasNonRootConfig = false;
-    try {
-      const dockerPath = path.join(targetDir, 'Dockerfile');
-      const content = await fs.readFile(dockerPath, 'utf-8');
-      hasNonRootConfig = content.includes('USER ') && !content.includes('USER root');
-    } catch {}
-
-    findings.push({
-      checkId: 'SANDBOX-002',
-      name: 'Non-Root Execution',
-      description: 'Containers should not run as root',
-      category: 'sandboxing',
-      severity: 'high',
-      passed: hasNonRootConfig,
-      message: hasNonRootConfig
-        ? 'Non-root user configured in Dockerfile'
-        : 'Configure containers to run as non-root user',
-      fixable: false,
-      guidance: 'Containers running as root can escape container isolation more easily. A container breakout as root grants full control of the host system.',
-    });
+    // SANDBOX-002: Check for non-root execution.
+    // #458 — this boolean was the class's root defect: it collapsed "no
+    // Dockerfile" with "runs as root". Absent Dockerfile => not-applicable
+    // (there is no container execution to measure — SANDBOX-001 carries the
+    // containerization advisory); unread => no record; read => measured.
+    // Reuses SANDBOX-001's Dockerfile read so one scan pass cannot classify
+    // the same subject two different ways.
+    const dockerfileRead = containerProbes[0];
+    if (dockerfileRead.state === 'absent') {
+      findings.push({
+        checkId: 'SANDBOX-002',
+        name: 'Non-Root Execution',
+        description: 'Containers should not run as root',
+        category: 'sandboxing',
+        notApplicable: {
+          subject: 'Dockerfile',
+          reason: 'No Dockerfile in the scanned tree, so there is no container execution to measure for root privilege. SANDBOX-001 carries the containerization advisory.',
+        },
+        message: 'Not applicable: no Dockerfile to measure for root execution',
+        fixable: false,
+      });
+    } else if (dockerfileRead.state === 'read') {
+      const hasNonRootConfig =
+        dockerfileRead.content.includes('USER ') && !dockerfileRead.content.includes('USER root');
+      findings.push({
+        checkId: 'SANDBOX-002',
+        name: 'Non-Root Execution',
+        description: 'Containers should not run as root',
+        category: 'sandboxing',
+        severity: 'high',
+        passed: hasNonRootConfig,
+        message: hasNonRootConfig
+          ? 'Non-root user configured in Dockerfile'
+          : 'Configure containers to run as non-root user',
+        fixable: false,
+        guidance: 'Containers running as root can escape container isolation more easily. A container breakout as root grants full control of the host system.',
+      });
+    }
 
     // SANDBOX-003: Check for resource limits
     let hasResourceLimits = false;
@@ -9090,36 +9175,62 @@ dist/
     const findings: SecurityFindingDraft[] = [];
     const mcpConfigPath = path.join(targetDir, 'mcp.json');
 
+    // #458 — one errno-classified read shared by TOOL-001/002/003. TOOL-001 is
+    // errno-gated in this cut; TOOL-002/003 keep their legacy behaviour
+    // (`mcpConfig` null => failed advisory) until the class sweep reaches them.
+    const mcpRead = await readCheckSubject(mcpConfigPath);
     let mcpConfig: Record<string, unknown> | null = null;
-    try {
-      const content = await fs.readFile(mcpConfigPath, 'utf-8');
-      mcpConfig = JSON.parse(content);
-    } catch {}
-
-    // TOOL-001: Check for tool whitelisting
-    let hasToolWhitelist = false;
-    if (mcpConfig?.servers) {
-      for (const [, server] of Object.entries(mcpConfig.servers as Record<string, { allowedTools?: string[] }>)) {
-        if (server.allowedTools && server.allowedTools.length > 0) {
-          hasToolWhitelist = true;
-          break;
-        }
-      }
+    if (mcpRead.state === 'read') {
+      try {
+        mcpConfig = JSON.parse(mcpRead.content);
+      } catch {}
     }
 
-    findings.push({
-      checkId: 'TOOL-001',
-      name: 'Tool Whitelisting',
-      description: 'MCP servers should have explicit tool whitelists',
-      category: 'tool-boundaries',
-      severity: 'high',
-      passed: hasToolWhitelist,
-      message: hasToolWhitelist
-        ? 'Tool whitelisting configured'
-        : 'Configure allowedTools to restrict MCP server capabilities',
-      fixable: false,
-      guidance: 'Without an explicit tool whitelist, MCP servers expose all available tools to the AI agent. A prompt injection attack can invoke any tool, including destructive ones.',
-    });
+    // TOOL-001: Check for tool whitelisting.
+    // #458 — absent mcp.json => not-applicable (nothing configures MCP servers
+    // here, so there are no tool boundaries to measure); unread => no record
+    // (the ledger's unreadable-inputs channel carries the obstruction);
+    // present-but-unparseable JSON keeps today's fail: a config that exists
+    // and cannot be parsed is a measured defect of the subject, not a missing
+    // subject.
+    if (mcpRead.state === 'absent') {
+      findings.push({
+        checkId: 'TOOL-001',
+        name: 'Tool Whitelisting',
+        description: 'MCP servers should have explicit tool whitelists',
+        category: 'tool-boundaries',
+        notApplicable: {
+          subject: 'mcp.json',
+          reason: 'No mcp.json in the scanned tree, so no MCP servers are configured and there are no tool boundaries to measure.',
+        },
+        message: 'Not applicable: no mcp.json to measure for tool whitelisting',
+        fixable: false,
+      });
+    } else if (mcpRead.state === 'read') {
+      let hasToolWhitelist = false;
+      if (mcpConfig?.servers) {
+        for (const [, server] of Object.entries(mcpConfig.servers as Record<string, { allowedTools?: string[] }>)) {
+          if (server.allowedTools && server.allowedTools.length > 0) {
+            hasToolWhitelist = true;
+            break;
+          }
+        }
+      }
+
+      findings.push({
+        checkId: 'TOOL-001',
+        name: 'Tool Whitelisting',
+        description: 'MCP servers should have explicit tool whitelists',
+        category: 'tool-boundaries',
+        severity: 'high',
+        passed: hasToolWhitelist,
+        message: hasToolWhitelist
+          ? 'Tool whitelisting configured'
+          : 'Configure allowedTools to restrict MCP server capabilities',
+        fixable: false,
+        guidance: 'Without an explicit tool whitelist, MCP servers expose all available tools to the AI agent. A prompt injection attack can invoke any tool, including destructive ones.',
+      });
+    }
 
     // TOOL-002: Check for resource constraints
     let hasResourceConstraints = false;

--- a/src/hardening/scanner.ts
+++ b/src/hardening/scanner.ts
@@ -368,6 +368,18 @@ async function readCheckSubject(filePath: string): Promise<SubjectRead> {
 }
 
 /**
+ * #458 — fold the classified reads of a check whose subject is ANY of several
+ * candidate files: `read` if any candidate was read, else `unread` if any
+ * candidate failed for a reason other than not-there (the coverage ledger
+ * discloses it), else `absent`.
+ */
+function combineSubjectReads(reads: SubjectRead[]): SubjectRead {
+  const read = reads.find((r) => r.state === 'read');
+  if (read) return read;
+  return reads.some((r) => r.state === 'unread') ? { state: 'unread' } : { state: 'absent' };
+}
+
+/**
  * #458 — the not-applicable record for a check whose subject is absent
  * (`readCheckSubject` / `readCheckDir` classified it `absent`). No `severity`,
  * no `passed`: the record names the subject the scan looked for and is
@@ -5304,6 +5316,7 @@ export class HardeningScanner {
     ];
 
     const permissionIssues: string[] = [];
+    let perm001Unread = false;
 
     for (const filename of sensitiveFiles) {
       const filePath = path.join(targetDir, filename);
@@ -5344,37 +5357,48 @@ export class HardeningScanner {
             }
           }
         }
-      } catch {
-        // File doesn't exist, skip
+      } catch (err) {
+        // #458 — a not-there errno is a completed measurement: the hazard is
+        // absent. Any other errno is a probe the check could not complete;
+        // `stat` failures are not ledgered by tracked-fs, so the check records
+        // the path for SCAN-UNREAD-001 itself and withholds its verdict below
+        // unless a hazard was measured on another file.
+        const code = (err as NodeJS.ErrnoException).code ?? '';
+        if (countsAsUnread(code)) {
+          this.coverage.noteReadFailure(filePath, code);
+          perm001Unread = true;
+        }
       }
     }
 
     const passed = permissionIssues.length === 0;
-    findings.push({
-      checkId: 'PERM-001',
-      name: 'Sensitive File Permissions',
-      description: 'Sensitive files have overly permissive permissions',
-      category: 'permissions',
-      severity: 'high',
-      passed,
-      message: passed
-        ? 'All sensitive files have appropriate permissions'
-        : `Files with overly permissive permissions: ${permissionIssues.join(', ')}`,
-      // `file` makes the failing finding survive the user-facing
-      // concrete-findings filter (#250).
-      file: passed ? undefined : permissionIssues[0],
-      fixable: true,
-      fixed: autoFix && !passed,
-      fix: passed ? undefined : `${this.cliName} secure --fix`,
-      // Cited instead of `fix` when the chmod above was swallowed (immutable
-      // flag, read-only mount, restrictive MAC policy) and verification
-      // proved the file is still world-readable. Names only the files that
-      // are still failing, because the re-scan recomputes this list.
-      manualFix: passed ? undefined : chmodFix(permissionIssues),
-      fixMessage: autoFix && !passed ? 'Changed permissions to 600' : undefined,
-      details: passed ? undefined : { files: permissionIssues },
-      guidance: 'Overly broad file permissions let any user on the system read sensitive config files that may contain credentials or API keys.',
-    });
+    if (permissionIssues.length > 0 || !perm001Unread) {
+      findings.push({
+        checkId: 'PERM-001',
+        name: 'Sensitive File Permissions',
+        description: 'Sensitive files have overly permissive permissions',
+        category: 'permissions',
+        severity: 'high',
+        passed,
+        message: passed
+          ? 'All sensitive files have appropriate permissions'
+          : `Files with overly permissive permissions: ${permissionIssues.join(', ')}`,
+        // `file` makes the failing finding survive the user-facing
+        // concrete-findings filter (#250).
+        file: passed ? undefined : permissionIssues[0],
+        fixable: true,
+        fixed: autoFix && !passed,
+        fix: passed ? undefined : `${this.cliName} secure --fix`,
+        // Cited instead of `fix` when the chmod above was swallowed (immutable
+        // flag, read-only mount, restrictive MAC policy) and verification
+        // proved the file is still world-readable. Names only the files that
+        // are still failing, because the re-scan recomputes this list.
+        manualFix: passed ? undefined : chmodFix(permissionIssues),
+        fixMessage: autoFix && !passed ? 'Changed permissions to 600' : undefined,
+        details: passed ? undefined : { files: permissionIssues },
+        guidance: 'Overly broad file permissions let any user on the system read sensitive config files that may contain credentials or API keys.',
+      });
+    }
 
     return findings;
   }
@@ -5985,32 +6009,39 @@ dist/
     ];
 
     let hasCredentialsInRules = false;
+    const cursorReads: SubjectRead[] = [];
     for (const cursorPath of cursorPaths) {
-      try {
-        const content = await fs.readFile(cursorPath, 'utf-8');
-        for (const { pattern } of CREDENTIAL_PATTERNS) {
-          if (pattern.test(content)) {
-            hasCredentialsInRules = true;
-            break;
-          }
+      const read = await readCheckSubject(cursorPath);
+      cursorReads.push(read);
+      if (read.state !== 'read') continue;
+      const content = read.content;
+      for (const { pattern } of CREDENTIAL_PATTERNS) {
+        if (pattern.test(content)) {
+          hasCredentialsInRules = true;
+          break;
         }
-      } catch {}
+      }
     }
+    const cursorRead = combineSubjectReads(cursorReads);
 
-    findings.push({
-      checkId: 'CURSOR-001',
-      name: 'Cursor Rules Contain Credentials',
-      description: 'Cursor configuration files contain exposed credentials',
-      category: 'cursor',
-      severity: 'critical',
-      passed: !hasCredentialsInRules,
-      message: hasCredentialsInRules
-        ? 'Cursor rules contain exposed credentials'
-        : 'No credentials found in Cursor rules',
-      fixable: false,
-      fix: hasCredentialsInRules ? 'opena2a protect .  — migrates hardcoded secrets into the Secretless vault (local, keychain, 1Password, or HashiCorp Vault). Keys are injected at runtime; source files reference them by name only.' : undefined,
-      guidance: 'Cursor rules files are often committed to git. Credentials embedded there get pushed to remotes where anyone with repo access can extract them.',
-    });
+    if (cursorRead.state === 'absent') {
+      findings.push(notApplicableRecord({ checkId: 'CURSOR-001', name: 'Cursor Rules Contain Credentials', description: 'Cursor configuration files contain exposed credentials', category: 'cursor' }, 'Cursor rules (.cursor/rules, .cursorrules)', 'Neither .cursor/rules nor .cursorrules in the scanned tree, so there are no Cursor rules to inspect.'));
+    } else if (cursorRead.state === 'read') {
+      findings.push({
+        checkId: 'CURSOR-001',
+        name: 'Cursor Rules Contain Credentials',
+        description: 'Cursor configuration files contain exposed credentials',
+        category: 'cursor',
+        severity: 'critical',
+        passed: !hasCredentialsInRules,
+        message: hasCredentialsInRules
+          ? 'Cursor rules contain exposed credentials'
+          : 'No credentials found in Cursor rules',
+        fixable: false,
+        fix: hasCredentialsInRules ? 'opena2a protect .  — migrates hardcoded secrets into the Secretless vault (local, keychain, 1Password, or HashiCorp Vault). Keys are injected at runtime; source files reference them by name only.' : undefined,
+        guidance: 'Cursor rules files are often committed to git. Credentials embedded there get pushed to remotes where anyone with repo access can extract them.',
+      });
+    }
 
     return findings;
   }
@@ -6024,10 +6055,13 @@ dist/
 
     let vscodeConfig: Record<string, unknown> | null = null;
     let vscodeContent = '';
-    try {
-      vscodeContent = await fs.readFile(vscodeMcpPath, 'utf-8');
-      vscodeConfig = JSON.parse(vscodeContent);
-    } catch {}
+    const vscodeRead = await readCheckSubject(vscodeMcpPath);
+    if (vscodeRead.state === 'read') {
+      vscodeContent = vscodeRead.content;
+      try {
+        vscodeConfig = JSON.parse(vscodeContent);
+      } catch {}
+    }
 
     // VSCODE-001: Check for credentials in VSCode MCP config
     let hasCredentials = false;
@@ -6038,19 +6072,23 @@ dist/
       }
     }
 
-    findings.push({
-      checkId: 'VSCODE-001',
-      name: 'VSCode MCP Config Credentials',
-      description: 'VSCode MCP configuration contains exposed credentials',
-      category: 'vscode',
-      severity: 'critical',
-      passed: !hasCredentials,
-      message: hasCredentials
-        ? 'VSCode MCP config contains exposed credentials'
-        : 'No credentials in VSCode MCP config',
-      fixable: false,
-      guidance: 'MCP config files are shared across workspaces and often committed to repos. Credentials there are exposed to every tool and extension that reads the config.',
-    });
+    if (vscodeRead.state === 'absent') {
+      findings.push(notApplicableRecord({ checkId: 'VSCODE-001', name: 'VSCode MCP Config Credentials', description: 'VSCode MCP configuration contains exposed credentials', category: 'vscode' }, '.vscode/mcp.json', 'No .vscode/mcp.json in the scanned tree, so there is no VS Code MCP configuration to inspect.'));
+    } else if (vscodeRead.state === 'read') {
+      findings.push({
+        checkId: 'VSCODE-001',
+        name: 'VSCode MCP Config Credentials',
+        description: 'VSCode MCP configuration contains exposed credentials',
+        category: 'vscode',
+        severity: 'critical',
+        passed: !hasCredentials,
+        message: hasCredentials
+          ? 'VSCode MCP config contains exposed credentials'
+          : 'No credentials in VSCode MCP config',
+        fixable: false,
+        guidance: 'MCP config files are shared across workspaces and often committed to repos. Credentials there are exposed to every tool and extension that reads the config.',
+      });
+    }
 
     // VSCODE-002: Check for overly permissive paths
     let hasRootAccess = false;
@@ -6063,19 +6101,23 @@ dist/
       }
     }
 
-    findings.push({
-      checkId: 'VSCODE-002',
-      name: 'VSCode MCP Root Access',
-      description: 'VSCode MCP server has root or home directory access',
-      category: 'vscode',
-      severity: 'high',
-      passed: !hasRootAccess,
-      message: hasRootAccess
-        ? 'VSCode MCP server has dangerous filesystem access'
-        : 'VSCode MCP filesystem access is scoped',
-      fixable: false,
-      guidance: 'An MCP server with root or home directory access can read SSH keys, cloud credentials, and any file on the system. Scope access to the project directory only.',
-    });
+    if (vscodeRead.state === 'absent') {
+      findings.push(notApplicableRecord({ checkId: 'VSCODE-002', name: 'VSCode MCP Root Access', description: 'VSCode MCP server has root or home directory access', category: 'vscode' }, '.vscode/mcp.json', 'No .vscode/mcp.json in the scanned tree, so there is no VS Code MCP configuration to inspect.'));
+    } else if (vscodeRead.state === 'read') {
+      findings.push({
+        checkId: 'VSCODE-002',
+        name: 'VSCode MCP Root Access',
+        description: 'VSCode MCP server has root or home directory access',
+        category: 'vscode',
+        severity: 'high',
+        passed: !hasRootAccess,
+        message: hasRootAccess
+          ? 'VSCode MCP server has dangerous filesystem access'
+          : 'VSCode MCP filesystem access is scoped',
+        fixable: false,
+        guidance: 'An MCP server with root or home directory access can read SSH keys, cloud credentials, and any file on the system. Scope access to the project directory only.',
+      });
+    }
 
     return findings;
   }
@@ -6615,12 +6657,11 @@ dist/
         fix: `List candidate key files yourself: find . -type f \\( -name '*.pem' -o -name '*.key' \\) -not -path '*/node_modules/*'`,
         guidance: 'The project tree is too large or deep, or contains an un-ignored node_modules — so the scanner could not confirm no private keys are committed. Verify manually and ensure keys are outside the repo or in a secrets manager.',
       });
-    } else {
-      // The passed branch may not claim the whole tree when a directory was
-      // not listed: "no key files found" without the caveat asserts an
-      // absence the scan could not measure (#588). The record carries the
-      // remedy; this message only stops over-claiming.
-      const unlisted = this.coverage.unreadableInputs.directories > 0;
+    } else if (this.coverage.unreadableInputs.directories === 0) {
+      // #458 — "no private key files" is measured only over what the walk
+      // listed. A directory it could not list makes that absence unmeasurable:
+      // no verdict, rather than a pass with a caveat. SCAN-UNREAD-001 names
+      // the directory and the remedy.
       findings.push({
         checkId: 'CRED-002',
         name: 'Private Key Files',
@@ -6628,9 +6669,7 @@ dist/
         category: 'credentials',
         severity: 'critical',
         passed: true,
-        message: unlisted
-          ? 'No private key files found among what could be listed (a directory could not be listed — see SCAN-UNREAD-001)'
-          : 'No private key files found in project directory',
+        message: 'No private key files found in project directory',
         fixable: false,
         guidance: 'Private key files (.pem, .key) in a project directory are easily committed to git. Once pushed, the keys are compromised and must be rotated.',
       });
@@ -6638,37 +6677,50 @@ dist/
 
     // CRED-003: Check package.json for hardcoded secrets
     let hasSecretsInPackageJson = false;
-    try {
-      const content = await fs.readFile(path.join(targetDir, 'package.json'), 'utf-8');
+    const pkgReadCred003 = await readCheckSubject(path.join(targetDir, 'package.json'));
+    if (pkgReadCred003.state === 'read') {
+      const content = pkgReadCred003.content;
       for (const { pattern } of CREDENTIAL_PATTERNS) {
         if (pattern.test(content)) {
           hasSecretsInPackageJson = true;
           break;
         }
       }
-    } catch {}
+    }
 
-    findings.push({
-      checkId: 'CRED-003',
-      name: 'Secrets in package.json',
-      description: 'package.json contains hardcoded secrets',
-      category: 'credentials',
-      severity: 'critical',
-      passed: !hasSecretsInPackageJson,
-      message: hasSecretsInPackageJson
-        ? 'package.json contains hardcoded secrets'
-        : 'No secrets found in package.json',
-      fixable: false,
-      fix: hasSecretsInPackageJson ? 'opena2a protect .  — migrates hardcoded secrets into the Secretless vault (local, keychain, 1Password, or HashiCorp Vault). Keys are injected at runtime; source files reference them by name only.' : undefined,
-      guidance: 'package.json is always committed to git and published to npm. Secrets there are visible to anyone who installs or forks your package.',
-    });
+    if (pkgReadCred003.state === 'absent') {
+      findings.push(notApplicableRecord({ checkId: 'CRED-003', name: 'Secrets in package.json', description: 'package.json contains hardcoded secrets', category: 'credentials' }, 'package.json', 'No package.json in the scanned tree, so there is no dependency manifest to inspect.'));
+    } else if (pkgReadCred003.state === 'read') {
+      findings.push({
+        checkId: 'CRED-003',
+        name: 'Secrets in package.json',
+        description: 'package.json contains hardcoded secrets',
+        category: 'credentials',
+        severity: 'critical',
+        passed: !hasSecretsInPackageJson,
+        message: hasSecretsInPackageJson
+          ? 'package.json contains hardcoded secrets'
+          : 'No secrets found in package.json',
+        fixable: false,
+        fix: hasSecretsInPackageJson ? 'opena2a protect .  — migrates hardcoded secrets into the Secretless vault (local, keychain, 1Password, or HashiCorp Vault). Keys are injected at runtime; source files reference them by name only.' : undefined,
+        guidance: 'package.json is always committed to git and published to npm. Secrets there are visible to anyone who installs or forks your package.',
+      });
+    }
 
     // CRED-004: Check for JWT secrets in config
     let hasJwtSecret = false;
     const configFiles = ['config.json', 'config.yaml', 'config.yml', 'settings.json'];
-    for (const file of configFiles) {
-      try {
-        const content = await fs.readFile(path.join(targetDir, file), 'utf-8');
+    // #458: one classified read per candidate file. Absent everywhere
+    // => not-applicable; nothing read and something unread => no record (the
+    // coverage ledger discloses it).
+    const configFileReads: SubjectRead[] = [];
+    for (const configFile of configFiles) {
+      configFileReads.push(await readCheckSubject(path.join(targetDir, configFile)));
+    }
+    const configRead = combineSubjectReads(configFileReads);
+    for (const configFileRead of configFileReads) {
+      if (configFileRead.state === 'read') {
+        const content = configFileRead.content;
         if (content.includes('jwt') && (content.includes('secret') || content.includes('key'))) {
           // Check if it's a hardcoded value (not env reference)
           if (!content.includes('${') && !content.includes('process.env')) {
@@ -6676,23 +6728,27 @@ dist/
             break;
           }
         }
-      } catch {}
+      }
     }
 
-    findings.push({
-      checkId: 'CRED-004',
-      name: 'JWT Secret in Config',
-      description: 'JWT secret found hardcoded in configuration file',
-      category: 'credentials',
-      severity: 'critical',
-      passed: !hasJwtSecret,
-      message: hasJwtSecret
-        ? 'JWT secret hardcoded in config'
-        : 'No hardcoded JWT secrets found',
-      fixable: false,
-      fix: hasJwtSecret ? 'opena2a protect .  — migrates hardcoded secrets into the Secretless vault (local, keychain, 1Password, or HashiCorp Vault). Keys are injected at runtime; source files reference them by name only.' : undefined,
-      guidance: 'A hardcoded JWT secret lets anyone who reads the config forge valid authentication tokens and impersonate any user.',
-    });
+    if (configRead.state === 'absent') {
+      findings.push(notApplicableRecord({ checkId: 'CRED-004', name: 'JWT Secret in Config', description: 'JWT secret found hardcoded in configuration file', category: 'credentials' }, `config file (${configFiles.join(', ')})`, `None of ${configFiles.join(', ')} in the scanned tree, so there is no application configuration to inspect.`));
+    } else if (configRead.state === 'read') {
+      findings.push({
+        checkId: 'CRED-004',
+        name: 'JWT Secret in Config',
+        description: 'JWT secret found hardcoded in configuration file',
+        category: 'credentials',
+        severity: 'critical',
+        passed: !hasJwtSecret,
+        message: hasJwtSecret
+          ? 'JWT secret hardcoded in config'
+          : 'No hardcoded JWT secrets found',
+        fixable: false,
+        fix: hasJwtSecret ? 'opena2a protect .  — migrates hardcoded secrets into the Secretless vault (local, keychain, 1Password, or HashiCorp Vault). Keys are injected at runtime; source files reference them by name only.' : undefined,
+        guidance: 'A hardcoded JWT secret lets anyone who reads the config forge valid authentication tokens and impersonate any user.',
+      });
+    }
 
     return findings;
   }
@@ -6706,6 +6762,7 @@ dist/
     // PERM-002: Check for executable config files
     const configFiles = ['config.json', 'mcp.json', 'settings.json', '.env'];
     const executableConfigs: string[] = [];
+    let perm002Unread = false;
 
     for (const file of configFiles) {
       try {
@@ -6714,28 +6771,38 @@ dist/
         if (mode & 0o111) {
           executableConfigs.push(file);
         }
-      } catch {}
+      } catch (err) {
+        // #458 — see PERM-001: not-there is measured absence, anything else is unread.
+        const code = (err as NodeJS.ErrnoException).code ?? '';
+        if (countsAsUnread(code)) {
+          this.coverage.noteReadFailure(path.join(targetDir, file), code);
+          perm002Unread = true;
+        }
+      }
     }
 
-    findings.push({
-      checkId: 'PERM-002',
-      name: 'Executable Config Files',
-      description: 'Configuration files have executable permission',
-      category: 'permissions',
-      severity: 'medium',
-      passed: executableConfigs.length === 0,
-      message: executableConfigs.length === 0
-        ? 'No config files have executable permissions'
-        : `Config files with executable permission: ${executableConfigs.join(', ')}`,
-      fixable: true,
-      fixed: false,
-      details: executableConfigs.length > 0 ? { files: executableConfigs } : undefined,
-      guidance: 'Executable config files can be run as scripts. An attacker who modifies a config file with execute permission can trick the system into running arbitrary code.',
-    });
+    if (executableConfigs.length > 0 || !perm002Unread) {
+      findings.push({
+        checkId: 'PERM-002',
+        name: 'Executable Config Files',
+        description: 'Configuration files have executable permission',
+        category: 'permissions',
+        severity: 'medium',
+        passed: executableConfigs.length === 0,
+        message: executableConfigs.length === 0
+          ? 'No config files have executable permissions'
+          : `Config files with executable permission: ${executableConfigs.join(', ')}`,
+        fixable: true,
+        fixed: false,
+        details: executableConfigs.length > 0 ? { files: executableConfigs } : undefined,
+        guidance: 'Executable config files can be run as scripts. An attacker who modifies a config file with execute permission can trick the system into running arbitrary code.',
+      });
+    }
 
     // PERM-003: Check for group-writable sensitive files
     const sensitiveFiles = ['.env', '.env.local', 'secrets.json', 'credentials.json'];
     const groupWritable: string[] = [];
+    let perm003Unread = false;
 
     for (const file of sensitiveFiles) {
       try {
@@ -6744,24 +6811,33 @@ dist/
         if (mode & 0o020) {
           groupWritable.push(file);
         }
-      } catch {}
+      } catch (err) {
+        // #458 — see PERM-001: not-there is measured absence, anything else is unread.
+        const code = (err as NodeJS.ErrnoException).code ?? '';
+        if (countsAsUnread(code)) {
+          this.coverage.noteReadFailure(path.join(targetDir, file), code);
+          perm003Unread = true;
+        }
+      }
     }
 
-    findings.push({
-      checkId: 'PERM-003',
-      name: 'Group-Writable Sensitive Files',
-      description: 'Sensitive files have group write permission',
-      category: 'permissions',
-      severity: 'high',
-      passed: groupWritable.length === 0,
-      message: groupWritable.length === 0
-        ? 'No sensitive files have group write permission'
-        : `Group-writable sensitive files: ${groupWritable.join(', ')}`,
-      fixable: true,
-      fixed: false,
-      details: groupWritable.length > 0 ? { files: groupWritable } : undefined,
-      guidance: 'Group-writable sensitive files allow other users in the same group to modify credentials or inject malicious configuration values.',
-    });
+    if (groupWritable.length > 0 || !perm003Unread) {
+      findings.push({
+        checkId: 'PERM-003',
+        name: 'Group-Writable Sensitive Files',
+        description: 'Sensitive files have group write permission',
+        category: 'permissions',
+        severity: 'high',
+        passed: groupWritable.length === 0,
+        message: groupWritable.length === 0
+          ? 'No sensitive files have group write permission'
+          : `Group-writable sensitive files: ${groupWritable.join(', ')}`,
+        fixable: true,
+        fixed: false,
+        details: groupWritable.length > 0 ? { files: groupWritable } : undefined,
+        guidance: 'Group-writable sensitive files allow other users in the same group to modify credentials or inject malicious configuration values.',
+      });
+    }
 
     return findings;
   }
@@ -6776,92 +6852,112 @@ dist/
     let devModeEnabled = false;
     const envIndicators = ['NODE_ENV=development', 'DEBUG=true', 'DEV_MODE=true'];
     const envFiles = ['.env', '.env.local', 'config.json'];
+    // #458: one classified read per candidate file, shared by ENV-001/002/003. Absent everywhere
+    // => not-applicable; nothing read and something unread => no record (the
+    // coverage ledger discloses it).
+    const envFileReads: SubjectRead[] = [];
+    for (const envFile of envFiles) {
+      envFileReads.push(await readCheckSubject(path.join(targetDir, envFile)));
+    }
+    const envRead = combineSubjectReads(envFileReads);
 
-    for (const file of envFiles) {
-      try {
-        const content = await fs.readFile(path.join(targetDir, file), 'utf-8');
+    for (const envFileRead of envFileReads) {
+      if (envFileRead.state === 'read') {
+        const content = envFileRead.content;
         for (const indicator of envIndicators) {
           if (content.includes(indicator)) {
             devModeEnabled = true;
             break;
           }
         }
-      } catch {}
+      }
     }
 
-    findings.push({
-      checkId: 'ENV-001',
-      name: 'Development Mode Enabled',
-      description: 'Development mode indicators found in configuration',
-      category: 'environment',
-      severity: 'medium',
-      passed: !devModeEnabled,
-      message: devModeEnabled
-        ? 'Development mode enabled - ensure this is disabled in production'
-        : 'No development mode indicators found',
-      fixable: false,
-      guidance: 'Development mode typically disables security features like CSRF protection, strict CORS, and error sanitization, leaving the application exposed in production.',
-    });
+    if (envRead.state === 'absent') {
+      findings.push(notApplicableRecord({ checkId: 'ENV-001', name: 'Development Mode Enabled', description: 'Development mode indicators found in configuration', category: 'environment' }, `environment file (${envFiles.join(', ')})`, `None of ${envFiles.join(', ')} in the scanned tree, so there is no environment configuration to inspect.`));
+    } else if (envRead.state === 'read') {
+      findings.push({
+        checkId: 'ENV-001',
+        name: 'Development Mode Enabled',
+        description: 'Development mode indicators found in configuration',
+        category: 'environment',
+        severity: 'medium',
+        passed: !devModeEnabled,
+        message: devModeEnabled
+          ? 'Development mode enabled - ensure this is disabled in production'
+          : 'No development mode indicators found',
+        fixable: false,
+        guidance: 'Development mode typically disables security features like CSRF protection, strict CORS, and error sanitization, leaving the application exposed in production.',
+      });
+    }
 
     // ENV-002: Check for debug flags
     let hasDebugFlags = false;
     const debugPatterns = ['DEBUG=', 'VERBOSE=true', 'LOG_LEVEL=debug', 'TRACE=true'];
 
-    for (const file of envFiles) {
-      try {
-        const content = await fs.readFile(path.join(targetDir, file), 'utf-8');
+    for (const envFileRead of envFileReads) {
+      if (envFileRead.state === 'read') {
+        const content = envFileRead.content;
         for (const pattern of debugPatterns) {
           if (content.includes(pattern)) {
             hasDebugFlags = true;
             break;
           }
         }
-      } catch {}
+      }
     }
 
-    findings.push({
-      checkId: 'ENV-002',
-      name: 'Debug Flags Enabled',
-      description: 'Debug or verbose logging flags are enabled',
-      category: 'environment',
-      severity: 'low',
-      passed: !hasDebugFlags,
-      message: hasDebugFlags
-        ? 'Debug flags enabled - may expose sensitive information in logs'
-        : 'No debug flags detected',
-      fixable: false,
-      guidance: 'Debug and verbose logging flags can leak internal state, database queries, and credential values into log files or console output.',
-    });
+    if (envRead.state === 'absent') {
+      findings.push(notApplicableRecord({ checkId: 'ENV-002', name: 'Debug Flags Enabled', description: 'Debug or verbose logging flags are enabled', category: 'environment' }, `environment file (${envFiles.join(', ')})`, `None of ${envFiles.join(', ')} in the scanned tree, so there is no environment configuration to inspect.`));
+    } else if (envRead.state === 'read') {
+      findings.push({
+        checkId: 'ENV-002',
+        name: 'Debug Flags Enabled',
+        description: 'Debug or verbose logging flags are enabled',
+        category: 'environment',
+        severity: 'low',
+        passed: !hasDebugFlags,
+        message: hasDebugFlags
+          ? 'Debug flags enabled - may expose sensitive information in logs'
+          : 'No debug flags detected',
+        fixable: false,
+        guidance: 'Debug and verbose logging flags can leak internal state, database queries, and credential values into log files or console output.',
+      });
+    }
 
     // ENV-003: Check for error verbosity settings
     let verboseErrors = false;
     const errorPatterns = ['SHOW_ERRORS=true', 'DISPLAY_ERRORS=true', 'STACK_TRACE=true'];
 
-    for (const file of envFiles) {
-      try {
-        const content = await fs.readFile(path.join(targetDir, file), 'utf-8');
+    for (const envFileRead of envFileReads) {
+      if (envFileRead.state === 'read') {
+        const content = envFileRead.content;
         for (const pattern of errorPatterns) {
           if (content.includes(pattern)) {
             verboseErrors = true;
             break;
           }
         }
-      } catch {}
+      }
     }
 
-    findings.push({
-      checkId: 'ENV-003',
-      name: 'Verbose Error Messages',
-      description: 'Configuration enables verbose error messages',
-      category: 'environment',
-      severity: 'medium',
-      passed: !verboseErrors,
-      message: verboseErrors
-        ? 'Verbose error messages enabled - may leak sensitive information'
-        : 'Error verbosity settings are appropriate',
-      fixable: false,
-      guidance: 'Verbose error messages expose stack traces, file paths, and internal logic to attackers, making it easier to find exploitable weaknesses.',
-    });
+    if (envRead.state === 'absent') {
+      findings.push(notApplicableRecord({ checkId: 'ENV-003', name: 'Verbose Error Messages', description: 'Configuration enables verbose error messages', category: 'environment' }, `environment file (${envFiles.join(', ')})`, `None of ${envFiles.join(', ')} in the scanned tree, so there is no environment configuration to inspect.`));
+    } else if (envRead.state === 'read') {
+      findings.push({
+        checkId: 'ENV-003',
+        name: 'Verbose Error Messages',
+        description: 'Configuration enables verbose error messages',
+        category: 'environment',
+        severity: 'medium',
+        passed: !verboseErrors,
+        message: verboseErrors
+          ? 'Verbose error messages enabled - may leak sensitive information'
+          : 'Error verbosity settings are appropriate',
+        fixable: false,
+        guidance: 'Verbose error messages expose stack traces, file paths, and internal logic to attackers, making it easier to find exploitable weaknesses.',
+      });
+    }
 
     // ENV-004: Check for production environment validation
     let hasEnvValidation = false;
@@ -6953,9 +7049,9 @@ dist/
     let sensitiveLogFile: string | undefined;
     let sensitiveLogLine: number | undefined;
 
-    try {
-      const files = await fs.readdir(targetDir);
-      for (const file of files) {
+    const dirReadLog002 = await readCheckDir(targetDir, (file) => file.endsWith('.ts') || file.endsWith('.js'));
+    if (dirReadLog002.state === 'read') {
+      for (const file of dirReadLog002.entries) {
         // Extension list deliberately UNCHANGED here — widening it is #414,
         // which is blocked on this fix precisely because a widened read
         // produced no observable change while the finding was being dropped.
@@ -6992,41 +7088,46 @@ dist/
           } catch {}
         }
       }
-    } catch {}
+    }
 
     const sensitiveInLogs = sensitiveLogFile !== undefined;
 
-    findings.push({
-      checkId: 'LOG-002',
-      name: 'Sensitive Data in Logs',
-      description: 'Potential sensitive data being logged',
-      category: 'logging',
-      severity: 'high',
-      passed: !sensitiveInLogs,
-      message: sensitiveInLogs
-        ? 'Code may be logging sensitive data - review console.log statements'
-        : 'No obvious sensitive data logging patterns found',
-      // Only set when the check actually matched. A passed LOG-002 stays
-      // pathless: it has no evidence to point at.
-      file: sensitiveLogFile,
-      // Cited ONLY when a single file matched. `.hmaignore` can re-point a
-      // multi-file finding onto a surviving path (#280, `retainAfterPathSuppression`)
-      // and that re-point moves `file` without moving `line` — so a line from
-      // the ignored file would be printed against the surviving one, and
-      // `Verify: sed -n '5p' z.js` would print nothing. No line is better than
-      // a line that sends the reader somewhere the match is not.
-      line: sensitiveLogFiles.length === 1 ? sensitiveLogLine : undefined,
-      // EVERY matching file, not just the cited one. `.hmaignore` suppression
-      // keys on all covered paths (#280), so listing one path here would let a
-      // single ignored file delete a finding that also covers un-ignored ones.
-      ...(sensitiveLogFiles.length > 0 ? { details: { files: sensitiveLogFiles } } : {}),
-      fixable: false,
-      guidance: 'Passwords, API keys, and tokens logged to console or files persist in log aggregators and crash reports, where they can be harvested by anyone with log access.',
-    });
+    if (dirReadLog002.state === 'absent') {
+      findings.push(notApplicableRecord({ checkId: 'LOG-002', name: 'Sensitive Data in Logs', description: 'Potential sensitive data being logged', category: 'logging' }, 'source files (.ts, .js)', 'No .ts or .js files at the scanned root, so there is no source to inspect.'));
+    } else if (dirReadLog002.state === 'read') {
+      findings.push({
+        checkId: 'LOG-002',
+        name: 'Sensitive Data in Logs',
+        description: 'Potential sensitive data being logged',
+        category: 'logging',
+        severity: 'high',
+        passed: !sensitiveInLogs,
+        message: sensitiveInLogs
+          ? 'Code may be logging sensitive data - review console.log statements'
+          : 'No obvious sensitive data logging patterns found',
+        // Only set when the check actually matched. A passed LOG-002 stays
+        // pathless: it has no evidence to point at.
+        file: sensitiveLogFile,
+        // Cited ONLY when a single file matched. `.hmaignore` can re-point a
+        // multi-file finding onto a surviving path (#280, `retainAfterPathSuppression`)
+        // and that re-point moves `file` without moving `line` — so a line from
+        // the ignored file would be printed against the surviving one, and
+        // `Verify: sed -n '5p' z.js` would print nothing. No line is better than
+        // a line that sends the reader somewhere the match is not.
+        line: sensitiveLogFiles.length === 1 ? sensitiveLogLine : undefined,
+        // EVERY matching file, not just the cited one. `.hmaignore` suppression
+        // keys on all covered paths (#280), so listing one path here would let a
+        // single ignored file delete a finding that also covers un-ignored ones.
+        ...(sensitiveLogFiles.length > 0 ? { details: { files: sensitiveLogFiles } } : {}),
+        fixable: false,
+        guidance: 'Passwords, API keys, and tokens logged to console or files persist in log aggregators and crash reports, where they can be harvested by anyone with log access.',
+      });
+    }
 
     // LOG-003: Check for log file permissions
     const logFiles = ['app.log', 'error.log', 'debug.log', 'access.log'];
     const worldReadableLogs: string[] = [];
+    let log003Unread = false;
 
     for (const logFile of logFiles) {
       try {
@@ -7035,23 +7136,32 @@ dist/
         if (mode & 0o004) {
           worldReadableLogs.push(logFile);
         }
-      } catch {}
+      } catch (err) {
+        // #458 — see PERM-001: not-there is measured absence, anything else is unread.
+        const code = (err as NodeJS.ErrnoException).code ?? '';
+        if (countsAsUnread(code)) {
+          this.coverage.noteReadFailure(path.join(targetDir, logFile), code);
+          log003Unread = true;
+        }
+      }
     }
 
-    findings.push({
-      checkId: 'LOG-003',
-      name: 'Log File Permissions',
-      description: 'Log files have overly permissive permissions',
-      category: 'logging',
-      severity: 'medium',
-      passed: worldReadableLogs.length === 0,
-      message: worldReadableLogs.length === 0
-        ? 'No world-readable log files found'
-        : `World-readable log files: ${worldReadableLogs.join(', ')}`,
-      fixable: true,
-      fixed: false,
-      guidance: 'World-readable log files let any local user read application logs, which often contain request details, internal errors, and sometimes credentials.',
-    });
+    if (worldReadableLogs.length > 0 || !log003Unread) {
+      findings.push({
+        checkId: 'LOG-003',
+        name: 'Log File Permissions',
+        description: 'Log files have overly permissive permissions',
+        category: 'logging',
+        severity: 'medium',
+        passed: worldReadableLogs.length === 0,
+        message: worldReadableLogs.length === 0
+          ? 'No world-readable log files found'
+          : `World-readable log files: ${worldReadableLogs.join(', ')}`,
+        fixable: true,
+        fixed: false,
+        guidance: 'World-readable log files let any local user read application logs, which often contain request details, internal errors, and sometimes credentials.',
+      });
+    }
 
     // LOG-004: Check for audit logging capability
     let hasAuditLogging = false;
@@ -7127,57 +7237,70 @@ dist/
     const vulnerablePackages = ['event-stream', 'flatmap-stream', 'eslint-scope@3.7.2'];
     let hasVulnerablePackage = false;
 
-    try {
-      const pkgJson = await fs.readFile(path.join(targetDir, 'package.json'), 'utf-8');
+    const pkgReadDep002 = await readCheckSubject(path.join(targetDir, 'package.json'));
+    if (pkgReadDep002.state === 'read') {
+      const pkgJson = pkgReadDep002.content;
       for (const pkg of vulnerablePackages) {
         if (pkgJson.includes(pkg.split('@')[0])) {
           hasVulnerablePackage = true;
           break;
         }
       }
-    } catch {}
+    }
 
-    findings.push({
-      checkId: 'DEP-002',
-      name: 'Known Vulnerable Packages',
-      description: 'Package.json may contain known vulnerable packages',
-      category: 'dependencies',
-      severity: 'critical',
-      passed: !hasVulnerablePackage,
-      message: hasVulnerablePackage
-        ? 'Potentially vulnerable package detected - run npm audit'
-        : 'No known vulnerable packages in direct dependencies',
-      fixable: false,
-      guidance: 'These packages have confirmed supply-chain compromises (e.g., event-stream injected a cryptocurrency-stealing payload). Remove or replace them immediately.',
-    });
+    if (pkgReadDep002.state === 'absent') {
+      findings.push(notApplicableRecord({ checkId: 'DEP-002', name: 'Known Vulnerable Packages', description: 'Package.json may contain known vulnerable packages', category: 'dependencies' }, 'package.json', 'No package.json in the scanned tree, so there is no dependency manifest to inspect.'));
+    } else if (pkgReadDep002.state === 'read') {
+      findings.push({
+        checkId: 'DEP-002',
+        name: 'Known Vulnerable Packages',
+        description: 'Package.json may contain known vulnerable packages',
+        category: 'dependencies',
+        severity: 'critical',
+        passed: !hasVulnerablePackage,
+        message: hasVulnerablePackage
+          ? 'Potentially vulnerable package detected - run npm audit'
+          : 'No known vulnerable packages in direct dependencies',
+        fixable: false,
+        guidance: 'These packages have confirmed supply-chain compromises (e.g., event-stream injected a cryptocurrency-stealing payload). Remove or replace them immediately.',
+      });
+    }
 
     // DEP-003: Check for wildcard versions
     let hasWildcardVersions = false;
-    try {
-      const pkgJson = await fs.readFile(path.join(targetDir, 'package.json'), 'utf-8');
-      const pkg = JSON.parse(pkgJson);
-      const allDeps = { ...pkg.dependencies, ...pkg.devDependencies };
-      for (const [, version] of Object.entries(allDeps)) {
-        if (version === '*' || version === 'latest') {
-          hasWildcardVersions = true;
-          break;
+    const pkgReadDep003 = await readCheckSubject(path.join(targetDir, 'package.json'));
+    if (pkgReadDep003.state === 'read') {
+      // A present but unparseable manifest keeps today's verdict.
+      try {
+        const pkgJson = pkgReadDep003.content;
+        const pkg = JSON.parse(pkgJson);
+        const allDeps = { ...pkg.dependencies, ...pkg.devDependencies };
+        for (const [, version] of Object.entries(allDeps)) {
+          if (version === '*' || version === 'latest') {
+            hasWildcardVersions = true;
+            break;
+          }
         }
-      }
-    } catch {}
+      } catch {}
+    }
 
-    findings.push({
-      checkId: 'DEP-003',
-      name: 'Wildcard Dependency Versions',
-      description: 'Package.json uses wildcard or latest versions',
-      category: 'dependencies',
-      severity: 'high',
-      passed: !hasWildcardVersions,
-      message: hasWildcardVersions
-        ? 'Wildcard versions detected - pin dependencies for reproducible builds'
-        : 'All dependency versions are properly specified',
-      fixable: false,
-      guidance: 'Wildcard (*) or "latest" versions accept any future release, including ones compromised by supply-chain attacks. Pin versions and use a lock file.',
-    });
+    if (pkgReadDep003.state === 'absent') {
+      findings.push(notApplicableRecord({ checkId: 'DEP-003', name: 'Wildcard Dependency Versions', description: 'Package.json uses wildcard or latest versions', category: 'dependencies' }, 'package.json', 'No package.json in the scanned tree, so there is no dependency manifest to inspect.'));
+    } else if (pkgReadDep003.state === 'read') {
+      findings.push({
+        checkId: 'DEP-003',
+        name: 'Wildcard Dependency Versions',
+        description: 'Package.json uses wildcard or latest versions',
+        category: 'dependencies',
+        severity: 'high',
+        passed: !hasWildcardVersions,
+        message: hasWildcardVersions
+          ? 'Wildcard versions detected - pin dependencies for reproducible builds'
+          : 'All dependency versions are properly specified',
+        fixable: false,
+        guidance: 'Wildcard (*) or "latest" versions accept any future release, including ones compromised by supply-chain attacks. Pin versions and use a lock file.',
+      });
+    }
 
     // DEP-004: Check for npm scripts security
     let hasDangerousScripts = false;
@@ -7191,40 +7314,48 @@ dist/
       /\$\(wget\b/,             // $(wget
     ];
     const pkgJsonPath = path.join(targetDir, 'package.json');
-    try {
-      const pkgJson = await fs.readFile(pkgJsonPath, 'utf-8');
-      const pkg = JSON.parse(pkgJson);
-      if (pkg.scripts) {
-        for (const [, script] of Object.entries(pkg.scripts)) {
-          if (typeof script === 'string') {
-            for (const pattern of dangerousScriptRegexes) {
-              if (pattern.test(script)) {
-                hasDangerousScripts = true;
-                break;
+    const pkgReadDep004 = await readCheckSubject(pkgJsonPath);
+    if (pkgReadDep004.state === 'read') {
+      // A present but unparseable manifest keeps today's verdict.
+      try {
+        const pkgJson = pkgReadDep004.content;
+        const pkg = JSON.parse(pkgJson);
+        if (pkg.scripts) {
+          for (const [, script] of Object.entries(pkg.scripts)) {
+            if (typeof script === 'string') {
+              for (const pattern of dangerousScriptRegexes) {
+                if (pattern.test(script)) {
+                  hasDangerousScripts = true;
+                  break;
+                }
               }
             }
           }
         }
-      }
-    } catch {}
+      } catch {}
+    }
 
-    findings.push({
-      checkId: 'DEP-004',
-      name: 'Dangerous npm Scripts',
-      description: 'npm scripts contain potentially dangerous commands',
-      category: 'dependencies',
-      severity: 'critical',
-      passed: !hasDangerousScripts,
-      file: hasDangerousScripts ? 'package.json' : undefined,
-      message: hasDangerousScripts
-        ? 'Dangerous patterns in npm scripts (curl|sh, eval) - review carefully'
-        : 'npm scripts appear safe',
-      fixable: false,
-      fix: hasDangerousScripts
-        ? 'Remove the curl|sh or wget|sh pattern from package.json scripts. Replace with a pinned package install: npm install --save-exact <package>  or vendor the script with a pinned checksum.'
-        : undefined,
-      guidance: 'Scripts that pipe curl/wget to sh execute arbitrary remote code during npm install. An attacker who compromises the URL controls your build environment.',
-    });
+    if (pkgReadDep004.state === 'absent') {
+      findings.push(notApplicableRecord({ checkId: 'DEP-004', name: 'Dangerous npm Scripts', description: 'npm scripts contain potentially dangerous commands', category: 'dependencies' }, 'package.json', 'No package.json in the scanned tree, so there is no dependency manifest to inspect.'));
+    } else if (pkgReadDep004.state === 'read') {
+      findings.push({
+        checkId: 'DEP-004',
+        name: 'Dangerous npm Scripts',
+        description: 'npm scripts contain potentially dangerous commands',
+        category: 'dependencies',
+        severity: 'critical',
+        passed: !hasDangerousScripts,
+        file: hasDangerousScripts ? 'package.json' : undefined,
+        message: hasDangerousScripts
+          ? 'Dangerous patterns in npm scripts (curl|sh, eval) - review carefully'
+          : 'npm scripts appear safe',
+        fixable: false,
+        fix: hasDangerousScripts
+          ? 'Remove the curl|sh or wget|sh pattern from package.json scripts. Replace with a pinned package install: npm install --save-exact <package>  or vendor the script with a pinned checksum.'
+          : undefined,
+        guidance: 'Scripts that pipe curl/wget to sh execute arbitrary remote code during npm install. An attacker who compromises the URL controls your build environment.',
+      });
+    }
 
     return findings;
   }
@@ -7379,34 +7510,43 @@ dist/
       'Dockerfile.dev',
       'docker/Dockerfile',
     ];
+    // #458: classified reads; the first readable candidate decides, an
+    // unreadable one is disclosed on the coverage ledger, none present =>
+    // not-applicable.
+    const dockerfileReads: SubjectRead[] = [];
     for (const candidate of dockerfileCandidates) {
       const candidatePath = path.join(targetDir, candidate);
-      try {
-        const dockerfile = await fs.readFile(candidatePath, 'utf-8');
+      const dockerfileRead = await readCheckSubject(candidatePath);
+      dockerfileReads.push(dockerfileRead);
+      if (dockerfileRead.state === 'read') {
+        const dockerfile = dockerfileRead.content;
         dockerfilePath = candidatePath;
         if (dockerfile.includes('USER root') || !dockerfile.includes('USER ')) {
           hasSecureDockerfile = false;
         }
         break; // Use the first Dockerfile found
-      } catch {
-        // File not found, try next candidate
       }
     }
+    const dockerfileProbe = combineSubjectReads(dockerfileReads);
 
-    findings.push({
-      checkId: 'PROC-001',
-      name: 'Container User',
-      description: 'Dockerfile runs as root or has no USER directive',
-      category: 'process',
-      severity: 'high',
-      passed: hasSecureDockerfile,
-      file: !hasSecureDockerfile && dockerfilePath ? path.relative(targetDir, dockerfilePath) : undefined,
-      message: hasSecureDockerfile
-        ? 'Container runs as non-root user or no Dockerfile present'
-        : 'Dockerfile runs as root - add USER directive for non-root user',
-      fixable: false,
-      guidance: 'A container running as root means any exploit that escapes the application gets full control of the container and potentially the host system.',
-    });
+    if (dockerfileProbe.state === 'absent') {
+      findings.push(notApplicableRecord({ checkId: 'PROC-001', name: 'Container User', description: 'Dockerfile runs as root or has no USER directive', category: 'process' }, 'Dockerfile', `No Dockerfile at any of the probed locations (${dockerfileCandidates.join(', ')}), so there is no container build to inspect.`));
+    } else if (dockerfileProbe.state === 'read') {
+      findings.push({
+        checkId: 'PROC-001',
+        name: 'Container User',
+        description: 'Dockerfile runs as root or has no USER directive',
+        category: 'process',
+        severity: 'high',
+        passed: hasSecureDockerfile,
+        file: !hasSecureDockerfile && dockerfilePath ? path.relative(targetDir, dockerfilePath) : undefined,
+        message: hasSecureDockerfile
+          ? 'Container runs as non-root user or no Dockerfile present'
+          : 'Dockerfile runs as root - add USER directive for non-root user',
+        fixable: false,
+        guidance: 'A container running as root means any exploit that escapes the application gets full control of the container and potentially the host system.',
+      });
+    }
 
     // PROC-002: Check for security headers middleware
     let hasSecurityHeaders = false;
@@ -7506,95 +7646,117 @@ dist/
     const claudeSettingsPath = path.join(targetDir, '.claude', 'settings.json');
 
     let claudeSettings: Record<string, unknown> | null = null;
-    try {
-      const content = await fs.readFile(claudeSettingsPath, 'utf-8');
-      claudeSettings = JSON.parse(content);
-    } catch {}
+    // #458 — the settings file is the SUBJECT of CLAUDE-004/005/007: absent is
+    // not-applicable, unread is no record. Present-but-unparseable is still a
+    // read subject: the checks keep their pass, with a parse-failure message.
+    const claudeSettingsRead = await readCheckSubject(claudeSettingsPath);
+    if (claudeSettingsRead.state === 'read') {
+      try {
+        claudeSettings = JSON.parse(claudeSettingsRead.content);
+      } catch {}
+    }
 
     // CLAUDE-004: Check for deny rules
     const permissions = claudeSettings?.permissions as { deny?: string[] } | undefined;
     const hasDenyRules = permissions?.deny && permissions.deny.length > 0;
 
-    findings.push({
-      checkId: 'CLAUDE-004',
-      name: 'Claude Deny Rules',
-      description: 'No deny rules configured for Claude Code',
-      category: 'claude-code',
-      severity: 'medium',
-      passed: hasDenyRules || !claudeSettings,
-      message: hasDenyRules
-        ? 'Claude Code has deny rules configured'
-        : claudeSettings
-          ? 'Consider adding deny rules to block dangerous operations'
-          : 'No Claude settings file found',
-      fixable: false,
-      guidance: 'Without deny rules, Claude Code can execute any tool or command. Deny rules act as a blocklist to prevent dangerous operations like rm -rf or credential access.',
-    });
+    if (claudeSettingsRead.state === 'absent') {
+      findings.push(notApplicableRecord({ checkId: 'CLAUDE-004', name: 'Claude Deny Rules', description: 'No deny rules configured for Claude Code', category: 'claude-code' }, '.claude/settings.json', 'No .claude/settings.json in the scanned tree, so there is no Claude Code configuration to inspect.'));
+    } else if (claudeSettingsRead.state === 'read') {
+      findings.push({
+        checkId: 'CLAUDE-004',
+        name: 'Claude Deny Rules',
+        description: 'No deny rules configured for Claude Code',
+        category: 'claude-code',
+        severity: 'medium',
+        passed: hasDenyRules || !claudeSettings,
+        message: hasDenyRules
+          ? 'Claude Code has deny rules configured'
+          : claudeSettings
+            ? 'Consider adding deny rules to block dangerous operations'
+            : 'Claude settings file could not be parsed',
+        fixable: false,
+        guidance: 'Without deny rules, Claude Code can execute any tool or command. Deny rules act as a blocklist to prevent dangerous operations like rm -rf or credential access.',
+      });
+    }
 
     // CLAUDE-005: Check for memory/context persistence
     const memorySettings = claudeSettings?.memory as { enabled?: boolean } | undefined;
     const hasMemoryEnabled = memorySettings?.enabled === true;
 
-    findings.push({
-      checkId: 'CLAUDE-005',
-      name: 'Claude Memory Persistence',
-      description: 'Claude memory persistence may store sensitive context',
-      category: 'claude-code',
-      severity: 'low',
-      passed: !hasMemoryEnabled,
-      message: hasMemoryEnabled
-        ? 'Claude memory enabled - be aware sensitive data may persist'
-        : 'Claude memory not explicitly enabled',
-      fixable: false,
-      guidance: 'Persistent memory can retain API keys, internal URLs, or confidential instructions across sessions. An attacker who gains access to the memory store can extract this data.',
-    });
+    if (claudeSettingsRead.state === 'absent') {
+      findings.push(notApplicableRecord({ checkId: 'CLAUDE-005', name: 'Claude Memory Persistence', description: 'Claude memory persistence may store sensitive context', category: 'claude-code' }, '.claude/settings.json', 'No .claude/settings.json in the scanned tree, so there is no Claude Code configuration to inspect.'));
+    } else if (claudeSettingsRead.state === 'read') {
+      findings.push({
+        checkId: 'CLAUDE-005',
+        name: 'Claude Memory Persistence',
+        description: 'Claude memory persistence may store sensitive context',
+        category: 'claude-code',
+        severity: 'low',
+        passed: !hasMemoryEnabled,
+        message: hasMemoryEnabled
+          ? 'Claude memory enabled - be aware sensitive data may persist'
+          : 'Claude memory not explicitly enabled',
+        fixable: false,
+        guidance: 'Persistent memory can retain API keys, internal URLs, or confidential instructions across sessions. An attacker who gains access to the memory store can extract this data.',
+      });
+    }
 
     // CLAUDE-006: Check CLAUDE.md for sensitive instructions
     let hasSensitiveInstructions = false;
     const sensitivePatterns = ['never share', 'confidential', 'internal only', 'do not disclose'];
 
-    try {
-      const claudeMd = await fs.readFile(path.join(targetDir, 'CLAUDE.md'), 'utf-8');
+    const claudeMdRead = await readCheckSubject(path.join(targetDir, 'CLAUDE.md'));
+    if (claudeMdRead.state === 'read') {
+      const claudeMd = claudeMdRead.content;
       for (const pattern of sensitivePatterns) {
         if (claudeMd.toLowerCase().includes(pattern)) {
           hasSensitiveInstructions = true;
           break;
         }
       }
-    } catch {}
+    }
 
-    findings.push({
-      checkId: 'CLAUDE-006',
-      name: 'Sensitive Instructions in CLAUDE.md',
-      description: 'CLAUDE.md may contain sensitive instructions that could be extracted',
-      category: 'claude-code',
-      severity: 'medium',
-      passed: !hasSensitiveInstructions,
-      message: hasSensitiveInstructions
-        ? 'CLAUDE.md contains sensitive instructions - these may be extractable via prompt injection'
-        : 'No obviously sensitive instructions detected in CLAUDE.md',
-      fixable: false,
-      guidance: 'CLAUDE.md is typically committed to version control. Sensitive instructions there can be extracted via prompt injection or by anyone with repo access.',
-    });
+    if (claudeMdRead.state === 'absent') {
+      findings.push(notApplicableRecord({ checkId: 'CLAUDE-006', name: 'Sensitive Instructions in CLAUDE.md', description: 'CLAUDE.md may contain sensitive instructions that could be extracted', category: 'claude-code' }, 'CLAUDE.md', 'No CLAUDE.md in the scanned tree, so there are no Claude Code instructions to inspect.'));
+    } else if (claudeMdRead.state === 'read') {
+      findings.push({
+        checkId: 'CLAUDE-006',
+        name: 'Sensitive Instructions in CLAUDE.md',
+        description: 'CLAUDE.md may contain sensitive instructions that could be extracted',
+        category: 'claude-code',
+        severity: 'medium',
+        passed: !hasSensitiveInstructions,
+        message: hasSensitiveInstructions
+          ? 'CLAUDE.md contains sensitive instructions - these may be extractable via prompt injection'
+          : 'No obviously sensitive instructions detected in CLAUDE.md',
+        fixable: false,
+        guidance: 'CLAUDE.md is typically committed to version control. Sensitive instructions there can be extracted via prompt injection or by anyone with repo access.',
+      });
+    }
 
     // CLAUDE-007: Check for tool timeout configuration
     const hasToolTimeout = (claudeSettings as Record<string, unknown>)?.toolTimeout !== undefined;
 
-    findings.push({
-      checkId: 'CLAUDE-007',
-      name: 'Tool Timeout Configuration',
-      description: 'No tool timeout configured for Claude operations',
-      category: 'claude-code',
-      severity: 'low',
-      passed: hasToolTimeout || !claudeSettings,
-      message: hasToolTimeout
-        ? 'Tool timeout is configured'
-        : claudeSettings
-          ? 'Consider setting tool timeouts to prevent runaway operations'
-          : 'No Claude settings found',
-      fixable: false,
-      guidance: 'Without tool timeouts, a stuck or malicious tool call can hang indefinitely, consuming resources and blocking the agent from responding.',
-    });
+    if (claudeSettingsRead.state === 'absent') {
+      findings.push(notApplicableRecord({ checkId: 'CLAUDE-007', name: 'Tool Timeout Configuration', description: 'No tool timeout configured for Claude operations', category: 'claude-code' }, '.claude/settings.json', 'No .claude/settings.json in the scanned tree, so there is no Claude Code configuration to inspect.'));
+    } else if (claudeSettingsRead.state === 'read') {
+      findings.push({
+        checkId: 'CLAUDE-007',
+        name: 'Tool Timeout Configuration',
+        description: 'No tool timeout configured for Claude operations',
+        category: 'claude-code',
+        severity: 'low',
+        passed: hasToolTimeout || !claudeSettings,
+        message: hasToolTimeout
+          ? 'Tool timeout is configured'
+          : claudeSettings
+            ? 'Consider setting tool timeouts to prevent runaway operations'
+            : 'Claude settings file could not be parsed',
+        fixable: false,
+        guidance: 'Without tool timeouts, a stuck or malicious tool call can hang indefinitely, consuming resources and blocking the agent from responding.',
+      });
+    }
 
     return findings;
   }
@@ -7607,48 +7769,61 @@ dist/
     const mcpConfigPath = path.join(targetDir, 'mcp.json');
 
     let mcpConfig: Record<string, unknown> | null = null;
-    try {
-      const content = await fs.readFile(mcpConfigPath, 'utf-8');
-      mcpConfig = JSON.parse(content);
-    } catch {}
+    // #458: MCP-006..009 branch on this classified read — absent mcp.json =>
+    // not-applicable naming the subject, unread => no record, and a present
+    // but unparseable file keeps today's verdict.
+    const mcpReadExt = await readCheckSubject(mcpConfigPath);
+    if (mcpReadExt.state === 'read') {
+      try {
+        mcpConfig = JSON.parse(mcpReadExt.content);
+      } catch {}
+    }
 
     // MCP-006: Check for request timeout
     const hasTimeout = (mcpConfig as Record<string, unknown>)?.timeout !== undefined;
 
-    findings.push({
-      checkId: 'MCP-006',
-      name: 'MCP Request Timeout',
-      description: 'No request timeout configured for MCP servers',
-      category: 'mcp',
-      severity: 'medium',
-      passed: hasTimeout || !mcpConfig,
-      message: hasTimeout
-        ? 'MCP timeout is configured'
-        : mcpConfig
-          ? 'Consider setting request timeouts for MCP servers'
-          : 'No MCP config found',
-      fixable: false,
-      guidance: 'Without request timeouts, a hung or malicious MCP server can block the agent indefinitely, causing denial-of-service and preventing other tools from executing.',
-    });
+    if (mcpReadExt.state === 'absent') {
+      findings.push(notApplicableRecord({ checkId: 'MCP-006', name: 'MCP Request Timeout', description: 'No request timeout configured for MCP servers', category: 'mcp' }, 'mcp.json', 'No mcp.json in the scanned tree, so no MCP servers are configured and there is no MCP transport to inspect.'));
+    } else if (mcpReadExt.state === 'read') {
+      findings.push({
+        checkId: 'MCP-006',
+        name: 'MCP Request Timeout',
+        description: 'No request timeout configured for MCP servers',
+        category: 'mcp',
+        severity: 'medium',
+        passed: hasTimeout || !mcpConfig,
+        message: hasTimeout
+          ? 'MCP timeout is configured'
+          : mcpConfig
+            ? 'Consider setting request timeouts for MCP servers'
+            : 'No MCP config found',
+        fixable: false,
+        guidance: 'Without request timeouts, a hung or malicious MCP server can block the agent indefinitely, causing denial-of-service and preventing other tools from executing.',
+      });
+    }
 
     // MCP-007: Check for retry limits
     const hasRetryConfig = (mcpConfig as Record<string, unknown>)?.retries !== undefined;
 
-    findings.push({
-      checkId: 'MCP-007',
-      name: 'MCP Retry Limits',
-      description: 'No retry limits configured for MCP servers',
-      category: 'mcp',
-      severity: 'low',
-      passed: hasRetryConfig || !mcpConfig,
-      message: hasRetryConfig
-        ? 'MCP retry limits configured'
-        : mcpConfig
-          ? 'Consider setting retry limits to prevent infinite loops'
-          : 'No MCP config found',
-      fixable: false,
-      guidance: 'Without retry limits, a failing MCP server can trigger infinite retry loops that waste API credits, saturate network connections, and stall the agent.',
-    });
+    if (mcpReadExt.state === 'absent') {
+      findings.push(notApplicableRecord({ checkId: 'MCP-007', name: 'MCP Retry Limits', description: 'No retry limits configured for MCP servers', category: 'mcp' }, 'mcp.json', 'No mcp.json in the scanned tree, so no MCP servers are configured and there is no MCP transport to inspect.'));
+    } else if (mcpReadExt.state === 'read') {
+      findings.push({
+        checkId: 'MCP-007',
+        name: 'MCP Retry Limits',
+        description: 'No retry limits configured for MCP servers',
+        category: 'mcp',
+        severity: 'low',
+        passed: hasRetryConfig || !mcpConfig,
+        message: hasRetryConfig
+          ? 'MCP retry limits configured'
+          : mcpConfig
+            ? 'Consider setting retry limits to prevent infinite loops'
+            : 'No MCP config found',
+        fixable: false,
+        guidance: 'Without retry limits, a failing MCP server can trigger infinite retry loops that waste API credits, saturate network connections, and stall the agent.',
+      });
+    }
 
     // MCP-008: Check for localhost binding
     let allLocalhostBound = true;
@@ -7664,19 +7839,23 @@ dist/
       }
     }
 
-    findings.push({
-      checkId: 'MCP-008',
-      name: 'MCP Localhost Binding',
-      description: 'MCP servers should bind to localhost only',
-      category: 'mcp',
-      severity: 'high',
-      passed: allLocalhostBound,
-      message: allLocalhostBound
-        ? 'MCP servers properly bound to localhost'
-        : 'Some MCP servers not bound to localhost - may be network accessible',
-      fixable: false,
-      guidance: 'MCP servers running over network (SSE/HTTP) without authentication let any network-adjacent attacker connect and issue tool calls.',
-    });
+    if (mcpReadExt.state === 'absent') {
+      findings.push(notApplicableRecord({ checkId: 'MCP-008', name: 'MCP Localhost Binding', description: 'MCP servers should bind to localhost only', category: 'mcp' }, 'mcp.json', 'No mcp.json in the scanned tree, so no MCP servers are configured and there is no MCP transport to inspect.'));
+    } else if (mcpReadExt.state === 'read') {
+      findings.push({
+        checkId: 'MCP-008',
+        name: 'MCP Localhost Binding',
+        description: 'MCP servers should bind to localhost only',
+        category: 'mcp',
+        severity: 'high',
+        passed: allLocalhostBound,
+        message: allLocalhostBound
+          ? 'MCP servers properly bound to localhost'
+          : 'Some MCP servers not bound to localhost - may be network accessible',
+        fixable: false,
+        guidance: 'MCP servers running over network (SSE/HTTP) without authentication let any network-adjacent attacker connect and issue tool calls.',
+      });
+    }
 
     // MCP-009: Check for sensitive tool names
     const sensitiveTools = ['execute', 'shell', 'eval', 'system', 'exec', 'spawn'];
@@ -7693,19 +7872,23 @@ dist/
       }
     }
 
-    findings.push({
-      checkId: 'MCP-009',
-      name: 'Sensitive MCP Tools',
-      description: 'MCP configuration includes potentially dangerous tools',
-      category: 'mcp',
-      severity: 'high',
-      passed: !hasSensitiveTools,
-      message: hasSensitiveTools
-        ? 'Sensitive tool names detected (shell, exec, eval) - ensure proper restrictions'
-        : 'No obviously sensitive tool names in MCP config',
-      fixable: false,
-      guidance: 'Tools named shell, exec, or eval typically provide arbitrary code execution. A prompt injection that invokes these tools can fully compromise the host system.',
-    });
+    if (mcpReadExt.state === 'absent') {
+      findings.push(notApplicableRecord({ checkId: 'MCP-009', name: 'Sensitive MCP Tools', description: 'MCP configuration includes potentially dangerous tools', category: 'mcp' }, 'mcp.json', 'No mcp.json in the scanned tree, so no MCP servers are configured and there is no MCP transport to inspect.'));
+    } else if (mcpReadExt.state === 'read') {
+      findings.push({
+        checkId: 'MCP-009',
+        name: 'Sensitive MCP Tools',
+        description: 'MCP configuration includes potentially dangerous tools',
+        category: 'mcp',
+        severity: 'high',
+        passed: !hasSensitiveTools,
+        message: hasSensitiveTools
+          ? 'Sensitive tool names detected (shell, exec, eval) - ensure proper restrictions'
+          : 'No obviously sensitive tool names in MCP config',
+        fixable: false,
+        guidance: 'Tools named shell, exec, or eval typically provide arbitrary code execution. A prompt injection that invokes these tools can fully compromise the host system.',
+      });
+    }
 
     // MCP-010: Check for logging configuration
     let hasLogging = false;
@@ -7780,9 +7963,9 @@ dist/
     let hasDebugEndpoints = false;
     const debugEndpoints = ['/debug', '/admin', '/metrics', '/health', '/status', '/__debug'];
 
-    try {
-      const files = await fs.readdir(targetDir);
-      for (const file of files) {
+    const dirReadNet004 = await readCheckDir(targetDir, (file) => file.endsWith('.ts') || file.endsWith('.js'));
+    if (dirReadNet004.state === 'read') {
+      for (const file of dirReadNet004.entries) {
         if (file.endsWith('.ts') || file.endsWith('.js')) {
           try {
             const content = await fs.readFile(path.join(targetDir, file), 'utf-8');
@@ -7795,32 +7978,39 @@ dist/
           } catch {}
         }
       }
-    } catch {}
+    }
 
-    findings.push({
-      checkId: 'NET-004',
-      name: 'Debug Endpoints',
-      description: 'Debug or admin endpoints may be exposed',
-      category: 'network',
-      severity: 'medium',
-      passed: !hasDebugEndpoints,
-      message: hasDebugEndpoints
-        ? 'Debug/admin endpoints detected - ensure they are protected or disabled in production'
-        : 'No obvious debug endpoints found',
-      fixable: false,
-      guidance: 'Debug and admin endpoints expose internal state, configuration, and metrics. Attackers use these to map your infrastructure and find weaknesses.',
-    });
+    if (dirReadNet004.state === 'absent') {
+      findings.push(notApplicableRecord({ checkId: 'NET-004', name: 'Debug Endpoints', description: 'Debug or admin endpoints may be exposed', category: 'network' }, 'source files (.ts, .js)', 'No .ts or .js files at the scanned root, so there is no source to inspect.'));
+    } else if (dirReadNet004.state === 'read') {
+      findings.push({
+        checkId: 'NET-004',
+        name: 'Debug Endpoints',
+        description: 'Debug or admin endpoints may be exposed',
+        category: 'network',
+        severity: 'medium',
+        passed: !hasDebugEndpoints,
+        message: hasDebugEndpoints
+          ? 'Debug/admin endpoints detected - ensure they are protected or disabled in production'
+          : 'No obvious debug endpoints found',
+        fixable: false,
+        guidance: 'Debug and admin endpoints expose internal state, configuration, and metrics. Attackers use these to map your infrastructure and find weaknesses.',
+      });
+    }
 
     // NET-005: Check for WebSocket security
     let hasWebsocket = false;
     let hasWsAuth = false;
 
-    try {
-      const pkgJson = await fs.readFile(path.join(targetDir, 'package.json'), 'utf-8');
+    const pkgReadNet005 = await readCheckSubject(path.join(targetDir, 'package.json'));
+    if (pkgReadNet005.state === 'read') {
+      const pkgJson = pkgReadNet005.content;
       hasWebsocket = pkgJson.includes('ws') || pkgJson.includes('socket.io') || pkgJson.includes('websocket');
 
       if (hasWebsocket) {
-        const files = await fs.readdir(targetDir);
+        // #458: a listing failure must not escape the read branch; the tracked
+        // fs ledgers it, and an empty listing keeps today's verdict.
+        const files = await fs.readdir(targetDir).catch(() => [] as string[]);
         for (const file of files) {
           if (file.endsWith('.ts') || file.endsWith('.js')) {
             try {
@@ -7833,23 +8023,27 @@ dist/
           }
         }
       }
-    } catch {}
+    }
 
-    findings.push({
-      checkId: 'NET-005',
-      name: 'WebSocket Security',
-      description: 'WebSocket connections may lack authentication',
-      category: 'network',
-      severity: 'high',
-      passed: !hasWebsocket || hasWsAuth,
-      message: !hasWebsocket
-        ? 'No WebSocket usage detected'
-        : hasWsAuth
-          ? 'WebSocket authentication detected'
-          : 'WebSocket without obvious authentication - ensure connections are verified',
-      fixable: false,
-      guidance: 'Unauthenticated WebSocket connections let any client send commands to your backend. Unlike HTTP, WebSockets maintain persistent connections that bypass traditional request-based security.',
-    });
+    if (pkgReadNet005.state === 'absent') {
+      findings.push(notApplicableRecord({ checkId: 'NET-005', name: 'WebSocket Security', description: 'WebSocket connections may lack authentication', category: 'network' }, 'package.json', 'No package.json in the scanned tree, so there is no dependency manifest to inspect.'));
+    } else if (pkgReadNet005.state === 'read') {
+      findings.push({
+        checkId: 'NET-005',
+        name: 'WebSocket Security',
+        description: 'WebSocket connections may lack authentication',
+        category: 'network',
+        severity: 'high',
+        passed: !hasWebsocket || hasWsAuth,
+        message: !hasWebsocket
+          ? 'No WebSocket usage detected'
+          : hasWsAuth
+            ? 'WebSocket authentication detected'
+            : 'WebSocket without obvious authentication - ensure connections are verified',
+        fixable: false,
+        guidance: 'Unauthenticated WebSocket connections let any client send commands to your backend. Unlike HTTP, WebSockets maintain persistent connections that bypass traditional request-based security.',
+      });
+    }
 
     // NET-006: Check for proxy configuration
     let hasProxyConfig = false;
@@ -7944,9 +8138,9 @@ dist/
 
     // API-003: Check for API key in URL
     let hasKeyInUrl = false;
-    try {
-      const files = await fs.readdir(targetDir);
-      for (const file of files) {
+    const dirReadApi003 = await readCheckDir(targetDir, (file) => file.endsWith('.ts') || file.endsWith('.js'));
+    if (dirReadApi003.state === 'read') {
+      for (const file of dirReadApi003.entries) {
         if (file.endsWith('.ts') || file.endsWith('.js')) {
           try {
             const content = await fs.readFile(path.join(targetDir, file), 'utf-8');
@@ -7959,21 +8153,25 @@ dist/
           } catch {}
         }
       }
-    } catch {}
+    }
 
-    findings.push({
-      checkId: 'API-003',
-      name: 'API Key in URL',
-      description: 'API keys may be passed in URL query parameters',
-      category: 'api',
-      severity: 'high',
-      passed: !hasKeyInUrl,
-      message: hasKeyInUrl
-        ? 'API key in URL pattern detected - use headers instead'
-        : 'No obvious API key in URL patterns found',
-      fixable: false,
-      guidance: 'API keys in URLs are logged by browsers, proxies, and web servers. They appear in referrer headers and browser history, making them easy to steal.',
-    });
+    if (dirReadApi003.state === 'absent') {
+      findings.push(notApplicableRecord({ checkId: 'API-003', name: 'API Key in URL', description: 'API keys may be passed in URL query parameters', category: 'api' }, 'source files (.ts, .js)', 'No .ts or .js files at the scanned root, so there is no source to inspect.'));
+    } else if (dirReadApi003.state === 'read') {
+      findings.push({
+        checkId: 'API-003',
+        name: 'API Key in URL',
+        description: 'API keys may be passed in URL query parameters',
+        category: 'api',
+        severity: 'high',
+        passed: !hasKeyInUrl,
+        message: hasKeyInUrl
+          ? 'API key in URL pattern detected - use headers instead'
+          : 'No obvious API key in URL patterns found',
+        fixable: false,
+        guidance: 'API keys in URLs are logged by browsers, proxies, and web servers. They appear in referrer headers and browser history, making them easy to steal.',
+      });
+    }
 
     // API-004: Check for response headers security
     let hasSecurityHeaders = false;
@@ -8115,9 +8313,9 @@ dist/
     let hasHardcodedConnStr = false;
     const connPatterns = ['mongodb://', 'postgres://', 'mysql://', 'redis://', 'amqp://'];
 
-    try {
-      const files = await fs.readdir(targetDir);
-      for (const file of files) {
+    const dirReadSec004 = await readCheckDir(targetDir, (file) => file.endsWith('.ts') || file.endsWith('.js') || file.endsWith('.json'));
+    if (dirReadSec004.state === 'read') {
+      for (const file of dirReadSec004.entries) {
         if (file.endsWith('.ts') || file.endsWith('.js') || file.endsWith('.json')) {
           try {
             const content = await fs.readFile(path.join(targetDir, file), 'utf-8');
@@ -8130,22 +8328,26 @@ dist/
           } catch {}
         }
       }
-    } catch {}
+    }
 
-    findings.push({
-      checkId: 'SEC-004',
-      name: 'Hardcoded Connection Strings',
-      description: 'Connection strings may be hardcoded',
-      category: 'secrets',
-      severity: 'critical',
-      passed: !hasHardcodedConnStr,
-      message: hasHardcodedConnStr
-        ? 'Hardcoded connection strings detected'
-        : 'No hardcoded connection strings found',
-      fixable: false,
-      fix: hasHardcodedConnStr ? 'opena2a protect .  — migrates hardcoded secrets into the Secretless vault (local, keychain, 1Password, or HashiCorp Vault). Keys are injected at runtime; source files reference them by name only.' : undefined,
-      guidance: 'Hardcoded connection strings contain database hostnames, ports, and credentials. Anyone with code access can connect directly to your database.',
-    });
+    if (dirReadSec004.state === 'absent') {
+      findings.push(notApplicableRecord({ checkId: 'SEC-004', name: 'Hardcoded Connection Strings', description: 'Connection strings may be hardcoded', category: 'secrets' }, 'source or config files (.ts, .js, .json)', 'No .ts, .js or .json files at the scanned root, so there is nothing to inspect.'));
+    } else if (dirReadSec004.state === 'read') {
+      findings.push({
+        checkId: 'SEC-004',
+        name: 'Hardcoded Connection Strings',
+        description: 'Connection strings may be hardcoded',
+        category: 'secrets',
+        severity: 'critical',
+        passed: !hasHardcodedConnStr,
+        message: hasHardcodedConnStr
+          ? 'Hardcoded connection strings detected'
+          : 'No hardcoded connection strings found',
+        fixable: false,
+        fix: hasHardcodedConnStr ? 'opena2a protect .  — migrates hardcoded secrets into the Secretless vault (local, keychain, 1Password, or HashiCorp Vault). Keys are injected at runtime; source files reference them by name only.' : undefined,
+        guidance: 'Hardcoded connection strings contain database hostnames, ports, and credentials. Anyone with code access can connect directly to your database.',
+      });
+    }
 
     return findings;
   }
@@ -8160,12 +8362,15 @@ dist/
     let hasFileUpload = false;
     let hasUploadSecurity = false;
 
-    try {
-      const pkgJson = await fs.readFile(path.join(targetDir, 'package.json'), 'utf-8');
+    const pkgReadIo001 = await readCheckSubject(path.join(targetDir, 'package.json'));
+    if (pkgReadIo001.state === 'read') {
+      const pkgJson = pkgReadIo001.content;
       hasFileUpload = pkgJson.includes('multer') || pkgJson.includes('formidable') || pkgJson.includes('busboy');
 
       if (hasFileUpload) {
-        const files = await fs.readdir(targetDir);
+        // #458: a listing failure must not escape the read branch; the tracked
+        // fs ledgers it, and an empty listing keeps today's verdict.
+        const files = await fs.readdir(targetDir).catch(() => [] as string[]);
         for (const file of files) {
           if (file.endsWith('.ts') || file.endsWith('.js')) {
             try {
@@ -8178,53 +8383,62 @@ dist/
           }
         }
       }
-    } catch {}
+    }
 
-    findings.push({
-      checkId: 'IO-001',
-      name: 'File Upload Security',
-      description: 'File upload without proper validation',
-      category: 'io',
-      severity: 'high',
-      passed: !hasFileUpload || hasUploadSecurity,
-      message: !hasFileUpload
-        ? 'No file upload handling detected'
-        : hasUploadSecurity
-          ? 'File upload validation detected'
-          : 'File upload without obvious validation - add file type/size limits',
-      fixable: false,
-      guidance: 'Unrestricted file uploads let attackers send malicious executables, web shells, or oversized files that can compromise the server or exhaust disk space.',
-    });
+    if (pkgReadIo001.state === 'absent') {
+      findings.push(notApplicableRecord({ checkId: 'IO-001', name: 'File Upload Security', description: 'File upload without proper validation', category: 'io' }, 'package.json', 'No package.json in the scanned tree, so there is no dependency manifest to inspect.'));
+    } else if (pkgReadIo001.state === 'read') {
+      findings.push({
+        checkId: 'IO-001',
+        name: 'File Upload Security',
+        description: 'File upload without proper validation',
+        category: 'io',
+        severity: 'high',
+        passed: !hasFileUpload || hasUploadSecurity,
+        message: !hasFileUpload
+          ? 'No file upload handling detected'
+          : hasUploadSecurity
+            ? 'File upload validation detected'
+            : 'File upload without obvious validation - add file type/size limits',
+        fixable: false,
+        guidance: 'Unrestricted file uploads let attackers send malicious executables, web shells, or oversized files that can compromise the server or exhaust disk space.',
+      });
+    }
 
     // IO-002: Check for SQL/NoSQL injection protection
     let hasDbLibrary = false;
     let hasParameterization = false;
 
-    try {
-      const pkgJson = await fs.readFile(path.join(targetDir, 'package.json'), 'utf-8');
+    const pkgReadIo002 = await readCheckSubject(path.join(targetDir, 'package.json'));
+    if (pkgReadIo002.state === 'read') {
+      const pkgJson = pkgReadIo002.content;
       hasDbLibrary = pkgJson.includes('pg') || pkgJson.includes('mysql') || pkgJson.includes('mongodb') || pkgJson.includes('prisma') || pkgJson.includes('sequelize');
 
       if (hasDbLibrary) {
         // ORMs and query builders generally handle parameterization
         hasParameterization = pkgJson.includes('prisma') || pkgJson.includes('sequelize') || pkgJson.includes('typeorm') || pkgJson.includes('knex');
       }
-    } catch {}
+    }
 
-    findings.push({
-      checkId: 'IO-002',
-      name: 'Query Parameterization',
-      description: 'Database queries may be vulnerable to injection',
-      category: 'io',
-      severity: 'critical',
-      passed: !hasDbLibrary || hasParameterization,
-      message: !hasDbLibrary
-        ? 'No database library detected'
-        : hasParameterization
-          ? 'ORM/query builder detected - provides parameterization'
-          : 'Raw database driver detected - ensure parameterized queries are used',
-      fixable: false,
-      guidance: 'Raw database queries built with string concatenation let attackers inject SQL or NoSQL commands that can read, modify, or delete all data in the database.',
-    });
+    if (pkgReadIo002.state === 'absent') {
+      findings.push(notApplicableRecord({ checkId: 'IO-002', name: 'Query Parameterization', description: 'Database queries may be vulnerable to injection', category: 'io' }, 'package.json', 'No package.json in the scanned tree, so there is no dependency manifest to inspect.'));
+    } else if (pkgReadIo002.state === 'read') {
+      findings.push({
+        checkId: 'IO-002',
+        name: 'Query Parameterization',
+        description: 'Database queries may be vulnerable to injection',
+        category: 'io',
+        severity: 'critical',
+        passed: !hasDbLibrary || hasParameterization,
+        message: !hasDbLibrary
+          ? 'No database library detected'
+          : hasParameterization
+            ? 'ORM/query builder detected - provides parameterization'
+            : 'Raw database driver detected - ensure parameterized queries are used',
+        fixable: false,
+        guidance: 'Raw database queries built with string concatenation let attackers inject SQL or NoSQL commands that can read, modify, or delete all data in the database.',
+      });
+    }
 
     // IO-003: Check for XSS protection
     let hasXssProtection = false;
@@ -8254,9 +8468,9 @@ dist/
 
     // IO-004: Check for path traversal protection
     let hasPathTraversal = false;
-    try {
-      const files = await fs.readdir(targetDir);
-      for (const file of files) {
+    const dirReadIo004 = await readCheckDir(targetDir, (file) => file.endsWith('.ts') || file.endsWith('.js'));
+    if (dirReadIo004.state === 'read') {
+      for (const file of dirReadIo004.entries) {
         if (file.endsWith('.ts') || file.endsWith('.js')) {
           try {
             const content = await fs.readFile(path.join(targetDir, file), 'utf-8');
@@ -8269,21 +8483,25 @@ dist/
           } catch {}
         }
       }
-    } catch {}
+    }
 
-    findings.push({
-      checkId: 'IO-004',
-      name: 'Path Traversal Protection',
-      description: 'Potential path traversal vulnerability',
-      category: 'io',
-      severity: 'high',
-      passed: !hasPathTraversal,
-      message: hasPathTraversal
-        ? 'Potential path traversal detected - use path.resolve/normalize'
-        : 'No obvious path traversal vulnerabilities found',
-      fixable: false,
-      guidance: 'Path traversal (../) in file paths lets attackers read sensitive files like /etc/passwd or .env by escaping the intended directory.',
-    });
+    if (dirReadIo004.state === 'absent') {
+      findings.push(notApplicableRecord({ checkId: 'IO-004', name: 'Path Traversal Protection', description: 'Potential path traversal vulnerability', category: 'io' }, 'source files (.ts, .js)', 'No .ts or .js files at the scanned root, so there is no source to inspect.'));
+    } else if (dirReadIo004.state === 'read') {
+      findings.push({
+        checkId: 'IO-004',
+        name: 'Path Traversal Protection',
+        description: 'Potential path traversal vulnerability',
+        category: 'io',
+        severity: 'high',
+        passed: !hasPathTraversal,
+        message: hasPathTraversal
+          ? 'Potential path traversal detected - use path.resolve/normalize'
+          : 'No obvious path traversal vulnerabilities found',
+        fixable: false,
+        guidance: 'Path traversal (../) in file paths lets attackers read sensitive files like /etc/passwd or .env by escaping the intended directory.',
+      });
+    }
 
     return findings;
   }
@@ -8570,10 +8788,10 @@ dist/
 
     // INJ-004: Check for command injection protection
     let hasCmdProtection = false;
-    try {
-      const files = await fs.readdir(targetDir);
+    const dirReadInj004 = await readCheckDir(targetDir, (file) => file.endsWith('.ts') || file.endsWith('.js'));
+    if (dirReadInj004.state === 'read') {
       let hasExec = false;
-      for (const file of files) {
+      for (const file of dirReadInj004.entries) {
         if (file.endsWith('.ts') || file.endsWith('.js')) {
           try {
             const content = await fs.readFile(path.join(targetDir, file), 'utf-8');
@@ -8592,23 +8810,25 @@ dist/
         }
       }
       if (!hasExec) hasCmdProtection = true; // No exec calls found
-    } catch {
-      hasCmdProtection = true;
     }
 
-    findings.push({
-      checkId: 'INJ-004',
-      name: 'Command Injection Protection',
-      description: 'Shell commands should use safe execution patterns',
-      category: 'input-validation',
-      severity: 'critical',
-      passed: hasCmdProtection,
-      message: hasCmdProtection
-        ? 'Safe command execution patterns detected or no shell commands found'
-        : 'Use execFile instead of exec, or disable shell interpolation',
-      fixable: false,
-      guidance: 'Using exec() with user-controlled input lets attackers inject shell metacharacters (;, |, $()) to run arbitrary commands on the host system.',
-    });
+    if (dirReadInj004.state === 'absent') {
+      findings.push(notApplicableRecord({ checkId: 'INJ-004', name: 'Command Injection Protection', description: 'Shell commands should use safe execution patterns', category: 'input-validation' }, 'source files (.ts, .js)', 'No .ts or .js files at the scanned root, so there is no source to inspect.'));
+    } else if (dirReadInj004.state === 'read') {
+      findings.push({
+        checkId: 'INJ-004',
+        name: 'Command Injection Protection',
+        description: 'Shell commands should use safe execution patterns',
+        category: 'input-validation',
+        severity: 'critical',
+        passed: hasCmdProtection,
+        message: hasCmdProtection
+          ? 'Safe command execution patterns detected or no shell commands found'
+          : 'Use execFile instead of exec, or disable shell interpolation',
+        fixable: false,
+        guidance: 'Using exec() with user-controlled input lets attackers inject shell metacharacters (;, |, $()) to run arbitrary commands on the host system.',
+      });
+    }
 
     return findings;
   }
@@ -9030,9 +9250,9 @@ dist/
 
     // ENCRYPT-003: Check for weak algorithms
     let hasWeakAlgorithms = false;
-    try {
-      const files = await fs.readdir(targetDir);
-      for (const file of files) {
+    const dirReadEncrypt003 = await readCheckDir(targetDir, (file) => file.endsWith('.ts') || file.endsWith('.js'));
+    if (dirReadEncrypt003.state === 'read') {
+      for (const file of dirReadEncrypt003.entries) {
         if (file.endsWith('.ts') || file.endsWith('.js')) {
           try {
             const content = await fs.readFile(path.join(targetDir, file), 'utf-8');
@@ -9048,21 +9268,25 @@ dist/
           } catch {}
         }
       }
-    } catch {}
+    }
 
-    findings.push({
-      checkId: 'ENCRYPT-003',
-      name: 'Weak Cryptographic Algorithms',
-      description: 'Avoid using weak cryptographic algorithms',
-      category: 'encryption',
-      severity: 'high',
-      passed: !hasWeakAlgorithms,
-      message: hasWeakAlgorithms
-        ? 'Weak algorithms detected (MD5/SHA1/DES) - use SHA-256+ and AES'
-        : 'No weak cryptographic algorithms detected',
-      fixable: false,
-      guidance: 'MD5 and SHA1 have known collision attacks, and DES has a 56-bit key easily brute-forced with modern hardware. Data protected by these algorithms should be considered unprotected.',
-    });
+    if (dirReadEncrypt003.state === 'absent') {
+      findings.push(notApplicableRecord({ checkId: 'ENCRYPT-003', name: 'Weak Cryptographic Algorithms', description: 'Avoid using weak cryptographic algorithms', category: 'encryption' }, 'source files (.ts, .js)', 'No .ts or .js files at the scanned root, so there is no source to inspect.'));
+    } else if (dirReadEncrypt003.state === 'read') {
+      findings.push({
+        checkId: 'ENCRYPT-003',
+        name: 'Weak Cryptographic Algorithms',
+        description: 'Avoid using weak cryptographic algorithms',
+        category: 'encryption',
+        severity: 'high',
+        passed: !hasWeakAlgorithms,
+        message: hasWeakAlgorithms
+          ? 'Weak algorithms detected (MD5/SHA1/DES) - use SHA-256+ and AES'
+          : 'No weak cryptographic algorithms detected',
+        fixable: false,
+        guidance: 'MD5 and SHA1 have known collision attacks, and DES has a 56-bit key easily brute-forced with modern hardware. Data protected by these algorithms should be considered unprotected.',
+      });
+    }
 
     // ENCRYPT-004: Check for TLS configuration
     let hasTlsConfig = false;

--- a/src/hardening/scanner.ts
+++ b/src/hardening/scanner.ts
@@ -9507,9 +9507,11 @@ dist/
     // (GIT-001's advisory shape), which keeps it off the pathless noise floor.
     // The probes go through `readCheckSubject` rather than `fs.access` because
     // tracked-fs does not ledger a failed `access` — a probe obstructed by
-    // EACCES must reach the unreadable-inputs channel, not vanish. Every
-    // probed path is content-read by SANDBOX-002/003/004 when present, so
-    // coverage counts do not move.
+    // EACCES must reach the unreadable-inputs channel, not vanish. SANDBOX-
+    // 002/003/004 reuse these probes, so `filesRead` does not inflate. Other
+    // coverage counts do move: probes that were `access` calls are now
+    // content reads, so this category's `pathsInspected` shrinks and its
+    // examined/unevidenced accounting shifts accordingly (measured).
     const containerProbes = [
       await readCheckSubject(path.join(targetDir, 'Dockerfile')),
       await readCheckSubject(path.join(targetDir, 'docker-compose.yml')),
@@ -9580,11 +9582,13 @@ dist/
     }
 
     // SANDBOX-003: Check for resource limits
-    // #458 — both compose spellings are probed; a readable .yaml decides,
-    // else a readable .yml (the original precedence, verdict unchanged). Both
-    // absent => not-applicable; neither read and either obstructed => nothing.
-    const composeYmlRead = await readCheckSubject(path.join(targetDir, 'docker-compose.yml'));
-    const composeYamlRead = await readCheckSubject(path.join(targetDir, 'docker-compose.yaml'));
+    // #458 — reuses SANDBOX-001's compose probes so one scan pass cannot
+    // classify the same subject two different ways (and does not read it
+    // twice). A readable .yaml decides, else a readable .yml (the original
+    // precedence, verdict unchanged). Both absent => not-applicable; neither
+    // read and either obstructed => nothing.
+    const composeYmlRead = containerProbes[1];
+    const composeYamlRead = containerProbes[2];
     const composeRead: SubjectRead =
       composeYamlRead.state === 'read' ? composeYamlRead
       : composeYmlRead.state === 'read' ? composeYmlRead
@@ -9653,8 +9657,8 @@ dist/
     const findings: SecurityFindingDraft[] = [];
     const mcpConfigPath = path.join(targetDir, 'mcp.json');
 
-    // #458 — one errno-classified read shared by TOOL-001/002/003. TOOL-001 is
-    // TOOL-002/003 branch on the same read (#458): absent mcp.json =>
+    // #458 — one errno-classified read shared by TOOL-001/002/003.
+    // TOOL-002/003 branch on the same read: absent mcp.json =>
     // not-applicable naming the subject, unread => nothing, read => their
     // verdict, unchanged.
     const mcpRead = await readCheckSubject(mcpConfigPath);

--- a/src/hardening/scanner.ts
+++ b/src/hardening/scanner.ts
@@ -1344,9 +1344,19 @@ export function findingAppliesTo(finding: SecurityFindingDraft, projectType: Pro
  * the CLI's `result`, not to the scanner instance.
  */
 export function isReportableFinding(
-  f: { passed?: boolean; fixed?: boolean; file?: string; checkId: string },
+  f: {
+    passed?: boolean;
+    fixed?: boolean;
+    file?: string;
+    checkId: string;
+    notApplicable?: { subject: string; reason: string };
+  },
   projectType: ProjectType,
 ): boolean {
+  // #458 — the same clause as the rendered-list filter in `scan()`: the CLI's
+  // refilters rebuild `result.findings` from `allFindings` through this
+  // predicate, and `allFindings` is where not-applicable records live.
+  if (f.notApplicable || typeof f.passed !== 'boolean') return false;
   return retainForVerdict(f) && Boolean(f.file) && findingAppliesTo(f as SecurityFindingDraft, projectType);
 }
 
@@ -3572,6 +3582,13 @@ export class HardeningScanner {
     // survives it, naming a check on the command line removed that check's
     // penalties and RAISED the score.
     let filteredFindings = findings.filter((f) => {
+      // #458 — a not-applicable record carries no pass/fail state and never
+      // renders: it names an absent subject, not a file. Stated here, at the
+      // site that enforces it, so `result.findings` holds measured records
+      // only (the Registry publish mapping and `isReportableFinding` rely on
+      // that; an NA record reaches `allFindings` and nothing else).
+      if (f.notApplicable || typeof f.passed !== 'boolean') return false;
+
       // Keep fixed findings (so users can see what was fixed)
       // Otherwise, only show failed checks
       if (!f.fixed && f.passed) return false;

--- a/src/hardening/scanner.ts
+++ b/src/hardening/scanner.ts
@@ -27,7 +27,7 @@ import {
   inferActualCapabilities,
   validateCapabilities,
 } from './skill-capability-validator';
-import { clampScoreToVerdictBand, countsAgainstScore, expandSuppressed, retainForVerdict, summarizeSuppressed } from '../ui/verdict-band';
+import { clampScoreToVerdictBand, countsAgainstScore, expandSuppressed, isMeasured, retainForVerdict, summarizeSuppressed } from '../ui/verdict-band';
 import { shellQuote, citationTarget, citationPath, citationPaths, commandNaming } from '../ui/shell-quote';
 import {
   isPathWithinDirectory as containIsPathWithinDirectory,
@@ -1221,7 +1221,7 @@ const SEVERITY_WEIGHTS: Record<Severity, number> = {
  * when it fires across dozens of files in a large repository. All findings
  * are still reported — only the score contribution is capped.
  */
-export function calculateSecurityScore(findings: Array<{ passed?: boolean; fixed?: boolean; severity: string; category?: string; checkId?: string }>): {
+export function calculateSecurityScore(findings: Array<{ passed?: boolean; fixed?: boolean; severity?: string; category?: string; checkId?: string }>): {
   score: number;
   maxScore: number;
 } {
@@ -3702,6 +3702,11 @@ export class HardeningScanner {
     }> = [];
     let unevidencedFailures = 0;
     for (const f of findings) {
+      // #458 — a not-applicable record has no pass/fail state and no severity:
+      // without this guard it falls past `passed && !fixed` and (carrying no
+      // `file`) is rolled up as an unevidenced FAILURE — a check that measured
+      // nothing counted as a failure we suppressed.
+      if (!isMeasured(f)) continue;
       if (f.passed && !f.fixed) continue;
       if (survived.has(f)) continue;
       if (ignoredChecks.has(f.checkId.toUpperCase())) continue;

--- a/src/hardening/scanner.ts
+++ b/src/hardening/scanner.ts
@@ -7089,35 +7089,39 @@ dist/
     const findings: SecurityFindingDraft[] = [];
 
     // DEP-001: Check for package-lock.json
-    let hasLockFile = false;
-    try {
-      await fs.access(path.join(targetDir, 'package-lock.json'));
-      hasLockFile = true;
-    } catch {
-      try {
-        await fs.access(path.join(targetDir, 'yarn.lock'));
-        hasLockFile = true;
-      } catch {
-        try {
-          await fs.access(path.join(targetDir, 'pnpm-lock.yaml'));
-          hasLockFile = true;
-        } catch {}
-      }
+    // #458: a lock file is a MUST-exist artifact, so its absence is the
+    // finding (an absent-mitigation advisory whose `file` names the path the
+    // fix creates), never a not-applicable record. Content reads rather than
+    // `fs.access` so an unreadable candidate reaches the coverage ledger;
+    // the loop stops at the first lock file it can read.
+    const lockFileProbes: SubjectRead[] = [];
+    for (const lockFile of ['package-lock.json', 'yarn.lock', 'pnpm-lock.yaml']) {
+      const probe = await readCheckSubject(path.join(targetDir, lockFile));
+      lockFileProbes.push(probe);
+      if (probe.state === 'read') break;
     }
+    const hasLockFile = lockFileProbes.some((probe) => probe.state === 'read');
 
-    findings.push({
-      checkId: 'DEP-001',
-      name: 'Dependency Lock File',
-      description: 'No dependency lock file found',
-      category: 'dependencies',
-      severity: 'medium',
-      passed: hasLockFile,
-      message: hasLockFile
-        ? 'Dependency lock file present'
-        : 'No lock file found - dependency versions may vary between installs',
-      fixable: false,
-      guidance: 'Without a lock file, npm install can resolve to different package versions on different machines, including versions with known vulnerabilities or supply-chain backdoors.',
-    });
+    if (hasLockFile || lockFileProbes.every((probe) => probe.state === 'absent')) {
+      const dep001: SecurityFindingDraft = {
+        checkId: 'DEP-001',
+        name: 'Dependency Lock File',
+        description: 'No dependency lock file found',
+        category: 'dependencies',
+        severity: 'medium',
+        passed: hasLockFile,
+        message: hasLockFile
+          ? 'Dependency lock file present'
+          : 'No lock file found - dependency versions may vary between installs',
+        fixable: false,
+        guidance: 'Without a lock file, npm install can resolve to different package versions on different machines, including versions with known vulnerabilities or supply-chain backdoors.',
+      };
+      if (!hasLockFile) {
+        // Absent-mitigation advisory: `file` is the path the fix creates.
+        dep001.file = 'package-lock.json';
+      }
+      findings.push(dep001);
+    }
 
     // DEP-002: Check for known vulnerable packages
     const vulnerablePackages = ['event-stream', 'flatmap-stream', 'eslint-scope@3.7.2'];

--- a/src/hardening/scanner.ts
+++ b/src/hardening/scanner.ts
@@ -1491,12 +1491,21 @@ export function isReportableFinding(
  *
  * Consumers of allFindings (corpus release-smoke, benchmark, OASB-2
  * composite) get a clean signal without dropping legitimate findings.
+ *
+ * #458 — not-applicable records (no `passed`, no `file`) follow the same
+ * type rule, stated below as a decision rather than left to the fall-through:
+ * project-type scope wins over the not-applicable channel. A check scoped
+ * off the project type leaves NO record at all — the same outcome as the
+ * checks that never ran — so a library tree does not carry a PROC-001
+ * "no Dockerfile" record for a container check that cannot apply to it.
+ * `noise-floor.test.ts` pins both directions.
  */
 export function dropPathlessNoiseFloor(
   findings: SecurityFindingDraft[],
   projectType: ProjectType,
 ): SecurityFindingDraft[] {
   return findings.filter((f) => {
+    if (f.notApplicable) return findingAppliesTo(f, projectType);
     if (f.passed || f.fixed) return true;
     if (f.file) return true;
     return findingAppliesTo(f, projectType);
@@ -7783,7 +7792,7 @@ dist/
     const hasTimeout = (mcpConfig as Record<string, unknown>)?.timeout !== undefined;
 
     if (mcpReadExt.state === 'absent') {
-      findings.push(notApplicableRecord({ checkId: 'MCP-006', name: 'MCP Request Timeout', description: 'No request timeout configured for MCP servers', category: 'mcp' }, 'mcp.json', 'No mcp.json in the scanned tree, so no MCP servers are configured and there is no MCP transport to inspect.'));
+      findings.push(notApplicableRecord({ checkId: 'MCP-006', name: 'MCP Request Timeout', description: 'No request timeout configured for MCP servers', category: 'mcp' }, 'mcp.json', 'No mcp.json in the scanned tree. This check reads only mcp.json, so MCP servers configured elsewhere (for example .mcp.json) are outside its scope.'));
     } else if (mcpReadExt.state === 'read') {
       findings.push({
         checkId: 'MCP-006',
@@ -7806,7 +7815,7 @@ dist/
     const hasRetryConfig = (mcpConfig as Record<string, unknown>)?.retries !== undefined;
 
     if (mcpReadExt.state === 'absent') {
-      findings.push(notApplicableRecord({ checkId: 'MCP-007', name: 'MCP Retry Limits', description: 'No retry limits configured for MCP servers', category: 'mcp' }, 'mcp.json', 'No mcp.json in the scanned tree, so no MCP servers are configured and there is no MCP transport to inspect.'));
+      findings.push(notApplicableRecord({ checkId: 'MCP-007', name: 'MCP Retry Limits', description: 'No retry limits configured for MCP servers', category: 'mcp' }, 'mcp.json', 'No mcp.json in the scanned tree. This check reads only mcp.json, so MCP servers configured elsewhere (for example .mcp.json) are outside its scope.'));
     } else if (mcpReadExt.state === 'read') {
       findings.push({
         checkId: 'MCP-007',
@@ -7840,7 +7849,7 @@ dist/
     }
 
     if (mcpReadExt.state === 'absent') {
-      findings.push(notApplicableRecord({ checkId: 'MCP-008', name: 'MCP Localhost Binding', description: 'MCP servers should bind to localhost only', category: 'mcp' }, 'mcp.json', 'No mcp.json in the scanned tree, so no MCP servers are configured and there is no MCP transport to inspect.'));
+      findings.push(notApplicableRecord({ checkId: 'MCP-008', name: 'MCP Localhost Binding', description: 'MCP servers should bind to localhost only', category: 'mcp' }, 'mcp.json', 'No mcp.json in the scanned tree. This check reads only mcp.json, so MCP servers configured elsewhere (for example .mcp.json) are outside its scope.'));
     } else if (mcpReadExt.state === 'read') {
       findings.push({
         checkId: 'MCP-008',
@@ -7873,7 +7882,7 @@ dist/
     }
 
     if (mcpReadExt.state === 'absent') {
-      findings.push(notApplicableRecord({ checkId: 'MCP-009', name: 'Sensitive MCP Tools', description: 'MCP configuration includes potentially dangerous tools', category: 'mcp' }, 'mcp.json', 'No mcp.json in the scanned tree, so no MCP servers are configured and there is no MCP transport to inspect.'));
+      findings.push(notApplicableRecord({ checkId: 'MCP-009', name: 'Sensitive MCP Tools', description: 'MCP configuration includes potentially dangerous tools', category: 'mcp' }, 'mcp.json', 'No mcp.json in the scanned tree. This check reads only mcp.json, so MCP servers configured elsewhere (for example .mcp.json) are outside its scope.'));
     } else if (mcpReadExt.state === 'read') {
       findings.push({
         checkId: 'MCP-009',
@@ -9684,7 +9693,7 @@ dist/
         category: 'tool-boundaries',
         notApplicable: {
           subject: 'mcp.json',
-          reason: 'No mcp.json in the scanned tree, so no MCP servers are configured and there are no tool boundaries to measure.',
+          reason: 'No mcp.json in the scanned tree. This check reads only mcp.json, so tool boundaries configured elsewhere (for example .mcp.json) are outside its scope.',
         },
         message: 'Not applicable: no mcp.json to measure for tool whitelisting',
         fixable: false,
@@ -9727,7 +9736,7 @@ dist/
     }
 
     if (mcpRead.state === 'absent') {
-      findings.push(notApplicableRecord({ checkId: 'TOOL-002', name: 'Tool Resource Constraints', description: 'MCP tools should have resource constraints', category: 'tool-boundaries' }, 'mcp.json', 'No mcp.json in the scanned tree, so no MCP servers are configured and there are no tool boundaries to measure.'));
+      findings.push(notApplicableRecord({ checkId: 'TOOL-002', name: 'Tool Resource Constraints', description: 'MCP tools should have resource constraints', category: 'tool-boundaries' }, 'mcp.json', 'No mcp.json in the scanned tree. This check reads only mcp.json, so tool boundaries configured elsewhere (for example .mcp.json) are outside its scope.'));
     } else if (mcpRead.state === 'read') {
       findings.push({
         checkId: 'TOOL-002',
@@ -9759,7 +9768,7 @@ dist/
     }
 
     if (mcpRead.state === 'absent') {
-      findings.push(notApplicableRecord({ checkId: 'TOOL-003', name: 'Dangerous Tool Detection', description: 'Identify potentially dangerous MCP tools', category: 'tool-boundaries' }, 'mcp.json', 'No mcp.json in the scanned tree, so no MCP servers are configured and there are no tool boundaries to measure.'));
+      findings.push(notApplicableRecord({ checkId: 'TOOL-003', name: 'Dangerous Tool Detection', description: 'Identify potentially dangerous MCP tools', category: 'tool-boundaries' }, 'mcp.json', 'No mcp.json in the scanned tree. This check reads only mcp.json, so tool boundaries configured elsewhere (for example .mcp.json) are outside its scope.'));
     } else if (mcpRead.state === 'read') {
       findings.push({
         checkId: 'TOOL-003',

--- a/src/hardening/security-check.ts
+++ b/src/hardening/security-check.ts
@@ -61,7 +61,15 @@ export interface SecurityFinding {
   name: string;
   description: string;
   category: string;
-  severity: Severity;
+  /**
+   * Absent EXACTLY when `notApplicable` is set: a severity is a measured
+   * weight, and a check that measured nothing has no honest value to put
+   * here (#458). Every other finding carries one. Consumers that weigh or
+   * render severity test `notApplicable` first (the render filter already
+   * drops NA records from `result.findings`, so a post-filter consumer
+   * narrows by that fact, not by inventing a default).
+   */
+  severity?: Severity;
   /**
    * Whether the check found its subject and MEASURED it clean.
    *

--- a/src/hardening/security-check.ts
+++ b/src/hardening/security-check.ts
@@ -95,6 +95,12 @@ export interface SecurityFinding {
    * failure with `file` set to the path the fix creates, never this. Any errno
    * other than not-there is an unread input (`buildUnreadInputFinding`), never
    * this either.
+   *
+   * `subject` and `reason` are EMITTER LITERALS: fixed strings in the check's
+   * source, never scanned bytes and never derived from file content. That rule
+   * is what keeps them outside the redaction boundary's byte-carrying set
+   * (`finding-emit.ts` `BYTE_CARRYING_FIELDS`) without teaching the redactor
+   * to walk nested fields.
    */
   notApplicable?: { subject: string; reason: string };
   message: string;

--- a/src/hardening/security-check.ts
+++ b/src/hardening/security-check.ts
@@ -62,7 +62,33 @@ export interface SecurityFinding {
   description: string;
   category: string;
   severity: Severity;
-  passed: boolean;
+  /**
+   * Whether the check found its subject and MEASURED it clean.
+   *
+   * #458 — three states, not two. `true`: measured, clean. `false`: measured,
+   * defective (or, for an absent-mitigation advisory, `file` is the path the
+   * fix creates — GIT-001 / SANDBOX-001 shape). OMITTED: nothing was measured
+   * and `notApplicable` says why. A consumer that reads `passed` as a boolean
+   * turns the third state into whichever of the other two its comparison
+   * favours (`!== false` credits an unmeasured control as passed, `!f.passed`
+   * scores it as failed), so a consumer tests `notApplicable` first.
+   */
+  passed?: boolean;
+  /**
+   * #458 — the check's subject does not exist in this tree (a not-there errno:
+   * `coverage-ledger.ts` `countsAsUnread` is false), so the check measured
+   * nothing. `subject` names what was looked for (`Dockerfile`, `.mcp.json`,
+   * `source files`); `reason` says why that makes the check not applicable
+   * rather than failed. Carried WITHOUT `passed`, without severity weight and
+   * without a score contribution (`countsAgainstScore` and `retainForVerdict`
+   * both return false on it before reading anything else).
+   *
+   * Not for a subject that MUST exist: a required artifact's absence is a
+   * failure with `file` set to the path the fix creates, never this. Any errno
+   * other than not-there is an unread input (`buildUnreadInputFinding`), never
+   * this either.
+   */
+  notApplicable?: { subject: string; reason: string };
   message: string;
   fixable: boolean;
   fixed?: boolean;

--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -201,6 +201,71 @@ export type ToolResult = {
 };
 
 /** The text a refusal returns, in the shape the transport expects. */
+/**
+ * The `hackmyagent_benchmark` assessor, extracted so a test can reach it (the
+ * tool-handler closure above is never executed by the suite).
+ *
+ * INTERIM (#458 steps 1-2). #458 step 5 replaces this function wholesale with
+ * `generateBenchmarkReport` (`cli.ts`), the assessor `benchmark` itself uses;
+ * until then the two differ, and this one keeps its legacy reading that a
+ * control with NO record for a check id is credited as passed (`!== false`).
+ */
+export interface BenchmarkAssessment {
+  passed: number;
+  failed: number;
+  unverified: number;
+  compliance: number;
+  rating: string;
+  lines: string[];
+  text: string;
+}
+
+export function assessBenchmarkFindings(
+  allFindings: ReadonlyArray<Pick<SecurityFinding, 'checkId' | 'passed' | 'notApplicable'>>,
+  level: BenchmarkLevel,
+): BenchmarkAssessment {
+  const controls = getControlsForLevel(level);
+  const checkIdResults = new Map<string, boolean | undefined>();
+  for (const f of allFindings) {
+    checkIdResults.set(f.checkId, f.passed);
+  }
+
+  let passed = 0;
+  let failed = 0;
+  let unverified = 0;
+  const lines: string[] = [];
+
+  for (const control of controls) {
+    if (control.checkIds.length === 0) {
+      if (control.verification === 'forward' || control.verification === 'manual') {
+        unverified++;
+        lines.push(`[UNVERIFIED] ${control.id} ${control.name} (${control.verification})`);
+      }
+      continue;
+    }
+
+    const allPass = control.checkIds.every((id) => checkIdResults.get(id) !== false);
+    if (allPass) {
+      passed++;
+      lines.push(`[PASS] ${control.id} ${control.name}`);
+    } else {
+      failed++;
+      const failedChecks = control.checkIds.filter((id) => checkIdResults.get(id) === false);
+      lines.push(`[FAIL] ${control.id} ${control.name} (${failedChecks.join(', ')})`);
+    }
+  }
+
+  const total = passed + failed;
+  const compliance = total > 0 ? Math.round((passed / total) * 100) : 0;
+  const rating = calculateRating(compliance, compliance, compliance, level);
+  const text =
+    `OASB-1 ${level} Assessment: ${compliance}% compliance (${rating})\n` +
+    `Passed: ${passed} | Failed: ${failed} | Unverified: ${unverified}\n\n` +
+    lines.join('\n');
+
+  return { passed, failed, unverified, compliance, rating, lines, text };
+}
+
 function refuse(refusal: RootRefusal): ToolResult {
   return { content: [{ type: 'text', text: describeRootRefusal(refusal) }], isError: true };
 }
@@ -366,52 +431,8 @@ export async function handleToolCall(
           const result = await scanner.scan({ targetDir: dir });
 
           // Generate benchmark assessment
-          const allFindings = result.allFindings || result.findings;
-          const controls = getControlsForLevel(level);
-          const checkIdResults = new Map<string, boolean>();
-          for (const f of allFindings) {
-            checkIdResults.set(f.checkId, f.passed);
-          }
-
-          let passed = 0;
-          let failed = 0;
-          let unverified = 0;
-          const controlResults: string[] = [];
-
-          for (const control of controls) {
-            if (control.checkIds.length === 0) {
-              if (control.verification === 'forward' || control.verification === 'manual') {
-                unverified++;
-                controlResults.push(`[UNVERIFIED] ${control.id} ${control.name} (${control.verification})`);
-              }
-              continue;
-            }
-
-            const allPass = control.checkIds.every((id) => checkIdResults.get(id) !== false);
-            if (allPass) {
-              passed++;
-              controlResults.push(`[PASS] ${control.id} ${control.name}`);
-            } else {
-              failed++;
-              const failedChecks = control.checkIds.filter((id) => checkIdResults.get(id) === false);
-              controlResults.push(`[FAIL] ${control.id} ${control.name} (${failedChecks.join(', ')})`);
-            }
-          }
-
-          const total = passed + failed;
-          const compliance = total > 0 ? Math.round((passed / total) * 100) : 0;
-          const rating = calculateRating(compliance, compliance, compliance, level);
-
-          return {
-            content: [
-              {
-                type: 'text',
-                text: `OASB-1 ${level} Assessment: ${compliance}% compliance (${rating})\n` +
-                  `Passed: ${passed} | Failed: ${failed} | Unverified: ${unverified}\n\n` +
-                  controlResults.join('\n'),
-              },
-            ],
-          };
+          const assessment = assessBenchmarkFindings(result.allFindings || result.findings, level);
+          return { content: [{ type: 'text', text: assessment.text }] };
         }
 
       default:

--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -213,6 +213,7 @@ export type ToolResult = {
 export interface BenchmarkAssessment {
   passed: number;
   failed: number;
+  notApplicable: number;
   unverified: number;
   compliance: number;
   rating: string;
@@ -225,13 +226,17 @@ export function assessBenchmarkFindings(
   level: BenchmarkLevel,
 ): BenchmarkAssessment {
   const controls = getControlsForLevel(level);
-  const checkIdResults = new Map<string, boolean | undefined>();
+  // #458 — last record per checkId wins, as before, but the record keeps its
+  // notApplicable marker: a not-applicable record has no pass/fail state and
+  // must never be read as the legacy "no false => pass".
+  const checkIdResults = new Map<string, Pick<SecurityFinding, 'passed' | 'notApplicable'>>();
   for (const f of allFindings) {
-    checkIdResults.set(f.checkId, f.passed);
+    checkIdResults.set(f.checkId, { passed: f.passed, notApplicable: f.notApplicable });
   }
 
   let passed = 0;
   let failed = 0;
+  let notApplicable = 0;
   let unverified = 0;
   const lines: string[] = [];
 
@@ -244,26 +249,56 @@ export function assessBenchmarkFindings(
       continue;
     }
 
-    const allPass = control.checkIds.every((id) => checkIdResults.get(id) !== false);
-    if (allPass) {
-      passed++;
-      lines.push(`[PASS] ${control.id} ${control.name}`);
-    } else {
+    const records = control.checkIds.map((id) => ({ id, record: checkIdResults.get(id) }));
+    // notApplicable is decided per record FIRST, in the same order as
+    // `countsAgainstScore`: an NA record's `passed` is not read at all.
+    const failedChecks = records.filter(
+      ({ record }) => record !== undefined && !record.notApplicable && record.passed === false,
+    );
+    if (failedChecks.length > 0) {
       failed++;
-      const failedChecks = control.checkIds.filter((id) => checkIdResults.get(id) === false);
-      lines.push(`[FAIL] ${control.id} ${control.name} (${failedChecks.join(', ')})`);
+      lines.push(
+        `[FAIL] ${control.id} ${control.name} (${failedChecks.map(({ id }) => id).join(', ')})`,
+      );
+      continue;
     }
+
+    const naChecks = records.filter(({ record }) => record?.notApplicable);
+    const anyMeasured = records.some(({ record }) => record !== undefined && !record.notApplicable);
+    if (naChecks.length > 0 && !anyMeasured) {
+      // Every record this control has is a positive not-applicable: the
+      // control's subject is absent from the scanned tree, so the control was
+      // neither satisfied nor violated. Own bucket, own line, excluded from
+      // the compliance denominator below.
+      notApplicable++;
+      lines.push(
+        `[NOT-APPLICABLE] ${control.id} ${control.name} (${naChecks
+          .map(({ id, record }) => `${id}: no ${record!.notApplicable!.subject}`)
+          .join(', ')})`,
+      );
+      continue;
+    }
+
+    // Legacy credit, deliberately kept: a control none of whose checkIds
+    // produced ANY record still counts as a pass, exactly as
+    // `get(id) !== false` did before #458. The ruling narrows that credit
+    // only where a positive not-applicable record exists; the absent-record
+    // credit is pinned by the #458 test so a future change of it is loud.
+    passed++;
+    lines.push(`[PASS] ${control.id} ${control.name}`);
   }
 
+  // notApplicable is excluded: an absent subject shrinks the denominator, it
+  // does not dent compliance (#458 ruling, CA + CPO 2026-08-24).
   const total = passed + failed;
   const compliance = total > 0 ? Math.round((passed / total) * 100) : 0;
   const rating = calculateRating(compliance, compliance, compliance, level);
   const text =
     `OASB-1 ${level} Assessment: ${compliance}% compliance (${rating})\n` +
-    `Passed: ${passed} | Failed: ${failed} | Unverified: ${unverified}\n\n` +
+    `Passed: ${passed} | Failed: ${failed} | Not applicable: ${notApplicable} | Unverified: ${unverified}\n\n` +
     lines.join('\n');
 
-  return { passed, failed, unverified, compliance, rating, lines, text };
+  return { passed, failed, notApplicable, unverified, compliance, rating, lines, text };
 }
 
 function refuse(refusal: RootRefusal): ToolResult {

--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -34,7 +34,7 @@ import {
 import { citationTarget } from './ui/shell-quote';
 import { assertRedactionProvenance } from './hardening/finding-emit';
 import { getCheckCounts } from './hardening/taxonomy';
-import { countsAgainstScore, confirmedFix } from './ui/verdict-band';
+import { countsAgainstScore, confirmedFix, isMeasured } from './ui/verdict-band';
 import {
   resolveRoots,
   resolveWithinRoots,
@@ -117,6 +117,9 @@ function formatFindingsForLLM(findings: SecurityFinding[]): string {
 
   const lines: string[] = [];
   for (const f of findings) {
+    // #458 — a not-applicable record has no severity to print; its disclosure
+    // rides the summary's not-applicable bucket, not the LLM findings list.
+    if (!isMeasured(f)) continue;
     const location = f.file ? (f.line ? `${f.file}:${f.line}` : f.file) : '';
     lines.push(`[${f.severity.toUpperCase()}] ${f.checkId}: ${f.name}`);
     if (location) lines.push(`  Location: ${location}`);
@@ -186,6 +189,8 @@ export function buildDeepScanLayer1(findings: SecurityFinding[]): Array<{
 }> {
   assertRedactionProvenance(findings, 'mcp-deep-scan');
   return findings
+    // #458 — layer 1 maps `severity` below; a not-applicable record has none.
+    .filter(isMeasured)
     .filter((f) => countsAgainstScore(f))
     .map((f) => ({
       checkId: f.checkId,

--- a/src/nanomind-core/orchestrate.ts
+++ b/src/nanomind-core/orchestrate.ts
@@ -19,7 +19,7 @@ import type { NanoMindScanResult, ArtifactSummary, CoverageCandidate, SemanticFa
 import { ANALYZER_FAMILY_COUNT } from './analyzers/family-coverage.js';
 import type { AnalystResponse, ArtifactCoverageVerdict } from './inference/security-analyst.js';
 import { routeAnalystVerdict, combineVerdict } from './analyst-coverage.js';
-import { countsAgainstScore } from '../ui/verdict-band';
+import { countsAgainstScore, isMeasured } from '../ui/verdict-band';
 import { redactOpenBagForPublish } from '../hardening/finding-emit';
 
 export type { ArtifactSummary } from './scanner-bridge.js';
@@ -392,7 +392,7 @@ async function runAnalystOnFindings(
   // by injection through THIS function with a stubbed `runInference`, not by
   // grep — a text guard is satisfied by dead code; an injection is not.
   const results: AnalystResponse[] = [];
-  const failed = findings.filter(f => countsAgainstScore(f));
+  const failed = findings.filter(isMeasured).filter(f => countsAgainstScore(f));
 
   // Limit to top 10 most important findings to keep inference time reasonable
   const prioritized = failed

--- a/src/nanomind-core/scanner-bridge.ts
+++ b/src/nanomind-core/scanner-bridge.ts
@@ -1088,6 +1088,11 @@ export function mergeFindings(
       for (const idx of matchIndices) {
         const staticFinding = merged[idx];
 
+        // #458 — a not-applicable static record measured nothing, so there is
+        // nothing for the AST layer to enhance or suppress; it stays as-is.
+        // (`typeof` narrows `passed` for the rule below; an NA record has none.)
+        if (staticFinding.notApplicable || typeof staticFinding.passed !== 'boolean') continue;
+
         // Rule: If AST says passed but static says failed, static wins
         if (!validateEnhancement(staticFinding.passed, astFinding.passed)) {
           // Suppression blocked -- keep static finding as-is

--- a/src/registry/client.ts
+++ b/src/registry/client.ts
@@ -9,7 +9,7 @@ import { createHash } from 'crypto';
 import type { SecurityFinding, Severity } from '../hardening';
 import { assertRedactionProvenance } from '../hardening/finding-emit';
 import type { AttackReport } from '../attack';
-import { countsAgainstScore } from '../ui/verdict-band';
+import { countsAgainstScore, isMeasured } from '../ui/verdict-band';
 
 // Registry ScanResult format (must match hackmyagent_service.go:175-200)
 export interface ScanReportPayload {
@@ -486,7 +486,7 @@ export function buildScanReport(
   findings: SecurityFinding[],
 ): ScanReportPayload {
   assertRedactionProvenance(findings, 'registry-scan-report');
-  const failed = findings.filter(f => countsAgainstScore(f));
+  const failed = findings.filter(isMeasured).filter(f => countsAgainstScore(f));
 
   const counts = countBySeverity(failed);
   const status = deriveStatus(counts);
@@ -590,7 +590,7 @@ export function buildCommunityReport(
   options?: { packageType?: string; version?: string },
 ): CommunityScanPayload {
   assertRedactionProvenance(findings, 'registry-community-report');
-  const failed = findings.filter(f => countsAgainstScore(f));
+  const failed = findings.filter(isMeasured).filter(f => countsAgainstScore(f));
   // Only send package-relevant findings to registry — local dev hygiene
   // checks (git, permissions, env, IDE config) don't belong on a package page
   const registryFindings = failed.filter(isRegistryRelevant);

--- a/src/registry/publish.ts
+++ b/src/registry/publish.ts
@@ -259,8 +259,11 @@ export function buildPublishPayload(data: PublishScanData, toolVersion: string):
   };
 
   if (data.hardeningFindings) {
-    const total = data.hardeningFindings.length;
-    const failed = data.hardeningFindings.filter(f => countsAgainstScore(f)).length;
+    // #458 — the sub-report counts measured findings only, matching the wire
+    // list above: a not-applicable record is in no denominator anywhere.
+    const measured = data.hardeningFindings.filter(isMeasured);
+    const total = measured.length;
+    const failed = measured.filter(f => countsAgainstScore(f)).length;
     subReports.hardening = {
       totalChecks: total,
       failedChecks: failed,

--- a/src/registry/publish.ts
+++ b/src/registry/publish.ts
@@ -14,7 +14,7 @@ import { join, relative } from 'path';
 import type { SecurityFinding, Severity } from '../hardening';
 import { assertRedactionProvenance } from '../hardening/finding-emit';
 import { calculateSecurityScore } from '../hardening';
-import { clampScoreToVerdictBand, countsAgainstScore } from '../ui/verdict-band';
+import { clampScoreToVerdictBand, countsAgainstScore, isMeasured } from '../ui/verdict-band';
 import type { AttackReport } from '../attack';
 import type { SoulScanResult } from '../soul';
 import type { BenchmarkResult } from '../benchmarks';
@@ -178,6 +178,10 @@ export function buildPublishPayload(data: PublishScanData, toolVersion: string):
   // Map hardening findings
   if (data.hardeningFindings) {
     for (const f of data.hardeningFindings) {
+      // #458 — a not-applicable record is not a finding on the wire: the OASB-1
+      // status channel carries not-applicable; the signed publish canonical
+      // carries measured findings only.
+      if (!isMeasured(f)) continue;
       findings.push({
         checkId: f.checkId,
         name: f.name,

--- a/src/registry/remediation.ts
+++ b/src/registry/remediation.ts
@@ -1,5 +1,5 @@
 import type { SecurityFinding } from '../hardening/security-check.js';
-import { countsAgainstScore, confirmedFix } from '../ui/verdict-band';
+import { countsAgainstScore, confirmedFix, isMeasured } from '../ui/verdict-band';
 
 interface RemediationReport {
   findingId: string;
@@ -34,7 +34,7 @@ export async function reportRemediation(
   // the same finding to `/remediation/track` as still open — one call, two
   // contradictory claims about the same checkId. (`|| f.fixVerified` was also
   // dead: `fixed` is already true wherever `fixVerified` is set.)
-  const fixedFindings = findings.filter(f => confirmedFix(f));
+  const fixedFindings = findings.filter(isMeasured).filter(f => confirmedFix(f));
 
   if (fixedFindings.length === 0) {
     return;
@@ -73,7 +73,7 @@ export async function reportFindings(
   findings: SecurityFinding[],
   score: number,
 ): Promise<void> {
-  const failedFindings = findings.filter(f => countsAgainstScore(f));
+  const failedFindings = findings.filter(isMeasured).filter(f => countsAgainstScore(f));
 
   if (failedFindings.length === 0) {
     return;

--- a/src/ui/verdict-band.ts
+++ b/src/ui/verdict-band.ts
@@ -109,7 +109,22 @@ export function countsAgainstScore(f: {
  * fix summary leads with what was confirmed (`fixSummaryLine`); the MCP
  * summary and the OpenClaw arm counted every attempt.
  */
-export function confirmedFix(f: { passed?: boolean; fixed?: boolean; fixVerified?: boolean }): boolean {
+export function confirmedFix(f: {
+  passed?: boolean;
+  fixed?: boolean;
+  fixVerified?: boolean;
+  notApplicable?: { subject: string; reason: string };
+}): boolean {
+  // #458 — nothing was measured, so nothing can be a confirmed fix. This is
+  // the one predicate where the NA short-circuit in `countsAgainstScore`
+  // INVERTS instead of composing: on an NA record `countsAgainstScore` is
+  // false, so `!countsAgainstScore(f)` reads "not an issue" as "confirmed",
+  // and an NA record carrying a stray `fixed: true` would be published as a
+  // remediation (src/registry/remediation.ts). No current emitter writes that
+  // shape; the guard exists so the three-way partition (issue / confirmed
+  // fix / not-applicable) never depends on emitter discipline. Same
+  // first-position rule as the two siblings.
+  if (f.notApplicable) return false;
   return f.fixed === true && !countsAgainstScore(f);
 }
 

--- a/src/ui/verdict-band.ts
+++ b/src/ui/verdict-band.ts
@@ -78,7 +78,13 @@ export function countsAgainstScore(f: {
   passed?: boolean;
   fixed?: boolean;
   fixVerified?: boolean;
+  notApplicable?: { subject: string; reason: string };
 }): boolean {
+  // #458 — nothing was measured. Tested before everything else: a
+  // not-applicable record carries no `passed`, and on `!f.fixed` alone it
+  // counted against the score as an outstanding failure (measured on
+  // c0ee1f7: `countsAgainstScore({ notApplicable: {…} })` was true).
+  if (f.notApplicable) return false;
   // Fixed, but the verification pass proved the issue survived.
   //
   // Tested BEFORE `passed`, not after. Twelve checks report
@@ -128,7 +134,16 @@ export function confirmedFix(f: { passed?: boolean; fixed?: boolean; fixVerified
  * left the suite green at 221 files / 2886 tests, because only the `secure`
  * copy was reachable from a test. One rule, one place, one guard.
  */
-export function retainForVerdict(f: { passed?: boolean; fixed?: boolean }): boolean {
+export function retainForVerdict(f: {
+  passed?: boolean;
+  fixed?: boolean;
+  notApplicable?: { subject: string; reason: string };
+}): boolean {
+  // #458 — a not-applicable record is neither an outstanding issue nor a fix.
+  // It reaches `allFindings` under `notApplicable`; it is not a verdict line.
+  // Same first-position rule as `countsAgainstScore`: on `!f.passed` alone the
+  // record (no `passed`) was retained as a failure.
+  if (f.notApplicable) return false;
   return !f.passed || Boolean(f.fixed);
 }
 

--- a/src/ui/verdict-band.ts
+++ b/src/ui/verdict-band.ts
@@ -32,6 +32,8 @@
  * incoherence.
  */
 
+import type { SecurityFinding, Severity } from '../hardening/security-check';
+
 /** Lowest score the meter still paints green. Mirrors the renderer in cli.ts. */
 export const GOOD_BAND_FLOOR = 70;
 
@@ -329,4 +331,24 @@ export function clampDisclosure(opts: {
 }): string {
   if (!opts.clamped || opts.rawScore === undefined) return '';
   return `  (score capped from ${opts.rawScore} to ${opts.score} — verdict is fail-direction)`;
+}
+
+/**
+ * #458 — a finding that measured its subject. A not-applicable record carries
+ * no `severity`: a severity is a measured weight, and a check that measured
+ * nothing has no honest value to put there. So "has a severity" and "was
+ * measured" are the same fact, and every consumer that weighs, sorts, buckets,
+ * or renders `severity` narrows through this guard first. The runtime check
+ * keys on the exact field the narrow claims — nothing is trusted from context.
+ *
+ * Generic so producer-side code holding `SecurityFindingDraft` (or a
+ * structural subset) narrows the type it actually has instead of asserting a
+ * different one.
+ */
+export type MeasuredFinding = SecurityFinding & { severity: Severity };
+
+export function isMeasured<T extends { severity?: Severity }>(
+  f: T
+): f is T & { severity: Severity } {
+  return f.severity !== undefined;
 }


### PR DESCRIPTION
Part of #458 (steps 1-2). #458 closes when step 3 (not-applicable-aware benchmark report, Seat 1) lands.

Ruling and execution record: `todo/COUNCIL_LEDGER.md` :35981/:35986 (contract), :36780 (CA ruling on the sweep gates), :36849 (execution, this branch).

## What changed

A hardening check whose subject is not in the scanned tree emitted either a pathless failure or, on 31 checks, a pass it never measured. Those 31 are the false-pass class named in the ruling: the 24 CA listed (CRED-003, CRED-004, DEP-002, DEP-003, DEP-004, ENCRYPT-003, ENV-001, ENV-002, ENV-003, INJ-004, IO-001, IO-002, IO-004, LOG-002, MCP-006, MCP-007, MCP-008, MCP-009, NET-004, NET-005, PROC-001, SEC-004, TOOL-003, API-003) plus 7 found in the sweep (CLAUDE-004, CLAUDE-005, CLAUDE-006, CLAUDE-007, CURSOR-001, VSCODE-001, VSCODE-002).

- 77 check IDs now emit `notApplicable: { subject, reason }` on an absent subject: 74 through `notApplicableRecord()` in `src/hardening/scanner.ts` and 3 inline (PROMPT-001, SANDBOX-002, TOOL-001). The record has no `severity` and no `passed`; it lands in `allFindings` only. `maxScore` is unchanged.
- Absent means the not-there errnos only (ENOENT, EISDIR, ENOTDIR via `countsAsUnread` in `coverage-ledger.ts`). Any other errno emits no record and `SCAN-UNREAD-001` discloses the subject.
- Hazard probes PERM-001, PERM-002, PERM-003 and LOG-003: not-there is a measured absence and passes; another errno notes the read failure and withholds the verdict unless a sibling hazard was measured. ELOOP fixture via a self-symlink.
- CRED-002 no longer passes with a caveat on an unreadable root; it emits no record and is disclosed.
- CLAUDE-004: a present but unparseable `.claude/settings.json` reads "could not be parsed", not "not found".
- Mitigation advisories stay failures with the path the fix creates: SANDBOX-001 (`file: "Dockerfile"`), DEP-001, GIT-001. GIT-002 is a content advisory and never NA. MCP-010 not converted.
- Consumers: `confirmedFix` never counts an NA record; the verdict band and issue list skip it; the Registry publish path never sends it as a measured finding (`src/registry/{client,publish,remediation}.ts`, `src/ui/verdict-band.ts`, `src/hardening/finding-emit.ts`); the MCP server assessor carries an interim NA bucket so its summary partition stays exact (`__tests__/mcp/mcp-server-not-applicable.test.ts`).
- Project-type scope wins over the not-applicable channel: a check scoped off the detected project type leaves no record at all — stated as an explicit branch in `dropPathlessNoiseFloor` with both directions pinned in `noise-floor.test.ts`. The MCP-006..009 and TOOL-001..003 absence reasons claim only what was probed (`mcp.json`), not that no MCP servers are configured anywhere.
- The publish-boundary filter is additionally pinned at the unit level: `publish-payload-not-applicable.test.ts` feeds synthetic NA records directly to `buildPublishPayload` (mutation-verified: removing the wire filter turns two cells red), and `subReports.hardening` counts measured findings only, so an NA record is in no denominator anywhere. The definition-only `groupFindingsBySeverity` was removed from `src/cli.ts`.
- Known gap, own unit: a populated `.cursor/rules/` directory reads as absent (EISDIR on the directory path); the rule files were not inspected before this change either.

## G1' — pathless failures per reference tree

Rule: checkId(R(T)) ⊆ PS ∩ Applicable(T), PS = the 21 present-subject checks of the census. Base column measured at faba293; the scanner is byte-identical from faba293 to cedaa0b (`git diff --stat faba293 cedaa0b -- src/hardening src/mcp-server.ts` is empty), so the base column holds against the merge base.

| Tree | base |R| | this PR |R| | this PR NA | Residual R(T) |
|---|---|---|---|---|
| empty dir | 1 | 0 | 13 | ∅ |
| one-marker mcp | 18 | 6 | 27 | ENV-004, LOG-001, LOG-004, SEC-001, SEC-002, SEC-003 |
| one-marker webapp | 38 | 20 | 33 | AUDIT-002, AUDIT-003, AUTH-001..004, ENCRYPT-004, ENV-004, IO-003, LOG-001, LOG-004, PROC-002, PROC-003, RATE-001, RATE-003, SEC-001..003, SESSION-002, SESSION-003 |
| one-marker api | 45 | 21 | 40 | webapp set + API-002 |
| one-marker library | 1 | 0 | 9 | ∅ |
| one-marker cli | — | 0 | 9 | ∅ |

Base empty's single pathless failure was DEP-001, which this PR moves onto the advisory shape (`file: package-lock.json`). The one-marker cli base cell was not measured (—). Every residual ID is a present-subject check (the marker file is the subject) inside the tree's applicable set: mcp ⊆ the 6-set, webapp ⊆ PS \ {API-002}, api ⊆ PS. 52 distinct IDs emit NA across the six trees; the other 25 of the 77 are type-scoped off or have their subject present there.

## G2' — empty directory

93/100. Passed: CRED-002, LOG-003, MCP-010, PERM-001, PERM-002, PERM-003. Advisories (failed, with fix path): DEP-001, GIT-001, SANDBOX-001. Not applicable (13): CLAUDE-004, CLAUDE-005, CLAUDE-006, CLAUDE-007, CRED-003, CRED-004, CURSOR-001, DEP-002, DEP-003, DEP-004, LOG-002, VSCODE-001, VSCODE-002. No pathless failure.

Verify (one-marker mcp, expect 27): `T=$(mktemp -d) && printf '{"name":"t","version":"1.0.0","dependencies":{"@modelcontextprotocol/sdk":"^1.0.0"}}' > "$T/package.json" && git -C "$T" init -q && node dist/cli.js secure "$T" --json | jq '[.allFindings[] | select(.notApplicable)] | length'`

## OASB-1 benchmark, two-sided (base = cedaa0b dist, head = this branch dist)

`generateBenchmarkReport` (`src/cli.ts`, `if (!finding.passed) hasFailure = true`) reads an NA record as a failure. The CLI benchmark is not a valid instrument until step 3 adds the NA-first clause (ruling Q3c); the table records the direction of the move, not a compliance claim. Format c/p/f/u = compliance %, passed, failed, unverified controls. Rating "Not Passing" in every cell.

| Tree | Level | base | head |
|---|---|---|---|
| empty | default, L1 | 69 / 9 / 4 / 13 | 29 / 2 / 5 / 19 |
| empty | L2 | 69 / 9 / 4 / 31 | 25 / 2 / 6 / 36 |
| empty | L3 | 69 / 9 / 4 / 33 | 25 / 2 / 6 / 38 |
| mcp | default, L1 | 43 / 9 / 12 / 5 | 21 / 4 / 15 / 7 |
| mcp | L2 | 38 / 9 / 15 / 20 | 18 / 4 / 18 / 22 |
| mcp | L3 | 38 / 9 / 15 / 22 | 18 / 4 / 18 / 24 |

Mechanisms: (i) false pass removed — empty L1 controls 3.3, 3.4, 4.3, 5.2, 9.3, 9.5 and mcp 3.4, 4.3 move passed → unverified (the corrected direction); (ii) NA read as failed by the pre-step-3 mapping — 5.1 passed → failed on both trees (CRED-003/CRED-004 NA on empty, CRED-004 on mcp), mcp 5.2 via MCP-006/MCP-009, mcp 9.5 via ENV-001/MCP-008; (iii) 9.4 unverified → failed on empty L2/L3 through the SANDBOX-001 file advisory. l2Compliance is 0 on head empty L2/L3 and on base and head mcp L2/L3; l3Compliance null everywhere. The 16 JSON cells are recorded in the ledger entry at :36849.

## G3 — tests

- `__tests__/hardening/absent-subject-not-applicable.test.ts` 44/44 at HEAD; red-proof against cedaa0b dist: 25 red / 19 green (the 19 green pin behaviour the base already had: advisories, present-subject passes, disclosure).
- `__tests__/mcp/mcp-scan-summary-partition` 23/23; `__tests__/mcp/mcp-server-not-applicable.test.ts`, `__tests__/ui/not-applicable-guard.test.ts`, `__tests__/registry/secure-publish-wire-parity.test.ts`, `__tests__/cli/benchmark-empty-denominator.test.ts`, `__tests__/hardening/noise-floor.test.ts` (incl. the type-scope-vs-NA cells), `__tests__/registry/publish-payload-not-applicable.test.ts` green.
- Full suite at 2b60aa8 (final HEAD): 333 test files passed, 4707 passed | 4 skipped | 10 todo, vitest exit 0, 352s.

## #426

The SANDBOX-001 advisory keeps `passed: false` with `file: "Dockerfile"` on a tree without containerization and passes without the advisory when it is present; both pinned in `absent-subject-not-applicable.test.ts` (`SANDBOX-001 keeps the absent-mitigation advisory: passed false with file naming the path the fix creates`; `SANDBOX-001 passes when containerization is present, without the advisory file`). An obstructed Dockerfile probe emits nothing for SANDBOX-001 and SANDBOX-002 and `SCAN-UNREAD-001` names both subjects.

## Docs

`docs/release-playbook.md` B3 (empty directory) graded 95-100 with a single LOW; it now grades the measured state: score 93, `na` 13, `passed` exactly the six hazard probes, no not-applicable record with `severity` or `passed`, exactly two findings in the human output. Each value was run against the built CLI before the section was written.

## Base

Measurements labelled `base cedaa0b` were taken against cedaa0b. The branch was then rebased onto 68748d3 (#634, `-b` name normalization at cli.ts ~5004-5012 plus its test and CHANGELOG entry); at rebase time the cli.ts diff was the same 28 lines before and after; later commits on this branch changed cli.ts again (removing the definition-only `groupFindingsBySeverity`), leaving the final cli.ts diff at 19 insertions / 22 deletions across 10 hunks — still with no hunk in `generateBenchmarkReport`.

## Release pairing

- 0.33.0 hold: #458 steps 1, 2 and 3 ship together in 0.33.0; the tag is cut no earlier than 2026-08-27T21:05Z (ledger :35713). Merging this PR is not a release event.
- Any 0.32.x patch cuts from the `v0.32.0` tag, not from main.
- OASB site note on the `not-applicable` OASB-1 status ships WITH the 0.33.0 tag (Abdel, Rec).
- Changelog entry under `[Unreleased]` names the pre-step-3 benchmark reading so a reader of a 0.33.0 tag that carries all three steps sees why the figures moved.
