### PR TITLE
benchmark: a control whose subject is absent is not-applicable, never failed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,34 @@ All notable changes to HackMyAgent are documented in this file.
 
 ## [Unreleased]
 
+### A benchmark control whose subject artifact is absent reads `not-applicable`, never `failed`
+
+Step 3 of #458. Steps 1-2 gave a check whose subject artifact is absent (no
+`CLAUDE.md`, no `Dockerfile`, no `mcp.json`) a positive `notApplicable` record
+with `passed` omitted — and `generateBenchmarkReport`'s `!finding.passed` read
+that omission as a failure, so the benchmark counted "not applicable to this
+tree" against compliance. On an MCP-typed tree with none of those artifacts,
+nine scored controls read `failed` this way (L3: 18%, 4/22). The report now
+tests `notApplicable` first: a control whose every mapped check reported its
+subject absent is `not-applicable` — its own status and count
+(`notApplicableControls`, category `notApplicable`, per-control
+`notApplicableSubjects`), outside every compliance denominator exactly like
+`unverified` (same tree now: 38%, 5/13, 9 not applicable). A measured record
+outranks an NA sibling in both directions: one check measured and one absent
+leaves the control `passed` or `failed` by the measurement. A control with no
+record at all stays `unverified` — a type-scoped-off check leaves no record,
+and crediting that absence is the laundering #458 removed. Text output gains a
+`Not applicable: N controls` header line and `[.]` rows in `--verbose` naming
+the absent subjects; json/asp carry the new status and counts; SARIF is
+unchanged (it renders failures only). Named plainly, because this direction is
+accepted eyes-open under the four-state contract: absence RAISES the figure —
+deleting a failing `mcp.json` from the measured tree moved it from 29% to 38%
+and flipped control 5.1 from `failed` to `passed` (the measured sibling
+entered the numerator). A benchmark can only measure what is there; the
+scanner-side record says what was absent, and the `Not applicable:` line
+carries it into the report. (#458 step 3; the mcp-server assessor
+unification is step 5.)
+
 ### `-b` takes the benchmark name case-insensitively on both arms
 
 `secure -b OASB-2` was accepted (the composite arm lower-cased the name) while

--- a/__tests__/cli/benchmark-empty-denominator.test.ts
+++ b/__tests__/cli/benchmark-empty-denominator.test.ts
@@ -442,3 +442,87 @@ describe('#458 step 0: an unmeasured benchmark level is null and never feeds the
     expect(res.status).toBe(1);
   });
 });
