### PR TITLE
parity-gate: report on every PR via a changes predicate job

### DIFF
--- a/.github/workflows/parity-gate.yml
+++ b/.github/workflows/parity-gate.yml
@@ -2,11 +2,6 @@ name: parity-gate
 
 on:
   pull_request:
-    paths:
-      - "src/**"
-      - "package.json"
-      - "package-lock.json"
-      - ".github/workflows/parity-gate.yml"
   push:
     branches: [main]
   workflow_dispatch:
@@ -16,9 +11,60 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  # Decides whether the parity leg must run. The workflow triggers on EVERY
+  # pull request so the parity check is always reported — run or skip, never
+  # absent — which is what lets `parity / parity` be a required context on
+  # main without stranding PRs that touch none of the parity-relevant paths.
+  # (The previous `paths:` filter made the check absent, not skipped, on
+  # non-matching PRs, so it could not be made required without stranding
+  # them -- and an unrequired parity leg blocks nothing: #636 merged red.)
+  # quotePath=off keeps non-ASCII paths raw so `src/*` matches them; a
+  # path with an embedded newline can only over-match (parity runs), never
+  # suppress a match.
+  # The path predicate lives here and only here.
+  changes:
+    runs-on: ubuntu-latest
+    outputs:
+      parity: ${{ steps.diff.outputs.parity }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Compare against the merge base
+        id: diff
+        run: |
+          if [ "$GITHUB_EVENT_NAME" != "pull_request" ]; then
+            echo "parity=true" >> "$GITHUB_OUTPUT"
+            echo "Not a pull request: parity runs unconditionally."
+            exit 0
+          fi
+          base="$(git merge-base "origin/${GITHUB_BASE_REF}" HEAD)"
+          changed="$(git -c core.quotePath=off diff --name-only "$base" HEAD)"
+          parity=false
+          while IFS= read -r f; do
+            case "$f" in
+              src/*|package.json|package-lock.json|.github/workflows/parity-gate.yml)
+                parity=true
+                break
+                ;;
+            esac
+          done <<< "$changed"
+          echo "parity=$parity" >> "$GITHUB_OUTPUT"
+          {
+            echo "merge base: $base"
+            echo "parity: $parity"
+            echo "changed files:"
+            echo "$changed"
+          }
+
   parity:
+    needs: changes
+    if: needs.changes.outputs.parity == 'true'
     # opena2a-parity moved from opena2a-org to opena2a-standards on 2026-05-24.
     # Pinned to the current main SHA; bumps require an explicit, reviewable PR.
+    # The pin controls only the workflow steps: on cross-repo calls the
+    # harness and goldens check out from opena2a-parity main (see the checkout
+    # ref logic in parity.yml), so golden re-baselines land without a bump.
     # 2026-06-01: c861cf8 picks up scan-soul-hardened re-baseline for HMA 0.23.6
     # scope-aware clamp (expected score 74/B/standard, was 100/A/hardened) and
     # the parity workflow self-checkout owner-check fix (opena2a-standards


### PR DESCRIPTION
## Summary

Rewires `parity-gate.yml` so the `parity / parity` check is reported on every pull request — run or skip, never absent — which is the precondition for adding it to main's required status checks.

- Removes the `paths:` filter from the `pull_request` trigger. A paths-filtered workflow is absent (not skipped) on non-matching PRs, so its check cannot be made required without stranding those PRs. And while it stays unrequired, a red parity leg blocks nothing: #636 merged via auto-merge with its parity leg red (a true positive).
- Adds a `changes` job that computes the same predicate (`src/**`, `package.json`, `package-lock.json`, the workflow file itself) with plain `git diff --name-only` against the merge base — no third-party action. The predicate lives in exactly one place.
- The `parity` job gains `needs: changes` and runs only when the predicate matches; on non-matching PRs it reports as skipped, which satisfies a required status check.
- `core.quotePath=off` keeps non-ASCII paths unquoted so `src/*` matches them; a path with an embedded newline can only over-match (parity runs), never suppress a match.
- Non-PR events (push to main, workflow_dispatch) run parity unconditionally.

## Verification

- actionlint clean; full local build/test/lint green (333 test files, 4711 tests).
- This PR touches the workflow file (a matched path), so it exercises the run branch. The skip branch gets verified on the first subsequent PR touching none of the four paths, before the check is made required.