### PR TITLE
secure: validate -b on presence; each benchmark arm refuses formats it cannot render

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,38 @@ All notable changes to HackMyAgent are documented in this file.
 
 ## [Unreleased]
 
+### `-b` is validated on presence, and each benchmark arm refuses the formats it cannot render
+
+`secure <dir> -b ''` skipped the benchmark validator and the arm switch — both
+tested truthiness — so a CI job templating `-b "$BENCH"` over an unset
+variable ran the ordinary hardening report and exited 0 where it asked for a
+benchmark verdict. The empty name is
+now refused like any unknown one (`Unknown benchmark ''. Available: oasb-1,
+oasb-2`, exit 1). (#632)
+
+The benchmark arms rendered a fixed set of formats and fell to the text
+report for the rest: `-b oasb-1 --format asff` printed the prose OASB-1
+report, and the OASB-2 composite arm branches on `json` only, so `-b oasb-2
+--format sarif|html|asff` printed its prose too — a machine-format request
+answered with a human one, nothing in the exit code to say so (#563's class).
+Each arm now refuses a format it does not render where the other format
+errors are raised, listing what it does (`--format asff is not available with
+-b oasb-1. Use: text, json, sarif, html, asp`, exit 1), and `--help` marks
+`asff` as a non-benchmark format. (#633)
+
+At the same gate: the level validator excluded the composite arm, which
+consumes the level for its infrastructure half, so `-b oasb-2 -l L9` died on
+`RATING_LADDER[level] is not iterable`; it now reads `Invalid level 'L9'.
+Use: L1, L2, or L3`, exit 1. The other optional strings of the gate tested
+truthiness the same way — `--fail-below ''` removed the CI floor silently,
+`-l ''` fell to L1, `--format ''` to the text report, `--scan-depth ''` to a
+standard scan — and each now reaches its existing validation error (found by
+the adversarial review of this change). One exit-code consequence: `-b oasb-2
+--format sarif|html|asff` on a conformant tree was exit 0 with prose and is
+now exit 1 with the refusal. The asp gate's `.toLowerCase()` has been a no-op
+since #630 normalized the name before it; it now reads the normalized value
+directly.
+
 ### One benchmark assessor: the MCP server's compliance tool no longer credits absence
 
 Step 5 of #458, the last piece of its series. The MCP `hackmyagent_benchmark`

--- a/__tests__/cli/benchmark-flag-gating.test.ts
+++ b/__tests__/cli/benchmark-flag-gating.test.ts
@@ -1,0 +1,177 @@
+/**
+ * #632 / #633 — the `-b` gate validates on presence, and each benchmark arm
+ * refuses the formats it cannot render.
+ *
+ * Before: `-b ''` skipped the benchmark validator and the arm switch (both
+ * tested truthiness), so a CI template over an unset variable
+ * ran the ordinary report and exited 0 where a benchmark verdict was asked
+ * for. `-b oasb-1 --format asff` fell to the text report (the OASB-1 arm's
+ * switch has no asff case), and the OASB-2 composite arm branches on json
+ * only, so `--format sarif|html|asff` printed its prose too — a machine
+ * format request answered with a human one, nothing in the exit code to say
+ * so (#563's class). The level validator also excluded the composite arm,
+ * which consumes the level: `-b oasb-2 -l L9` died on
+ * `RATING_LADDER[level] is not iterable`.
+ *
+ * RED-ON-BASE cells fail on the 2a39b72 dist; PIN cells pass on both.
+ */
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { spawnSync } from 'node:child_process';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { assertDistFreshIfPresent, BUILT_CLI as CLI } from '../helpers/dist-freshness';
+
+beforeAll(assertDistFreshIfPresent);
+
+const QUICK = ['--scan-depth', 'quick', '--no-machine-posture'];
+
+let dir: string;
+
+beforeAll(() => {
+  dir = fs.mkdtempSync(path.join(os.tmpdir(), 'hma-632-'));
+  fs.writeFileSync(path.join(dir, 'package.json'), '{ "name": "fx632", "version": "1.0.0", "private": true }\n');
+  fs.writeFileSync(path.join(dir, 'index.js'), 'module.exports = () => 1;\n');
+});
+
+afterAll(() => {
+  try { fs.rmSync(dir, { recursive: true, force: true }); } catch { /* best effort */ }
+});
+
+function run(args: string[]) {
+  const r = spawnSync(process.execPath, [CLI, 'secure', dir, ...args, ...QUICK], {
+    encoding: 'utf8',
+    timeout: 240_000,
+    maxBuffer: 64 * 1024 * 1024,
+    env: { ...process.env, NO_COLOR: '1', OPENA2A_TELEMETRY: 'off', HOME: fs.mkdtempSync(path.join(os.tmpdir(), 'hma-home-')) },
+  });
+  return { status: r.status, stdout: r.stdout ?? '', stderr: r.stderr ?? '' };
+}
+
+function jsonBody(stdout: string): any {
+  const start = stdout.search(/[[{]/);
+  expect(start).toBeGreaterThanOrEqual(0);
+  return JSON.parse(stdout.slice(start));
+}
+
+describe('#632 -b validates on presence, not truthiness', { timeout: 300_000 }, () => {
+  it("RED-ON-BASE: -b '' is refused as an unknown benchmark, and no report is printed", () => {
+    const r = run(['-b', '']);
+    expect(r.status).toBe(1);
+    expect(r.stderr).toContain("Unknown benchmark ''");
+    expect(r.stderr).toContain('Available: oasb-1, oasb-2');
+    expect(r.stdout).not.toMatch(/Scan depth/);
+    expect(r.stdout).not.toMatch(/Security\s+━/);
+  });
+
+  it('PIN: -b bogus is still refused with the same line', () => {
+    const r = run(['-b', 'bogus']);
+    expect(r.status).toBe(1);
+    expect(r.stderr).toContain("Unknown benchmark 'bogus'");
+  });
+
+  it('RED-ON-BASE: -b oasb-2 -l L9 is refused by the level validator, not by the rating ladder', () => {
+    const r = run(['-b', 'oasb-2', '-l', 'L9']);
+    expect(r.status).toBe(1);
+    expect(r.stderr).toContain("Invalid level 'L9'");
+    expect(r.stderr).toContain('Use: L1, L2, or L3');
+    expect(r.stderr).not.toContain('not iterable');
+    expect(r.stdout).not.toMatch(/Scan depth/);
+  });
+});
+
+describe('#633 each benchmark arm refuses the formats it cannot render', { timeout: 300_000 }, () => {
+  it('RED-ON-BASE: -b oasb-1 --format asff is refused with the formats the arm renders', () => {
+    const r = run(['-b', 'oasb-1', '--format', 'asff']);
+    expect(r.status).toBe(1);
+    expect(r.stderr).toContain('--format asff is not available with -b oasb-1');
+    expect(r.stderr).toContain('Use: text, json, sarif, html, asp');
+    expect(r.stdout).not.toContain('OASB-1:');
+    expect(r.stdout).not.toContain('"Findings"');
+  });
+
+  it('RED-ON-BASE: the refusal names the benchmark as typed (spelling parity with #630)', () => {
+    const r = run(['-b', 'OASB-1', '--format', 'asff']);
+    expect(r.status).toBe(1);
+    expect(r.stderr).toContain('--format asff is not available with -b OASB-1');
+    expect(r.stdout).not.toContain('OASB-1:');
+  });
+
+  it.each(['sarif', 'html', 'asff'])('RED-ON-BASE: -b oasb-2 --format %s is refused; the composite arm renders text and json only', (format) => {
+    const r = run(['-b', 'oasb-2', '--format', format]);
+    expect(r.status).toBe(1);
+    expect(r.stderr).toContain(`--format ${format} is not available with -b oasb-2`);
+    expect(r.stderr).toContain('Use: text, json');
+    expect(r.stdout).not.toContain('OASB Composite');
+  });
+
+  it('PIN: -b oasb-2 --format json still emits the composite document', () => {
+    const r = run(['-b', 'oasb-2', '--format', 'json']);
+    expect(r.stderr).not.toContain('not available with -b');
+    expect(jsonBody(r.stdout).benchmark).toBe('OASB');
+  });
+
+  it('PIN: -b oasb-1 --format sarif still emits a SARIF log', () => {
+    const r = run(['-b', 'oasb-1', '--format', 'sarif']);
+    expect(r.stderr).not.toContain('not available with -b');
+    expect(Array.isArray(jsonBody(r.stdout).runs)).toBe(true);
+    expect([0, 1, 2]).toContain(r.status);
+  });
+
+  it('PIN: -b oasb-1 --format asp still emits the Agent Security Profile', () => {
+    const r = run(['-b', 'oasb-1', '--format', 'asp']);
+    expect(r.stderr).not.toContain('not available with -b');
+    expect(jsonBody(r.stdout).specVersion).toBe('1.0.0');
+  });
+
+  it('PIN: --format asff without -b still emits ASFF (the non-benchmark arm renders it)', () => {
+    const r = run(['--format', 'asff']);
+    expect(r.stderr).not.toContain('not available with -b');
+    // ASFF, not just JSON: the Security Hub document shape carries SchemaVersion.
+    const body = jsonBody(r.stdout);
+    expect(JSON.stringify(body)).toContain('SchemaVersion');
+  });
+});
+
+describe('the same class on the other optional strings of the secure gate: presence, not truthiness', { timeout: 300_000 }, () => {
+  it("RED-ON-BASE: --fail-below '' is a range error, not a silently removed floor", () => {
+    const r = run(['--fail-below', '']);
+    expect(r.status).toBe(1);
+    expect(r.stderr).toContain('--fail-below must be a number between 0 and 100');
+  });
+
+  it("RED-ON-BASE: -b oasb-1 -l '' is an invalid level, not L1", () => {
+    const r = run(['-b', 'oasb-1', '-l', '']);
+    expect(r.status).toBe(1);
+    expect(r.stderr).toContain("Invalid level ''");
+    expect(r.stdout).not.toMatch(/Rating: /);
+  });
+
+  it("RED-ON-BASE: --format '' is an invalid format, not the text report", () => {
+    const r = run(['--format', '']);
+    expect(r.status).toBe(1);
+    expect(r.stderr).toContain("Invalid format ''");
+    expect(r.stdout).not.toMatch(/Security\s+━/);
+  });
+
+  it("RED-ON-BASE: --scan-depth '' is an invalid depth, not a standard scan", () => {
+    // Raw spawn: the shared helper appends its own --scan-depth, which Commander would let win.
+    const r = spawnSync(process.execPath, [CLI, 'secure', dir, '--no-machine-posture', '--scan-depth', ''], {
+      encoding: 'utf8',
+      timeout: 240_000,
+      maxBuffer: 64 * 1024 * 1024,
+      env: { ...process.env, NO_COLOR: '1', OPENA2A_TELEMETRY: 'off', HOME: fs.mkdtempSync(path.join(os.tmpdir(), 'hma-home-')) },
+    });
+    expect(r.status).toBe(1);
+    expect(r.stderr ?? '').toContain("Invalid scan depth ''");
+    expect(r.stdout ?? '').not.toMatch(/Security\s+━/);
+  });
+
+  it('PIN: -b OASB-2 --format asp keeps the #563 line — the asp gate reads the normalized name', () => {
+    const r = run(['-b', 'OASB-2', '--format', 'asp']);
+    expect(r.status).toBe(1);
+    expect(r.stderr).toContain('--format asp');
+    expect(r.stderr).toContain('-b oasb-1');
+    expect(r.stdout).not.toContain('OASB Composite');
+  });
+});

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -4688,15 +4688,15 @@ Performs ${CHECK_COUNT} security checks across ${CATEGORY_COUNT} categories:
 Benchmark mode (--benchmark):
   oasb-1   OASB-1 infrastructure compliance (L1/L2/L3 levels)
            L1 = Essential (baseline), L2 = Standard, L3 = Hardened
-  oasb-2   OASB composite: infrastructure (50%) + governance (50%)
+  oasb-2   OASB composite: infrastructure (50%) + governance (50%); formats text, json
            Combines OASB-1 scan with scan-soul for a unified score
 
 Output formats (--format):
   text   Human-readable terminal output (default)
   json   Machine-readable JSON
-  sarif  GitHub Security tab / IDE integration
-  html   Shareable compliance report
-  asff   AWS Security Hub findings
+  sarif  GitHub Security tab / IDE integration (not with -b oasb-2)
+  html   Shareable compliance report (not with -b oasb-2)
+  asff   AWS Security Hub findings (without -b)
   asp    Agent Security Profile (with -b oasb-1)
 
 Severities: critical, high, medium, low
@@ -4736,7 +4736,7 @@ Examples:
   // it is fixed the promise is scoped to where it holds.
   .option('--ignore <checks>', 'Comma-separated check IDs to leave out of the findings list (e.g., CRED-001,GIT-002). Suppressed checks are still scored and still set the exit code for this command; use --fail-below for a score floor. With --benchmark the ignored checks cannot report, so a control measured only by them stays unverified')
   .option('--json', 'Output as JSON (deprecated: use --format json)')
-  .option('-f, --format <format>', 'Output format: text, json, sarif, html, asff; asp with -b oasb-1', 'text')
+  .option('-f, --format <format>', 'Output format: text, json, sarif, html (sarif/html not with -b oasb-2); asff without -b; asp with -b oasb-1', 'text')
   .option('--aws-account-id <id>', 'AWS account ID for ASFF format')
   .option('--aws-region <region>', 'AWS region for ASFF format')
   .option('-o, --output <file>', 'Write output to file instead of stdout')
@@ -4848,23 +4848,34 @@ Examples:
       const benchmarkAsGiven = options.benchmark;
       if (options.benchmark !== undefined) options.benchmark = options.benchmark.toLowerCase();
       const isOasb2 = options.benchmark === 'oasb-2';
-      if (options.benchmark && !isOasb2 && !isValidBenchmark(options.benchmark)) {
+      // #632 — validated on presence, not truthiness: `-b ''` (a CI template
+      // over an unset variable) skipped this gate and the
+      // `if (options.benchmark)` arm switch, so it ran the ordinary report and
+      // exited 0 where a benchmark verdict was asked for.
+      if (options.benchmark !== undefined && !isOasb2 && !isValidBenchmark(options.benchmark)) {
         // The rejection names the value the user typed, not the normalized one.
         console.error(`Error: Unknown benchmark '${escapeForDisplay(String(benchmarkAsGiven))}'. Available: ${[...AVAILABLE_BENCHMARKS, 'oasb-2'].join(', ')}`);
         process.exit(1);
       }
 
-      // Validate level if benchmark mode (not applicable for oasb-2)
+      // Validate level if benchmark mode. The composite arm consumes the level
+      // too (its infrastructure half is the OASB-1 report at `level`), and
+      // excluding it here let `-b oasb-2 -l L9` reach the rating ladder and
+      // die on `RATING_LADDER[level] is not iterable`.
       const validLevels = ['L1', 'L2', 'L3'];
-      const level = (options.level?.toUpperCase() || 'L1') as BenchmarkLevel;
-      if (options.benchmark && !isOasb2 && !validLevels.includes(level)) {
+      // Presence, not truthiness (#632's class): `-l ''` fell to L1 silently.
+      const level = (options.level === undefined ? 'L1' : options.level.toUpperCase()) as BenchmarkLevel;
+      if (options.benchmark !== undefined && !validLevels.includes(level)) {
         console.error(`Error: Invalid level '${escapeForDisplay(String(options.level))}'. Use: L1, L2, or L3`);
         process.exit(1);
       }
 
       // Determine output format (--json is deprecated alias for --format json)
       const validFormats = ['text', 'json', 'sarif', 'html', 'asp', 'asff'];
-      const format = options.json ? 'json' : (options.format || 'text');
+      // Commander supplies the 'text' default; `|| 'text'` let `--format ''`
+      // fall to the text report silently (#632's class). `??` keeps '' as
+      // given so it reaches the invalid-format error below.
+      const format = options.json ? 'json' : (options.format ?? 'text');
       if (!validFormats.includes(format)) {
         console.error(`Error: Invalid format '${escapeForDisplay(String(format))}'. Use: ${validFormats.join(', ')}`);
         process.exit(1);
@@ -4875,13 +4886,27 @@ Examples:
       // printed, so a CI job that asked for a machine format got a human one
       // with nothing in the exit code to say so. Refuse it where the other
       // format errors are raised, and name the flag it needs.
-      if (format === 'asp' && String(options.benchmark ?? '').toLowerCase() !== 'oasb-1') {
+      if (format === 'asp' && options.benchmark !== 'oasb-1') {
         console.error('Error: --format asp is the Agent Security Profile of an OASB-1 benchmark run. Use it with -b oasb-1.');
+        process.exit(1);
+      }
+      // #633 — each benchmark arm renders a fixed set of formats and fell to
+      // the text report for the rest (`-b oasb-1 --format asff`; `-b oasb-2
+      // --format sarif|html|asff`), so a consumer that asked for a machine
+      // format got prose with nothing in the exit code to say so. Same class
+      // as #563: refuse where the other format errors are raised, and list
+      // what the arm renders. `asp` outside OASB-1 keeps #563's line above.
+      const benchmarkFormats = isOasb2 ? ['text', 'json'] : ['text', 'json', 'sarif', 'html', 'asp'];
+      if (options.benchmark !== undefined && !benchmarkFormats.includes(format)) {
+        console.error(`Error: --format ${format} is not available with -b ${escapeForDisplay(String(benchmarkAsGiven))}. Use: ${benchmarkFormats.join(', ')}`);
         process.exit(1);
       }
 
       // Parse fail threshold
-      const failBelow = options.failBelow ? parseInt(options.failBelow, 10) : undefined;
+      // Presence, not truthiness: `--fail-below ''` (a CI template over an
+      // unset variable) removed the floor silently; now `''` parses to NaN
+      // and hits the range error below.
+      const failBelow = options.failBelow !== undefined ? parseInt(options.failBelow, 10) : undefined;
       if (failBelow !== undefined && (isNaN(failBelow) || failBelow < 0 || failBelow > 100)) {
         console.error(`Error: --fail-below must be a number between 0 and 100`);
         process.exit(1);
@@ -4903,7 +4928,8 @@ Examples:
 
       // Validate scan depth
       const validDepths = ['quick', 'standard', 'deep'];
-      const scanDepth = (options.scanDepth || 'standard') as 'quick' | 'standard' | 'deep';
+      // Presence, not truthiness: `--scan-depth ''` ran a standard scan silently.
+      const scanDepth = (options.scanDepth === undefined ? 'standard' : options.scanDepth) as 'quick' | 'standard' | 'deep';
       if (!validDepths.includes(scanDepth)) {
         console.error(`Error: Invalid scan depth '${escapeForDisplay(String(options.scanDepth))}'. Use: ${validDepths.join(', ')}`);
         process.exit(1);


### PR DESCRIPTION
## What

Three defects at the `secure` benchmark gate, one PR (the `-b` cluster the #630 review queued):

1. **`-b ''` ran the ordinary report and exited 0** (#632). The gate tested truthiness, so the empty string — the one spelling Commander lets through (`-b` alone is `argument missing`) — skipped validation and the truthiness-tested arm switch. A CI template over an unset `$BENCH` got a clean non-benchmark exit where it asked for a benchmark verdict. Now validated on presence: `Error: Unknown benchmark ''. Available: oasb-1, oasb-2`, exit 1.
2. **Each benchmark arm fell to the text report for a format it does not render** (#633). `-b oasb-1 --format asff` printed the prose OASB-1 report at exit 0; the OASB-2 composite arm branches on `json` only, so `-b oasb-2 --format sarif|html|asff` printed its prose too (measured before the edit — same class, second surface, swept here). Same fix as #563: refuse where the other format errors are raised, naming what the arm renders — `Error: --format asff is not available with -b oasb-1. Use: text, json, sarif, html, asp`, exit 1. The benchmark name is echoed as typed (#630's rule). `--help` now marks `asff` as `without -b` beside `asp (with -b oasb-1)`.
3. **`-b oasb-2 -l L9` crashed** (`Error: RATING_LADDER[level] is not iterable`, exit 1; no document on stdout under `--format json`, a scan-depth line and the version footer in text mode — found by the pre-edit measurement of this gate). The level validator excluded the composite arm, but that arm consumes the level for its infrastructure half. It now reads `Invalid level 'L9'. Use: L1, L2, or L3`, exit 1.
4. **The other optional strings of the same gate tested truthiness too** (found by this PR's adversarial round, folded because they are #632's class at the site being edited): `--fail-below ''` silently removed the CI floor on every arm; `-l ''` fell to L1; `--format ''` fell to the text report; `--scan-depth ''` ran a standard scan. Each is now a presence check that reaches the existing validation error (`--fail-below must be a number between 0 and 100`, `Invalid level ''`, `Invalid format ''`, `Invalid scan depth ''`), exit 1. `--help` now also says sarif/html are not available with `-b oasb-2` and that the composite renders text and json.

One exit-code consequence to note: `-b oasb-2 --format sarif|html|asff` on a conformant tree was exit 0 with prose and is now exit 1 with the refusal (CHANGELOG says so).

Cleanup: the asp gate's `.toLowerCase()` has been a no-op since #630 normalized the name before it; it now reads the normalized value directly.

## Not changed

`-b oasb-2 --format asp` keeps #563's line (that gate runs first; its own test pins it). The six PIN cells hold each rendered format's document unchanged (oasb-1 sarif/asp, oasb-2 json, asff without -b, `-b bogus`, `-b OASB-2 --format asp`). No scanner files.

## Verify

```
hackmyagent secure <dir> -b '' --scan-depth quick --no-machine-posture; echo "exit $?"
# before: the ordinary "Scan depth" report, exit 0 — after: Unknown benchmark '', exit 1
hackmyagent secure <dir> -b oasb-1 --format asff --scan-depth quick --no-machine-posture | head -1
# before: "OASB-1: Open Agent Security Benchmark v1.0.0" — after: nothing on stdout, refusal on stderr, exit 1
hackmyagent secure <dir> -b oasb-2 --format sarif --scan-depth quick --no-machine-posture | head -1
# before: "OASB Composite Security Assessment" — after: refusal, exit 1
hackmyagent secure <dir> -b oasb-2 -l L9 --scan-depth quick --no-machine-posture
# before: Error: RATING_LADDER[level] is not iterable — after: Invalid level 'L9'. Use: L1, L2, or L3
```

## Tests

`__tests__/cli/benchmark-flag-gating.test.ts` — 13 cells: 7 RED-ON-BASE (fail on the 2a39b72 dist: `-b ''`, `-l L9` on oasb-2, oasb-1 asff, as-typed spelling, oasb-2 sarif/html/asff) + 6 PIN (oasb-1 sarif/asp, oasb-2 json, asff without -b, `-b bogus`, `-b OASB-2 --format asp` keeps #563's line). Plus 4 RED-ON-BASE presence cells from the adversarial round (`--fail-below ''`, `-l ''`, `--format ''`, `--scan-depth ''`) — 17 cells in all; the asff PIN asserts `SchemaVersion`. Red-proof: main's `src/cli.ts` swapped in and rebuilt — 11 red / 6 green. Mutations, each one property, rebuilt, restored identical and re-run 17/17: M1 presence->truthiness (killed by the `-b ''` cell), M2 refusal deleted (5 cells), M3 asff added to the oasb-1 list (2), M4 sarif added to the oasb-2 list (1), M5 asp predicate inverted (2 PINs), M6 `!isOasb2` restored on the level gate (1) — proven on the first commit, whose mutated sites the amend did not touch (diff-verified); M7-M10 (each presence check reverted to truthiness) each killed by its new cell on the amended commit.

## Adversarial round (independent agent on git-archive trees of base and head)

0 CRITICAL / 0 HIGH. One MEDIUM regression (help listed sarif/html unqualified while the composite arm now refuses them) — fixed above. One inaccurate claim (the L9 crash's "empty stdout" was json-only) — corrected above. Pre-existing findings of the same truthiness class at this gate (`--fail-below ''`, `-l ''`, `--format ''`, `--scan-depth ''`) — folded, each with a red cell. Pre-existing findings of other classes filed, not fixed here: #646 (publish/contribute family silently dropped with `-b`), #647 (`-o` ignored for `--format text`), #648 (gate leftovers: `-l`/`-c` without `-b`, late category validation, `--aws-*` outside asff, `--json` over `--format`, footer on refused runs), #649 (`eval oracle --format` unvalidated), #650 (MCP benchmark level unvalidated). The round also confirmed by matrix: no base-refused input is accepted on head (20 pair cells); `''` cannot reach any downstream `options.benchmark` reader; the interpolated format token is one of the six validated literals; the benchmark name reaching the refusal is ASCII `[oOaAsSbB-12]` by a full unicode case-folding scan.

## Gate

Full suite on the final commit: 334 files / 4728 passed / 0 failed, npm exit 0. Lint 0. Self-scan exit 0 (634 files read, 62/62 groups, no in-scope critical/high). /pre-push-review PASS.

Merge != release: 0.33.0's tag is not before 2026-08-27T21:05Z; this merge lands before it, so the 6-probe token dry-run is re-run on the merge commit before tagging.

Closes #632, closes #633