+
+describe('#458 step 3: a control whose every check reports its subject absent is not-applicable, never failed', { timeout: 300_000 }, () => {
+  // package.json with only the MCP SDK: types as `mcp`, so the TOOL-/PROMPT-/
+  // MCP- emitters run and report their subjects (mcp.json, CLAUDE.md, ...)
+  // absent — nine scored controls whose records are ALL not-applicable.
+  let mcpDir: string;
+  beforeAll(() => {
+    mcpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'hma-458-s3-'));
+    fs.writeFileSync(path.join(mcpDir, 'package.json'), JSON.stringify({
+      name: 'fx-458-step3', version: '1.0.0',
+      dependencies: { '@modelcontextprotocol/sdk': '^1.0.0' },
+    }, null, 2));
+  });
+
+  it('RED-ON-BASE json: the all-NA controls read not-applicable and leave every count and denominator', () => {
+    const res = run(['secure', mcpDir, '-b', 'oasb-1', '-l', 'L3', '--no-machine-posture', '--format', 'json']);
+    const body = parseJson(res.stdout);
+    const byId: Record<string, string> = {};
+    for (const cat of body.categories) for (const c of cat.controls) byId[c.controlId] = c.status;
+    for (const id of ['2.3', '2.5', '3.1', '3.2', '4.1', '4.2', '5.2', '8.2', '9.5']) {
+      expect(byId[id], `control ${id}`).toBe('not-applicable');
+    }
+    expect(body.notApplicableControls).toBe(9);
+    expect(body.passedControls).toBe(5);
+    expect(body.failedControls).toBe(8);
+    expect(body.unverifiedControls).toBe(24);
+    // The NA set is outside the verified-controls denominator.
+    expect(body.compliance).toBe(Math.round((body.passedControls / (body.passedControls + body.failedControls)) * 100));
+    expect(body.compliance).toBe(38);
+    // The subjects are named, so the reader can see WHAT is absent.
+    const na = body.categories.flatMap((c: any) => c.controls).find((c: any) => c.controlId === '2.3');
+    expect(na.notApplicableSubjects).toContain('mcp.json');
+  });
+
+  it('RED-ON-BASE json: a measured record outranks an NA sibling in both directions (empty tree)', () => {
+    const res = run(['secure', empty, '-b', 'oasb-1', '-l', 'L3', '--no-machine-posture', '--format', 'json']);
+    const body = parseJson(res.stdout);
+    const byId: Record<string, string> = {};
+    for (const cat of body.categories) for (const c of cat.controls) byId[c.controlId] = c.status;
+    // 5.1: CRED-002 measured PASS + CRED-003/004 not-applicable -> passed.
+    expect(byId['5.1']).toBe('passed');
+    // 9.4: SANDBOX-001 measured FAIL (the ruled absent-mitigation advisory)
+    // + SANDBOX-002 not-applicable -> stays failed. [PIN either side]
+    expect(byId['9.4']).toBe('failed');
+    // Every NA record on this tree shares its control with a measured record.
+    expect(body.notApplicableControls).toBe(0);
+    // NA came out of `failed`, never out of `unverified`.
+    expect(body.unverifiedControls).toBe(38);
+  });
+
+  it('RED-ON-BASE text: the header counts not-applicable controls and --verbose names the absent subject', () => {
+    const res = run(['secure', mcpDir, '-b', 'oasb-1', '-l', 'L3', '--no-machine-posture', '--verbose']);
+    expect(res.out).toContain('Not applicable: 9 controls — subject artifacts absent from this tree');
+    expect(res.out).toMatch(/\[\.\] 2\.3: .* \(not applicable: mcp\.json absent\)/);
+    // Every NA control prints a row, including ones in categories with no
+    // measured control — the header's count and the rows must agree (the
+    // first cut printed 6 rows under a header saying 9).
+    const naRows = (res.out.match(/\[\.\] \d+\.\d+: /g) ?? []).length;
+    expect(naRows).toBe(9);
+    // A category holding only NA/unverified controls says so, not "no
+    // controls at this level".
+    expect(res.out).toMatch(/\[\.\] .*: N\/A \(\d+ not applicable/);
+    // asp carries the same accounting (the CHANGELOG's json/asp parity claim).
+    const asp = run(['secure', mcpDir, '-b', 'oasb-1', '-l', 'L3', '--no-machine-posture', '--format', 'asp']);
+    const aspBody = parseJson(asp.stdout);
+    expect(aspBody.securityPosture.notApplicableControls).toBe(9);
+    expect(aspBody.categories.reduce((n: number, c: any) => n + (c.notApplicable ?? 0), 0)).toBe(9);
+    // The compliance sentence counts measured controls only.
+    expect(res.out).toContain('Compliance: 38% (5/13 verified controls)');
+  });
+
+  it('PIN: the step-0 null contract and the #636 re-pins hold across step 3', () => {
+    const text = run(['secure', empty, '-b', 'oasb-1', '-l', 'L3', '--no-machine-posture', '--verbose']);
+    expect(text.out).toContain('Rating: Not Passing (L3 not assessed)');
+    expect(text.out).toContain('L2=0% L3=not assessed');
+    expect(text.status).toBe(1);
+    const res = run(['secure', empty, '-b', 'oasb-1', '-l', 'L3', '--no-machine-posture', '--format', 'json']);
+    const body = parseJson(res.stdout);
+    expect(body.l2Compliance).toBe(0);
+    expect(body.l3Compliance).toBeNull();
+    expect(body.rating).toBe('Not Passing');
+  });
+});
+

