### PR TITLE
mcp-server: one benchmark assessor — absence is never credited

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,27 @@ All notable changes to HackMyAgent are documented in this file.
 
 ## [Unreleased]
 
+### One benchmark assessor: the MCP server's compliance tool no longer credits absence
+
+Step 5 of #458, the last piece of its series. The MCP `hackmyagent_benchmark`
+tool had its own assessor, which kept the legacy reading `#458` names: a
+control none of whose checks produced any record counted as PASSED
+(`.get(id) !== false` over an empty map), so an assessment fed nothing read
+100% compliance — 23 of its 26 controls passing for free, the other three
+manual/forward unverified. `generateBenchmarkReport` — the
+function the CLI benchmark uses, extracted to `src/benchmarks/benchmark-report.ts`
+so both callers can import it — is now the one assessor: a control with no
+record is `unverified`, never credited; a level where nothing measured reports
+`not measured` and `Not Assessed` (step 0's contract), not a fabricated 0%;
+the not-applicable and measured-wins semantics are step 3's, identically on
+both surfaces. One alignment consequence on the MCP surface: a `forward`
+control that also maps automated checks (2.1) reads `unverified` even when a
+mapped check produced a measured failure — the CLI's long-standing reading,
+which unification adopts; the interim assessor reported it as failed. The
+forward-with-checkIds class is filed as #639. HTML reports now give `not-applicable` controls their own
+status class, distinct from unverified. (#458 steps 3-5 complete; steps 1-2
+shipped in the previous entries.)
+
 ### A benchmark control whose subject artifact is absent reads `not-applicable`, never `failed`
 
 Step 3 of #458. Steps 1-2 gave a check whose subject artifact is absent (no

--- a/__tests__/mcp/mcp-server-not-applicable.test.ts
+++ b/__tests__/mcp/mcp-server-not-applicable.test.ts
@@ -1,18 +1,21 @@
 /**
- * #458 — the benchmark assessor must not read a not-applicable record as the
- * legacy "no false => pass".
+ * #458 step 5 — the benchmark assessor is the ONE shared
+ * `generateBenchmarkReport`, under the ruled semantics.
  *
- * Measured at the extraction commit (088d451, behaviour-identical to main):
- * an NA record carries `passed: undefined`, so `checkIdResults.get(id) !==
- * false` credited its control as [PASS] and an L1 assessment fed NOTHING BUT
- * an NA record read 100% compliance with every control passing. The three
- * NA-bucket cells below go red there; the compatibility cells (measured
- * pass/fail beside an NA sibling, absent-record legacy credit) stay green at
- * both commits — they pin what #458 must NOT change.
+ * The interim assessor these pins replaced (deleted with step 5, as its own
+ * doc comment scheduled) kept the legacy credit: a control none of whose
+ * checkIds produced ANY record counted as [PASS] — `.get(id) !== false`, the
+ * executed defect #458 named. Measured on the pre-step-5 build (ff345e7):
+ * `assessBenchmarkFindings([], 'L1')` read 100% compliance — 23 of 26
+ * controls passing for free, the rest manual/forward unverified. Under the shared function that baseline is all-[UNVERIFIED],
+ * compliance `null`, rating `Not Assessed` (step 0's contract). The
+ * absence-is-never-credited cells below are red on that build; the
+ * measured-beside-NA compatibility cells keep their meaning.
  */
 import { describe, it, expect } from 'vitest';
 import { assessBenchmarkFindings } from '../../src/mcp-server';
 import { getControlsForLevel } from '../../src/benchmarks/oasb-1';
+import type { SecurityFinding } from '../../src/hardening/security-check';
 
 // Real L1 controls selected by SHAPE, not by hardcoded id: one with a single
 // checkId, one with at least two. The checkId->control mapping is
@@ -26,69 +29,83 @@ const citations = (id: string) => L1.filter((c) => c.checkIds.includes(id)).leng
 const single = L1.find((c) => c.checkIds.length === 1 && citations(c.checkIds[0]) === 1)!;
 const multi = L1.find((c) => c.checkIds.length >= 2 && c.checkIds.every((id) => citations(id) === 1))!;
 
-const na = (checkId: string) => ({
+// Complete records, not partials: the adapter takes real SecurityFinding[]
+// (tsc excludes tests, so a partial would pass vitest while lying about the
+// API — the step-5 review caught exactly that).
+const base = (checkId: string) => ({
   checkId,
-  notApplicable: { subject: 'system prompt', reason: 'no prompt file exists in the scanned tree' },
+  name: checkId,
+  description: `fixture record for ${checkId}`,
+  severity: 'medium' as const,
+  category: 'fixture',
+  message: 'fixture',
 });
-const pass = (checkId: string) => ({ checkId, passed: true });
-const fail = (checkId: string) => ({ checkId, passed: false });
+const na = (checkId: string): SecurityFinding => ({
+  ...base(checkId),
+  severity: undefined,
+  notApplicable: { subject: 'system prompt', reason: 'no prompt file exists in the scanned tree' },
+} as SecurityFinding);
+const pass = (checkId: string): SecurityFinding => ({ ...base(checkId), passed: true } as SecurityFinding);
+const fail = (checkId: string): SecurityFinding => ({ ...base(checkId), passed: false } as SecurityFinding);
 
 const baseline = assessBenchmarkFindings([], 'L1');
 
-describe('#458 benchmark assessor: not-applicable bucket', () => {
-  it('pins the premise: fixture controls exist and the empty baseline is all legacy credit', () => {
+describe('#458 step 5: the shared assessor never credits absence', () => {
+  it('premise + ruled baseline: no records at all is all-unverified, not measured, Not Assessed', () => {
     expect(single).toBeDefined();
     expect(multi).toBeDefined();
+    expect(baseline.passed).toBe(0);
     expect(baseline.failed).toBe(0);
-    // Every absent record is credited as a pass (legacy, kept — see below).
-    expect(baseline.compliance).toBe(100);
+    expect(baseline.notApplicable).toBe(0);
+    expect(baseline.compliance).toBeNull();
+    expect(baseline.rating).toBe('Not Assessed');
+    expect(baseline.text).toContain('not measured');
+    expect(baseline.lines).toContain(`[UNVERIFIED] ${single.id} ${single.name}`);
+    expect(baseline.lines.some((l) => l.startsWith('[PASS]'))).toBe(false);
   });
 
-  it('an NA record moves its control out of passed into notApplicable', () => {
+  it('an NA record moves its control into notApplicable, named with its absent subject', () => {
     const a = assessBenchmarkFindings([na(single.checkIds[0])], 'L1');
-    expect(a.notApplicable).toBe(baseline.notApplicable + 1);
-    expect(a.passed).toBe(baseline.passed - 1);
-    expect(a.failed).toBe(baseline.failed);
-    expect(a.lines).toContain(
-      `[NOT-APPLICABLE] ${single.id} ${single.name} (${single.checkIds[0]}: no system prompt)`,
-    );
-    expect(a.lines).not.toContain(`[PASS] ${single.id} ${single.name}`);
+    expect(a.notApplicable).toBe(1);
+    expect(a.passed).toBe(0);
+    expect(a.failed).toBe(0);
+    expect(a.lines).toContain(`[NOT-APPLICABLE] ${single.id} ${single.name} (no system prompt)`);
+    expect(a.lines).not.toContain(`[UNVERIFIED] ${single.id} ${single.name}`);
   });
 
-  it('NA is excluded from the compliance denominator and named in the summary line', () => {
-    const a = assessBenchmarkFindings([na(single.checkIds[0])], 'L1');
-    // If NA were bucketed as a failure, the denominator would keep the
-    // control and compliance would drop below 100.
+  it('NA is excluded from the denominator: one NA and one measured pass yields 100% over the one measurement', () => {
+    const a = assessBenchmarkFindings([na(single.checkIds[0]), pass(multi.checkIds[0]), pass(multi.checkIds[1])], 'L1');
+    expect(a.notApplicable).toBe(1);
+    expect(a.passed).toBe(1);
     expect(a.compliance).toBe(100);
     expect(a.text).toContain('Not applicable: 1');
   });
 
-  it('NA + an absent sibling checkId still reads NOT-APPLICABLE, not the legacy absent-record pass', () => {
+  it('NA + an absent sibling checkId still reads NOT-APPLICABLE, never unverified-by-the-sibling', () => {
     const a = assessBenchmarkFindings([na(multi.checkIds[0])], 'L1');
-    expect(a.lines).toContain(
-      `[NOT-APPLICABLE] ${multi.id} ${multi.name} (${multi.checkIds[0]}: no system prompt)`,
-    );
-    expect(a.notApplicable).toBe(baseline.notApplicable + 1);
+    expect(a.lines).toContain(`[NOT-APPLICABLE] ${multi.id} ${multi.name} (no system prompt)`);
+    expect(a.notApplicable).toBe(1);
   });
 
-  it('compat: one NA + one measured pass on the same control reads PASS', () => {
+  it('compat: one NA + one measured pass on the same control reads PASS (measured wins)', () => {
     const a = assessBenchmarkFindings([na(multi.checkIds[0]), pass(multi.checkIds[1])], 'L1');
     expect(a.lines).toContain(`[PASS] ${multi.id} ${multi.name}`);
-    expect(a.notApplicable).toBe(baseline.notApplicable);
+    expect(a.notApplicable).toBe(0);
   });
 
   it('compat: one NA + one measured failure reads FAIL, naming only the measured check', () => {
     const a = assessBenchmarkFindings([na(multi.checkIds[0]), fail(multi.checkIds[1])], 'L1');
     expect(a.lines).toContain(`[FAIL] ${multi.id} ${multi.name} (${multi.checkIds[1]})`);
-    expect(a.failed).toBe(baseline.failed + 1);
-    expect(a.notApplicable).toBe(baseline.notApplicable);
+    expect(a.failed).toBe(1);
+    expect(a.notApplicable).toBe(0);
   });
 
-  it('compat: pins the legacy credit #458 deliberately keeps — a control with NO records still passes', () => {
-    // Kept, not endorsed: the #458 ruling narrows the credit only where a
-    // positive NA record exists. This cell exists so a future fix of the
-    // absent-record credit is loud, not silent.
-    expect(baseline.passed).toBeGreaterThan(0);
-    expect(baseline.lines).toContain(`[PASS] ${single.id} ${single.name}`);
+  it('the legacy absent-record credit is DEAD: a control with no records is [UNVERIFIED], and nothing passes for free', () => {
+    // The interim pin held this door open on purpose ("kept, not endorsed");
+    // step 5 closes it. RED on the pre-step-5 build, where this control
+    // read [PASS] and the baseline read 100%.
+    expect(baseline.lines).toContain(`[UNVERIFIED] ${single.id} ${single.name}`);
+    expect(baseline.unverified).toBeGreaterThan(0);
+    expect(baseline.compliance).toBeNull();
   });
 });

--- a/src/benchmarks/benchmark-report.ts
+++ b/src/benchmarks/benchmark-report.ts
@@ -1,0 +1,231 @@
+/**
+ * OASB-1 benchmark evaluation over a scan's findings (#458 step 5).
+ *
+ * Extracted from `src/cli.ts` so the MCP server can share it: importing
+ * `cli.ts` is side-effectful (its top-level `program.parseAsync` runs the
+ * CLI), so the one honest way to have ONE assessor — the 0.33.0 hold
+ * condition — is for both callers to import this module. Behavior is the
+ * step-3 contract: NA-first, measured outranks an NA sibling, an all-NA
+ * control is `not-applicable` and leaves every denominator, and a control
+ * with no record at all is `unverified` — never credited.
+ */
+import {
+  OASB_1_CATEGORIES,
+  OASB_1_VERSION,
+  OASB_1_NAME,
+  getControlsForLevel,
+  getControlsForCategory,
+  calculateRating,
+  type BenchmarkLevel,
+  type BenchmarkControl,
+  type BenchmarkCategory,
+  type BenchmarkResult,
+  type BenchmarkCategoryResult,
+} from './index';
+import type { SecurityFinding } from '../hardening/security-check';
+import { escapeForDisplay } from '../ui/display-safe';
+
+export interface LocalControlResult {
+  control: BenchmarkControl;
+  status: 'passed' | 'failed' | 'unverified' | 'not-applicable';
+  findings: string[];
+  remediation?: string;
+  /** Absent subject artifacts, when status is `not-applicable` (#458). */
+  naSubjects?: string[];
+}
+
+
+export function generateBenchmarkReport(
+  findings: ReadonlyArray<SecurityFinding>,
+  level: BenchmarkLevel,
+  categoryFilter?: string
+): BenchmarkResult {
+  // Get controls for the specified level
+  let controls = getControlsForLevel(level);
+
+  // Filter by category if specified
+  if (categoryFilter) {
+    const categoryControls = getControlsForCategory(categoryFilter);
+    if (categoryControls.length === 0) {
+      console.error(`Error: Unknown category '${escapeForDisplay(String(categoryFilter))}'.`);
+      console.error(`Available categories: ${OASB_1_CATEGORIES.map((c: BenchmarkCategory) => c.name).join(', ')}`);
+      process.exit(1);
+    }
+    controls = controls.filter((c: BenchmarkControl) => c.category.toLowerCase() === categoryFilter.toLowerCase());
+  }
+
+  // Build a map of checkId -> finding for quick lookup
+  const findingsByCheckId = new Map<string, SecurityFinding>();
+  for (const finding of findings) {
+    findingsByCheckId.set(finding.checkId, finding);
+  }
+
+  // Evaluate each control
+  const controlResults: LocalControlResult[] = [];
+  let l1Passed = 0, l1Total = 0;
+  let l2Passed = 0, l2Total = 0;
+  let l3Passed = 0, l3Total = 0;
+  let passedCount = 0, failedCount = 0, unverifiedCount = 0, notApplicableCount = 0;
+
+  for (const control of controls) {
+    let status: 'passed' | 'failed' | 'unverified' | 'not-applicable';
+    const relatedFindings: string[] = [];
+    const naSubjects: string[] = [];
+    let remediation: string | undefined;
+
+    if (control.verification === 'manual' || control.verification === 'forward') {
+      // Manual/forward controls are unverified (human must check)
+      status = 'unverified';
+      unverifiedCount++;
+      // Use control's remediation for manual/forward controls
+      remediation = control.remediation;
+    } else if (control.checkIds.length === 0) {
+      // No automated checks defined
+      status = 'unverified';
+      unverifiedCount++;
+      remediation = control.remediation;
+    } else {
+      // Check all mapped check IDs
+      let hasMeasured = false;
+      let hasFailure = false;
+      let hasNotApplicable = false;
+      for (const checkId of control.checkIds) {
+        const finding = findingsByCheckId.get(checkId);
+        if (!finding) continue;
+        // #458 step 3 — the NA test comes FIRST: an NA record OMITS `passed`
+        // (never false), so the `!finding.passed` test below read "subject
+        // absent" as a failure and, before steps 1-2, the absent subject was
+        // a pathless HIGH. The record contributes no pass/fail value; it
+        // names its absent subject.
+        if (finding.notApplicable) {
+          hasNotApplicable = true;
+          if (!naSubjects.includes(finding.notApplicable.subject)) {
+            naSubjects.push(finding.notApplicable.subject);
+          }
+          continue;
+        }
+        hasMeasured = true;
+        if (!finding.passed) {
+          hasFailure = true;
+          relatedFindings.push(`${checkId}: ${finding.description}`);
+          if (finding.fix) {
+            remediation = remediation || finding.fix;
+          }
+        }
+      }
+      // Only mark as passed if we actually verified something. A MEASURED
+      // record outranks an NA sibling (a control with one check that measured
+      // and one whose subject is absent WAS measured); `not-applicable` is
+      // awarded only when NA records are all the control has; nothing at all
+      // stays `unverified` — a type-scoped-off check leaves NO record, and
+      // crediting that as anything would relaunder the absence #458 removed.
+      if (hasMeasured) {
+        if (hasFailure) {
+          status = 'failed';
+          failedCount++;
+          remediation = remediation || control.remediation;
+        } else {
+          status = 'passed';
+          passedCount++;
+        }
+      } else if (hasNotApplicable) {
+        status = 'not-applicable';
+        notApplicableCount++;
+      } else {
+        status = 'unverified';
+        unverifiedCount++;
+        remediation = control.remediation;
+      }
+    }
+
+    // Count by level for compliance calculation
+    // Positive gate (#458 step 3): only a MEASURED status enters a level
+    // denominator. `not-applicable` leaves it exactly like `unverified`.
+    if (control.scored && (status === 'passed' || status === 'failed')) {
+      if (control.level === 'L1') {
+        l1Total++;
+        if (status === 'passed') l1Passed++;
+      } else if (control.level === 'L2') {
+        l2Total++;
+        if (status === 'passed') l2Passed++;
+      } else if (control.level === 'L3') {
+        l3Total++;
+        if (status === 'passed') l3Passed++;
+      }
+    }
+
+    controlResults.push({ control, status, findings: relatedFindings, remediation, naSubjects });
+  }
+
+  // Compliance percentages. #458 step 0 — a level with no scored control
+  // that produced a result has no figure: `null`, never a default. The two
+  // L3 controls (3.5, 8.4) have no automated check, so `l3Compliance` was the
+  // old `: 100` default on every target and the L3 ladder read it as perfect
+  // (the sentence in #513's title); a category with no scored control read
+  // `Rating: Certified` beside `Compliance: 0% (0/0)` because the overall
+  // figure defaulted to 0 five lines below — the opposite default for the
+  // same case. CISO 2026-08-11 / CPO 2026-08-25: zero denominator => null,
+  // renders "not assessed", never feeds the ladder, never Not Passing.
+  const pct = (passed: number, total: number): number | null =>
+    total > 0 ? Math.round((passed / total) * 100) : null;
+  const l1Compliance = pct(l1Passed, l1Total);
+  const l2Compliance = pct(l2Passed, l2Total);
+  const l3Compliance = pct(l3Passed, l3Total);
+  const totalScored = l1Total + l2Total + l3Total;
+  const totalPassed = l1Passed + l2Passed + l3Passed;
+  const overallCompliance = pct(totalPassed, totalScored);
+
+  // Group results by category
+  const categoryResults: BenchmarkCategoryResult[] = [];
+  for (const category of OASB_1_CATEGORIES) {
+    if (categoryFilter && category.name.toLowerCase() !== categoryFilter.toLowerCase()) continue;
+
+    const catControls = controlResults.filter((r: LocalControlResult) => r.control.category === category.name);
+    if (catControls.length === 0) continue;
+
+    const passed = catControls.filter((r: LocalControlResult) => r.status === 'passed').length;
+    const failed = catControls.filter((r: LocalControlResult) => r.status === 'failed').length;
+    const unverified = catControls.filter((r: LocalControlResult) => r.status === 'unverified').length;
+    const notApplicable = catControls.filter((r: LocalControlResult) => r.status === 'not-applicable').length;
+    const compliance = (passed + failed) > 0 ? Math.round((passed / (passed + failed)) * 100) : 0;
+
+    categoryResults.push({
+      category: category.name,
+      compliance,
+      passed,
+      failed,
+      unverified,
+      notApplicable,
+      controls: catControls.map((r: LocalControlResult) => ({
+        controlId: r.control.id,
+        name: r.control.name,
+        level: r.control.level,
+        status: r.status,
+        findings: r.findings,
+        remediation: r.remediation,
+        ...(r.status === 'not-applicable' && r.naSubjects?.length ? { notApplicableSubjects: r.naSubjects } : {}),
+      })),
+    });
+  }
+
+  const rating = calculateRating(l1Compliance, l2Compliance, l3Compliance, level);
+
+  return {
+    benchmark: OASB_1_NAME,
+    version: OASB_1_VERSION,
+    level,
+    timestamp: new Date(),
+    compliance: overallCompliance,
+    l1Compliance,
+    l2Compliance,
+    l3Compliance,
+    rating,
+    categories: categoryResults,
+    totalControls: controls.length,
+    passedControls: passedCount,
+    failedControls: failedCount,
+    unverifiedControls: unverifiedCount,
+    notApplicableControls: notApplicableCount,
+  };
+}
+

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -360,6 +360,7 @@ import { shouldShowDeepProgress } from './ui/progress-gate';
 import { generateVerifyCommand } from './ui/verify-command';
 import { commandSucceeded } from './telemetry/command-success';
 import { escapeForDisplay, escapePathForDisplay } from './ui/display-safe';
+import { generateBenchmarkReport } from './benchmarks/benchmark-report';
 import { UsageError, usageError } from './checker/errors';
 import { RootRefusalError } from './mcp/roots';
 import { shellQuote, citationPath, citationTarget, commandNaming } from './ui/shell-quote';
@@ -3112,14 +3113,6 @@ function displayUnifiedCheck(opts: UnifiedCheckDisplayOptions): void {
 }
 
 // Benchmark compliance helpers
-interface LocalControlResult {
-  control: BenchmarkControl;
-  status: 'passed' | 'failed' | 'unverified' | 'not-applicable';
-  findings: string[];
-  remediation?: string;
-  /** Absent subject artifacts, when status is `not-applicable` (#458). */
-  naSubjects?: string[];
-}
 
 /**
  * #514 (disclosure half) — a benchmark run can exit 2 for an input it could
@@ -3146,200 +3139,6 @@ function printBenchmarkUnreadDisclosure(result: ScanResult): void {
     console.log(`  ${escapeForDisplay(f.message ?? f.file ?? '')}`);
   }
   console.log();
-}
-
-function generateBenchmarkReport(
-  findings: SecurityFinding[],
-  level: BenchmarkLevel,
-  categoryFilter?: string
-): BenchmarkResult {
-  // Get controls for the specified level
-  let controls = getControlsForLevel(level);
-
-  // Filter by category if specified
-  if (categoryFilter) {
-    const categoryControls = getControlsForCategory(categoryFilter);
-    if (categoryControls.length === 0) {
-      console.error(`Error: Unknown category '${escapeForDisplay(String(categoryFilter))}'.`);
-      console.error(`Available categories: ${OASB_1_CATEGORIES.map((c: BenchmarkCategory) => c.name).join(', ')}`);
-      process.exit(1);
-    }
-    controls = controls.filter((c: BenchmarkControl) => c.category.toLowerCase() === categoryFilter.toLowerCase());
-  }
-
-  // Build a map of checkId -> finding for quick lookup
-  const findingsByCheckId = new Map<string, SecurityFinding>();
-  for (const finding of findings) {
-    findingsByCheckId.set(finding.checkId, finding);
-  }
-
-  // Evaluate each control
-  const controlResults: LocalControlResult[] = [];
-  let l1Passed = 0, l1Total = 0;
-  let l2Passed = 0, l2Total = 0;
-  let l3Passed = 0, l3Total = 0;
-  let passedCount = 0, failedCount = 0, unverifiedCount = 0, notApplicableCount = 0;
-
-  for (const control of controls) {
-    let status: 'passed' | 'failed' | 'unverified' | 'not-applicable';
-    const relatedFindings: string[] = [];
-    const naSubjects: string[] = [];
-    let remediation: string | undefined;
-
-    if (control.verification === 'manual' || control.verification === 'forward') {
-      // Manual/forward controls are unverified (human must check)
-      status = 'unverified';
-      unverifiedCount++;
-      // Use control's remediation for manual/forward controls
-      remediation = control.remediation;
-    } else if (control.checkIds.length === 0) {
-      // No automated checks defined
-      status = 'unverified';
-      unverifiedCount++;
-      remediation = control.remediation;
-    } else {
-      // Check all mapped check IDs
-      let hasMeasured = false;
-      let hasFailure = false;
-      let hasNotApplicable = false;
-      for (const checkId of control.checkIds) {
-        const finding = findingsByCheckId.get(checkId);
-        if (!finding) continue;
-        // #458 step 3 — the NA test comes FIRST: an NA record OMITS `passed`
-        // (never false), so the `!finding.passed` test below read "subject
-        // absent" as a failure and, before steps 1-2, the absent subject was
-        // a pathless HIGH. The record contributes no pass/fail value; it
-        // names its absent subject.
-        if (finding.notApplicable) {
-          hasNotApplicable = true;
-          if (!naSubjects.includes(finding.notApplicable.subject)) {
-            naSubjects.push(finding.notApplicable.subject);
-          }
-          continue;
-        }
-        hasMeasured = true;
-        if (!finding.passed) {
-          hasFailure = true;
-          relatedFindings.push(`${checkId}: ${finding.description}`);
-          if (finding.fix) {
-            remediation = remediation || finding.fix;
-          }
-        }
-      }
-      // Only mark as passed if we actually verified something. A MEASURED
-      // record outranks an NA sibling (a control with one check that measured
-      // and one whose subject is absent WAS measured); `not-applicable` is
-      // awarded only when NA records are all the control has; nothing at all
-      // stays `unverified` — a type-scoped-off check leaves NO record, and
-      // crediting that as anything would relaunder the absence #458 removed.
-      if (hasMeasured) {
-        if (hasFailure) {
-          status = 'failed';
-          failedCount++;
-          remediation = remediation || control.remediation;
-        } else {
-          status = 'passed';
-          passedCount++;
-        }
-      } else if (hasNotApplicable) {
-        status = 'not-applicable';
-        notApplicableCount++;
-      } else {
-        status = 'unverified';
-        unverifiedCount++;
-        remediation = control.remediation;
-      }
-    }
-
-    // Count by level for compliance calculation
-    // Positive gate (#458 step 3): only a MEASURED status enters a level
-    // denominator. `not-applicable` leaves it exactly like `unverified`.
-    if (control.scored && (status === 'passed' || status === 'failed')) {
-      if (control.level === 'L1') {
-        l1Total++;
-        if (status === 'passed') l1Passed++;
-      } else if (control.level === 'L2') {
-        l2Total++;
-        if (status === 'passed') l2Passed++;
-      } else if (control.level === 'L3') {
-        l3Total++;
-        if (status === 'passed') l3Passed++;
-      }
-    }
-
-    controlResults.push({ control, status, findings: relatedFindings, remediation, naSubjects });
-  }
-
-  // Compliance percentages. #458 step 0 — a level with no scored control
-  // that produced a result has no figure: `null`, never a default. The two
-  // L3 controls (3.5, 8.4) have no automated check, so `l3Compliance` was the
-  // old `: 100` default on every target and the L3 ladder read it as perfect
-  // (the sentence in #513's title); a category with no scored control read
-  // `Rating: Certified` beside `Compliance: 0% (0/0)` because the overall
-  // figure defaulted to 0 five lines below — the opposite default for the
-  // same case. CISO 2026-08-11 / CPO 2026-08-25: zero denominator => null,
-  // renders "not assessed", never feeds the ladder, never Not Passing.
-  const pct = (passed: number, total: number): number | null =>
-    total > 0 ? Math.round((passed / total) * 100) : null;
-  const l1Compliance = pct(l1Passed, l1Total);
-  const l2Compliance = pct(l2Passed, l2Total);
-  const l3Compliance = pct(l3Passed, l3Total);
-  const totalScored = l1Total + l2Total + l3Total;
-  const totalPassed = l1Passed + l2Passed + l3Passed;
-  const overallCompliance = pct(totalPassed, totalScored);
-
-  // Group results by category
-  const categoryResults: BenchmarkCategoryResult[] = [];
-  for (const category of OASB_1_CATEGORIES) {
-    if (categoryFilter && category.name.toLowerCase() !== categoryFilter.toLowerCase()) continue;
-
-    const catControls = controlResults.filter((r: LocalControlResult) => r.control.category === category.name);
-    if (catControls.length === 0) continue;
-
-    const passed = catControls.filter((r: LocalControlResult) => r.status === 'passed').length;
-    const failed = catControls.filter((r: LocalControlResult) => r.status === 'failed').length;
-    const unverified = catControls.filter((r: LocalControlResult) => r.status === 'unverified').length;
-    const notApplicable = catControls.filter((r: LocalControlResult) => r.status === 'not-applicable').length;
-    const compliance = (passed + failed) > 0 ? Math.round((passed / (passed + failed)) * 100) : 0;
-
-    categoryResults.push({
-      category: category.name,
-      compliance,
-      passed,
-      failed,
-      unverified,
-      notApplicable,
-      controls: catControls.map((r: LocalControlResult) => ({
-        controlId: r.control.id,
-        name: r.control.name,
-        level: r.control.level,
-        status: r.status,
-        findings: r.findings,
-        remediation: r.remediation,
-        ...(r.status === 'not-applicable' && r.naSubjects?.length ? { notApplicableSubjects: r.naSubjects } : {}),
-      })),
-    });
-  }
-
-  const rating = calculateRating(l1Compliance, l2Compliance, l3Compliance, level);
-
-  return {
-    benchmark: OASB_1_NAME,
-    version: OASB_1_VERSION,
-    level,
-    timestamp: new Date(),
-    compliance: overallCompliance,
-    l1Compliance,
-    l2Compliance,
-    l3Compliance,
-    rating,
-    categories: categoryResults,
-    totalControls: controls.length,
-    passedControls: passedCount,
-    failedControls: failedCount,
-    unverifiedControls: unverifiedCount,
-    notApplicableControls: notApplicableCount,
-  };
 }
 
 // SARIF 2.1.0 output for GitHub Security tab and IDE integration
@@ -3590,7 +3389,7 @@ function generateHtmlReport(result: BenchmarkResult, targetDir: string, flags?: 
 
     const controlRows = cat.controls.map(ctrl => {
       const statusSvg = ctrl.status === 'passed' ? icons.check : ctrl.status === 'failed' ? icons.x : icons.circle;
-      const ctrlStatusClass = ctrl.status === 'passed' ? 'status-pass' : ctrl.status === 'failed' ? 'status-fail' : 'status-unverified';
+      const ctrlStatusClass = ctrl.status === 'passed' ? 'status-pass' : ctrl.status === 'failed' ? 'status-fail' : ctrl.status === 'not-applicable' ? 'status-na' : 'status-unverified';
       const findingsList = ctrl.findings.length > 0
         ? `<ul class="findings">${ctrl.findings.map(f => `<li>${escapeHtml(f)}</li>`).join('')}</ul>`
         : '';
@@ -3714,6 +3513,7 @@ function generateHtmlReport(result: BenchmarkResult, targetDir: string, flags?: 
     .status-fail { color: var(--danger); }
     .status-warn { color: var(--warning); }
     .status-unverified { color: var(--text-muted); }
+    .status-na { color: #8a8f98; opacity: 0.7; } /* #458: absent subject — distinct from unverified */
     .category-icon { display: flex; align-items: center; }
     .category-icon .icon { width: 18px; height: 18px; }
     .footer-btn .icon { width: 14px; height: 14px; margin-right: 0.375rem; }

--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -20,9 +20,6 @@ import {
   HardeningScanner,
   VERSION,
   OASB_1_VERSION,
-  getControlsForLevel,
-  getCheckIdsForLevel,
-  calculateRating,
   type BenchmarkLevel,
   type SecurityFinding,
 } from './index';
@@ -32,6 +29,7 @@ import {
   buildDeepScanResult,
 } from './semantic';
 import { citationTarget } from './ui/shell-quote';
+import { generateBenchmarkReport } from './benchmarks/benchmark-report';
 import { assertRedactionProvenance } from './hardening/finding-emit';
 import { getCheckCounts } from './hardening/taxonomy';
 import { countsAgainstScore, confirmedFix, isMeasured } from './ui/verdict-band';
@@ -207,103 +205,63 @@ export type ToolResult = {
 
 /** The text a refusal returns, in the shape the transport expects. */
 /**
- * The `hackmyagent_benchmark` assessor, extracted so a test can reach it (the
- * tool-handler closure above is never executed by the suite).
- *
- * INTERIM (#458 steps 1-2). #458 step 5 replaces this function wholesale with
- * `generateBenchmarkReport` (`cli.ts`), the assessor `benchmark` itself uses;
- * until then the two differ, and this one keeps its legacy reading that a
- * control with NO record for a check id is credited as passed (`!== false`).
+ * The `hackmyagent_benchmark` assessor — a thin adapter over the ONE shared
+ * `generateBenchmarkReport` (#458 step 5; the 0.33.0 hold condition). The
+ * interim implementation this replaces kept a legacy credit: a control none
+ * of whose checkIds produced any record counted as PASSED (`.get(id) !==
+ * false`, the executed defect #458 named). Under the shared function that
+ * control is `unverified` — absence is never credited — and a level where
+ * nothing measured has a `null` compliance and a `Not Assessed` rating
+ * (step 0's contract), not a fabricated 0%.
  */
 export interface BenchmarkAssessment {
   passed: number;
   failed: number;
   notApplicable: number;
   unverified: number;
-  compliance: number;
+  /** `null` when no scored control produced a result (step 0's contract). */
+  compliance: number | null;
   rating: string;
   lines: string[];
   text: string;
 }
 
 export function assessBenchmarkFindings(
-  allFindings: ReadonlyArray<Pick<SecurityFinding, 'checkId' | 'passed' | 'notApplicable'>>,
+  allFindings: ReadonlyArray<SecurityFinding>,
   level: BenchmarkLevel,
 ): BenchmarkAssessment {
-  const controls = getControlsForLevel(level);
-  // #458 — last record per checkId wins, as before, but the record keeps its
-  // notApplicable marker: a not-applicable record has no pass/fail state and
-  // must never be read as the legacy "no false => pass".
-  const checkIdResults = new Map<string, Pick<SecurityFinding, 'passed' | 'notApplicable'>>();
-  for (const f of allFindings) {
-    checkIdResults.set(f.checkId, { passed: f.passed, notApplicable: f.notApplicable });
-  }
-
-  let passed = 0;
-  let failed = 0;
-  let notApplicable = 0;
-  let unverified = 0;
+  const result = generateBenchmarkReport(allFindings, level);
   const lines: string[] = [];
-
-  for (const control of controls) {
-    if (control.checkIds.length === 0) {
-      if (control.verification === 'forward' || control.verification === 'manual') {
-        unverified++;
-        lines.push(`[UNVERIFIED] ${control.id} ${control.name} (${control.verification})`);
+  for (const cat of result.categories) {
+    for (const ctrl of cat.controls) {
+      if (ctrl.status === 'failed') {
+        const ids = ctrl.findings.map((f) => f.split(':')[0]).join(', ');
+        lines.push(`[FAIL] ${ctrl.controlId} ${ctrl.name}${ids ? ` (${ids})` : ''}`);
+      } else if (ctrl.status === 'passed') {
+        lines.push(`[PASS] ${ctrl.controlId} ${ctrl.name}`);
+      } else if (ctrl.status === 'not-applicable') {
+        const subjects = ctrl.notApplicableSubjects?.map((sub) => `no ${sub}`).join(', ') ?? 'subject absent';
+        lines.push(`[NOT-APPLICABLE] ${ctrl.controlId} ${ctrl.name} (${subjects})`);
+      } else {
+        lines.push(`[UNVERIFIED] ${ctrl.controlId} ${ctrl.name}`);
       }
-      continue;
     }
-
-    const records = control.checkIds.map((id) => ({ id, record: checkIdResults.get(id) }));
-    // notApplicable is decided per record FIRST, in the same order as
-    // `countsAgainstScore`: an NA record's `passed` is not read at all.
-    const failedChecks = records.filter(
-      ({ record }) => record !== undefined && !record.notApplicable && record.passed === false,
-    );
-    if (failedChecks.length > 0) {
-      failed++;
-      lines.push(
-        `[FAIL] ${control.id} ${control.name} (${failedChecks.map(({ id }) => id).join(', ')})`,
-      );
-      continue;
-    }
-
-    const naChecks = records.filter(({ record }) => record?.notApplicable);
-    const anyMeasured = records.some(({ record }) => record !== undefined && !record.notApplicable);
-    if (naChecks.length > 0 && !anyMeasured) {
-      // Every record this control has is a positive not-applicable: the
-      // control's subject is absent from the scanned tree, so the control was
-      // neither satisfied nor violated. Own bucket, own line, excluded from
-      // the compliance denominator below.
-      notApplicable++;
-      lines.push(
-        `[NOT-APPLICABLE] ${control.id} ${control.name} (${naChecks
-          .map(({ id, record }) => `${id}: no ${record!.notApplicable!.subject}`)
-          .join(', ')})`,
-      );
-      continue;
-    }
-
-    // Legacy credit, deliberately kept: a control none of whose checkIds
-    // produced ANY record still counts as a pass, exactly as
-    // `get(id) !== false` did before #458. The ruling narrows that credit
-    // only where a positive not-applicable record exists; the absent-record
-    // credit is pinned by the #458 test so a future change of it is loud.
-    passed++;
-    lines.push(`[PASS] ${control.id} ${control.name}`);
   }
-
-  // notApplicable is excluded: an absent subject shrinks the denominator, it
-  // does not dent compliance (#458 ruling, CA + CPO 2026-08-24).
-  const total = passed + failed;
-  const compliance = total > 0 ? Math.round((passed / total) * 100) : 0;
-  const rating = calculateRating(compliance, compliance, compliance, level);
+  const compliance = result.compliance;
   const text =
-    `OASB-1 ${level} Assessment: ${compliance}% compliance (${rating})\n` +
-    `Passed: ${passed} | Failed: ${failed} | Not applicable: ${notApplicable} | Unverified: ${unverified}\n\n` +
+    `OASB-1 ${level} Assessment: ${compliance === null ? 'not measured' : `${compliance}% compliance`} (${result.rating})\n` +
+    `Passed: ${result.passedControls} | Failed: ${result.failedControls} | Not applicable: ${result.notApplicableControls} | Unverified: ${result.unverifiedControls}\n\n` +
     lines.join('\n');
-
-  return { passed, failed, notApplicable, unverified, compliance, rating, lines, text };
+  return {
+    passed: result.passedControls,
+    failed: result.failedControls,
+    notApplicable: result.notApplicableControls,
+    unverified: result.unverifiedControls,
+    compliance,
+    rating: result.rating,
+    lines,
+    text,
+  };
 }
 
 function refuse(refusal: RootRefusal): ToolResult {


### PR DESCRIPTION
#458 step 5 — the last piece of the series, and the last item of the 0.33.0 hold condition (CPO :35713: emission change + NA guard + the mcp-server assessor replaced by `generateBenchmarkReport`, together).

The MCP `hackmyagent_benchmark` tool had its own assessor. Its interim form (#636) fixed the NA reading but deliberately kept the legacy credit #458 names: a control none of whose checkIds produced **any** record counted as PASSED (`.get(id) !== false` over an empty map) — measured on `ff345e7`, `assessBenchmarkFindings([], 'L1')` read **100% compliance, every control passing**.

Now there is one assessor. `generateBenchmarkReport` — extracted verbatim to `src/benchmarks/benchmark-report.ts`, because importing `cli.ts` is side-effectful (top-level `parseAsync`) — serves both the CLI benchmark and the MCP tool through a thin adapter:
- a control with **no record is `unverified`, never credited**; an assessment fed nothing reads `not measured` / `Not Assessed` (step 0's contract), not a fabricated 0% — `BenchmarkAssessment.compliance` is now `number | null`;
- step 3's semantics apply identically on both surfaces: NA-first, an all-NA control is `not-applicable` and outside every denominator, a measured record outranks an NA sibling in both directions;
- the interim implementation, its legacy-credit comment, and the fabricated-0% sibling are deleted wholesale; its pinned tests — whose own comments scheduled this — are rewritten to ruled-semantics pins, including the inverted cell: the legacy-credit door is **closed**, red on the pre-step-5 build;
- HTML reports give `not-applicable` controls their own status class, distinct from unverified (the step-3 review's LOW).

Evidence (branch over `ff345e7`):
- Red-proof both directions: the old interim pins went loud on the new code (5 failed — by design, their comments say so), and the rewritten cells are red on the `ff345e7` dist (5 failed | 2 passed: the base credits absence and fabricates 0%).
- Mutations (copy-restore diff-identical, rebuild green): NA count dropped in the adapter → the NA cell red; the no-record branch crediting passed again → the DEAD cell red; the all-NA branch crediting passed → the NA cell red; null rendered as 0% → the baseline cell red. One earlier mutation "survivor" was a mis-paired filter (the mutation and the guarding cell addressed different branches); re-paired correctly, both properties kill — recorded honestly rather than counted.
- Targeted: 11 files / 127 green (all mcp suites + the four benchmark suites). Full suite: Tests 4711 passed | 4 skipped | 10 todo (4725), npm test exit 0 (at f2e46b3; a first run at 426759d was failed by the finding-cast-launder guard — the adapter's `as SecurityFinding[]` was exactly its class; fixed by making the shared function take `ReadonlyArray<SecurityFinding>`, no cast anywhere, and re-earned); lint 0; self-scan `secure --ci` exit 0, 0 CRITICAL/HIGH, instrumented (62/62 check groups). Independent review (72 tool calls): 0 CRITICAL/HIGH; 2 MEDIUM — (1) the forward-with-checkIds alignment consequence (control 2.1 reads `unverified` even over a measured failing record — the CLI's long-standing reading, adopted by unification; the interim reported it failed): disclosed in the CHANGELOG and filed as #639 (a design question — measured-first for forward controls, or strike the mapping — not a mid-gate one-liner); (2) the rewritten test file no longer typechecked against the new signature (partial fixtures; masked by the tests tsc-exclude): fixtures rebuilt as complete records, standalone typecheck clean. 4 LOW: stranded SARIF comment restored + EOF newline; orphaned mcp-server imports removed; the 'every control passing' overstatement corrected to the measured 23-of-26; the hypothetical fifth-status absorption recorded (fail-closed, closed union). Extraction fidelity PROVEN byte-identical modulo export; the 0%-fabrication sibling confirmed gone; html status-na measured (8 rows, bars <= 100%).

Closes #458.
