### PR TITLE
benchmark: a non-automated control's mapped checks refute it, never confirm it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,31 @@ All notable changes to HackMyAgent are documented in this file.
 
 ## [Unreleased]
 
+### A forward-verified control now fails when its mapped check fails
+
+OASB-1 control 2.1 (Explicit Capability Grants) is forward-verified and also
+maps two automated checks, SEM-MCP-001 and SEM-MCP-004. The assessor
+classified every manual/forward control `unverified` before reading its
+records, so a wildcard MCP grant (`allowedTools: ["*"]`) — the exact violation
+2.1's audit step names — moved nothing in any benchmark surface: an
+`mcp.json` carrying one, beside a lockfile, read `Rating: Certified`,
+`Compliance: 100% (11/11)`, exit 0, with `--fail-below 100` exit 0, while
+`secure` on the same directory reported the wildcard as a HIGH finding.
+Records are now read for every control that maps checks, and a
+manual/forward control's checks are refutation checks: a measured failure
+fails the control — the same tree now reads `Rating: Passing`,
+`Compliance: 92% (11/12)`, `[-] 2.1: Explicit Capability Grants`, and `--fail-below
+100` exits 1; SARIF gains an `OASB-1/2.1` result; the MCP server's benchmark
+tool reports `[FAIL] 2.1 Explicit Capability Grants (SEM-MCP-004)` — while a
+clean or absent-subject result leaves it `unverified`, never `passed` and
+never `not-applicable`, because automation cannot confirm what the label says
+a person must. 2.1 is the only control in this class; every other manual and
+forward control maps no check and is unchanged, so only a tree carrying a
+SEM-MCP-001 or SEM-MCP-004 finding can move (an empty directory and the
+benign MCP corpus fixture measured byte-identical apart from the timestamp).
+Verify: `hackmyagent secure <dir> -b oasb-1 -l L1 --verbose` and read the
+2.1 row. (#639)
+
 ### `-b` is validated on presence, and each benchmark arm refuses the formats it cannot render
 
 `secure <dir> -b ''` skipped the benchmark validator and the arm switch — both
@@ -49,12 +74,11 @@ so both callers can import it — is now the one assessor: a control with no
 record is `unverified`, never credited; a level where nothing measured reports
 `not measured` and `Not Assessed` (step 0's contract), not a fabricated 0%;
 the not-applicable and measured-wins semantics are step 3's, identically on
-both surfaces. One alignment consequence on the MCP surface: a `forward`
-control that also maps automated checks (2.1) reads `unverified` even when a
-mapped check produced a measured failure — the CLI's long-standing reading,
-which unification adopts; the interim assessor reported it as failed. The
-forward-with-checkIds class is filed as #639. HTML reports now give `not-applicable` controls their own
-status class, distinct from unverified. (#458 steps 3-5 complete; steps 1-2
+both surfaces. The one reading unification carried over from the CLI — a
+`forward` control that also maps automated checks (2.1) staying `unverified`
+on a measured failure — is corrected in the entry above (#639). HTML reports
+now give `not-applicable` controls their own status class, distinct from
+unverified. (#458 steps 3-5 complete; steps 1-2
 shipped in the previous entries.)
 
 ### A benchmark control whose subject artifact is absent reads `not-applicable`, never `failed`

--- a/__tests__/benchmarks/benchmark-report-refute-only.test.ts
+++ b/__tests__/benchmarks/benchmark-report-refute-only.test.ts
@@ -1,0 +1,215 @@
+/**
+ * #639 — checkIds on a non-automated OASB-1 control are refutation-only.
+ *
+ * Before: `generateBenchmarkReport` classified every manual/forward control
+ * `unverified` BEFORE reading its records, so control 2.1 (forward, mapping
+ * SEM-MCP-001 and SEM-MCP-004) never moved on a measured failure — a
+ * wildcard MCP grant, the exact violation its audit step names, changed no
+ * benchmark figure. Now: records are read for every control that maps
+ * checks; a non-automated control's checks can REFUTE it (any measured
+ * failure -> `failed`) and never confirm it (clean, absent-subject or no
+ * record -> `unverified`, never `passed`, never `not-applicable`).
+ *
+ * The subject control is selected by SHAPE, not by id, so the file fails
+ * loudly if the catalogue census changes. RED-ON-BASE cells fail on the
+ * 2a39b72 build; PIN cells pass on both.
+ */
+import { describe, it, expect } from 'vitest';
+import { generateBenchmarkReport } from '../../src/benchmarks/benchmark-report';
+import { OASB_1_CATEGORIES, getControlsForLevel } from '../../src/benchmarks/oasb-1';
+import type { BenchmarkControl } from '../../src/benchmarks/oasb-1';
+import { assessBenchmarkFindings } from '../../src/mcp-server';
+import type { SecurityFinding } from '../../src/hardening/security-check';
+
+const ALL: BenchmarkControl[] = OASB_1_CATEGORIES.flatMap((c) => c.controls);
+const automatedCited = new Set(ALL.filter((c) => c.verification === 'automated').flatMap((c) => c.checkIds));
+
+// The class under test: non-automated controls that map checks.
+const subjects = ALL.filter((c) => c.verification !== 'automated' && c.checkIds.length > 0);
+const subject = subjects[0];
+// A checkId of the subject that no automated control cites — its failure can
+// only reach the benchmark through the subject.
+const refutationId = subject?.checkIds.find((id) => !automatedCited.has(id));
+// A checkId the subject shares with an automated control.
+const sharedId = subject?.checkIds.find((id) => automatedCited.has(id));
+const sharedAutomated = sharedId ? ALL.find((c) => c.verification === 'automated' && c.checkIds.includes(sharedId)) : undefined;
+// Non-automated controls WITHOUT checkIds, one of each label.
+const forwardNoIds = ALL.find((c) => c.verification === 'forward' && c.checkIds.length === 0);
+const manualNoIds = ALL.find((c) => c.verification === 'manual' && c.checkIds.length === 0);
+
+const base = (checkId: string) => ({
+  checkId,
+  name: checkId,
+  description: `fixture record for ${checkId}`,
+  severity: 'high' as const,
+  category: 'mcp',
+  message: `fixture message for ${checkId}`,
+});
+const failed = (checkId: string): SecurityFinding => ({ ...base(checkId), passed: false, fix: `fixture fix for ${checkId}` } as SecurityFinding);
+const passed = (checkId: string): SecurityFinding => ({ ...base(checkId), passed: true } as SecurityFinding);
+const na = (checkId: string): SecurityFinding => ({
+  ...base(checkId),
+  severity: undefined,
+  notApplicable: { subject: 'mcp.json', reason: 'no MCP configuration exists in the scanned tree' },
+} as unknown as SecurityFinding);
+
+function statusOf(findings: SecurityFinding[], id: string) {
+  const r = generateBenchmarkReport(findings, 'L1');
+  const c = r.categories.flatMap((cat) => cat.controls).find((x) => x.controlId === id);
+  if (!c) throw new Error(`control ${id} absent from the L1 report`);
+  return { report: r, control: c };
+}
+
+describe('#639 premise: the class exists and is exactly what the rule was written for', () => {
+  it('exactly one non-automated control maps checkIds, and it is scored at L1', () => {
+    expect(subjects.map((c) => `${c.id}:${c.verification}`), 'census of non-automated controls with checkIds changed — re-read the #639 ruling before editing this file').toHaveLength(1);
+    expect(subject.scored).toBe(true);
+    expect(subject.level).toBe('L1');
+    expect(getControlsForLevel('L1').some((c) => c.id === subject.id)).toBe(true);
+  });
+
+  it('the subject maps one checkId no automated control cites, and one it shares with an automated control', () => {
+    expect(refutationId, `${subject.id} has no refutation-only checkId`).toBeDefined();
+    expect(sharedId, `${subject.id} shares no checkId with an automated control`).toBeDefined();
+    expect(sharedAutomated).toBeDefined();
+    expect(forwardNoIds).toBeDefined();
+    expect(manualNoIds).toBeDefined();
+  });
+});
+
+describe('#639 a non-automated control is failed by its checks and never passed by them', () => {
+  it('RED-ON-BASE: the refutation-only checkId failed alone -> failed, l1 0, Not Passing', () => {
+    const { report, control } = statusOf([failed(refutationId!)], subject.id);
+    expect(control.status).toBe('failed');
+    expect(control.findings[0]).toMatch(new RegExp(`^${refutationId}: `));
+    expect(control.remediation).toBe(`fixture fix for ${refutationId}`);
+    expect(report.failedControls).toBe(1);
+    expect(report.l1Compliance).toBe(0);
+    expect(report.rating).toBe('Not Passing');
+  });
+
+  it('RED-ON-BASE: the shared checkId failed -> the subject AND the automated control both fail', () => {
+    const { report, control } = statusOf([failed(sharedId!)], subject.id);
+    expect(control.status).toBe('failed');
+    const other = report.categories.flatMap((c) => c.controls).find((x) => x.controlId === sharedAutomated!.id)!;
+    expect(other.status).toBe('failed');
+    expect(report.failedControls).toBe(2);
+  });
+
+  it('RED-ON-BASE: shared passed + refutation-only failed -> failed (a clean sibling does not outvote a violation)', () => {
+    const { report, control } = statusOf([passed(sharedId!), failed(refutationId!)], subject.id);
+    expect(control.status).toBe('failed');
+    const other = report.categories.flatMap((c) => c.controls).find((x) => x.controlId === sharedAutomated!.id)!;
+    expect(other.status).toBe('passed');
+  });
+
+  it('RED-ON-BASE: absent-subject on one check + failed on the other -> failed', () => {
+    const { control } = statusOf([na(sharedId!), failed(refutationId!)], subject.id);
+    expect(control.status).toBe('failed');
+  });
+
+  it('PIN (kills the symmetric variant): every mapped check passed -> unverified, never passed, out of the denominator', () => {
+    const { report, control } = statusOf(subject.checkIds.map(passed), subject.id);
+    expect(control.status).toBe('unverified');
+    expect(control.findings).toEqual([]);
+    expect(control.remediation).toBe(subject.remediation);
+    // The shared id also credits the automated control, and that is the ONLY
+    // passed control: the subject did not enter the count or the denominator.
+    expect(report.passedControls).toBe(1);
+    expect(report.l1Compliance).toBe(100);
+  });
+
+  it('PIN (kills forward-NA): every mapped check absent-subject -> unverified, no notApplicableSubjects', () => {
+    const { report, control } = statusOf(subject.checkIds.map(na), subject.id);
+    expect(control.status).toBe('unverified');
+    expect((control as any).notApplicableSubjects).toBeUndefined();
+    // The automated sibling that shares an id IS not-applicable on the same records.
+    const other = report.categories.flatMap((c) => c.controls).find((x) => x.controlId === sharedAutomated!.id)!;
+    expect(other.status).toBe('not-applicable');
+    expect(report.notApplicableControls).toBe(1);
+  });
+
+  it('PIN: no record at all -> unverified, compliance null, Not Assessed', () => {
+    const { report, control } = statusOf([], subject.id);
+    expect(control.status).toBe('unverified');
+    expect(report.compliance).toBeNull();
+    expect(report.rating).toBe('Not Assessed');
+  });
+});
+
+describe('#639 the rule does not reach controls outside the class', () => {
+  it('PIN: non-automated controls WITHOUT checkIds stay unverified on empty and on unrelated records', () => {
+    for (const c of [forwardNoIds!, manualNoIds!]) {
+      const r0 = generateBenchmarkReport([], c.level as any);
+      const r1 = generateBenchmarkReport([failed(refutationId!), failed(sharedId!)], c.level as any);
+      for (const r of [r0, r1]) {
+        const x = r.categories.flatMap((cat) => cat.controls).find((y) => y.controlId === c.id);
+        expect(x?.status, `${c.id} (${c.verification}, no checkIds)`).toBe('unverified');
+      }
+    }
+  });
+
+  it('PIN: an automated control still takes all three measured states', () => {
+    const id = sharedAutomated!.id;
+    expect(statusOf([failed(sharedId!)], id).control.status).toBe('failed');
+    expect(statusOf(sharedAutomated!.checkIds.map(passed), id).control.status).toBe('passed');
+    expect(statusOf(sharedAutomated!.checkIds.map(na), id).control.status).toBe('not-applicable');
+  });
+
+  it('class guard: walks the catalogue — refutation-only on every non-automated control with checks, confirmation on every automated one', () => {
+    let automatedChecked = 0;
+    for (const c of ALL) {
+      if (c.checkIds.length === 0) continue;
+      const level = c.level;
+      const find = (fs: SecurityFinding[]) =>
+        generateBenchmarkReport(fs, level).categories.flatMap((cat) => cat.controls).find((x) => x.controlId === c.id)!;
+      if (c.verification === 'automated') {
+        automatedChecked++;
+        expect(find(c.checkIds.map(passed)).status, `${c.id} automated, all passed`).toBe('passed');
+      } else {
+        for (const id of c.checkIds) {
+          expect(find([failed(id)]).status, `${c.id} ${c.verification}, ${id} failed alone`).toBe('failed');
+        }
+        expect(find(c.checkIds.map(passed)).status, `${c.id} ${c.verification}, all passed`).toBe('unverified');
+      }
+    }
+    expect(automatedChecked).toBeGreaterThan(0);
+  });
+
+  it('the rule is keyed on "not automated", not on "forward": a manual control given a checkId in memory follows it', () => {
+    // No manual control carries checkIds in the catalogue today, so a predicate
+    // written as `=== 'forward'` would pass every other cell in this file.
+    // The catalogue objects are shared references; lend one a checkId and
+    // restore it.
+    const c = manualNoIds!;
+    const saved = c.checkIds;
+    try {
+      c.checkIds = ['ZZ-MANUAL-1'];
+      const find = (fs: SecurityFinding[]) =>
+        generateBenchmarkReport(fs, c.level).categories.flatMap((cat) => cat.controls).find((x) => x.controlId === c.id)!;
+      expect(find([failed('ZZ-MANUAL-1')]).status).toBe('failed');
+      expect(find([passed('ZZ-MANUAL-1')]).status).toBe('unverified');
+      expect(find([na('ZZ-MANUAL-1')]).status).toBe('unverified');
+    } finally {
+      c.checkIds = saved;
+    }
+  });
+});
+
+describe('#639 the MCP server benchmark tool renders the same verdict', () => {
+  it('RED-ON-BASE: the refutation-only checkId failed -> [FAIL] <subject> (<checkId>)', () => {
+    const r = assessBenchmarkFindings([failed(refutationId!)], 'L1');
+    const lines: string[] = (r as any).lines ?? [];
+    const row = lines.find((l) => l.includes(` ${subject.id} `));
+    expect(row, `no row for ${subject.id} in: ${lines.slice(0, 5).join(' | ')}`).toBeDefined();
+    expect(row).toMatch(/^\[FAIL\]/);
+    expect(row).toContain(refutationId!);
+  });
+
+  it('PIN: no records -> the subject stays [UNVERIFIED]', () => {
+    const r = assessBenchmarkFindings([], 'L1');
+    const lines: string[] = (r as any).lines ?? [];
+    const row = lines.find((l) => l.includes(` ${subject.id} `));
+    expect(row).toMatch(/^\[UNVERIFIED\]/);
+  });
+});

--- a/__tests__/benchmarks/oasb-1.test.ts
+++ b/__tests__/benchmarks/oasb-1.test.ts
@@ -94,8 +94,9 @@ describe('OASB-1 Benchmark', () => {
     it('manual and forward controls have empty checkIds or only semantic checkIds', () => {
       for (const control of allControls) {
         if (control.verification === 'manual' || control.verification === 'forward') {
-          // Semantic engine checkIds (SEM-*) are allowed on forward controls
-          // because they provide partial automated verification
+          // Semantic engine checkIds (SEM-*) are allowed on manual/forward
+          // controls as refutation checks: a measured failure fails the
+          // control, nothing they report passes it (#639)
           const nonSemanticIds = control.checkIds.filter((id) => !id.startsWith('SEM-'));
           expect(
             nonSemanticIds.length,

--- a/__tests__/cli/benchmark-forward-control-refutation.test.ts
+++ b/__tests__/cli/benchmark-forward-control-refutation.test.ts
@@ -1,0 +1,115 @@
+/**
+ * #639 — spawn-level: a wildcard MCP grant now moves the OASB-1 benchmark.
+ *
+ * Fixture: an `mcp.json` whose one server grants `allowedTools: ["*"]`
+ * (SEM-MCP-004, control 2.1's own audit step). Before: 2.1 read
+ * `unverified`, the tree beside a lockfile rated `Certified 100% (11/11)`
+ * at exit 0 and `--fail-below 100` exited 0. Now: `[-] 2.1`, `Passing`,
+ * `11/12`, `--fail-below 100` exits 1, SARIF carries `OASB-1/2.1`, and the
+ * same tree without the lockfile moves 56% (5/9) -> 50% (5/10).
+ *
+ * RED-ON-BASE cells fail on the 2a39b72 dist; PIN cells pass on both.
+ */
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { spawnSync } from 'node:child_process';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { assertDistFreshIfPresent, BUILT_CLI as CLI } from '../helpers/dist-freshness';
+
+beforeAll(assertDistFreshIfPresent);
+
+const MCP = '{"mcpServers":{"fs":{"command":"npx","args":["-y","@modelcontextprotocol/server-filesystem","./data"],"allowedTools":["*"]}}}\n';
+const FLAGS = ['-b', 'oasb-1', '-l', 'L1', '--no-machine-posture'];
+
+let wild: string;
+let wildLock: string;
+let empty: string;
+
+beforeAll(() => {
+  wild = fs.mkdtempSync(path.join(os.tmpdir(), 'hma-639-wild-'));
+  fs.writeFileSync(path.join(wild, 'mcp.json'), MCP);
+  wildLock = fs.mkdtempSync(path.join(os.tmpdir(), 'hma-639-lock-'));
+  fs.writeFileSync(path.join(wildLock, 'mcp.json'), MCP);
+  fs.writeFileSync(path.join(wildLock, 'package.json'), '{"name":"fx","version":"1.0.0","private":true,"dependencies":{}}\n');
+  fs.writeFileSync(path.join(wildLock, 'package-lock.json'), '{"name":"fx","version":"1.0.0","lockfileVersion":3,"requires":true,"packages":{"":{"name":"fx","version":"1.0.0"}}}\n');
+  empty = fs.mkdtempSync(path.join(os.tmpdir(), 'hma-639-empty-'));
+});
+
+afterAll(() => {
+  for (const d of [wild, wildLock, empty]) { try { fs.rmSync(d, { recursive: true, force: true }); } catch { /* best effort */ } }
+});
+
+function run(dir: string, args: string[]) {
+  const r = spawnSync(process.execPath, [CLI, 'secure', dir, ...FLAGS, ...args], {
+    encoding: 'utf8',
+    timeout: 240_000,
+    maxBuffer: 64 * 1024 * 1024,
+    env: { ...process.env, NO_COLOR: '1', OPENA2A_TELEMETRY: 'off', HOME: fs.mkdtempSync(path.join(os.tmpdir(), 'hma-home-')) },
+  });
+  return { status: r.status, stdout: r.stdout ?? '', stderr: r.stderr ?? '' };
+}
+
+function json(stdout: string): any {
+  return JSON.parse(stdout.slice(stdout.indexOf('{')));
+}
+
+describe('#639 a wildcard MCP grant fails OASB-1 control 2.1', { timeout: 300_000 }, () => {
+  it('fixture guard: the scan itself records the wildcard as SEM-MCP-004', () => {
+    const r = spawnSync(process.execPath, [CLI, 'secure', wild, '--no-machine-posture', '--format', 'json'], {
+      encoding: 'utf8', timeout: 240_000, maxBuffer: 64 * 1024 * 1024,
+      env: { ...process.env, NO_COLOR: '1', OPENA2A_TELEMETRY: 'off', HOME: fs.mkdtempSync(path.join(os.tmpdir(), 'hma-home-')) },
+    });
+    const body = json(r.stdout ?? '');
+    const recs = (body.allFindings ?? body.findings).filter((f: any) => f.checkId === 'SEM-MCP-004');
+    expect(recs.length).toBeGreaterThan(0);
+  });
+
+  it('RED-ON-BASE text: [-] 2.1, the category shows 1/2, compliance 50% (5/10)', () => {
+    const r = run(wild, ['--verbose']);
+    expect(r.stdout).toMatch(/\[-\] 2\.1: Explicit Capability Grants/);
+    expect(r.stdout).toMatch(/SEM-MCP-004: MCP server "fs" has allowedTools: \["\*"\]/);
+    expect(r.stdout).toMatch(/Capability & Authorization: 1\/2 \(50%\)/);
+    expect(r.stdout).toMatch(/Compliance: 50% \(5\/10 verified controls\)/);
+    expect(r.stdout).toMatch(/Unverified: 16 controls/);
+    expect(r.status).toBe(1);
+  });
+
+  it('RED-ON-BASE json: 2.1 failed with the SEM-MCP-004 finding and the record remediation', () => {
+    const body = json(run(wild, ['--format', 'json']).stdout);
+    const c = body.categories.flatMap((x: any) => x.controls).find((x: any) => x.controlId === '2.1');
+    expect(c.status).toBe('failed');
+    expect(c.findings[0]).toMatch(/^SEM-MCP-004: /);
+    expect(c.notApplicableSubjects).toBeUndefined();
+    expect(body.failedControls).toBe(5);
+    expect(body.unverifiedControls).toBe(16);
+    expect(body.l1Compliance).toBe(50);
+  });
+
+  it('RED-ON-BASE sarif: an OASB-1/2.1 result is emitted', () => {
+    const body = json(run(wild, ['--format', 'sarif']).stdout);
+    const ids = body.runs[0].results.map((x: any) => x.ruleId);
+    expect(ids).toContain('OASB-1/2.1');
+    expect(ids).toHaveLength(5);
+  });
+
+  it('RED-ON-BASE with a lockfile: Certified 100% (11/11) exit 0 becomes Passing 11/12, and --fail-below 100 exits 1', () => {
+    const r = run(wildLock, []);
+    expect(r.stdout).toMatch(/Rating: Passing/);
+    expect(r.stdout).toMatch(/Compliance: 92% \(11\/12 verified controls\)/);
+    expect(r.stdout).not.toMatch(/Certified/);
+    expect(r.status).toBe(0);
+    const gated = run(wildLock, ['--fail-below', '100']);
+    expect(gated.status).toBe(1);
+    const lenient = run(wildLock, ['--fail-below', '90']);
+    expect(lenient.status).toBe(0);
+  });
+
+  it('PIN: an empty directory is unmoved — 2.1 unverified, 3/4/19/0, compliance 43', () => {
+    const body = json(run(empty, ['--format', 'json']).stdout);
+    const c = body.categories.flatMap((x: any) => x.controls).find((x: any) => x.controlId === '2.1');
+    expect(c.status).toBe('unverified');
+    expect([body.passedControls, body.failedControls, body.unverifiedControls, body.notApplicableControls]).toEqual([3, 4, 19, 0]);
+    expect(body.compliance).toBe(43);
+  });
+});

--- a/src/benchmarks/benchmark-report.ts
+++ b/src/benchmarks/benchmark-report.ts
@@ -73,18 +73,23 @@ export function generateBenchmarkReport(
     const naSubjects: string[] = [];
     let remediation: string | undefined;
 
-    if (control.verification === 'manual' || control.verification === 'forward') {
-      // Manual/forward controls are unverified (human must check)
-      status = 'unverified';
-      unverifiedCount++;
-      // Use control's remediation for manual/forward controls
-      remediation = control.remediation;
-    } else if (control.checkIds.length === 0) {
-      // No automated checks defined
+    if (control.checkIds.length === 0) {
+      // No automated check maps to this control (manual, forward, or an
+      // empty mapping): a person must verify it; never credited.
       status = 'unverified';
       unverifiedCount++;
       remediation = control.remediation;
     } else {
+      // #639 — `verification` says whether the mapped checks are SUFFICIENT
+      // to settle the control. `automated`: they are. `manual`/`forward`:
+      // they are not, so their checks can only REFUTE it — a measured
+      // failure fails the control (the violation is the control's own audit
+      // step); a clean, absent-subject or missing record leaves it
+      // `unverified`, never passed and never not-applicable, because
+      // automation cannot confirm what the label says a person must.
+      // Before this the manual/forward test ran BEFORE the record scan, so
+      // a failing SEM-MCP-004 (2.1's wildcard-grant check) moved nothing.
+      const refuteOnly = control.verification !== 'automated';
       // Check all mapped check IDs
       let hasMeasured = false;
       let hasFailure = false;
@@ -113,21 +118,26 @@ export function generateBenchmarkReport(
           }
         }
       }
-      // Only mark as passed if we actually verified something. A MEASURED
-      // record outranks an NA sibling (a control with one check that measured
-      // and one whose subject is absent WAS measured); `not-applicable` is
-      // awarded only when NA records are all the control has; nothing at all
-      // stays `unverified` — a type-scoped-off check leaves NO record, and
-      // crediting that as anything would relaunder the absence #458 removed.
-      if (hasMeasured) {
-        if (hasFailure) {
-          status = 'failed';
-          failedCount++;
-          remediation = remediation || control.remediation;
-        } else {
-          status = 'passed';
-          passedCount++;
-        }
+      // Resolution: a measured failure fails the control whatever its
+      // verification; a refute-only control with no failure is unverified;
+      // an automated control is passed only when something MEASURED clean
+      // (a measured record outranks an NA sibling — a control with one
+      // check that measured and one whose subject is absent WAS measured),
+      // `not-applicable` only when NA records are all it has, and nothing
+      // at all stays `unverified` — a type-scoped-off check leaves NO
+      // record, and crediting that as anything would relaunder the absence
+      // #458 removed.
+      if (hasFailure) {
+        status = 'failed';
+        failedCount++;
+        remediation = remediation || control.remediation;
+      } else if (refuteOnly) {
+        status = 'unverified';
+        unverifiedCount++;
+        remediation = control.remediation;
+      } else if (hasMeasured) {
+        status = 'passed';
+        passedCount++;
       } else if (hasNotApplicable) {
         status = 'not-applicable';
         notApplicableCount++;

--- a/src/benchmarks/oasb-1.ts
+++ b/src/benchmarks/oasb-1.ts
@@ -32,10 +32,23 @@ export interface BenchmarkControl {
   /** Default value/state in most deployments */
   defaultValue?: string;
 
-  /** HackMyAgent check IDs that verify this control */
+  /**
+   * HackMyAgent check IDs mapped to this control. Whether they can SETTLE it
+   * is `verification`'s call: on an `automated` control they are sufficient
+   * (passed / failed / not-applicable); on a `manual` or `forward` control
+   * they are refutation-only — a measured failure fails the control, nothing
+   * they report can pass it. A check mapped onto a non-automated control must
+   * therefore be refutation-grade: its failure is a direct violation of the
+   * control's MUST text (#639).
+   */
   checkIds: string[];
 
-  /** Control is automated, manual, or forward-looking */
+  /**
+   * `automated`: the mapped checks are sufficient to settle the control.
+   * `manual`: a person must confirm it; mapped checks can only refute it.
+   * `forward`: as manual, and the requirement is ahead of current practice —
+   * no artifact convention exists yet for a scanner to confirm it.
+   */
   verification: 'automated' | 'manual' | 'forward';
 
   /** External references (OWASP, NIST, etc.) */


### PR DESCRIPTION
## What

OASB-1 control 2.1 (Explicit Capability Grants) is `forward`-verified and also maps two automated checks, SEM-MCP-001 and SEM-MCP-004. `generateBenchmarkReport` classified every manual/forward control `unverified` **before** reading its records, so a measured failure of a mapped check moved nothing in any benchmark surface. A wildcard MCP grant (`allowedTools: ["*"]`) is the exact violation 2.1's audit step 4 names; on main an `mcp.json` carrying one, beside a lockfile, reads `Rating: Certified`, `Compliance: 100% (11/11)`, exit 0, `--fail-below 100` exit 0 — while `secure` on the same directory reports the wildcard as a HIGH SEM-MCP-004 finding.

Ruled (two independent chief passes, converged; summary on the issue): records are read for every control that maps checks, and a manual/forward control's checks are **refutation checks** — a measured failure fails the control; a clean, absent-subject, or missing record leaves it `unverified`, never `passed`, never `not-applicable`, because automation cannot confirm what the label says a person must. Automated controls are unchanged. No catalogue change (2.1 keeps `forward` and its mapping; SEM-MCP-004 stays homed on 2.1), no new state, no shape change, no OASB-1 version bump.

## Observable deltas (measured on this build vs 2a39b72)

Fixture: `mcp.json` = `{"mcpServers":{"fs":{"command":"npx","args":["-y","@modelcontextprotocol/server-filesystem","./data"],"allowedTools":["*"]}}}`, `-b oasb-1 -l L1 --no-machine-posture`.

| surface | before | after |
|---|---|---|
| text | `Not Passing`, `56% (5/9)`, `Unverified: 17`, `[+] Capability & Authorization: 1/1 (100%)`, `[?] 2.1 (manual/forward)` | `Not Passing`, `50% (5/10)`, `Unverified: 16`, `[~] Capability & Authorization: 1/2 (50%)`, `[-] 2.1: Explicit Capability Grants` + the SEM-MCP-004 line under `--verbose` |
| json | 2.1 `unverified`, `failedControls` 4 | 2.1 `failed`, `findings[0]` = `SEM-MCP-004: ...`, `failedControls` 5, `l1Compliance` 50 |
| sarif | 4 results (6.1-6.4) | 5 results, `OASB-1/2.1` added |
| with a lockfile | `Certified`, `100% (11/11)`, exit 0; `--fail-below 100` exit 0 | `Passing`, `92% (11/12)`, exit 0; `--fail-below 100` exit 1; `--fail-below 90` exit 0 |
| MCP server tool | `[UNVERIFIED] 2.1 Explicit Capability Grants` | `[FAIL] 2.1 Explicit Capability Grants (SEM-MCP-004)` |
| empty directory | 2.1 `unverified`, 3/4/19/0, compliance 43 | identical (timestamp-stripped JSON byte-equal) |
| corpus `mcp/benign/readonly-fs-mcp` | 2.1 `unverified`, 5/4/17/0, compliance 56 | identical (timestamp-stripped JSON byte-equal) |

Ratings can only drop and exit codes can only rise, and only on trees that already carry a SEM-MCP-001/004 finding. 2.1 is the only control in the class today (census in the premise cell: exactly one non-automated control maps checkIds).

## Verify

```
mkdir -p /tmp/hma-639 && printf '%s\n' '{"mcpServers":{"fs":{"command":"npx","args":["-y","@modelcontextprotocol/server-filesystem","./data"],"allowedTools":["*"]}}}' > /tmp/hma-639/mcp.json
hackmyagent secure /tmp/hma-639 -b oasb-1 -l L1 --no-machine-posture --verbose | grep -E "^Rating|^Compliance|2\.1"
# before: Not Passing / 56% (5/9) / [?] 2.1 ... (manual/forward)   after: Not Passing / 50% (5/10) / [-] 2.1: Explicit Capability Grants
```

## Tests

- `__tests__/benchmarks/benchmark-report-refute-only.test.ts` — subject selected by shape (the premise cell fails loudly if the census changes); 5 RED-ON-BASE cells (refutation-only id failed alone -> failed / l1 0 / Not Passing; shared id failed -> both controls fail; clean sibling does not outvote a violation; NA + failed -> failed; MCP tool `[FAIL]` row) and PIN cells that kill the symmetric variant (all passed -> `unverified`, out of the denominator) and forward-NA (all NA -> `unverified`, no `notApplicableSubjects`), plus a class guard walking the catalogue.
- `__tests__/cli/benchmark-forward-control-refutation.test.ts` — the fixture above through the CLI: text, json, sarif, the lockfile `Certified -> Passing` cell with `--fail-below 100/90`, and the empty-directory PIN.
- Red-proof on main's assessor (its `benchmark-report.ts` swapped in, rebuilt): 10 red = the nine RED-marked cells + the class guard; every premise and PIN cell green on both builds. Mutations (one property each, rebuilt, then restored identical to HEAD and re-run 20/20): m1 `refuteOnly = false` (non-automated treated as automated) killed by the symmetric PIN, the forward-NA PIN and the class guard; m2 a refute-only control never fails (`hasFailure && !refuteOnly`) killed by all ten red cells; m3 honour NA for non-automated killed by the forward-NA PIN; m4 (`=== 'forward'` instead of `!== 'automated'`) is **unkillable today** — no manual control carries checkIds — and is recorded as such; the class guard kills it the day one does.
- JSDoc on `checkIds`/`verification` and the `oasb-1.test.ts` invariant comment now carry the rule; the step-5 CHANGELOG sentence that adopted the old reading is rewritten in this PR.

## Adversarial round (independent agent on git-archive trees of base and head)

0 CRITICAL / 0 HIGH, no regression: a 48-cell matrix (3 verification labels × checkIds empty/non-empty × 8 record sets) run on both builds differs in exactly the eight refute-only failure cells; all 16 automated cells identical; counters sum in every cell; every CHANGELOG number re-measured. Its m4 observation (the `=== 'forward'` mutant survived because no manual control carries checkIds) is closed: a cell now lends a manual control a checkId in memory (restored in `finally`) and asserts the same rule, and m4 is re-run killed. Pre-existing findings filed, not fixed here: #651 (assessor keeps only the last record per checkId — two wildcard servers show one finding in text/json while SARIF lists both; a later NA record can mask a measured failure on an automated control), #652 (latent `notAssessedLines` denominator mismatch, unreachable until a second refute-only control is mapped); #645 (dead `SEMANTIC_OASB_MAPPINGS` table) re-confirmed; #644's title narrowed by comment (SEM-MCP-003 does set a line).

## Gate

Full suite on the final commit (rebuilt first — an earlier run was void on a stale dist and is not counted): 335 files / 4732 passed / 0 failed, npm exit 0. Lint 0. Self-scan exit 0 (635 files read, 62/62 groups, no in-scope critical/high). /pre-push-review PASS.

Merge != release: 0.33.0's tag is not before 2026-08-27T21:05Z; this merges before it, so the token dry-run is re-run on the merge commit before tagging.

Closes #639