--- a/src/benchmarks/oasb-1.ts
+++ b/src/benchmarks/oasb-1.ts
@@ -89,6 +89,12 @@ export interface BenchmarkResult {
   failedControls: number;
   /** Controls that couldn't be verified (forward/manual) */
   unverifiedControls: number;
+  /**
+   * Controls whose every mapped automated check reported its subject absent
+   * (#458 step 3). Outside every compliance denominator, exactly like
+   * `unverifiedControls`.
+   */
+  notApplicableControls: number;
 }
 
 export interface BenchmarkCategoryResult {
@@ -97,6 +103,8 @@ export interface BenchmarkCategoryResult {
   passed: number;
   failed: number;
   unverified: number;
+  /** Controls whose subject artifacts are absent from this tree (#458). */
+  notApplicable: number;
   controls: BenchmarkControlResult[];
 }
 
@@ -104,11 +112,20 @@ export interface BenchmarkControlResult {
   controlId: string;
   name: string;
   level: BenchmarkLevel;
-  status: 'passed' | 'failed' | 'unverified';
+  /**
+   * `not-applicable` (#458 step 3): every automated check mapped to this
+   * control reported its subject artifact absent (a positive `notApplicable`
+   * record) and none produced a measurement. Distinct from `unverified`,
+   * which is "nothing reported at all" (manual/forward, no mapped check, a
+   * type-scoped-off check, or an unread input).
+   */
+  status: 'passed' | 'failed' | 'unverified' | 'not-applicable';
   /** Findings that relate to this control */
   findings: string[];
   /** Fix instructions if failed */
   remediation?: string;
+  /** The absent subject artifacts, when status is `not-applicable` (#458). */
+  notApplicableSubjects?: string[];
 }
 
 /**

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -3114,9 +3114,11 @@ function displayUnifiedCheck(opts: UnifiedCheckDisplayOptions): void {
 // Benchmark compliance helpers
 interface LocalControlResult {
   control: BenchmarkControl;
-  status: 'passed' | 'failed' | 'unverified';
+  status: 'passed' | 'failed' | 'unverified' | 'not-applicable';
   findings: string[];
   remediation?: string;
+  /** Absent subject artifacts, when status is `not-applicable` (#458). */
+  naSubjects?: string[];
 }
 
 /**
@@ -3176,11 +3178,12 @@ function generateBenchmarkReport(
   let l1Passed = 0, l1Total = 0;
   let l2Passed = 0, l2Total = 0;
   let l3Passed = 0, l3Total = 0;
-  let passedCount = 0, failedCount = 0, unverifiedCount = 0;
+  let passedCount = 0, failedCount = 0, unverifiedCount = 0, notApplicableCount = 0;
 
   for (const control of controls) {
-    let status: 'passed' | 'failed' | 'unverified';
+    let status: 'passed' | 'failed' | 'unverified' | 'not-applicable';
     const relatedFindings: string[] = [];
+    const naSubjects: string[] = [];
     let remediation: string | undefined;
 
     if (control.verification === 'manual' || control.verification === 'forward') {
@@ -3196,39 +3199,62 @@ function generateBenchmarkReport(
       remediation = control.remediation;
     } else {
       // Check all mapped check IDs
-      let hasAnyFinding = false;
+      let hasMeasured = false;
       let hasFailure = false;
+      let hasNotApplicable = false;
       for (const checkId of control.checkIds) {
         const finding = findingsByCheckId.get(checkId);
-        if (finding) {
-          hasAnyFinding = true;
-          if (!finding.passed) {
-            hasFailure = true;
-            relatedFindings.push(`${checkId}: ${finding.description}`);
-            if (finding.fix) {
-              remediation = remediation || finding.fix;
-            }
+        if (!finding) continue;
+        // #458 step 3 — the NA test comes FIRST: an NA record OMITS `passed`
+        // (never false), so the `!finding.passed` test below read "subject
+        // absent" as a failure and, before steps 1-2, the absent subject was
+        // a pathless HIGH. The record contributes no pass/fail value; it
+        // names its absent subject.
+        if (finding.notApplicable) {
+          hasNotApplicable = true;
+          if (!naSubjects.includes(finding.notApplicable.subject)) {
+            naSubjects.push(finding.notApplicable.subject);
+          }
+          continue;
+        }
+        hasMeasured = true;
+        if (!finding.passed) {
+          hasFailure = true;
+          relatedFindings.push(`${checkId}: ${finding.description}`);
+          if (finding.fix) {
+            remediation = remediation || finding.fix;
           }
         }
       }
-      // Only mark as passed if we actually verified something
-      // Missing findings = unverified (not passed)
-      if (!hasAnyFinding) {
+      // Only mark as passed if we actually verified something. A MEASURED
+      // record outranks an NA sibling (a control with one check that measured
+      // and one whose subject is absent WAS measured); `not-applicable` is
+      // awarded only when NA records are all the control has; nothing at all
+      // stays `unverified` — a type-scoped-off check leaves NO record, and
+      // crediting that as anything would relaunder the absence #458 removed.
+      if (hasMeasured) {
+        if (hasFailure) {
+          status = 'failed';
+          failedCount++;
+          remediation = remediation || control.remediation;
+        } else {
+          status = 'passed';
+          passedCount++;
+        }
+      } else if (hasNotApplicable) {
+        status = 'not-applicable';
+        notApplicableCount++;
+      } else {
         status = 'unverified';
         unverifiedCount++;
         remediation = control.remediation;
-      } else if (hasFailure) {
-        status = 'failed';
-        failedCount++;
-        remediation = remediation || control.remediation;
-      } else {
-        status = 'passed';
-        passedCount++;
       }
     }
 
     // Count by level for compliance calculation
-    if (control.scored && status !== 'unverified') {
+    // Positive gate (#458 step 3): only a MEASURED status enters a level
+    // denominator. `not-applicable` leaves it exactly like `unverified`.
+    if (control.scored && (status === 'passed' || status === 'failed')) {
       if (control.level === 'L1') {
         l1Total++;
         if (status === 'passed') l1Passed++;
@@ -3241,7 +3267,7 @@ function generateBenchmarkReport(
       }
     }
 
-    controlResults.push({ control, status, findings: relatedFindings, remediation });
+    controlResults.push({ control, status, findings: relatedFindings, remediation, naSubjects });
   }
 
   // Compliance percentages. #458 step 0 — a level with no scored control
@@ -3273,6 +3299,7 @@ function generateBenchmarkReport(
     const passed = catControls.filter((r: LocalControlResult) => r.status === 'passed').length;
     const failed = catControls.filter((r: LocalControlResult) => r.status === 'failed').length;
     const unverified = catControls.filter((r: LocalControlResult) => r.status === 'unverified').length;
+    const notApplicable = catControls.filter((r: LocalControlResult) => r.status === 'not-applicable').length;
     const compliance = (passed + failed) > 0 ? Math.round((passed / (passed + failed)) * 100) : 0;
 
     categoryResults.push({
@@ -3281,6 +3308,7 @@ function generateBenchmarkReport(
       passed,
       failed,
       unverified,
+      notApplicable,
       controls: catControls.map((r: LocalControlResult) => ({
         controlId: r.control.id,
         name: r.control.name,
@@ -3288,6 +3316,7 @@ function generateBenchmarkReport(
         status: r.status,
         findings: r.findings,
         remediation: r.remediation,
+        ...(r.status === 'not-applicable' && r.naSubjects?.length ? { notApplicableSubjects: r.naSubjects } : {}),
       })),
     });
   }
@@ -3309,6 +3338,7 @@ function generateBenchmarkReport(
     passedControls: passedCount,
     failedControls: failedCount,
     unverifiedControls: unverifiedCount,
+    notApplicableControls: notApplicableCount,
   };
 }
 
@@ -4371,6 +4401,9 @@ function generateAspOutput(benchmarkResult: BenchmarkResult, scanResult: { findi
       l1Compliance: benchmarkResult.l1Compliance,
       l2Compliance: benchmarkResult.l2Compliance,
       l3Compliance: benchmarkResult.l3Compliance,
+      // #458 step 3 — asp accounting must sum: passed + failed + unverified
+      // + notApplicable covers every control the level examined.
+      notApplicableControls: benchmarkResult.notApplicableControls,
     },
     capabilities,
     credentials: {
@@ -4392,6 +4425,7 @@ function generateAspOutput(benchmarkResult: BenchmarkResult, scanResult: { findi
       passed: cat.passed,
       failed: cat.failed,
       unverified: cat.unverified,
+      notApplicable: cat.notApplicable,
     })),
     failedControls: benchmarkResult.categories.flatMap(cat =>
       cat.controls.filter(c => c.status === 'failed').map(c => ({
@@ -4579,6 +4613,13 @@ function printBenchmarkReport(result: BenchmarkResult, verbose: boolean, targetD
   if (result.unverifiedControls > 0) {
     console.log(`Unverified: ${result.unverifiedControls} controls require manual/forward verification`);
   }
+  if (result.notApplicableControls > 0) {
+    // #458 step 3 — a control whose every automated check reported its
+    // subject artifact absent. Outside every denominator, like Unverified;
+    // named here so the counts above visibly do not include it.
+    const n = result.notApplicableControls;
+    console.log(`Not applicable: ${n} control${n === 1 ? '' : 's'} — subject artifacts absent from this tree`);
+  }
   for (const line of notAssessedLines(result, targetDir, flags)) {
     console.log(`${colors.dim}${line}${RESET()}`);
   }
@@ -4589,11 +4630,21 @@ function printBenchmarkReport(result: BenchmarkResult, verbose: boolean, targetD
   for (const catResult of result.categories) {
     const total = catResult.passed + catResult.failed;
     if (total === 0) {
-      console.log(`  [.] ${catResult.category}: N/A (no controls at this level)`);
-      continue;
-    }
+      // #458 step 3 — "no controls at this level" was the only sentence this
+      // branch had; a category can now hold controls that are all
+      // not-applicable (or unverified), and saying they do not exist hid
+      // them from the header's count. Name what is actually there, and let
+      // --verbose fall through so the [.]/[?] rows print.
+      const parts: string[] = [];
+      if (catResult.notApplicable > 0) parts.push(`${catResult.notApplicable} not applicable`);
+      if (catResult.unverified > 0) parts.push(`${catResult.unverified} unverified`);
+      const label = parts.length > 0 ? parts.join(', ') : 'no controls at this level';
+      console.log(`  [.] ${catResult.category}: N/A (${label})`);
+      if (!verbose || catResult.controls.length === 0) continue;
+    } else {
     const statusIcon = catResult.failed === 0 ? '[+]' : (catResult.passed > 0 ? '[~]' : '[-]');
     console.log(`  ${statusIcon} ${catResult.category}: ${catResult.passed}/${total} (${catResult.compliance}%)`);
+    }
 
     // Show failed controls
     if (verbose || catResult.failed > 0) {
@@ -4607,6 +4658,11 @@ function printBenchmarkReport(result: BenchmarkResult, verbose: boolean, targetD
           }
         } else if (verbose && ctrl.status === 'passed') {
           console.log(`     [+] ${ctrl.controlId}: ${ctrl.name}`);
+        } else if (verbose && ctrl.status === 'not-applicable') {
+          const subjects = ctrl.notApplicableSubjects?.length
+            ? ctrl.notApplicableSubjects.join(', ')
+            : 'subject artifact';
+          console.log(`     [.] ${ctrl.controlId}: ${ctrl.name} ${colors.dim}(not applicable: ${escapeForDisplay(subjects)} absent)${RESET()}`);
         } else if (verbose && ctrl.status === 'unverified') {
           // Look up the original control to determine why it's unverified
           const originalControl = OASB_1_CATEGORIES

--- a/src/registry/publish.test.ts
+++ b/src/registry/publish.test.ts
@@ -171,6 +171,7 @@ function makeOasbResult(): BenchmarkResult {
     passedControls: 39,
     failedControls: 5,
     unverifiedControls: 2,
+    notApplicableControls: 0,
   } as BenchmarkResult;
 }
 


### PR DESCRIPTION
#458 step 3. Since #636, a check whose subject artifact is absent emits a positive `notApplicable` record with `passed` **omitted** — and `generateBenchmarkReport`'s `if (!finding.passed)` read that omission as a failure, so "not applicable to this tree" counted against compliance. Measured on `b2e7e9a` with an MCP-typed tree holding none of the subject artifacts: nine scored controls read `failed` this way (L3: 18%, 4/22 verified).

Now (CA Q3c: the NA test comes first; CPO four-state contract):
- A control whose **every** mapped check reported its subject absent is `not-applicable` — its own status, `notApplicableControls`, category `notApplicable`, per-control `notApplicableSubjects` — and sits outside every compliance denominator exactly like `unverified` (same tree: 38%, 5/13, 9 not applicable; unverified unchanged at 24).
- A **measured record outranks an NA sibling in both directions**: empty tree, 5.1 = CRED-002 measured pass + two NA siblings → `passed`; 9.4 = SANDBOX-001 measured fail (the ruled advisory) + NA SANDBOX-002 → stays `failed`.
- A control with **no record at all stays `unverified`** — a type-scoped-off check leaves no record, and crediting that absence is the laundering #458 removed.
- Text: `Not applicable: N controls` header line; `--verbose` prints a `[.]` row per NA control naming the absent subjects, and a category holding only NA/unverified controls says that instead of "no controls at this level". json and asp carry the status and counts (asp sums: passed+failed+unverified+notApplicable covers the level). SARIF unchanged (failures only). The step-0 null contract and #636's re-pins hold (PIN cell).

**Direction, disclosed eyes-open (four-state contract):** absence raises the figure — deleting a failing `mcp.json` moved the measured tree 29% → 38% and flipped 5.1 `failed → passed` (the measured sibling entered the numerator). The CHANGELOG names it. The rename variant (`mcp.json → .mcp.json`, a live config location the scanner doesn't read) is filed as #637 (scanner lane, pre-existing scope gap).

Evidence (branch `910dafc` over `b2e7e9a`; touched file 31/31):
- Red-proof on the `b2e7e9a` dist: the 3 RED-ON-BASE cells red (base reads 2.3 `failed`, 18%, 4/22 — exactly the pre-fix numbers), PIN green on both.
- Mutations (src, rebuild, copy-restore diff-identical): NA clause removed → 3 red; NA wins over measured → the outrank cell red; NA enters the level denominators → 2 red; header line dropped → the text cell red.
- Independent adversarial review (55 tool calls, scoring-bias brief): 0 CRITICAL/HIGH; 3 MEDIUM — asp parity claim (fixed here: asp carries the counts), verbose naming 6 of 9 rows under a header saying 9 (fixed here: honest category label + all rows, asserted), and the deletion direction (recorded above); 2 LOW — stale `publish.test.ts` fixture (fixed, `notApplicableControls: 0`; Registry payload provably unchanged — `publish.ts` picks compliance/rating/l1-l3 only), html NA-vs-unverified indistinguishability (recorded to step 5's render pass). It also disproved: Map nondeterminism (every NA emitter is the absent arm of one classified read), attacker-forced NA on a readable artifact (strict ENOENT/EISDIR/ENOTDIR allowlist), asp counting NA as failures, and silent fixture drift.
- Full suite: Tests 4711 passed | 4 skipped | 10 todo (4725), npm test exit 0 (at 910dafc); lint 0; self-scan `secure --ci` exit 0, 0 CRITICAL/HIGH, instrumented (62/62 check groups).

Step 5 (unify the mcp-server assessor onto this function, delete the interim NA bucket, missing-checkId → unverified) completes the series and the 0.33.0 hold condition. Refs #458, #637.
