### PR TITLE
secure: one settled outcome feeds every outbound record; exit 2 sends nothing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,19 +31,28 @@ record, or omitted — a derived stand-in number is worse than no number).
 `measured/examined/total/unit`, so `jq '.coverage.measured'` is one
 predicate across `check`, `secure` and every wire (#283).
 
-A run that settled `EXIT_UNMEASURED` (2) now posts NOTHING: `--publish`,
-`--registry-report`, `--version-id`, `--ci-publish` and the contribution are
-withheld before their own preconditions, one line says so (`Registry:
-nothing sent — ...`), and `--json` carries
+A run that settled `EXIT_UNMEASURED` (2) posts no outcome record:
+`--publish`, `--registry-report`, `--version-id`, `--ci-publish` and the
+contribution are withheld before their own preconditions, one line says so
+(`Registry: nothing sent — ...`), and `--json` carries
 `publish: {success: false, attempted: false, reason: 'unmeasured'}`. No
 current wire can receive the disclosure honestly — the server manufactures
 `passed` from whatever counts arrive — so the smaller true statement is
-silence plus the sentence.
+silence plus the sentence. (The consent-gated NanoMind classification
+telemetry stream flushes during the scan and is outside this change's
+scope — moving it behind the settlement point is filed separately.) A run
+with an unread input AND a counted critical now exits 2, not 1: the
+per-channel finding lines used to assign over the unmeasured floor the
+settlement point had set, the precedence `raiseExitCode` documents.
 
 Update pipelines: a consumer that read the ci body's `status` or the event's
-`score` gets the run's real figures now (a suppressed critical counts; the
-direction can only be toward more findings disclosed); the publish payload
-no longer carries `subReports.hardening.passRate`. Verify:
+`score` gets the run's real figures now — a suppressed critical counts, and
+a `--fix`-confirmed repair no longer counts, so individual counts can move
+in either direction toward what the run settled. The community report's
+counts and status now describe the RUN (a machine-local critical fails it
+even though the vulnerability list stays package-relevant — the record
+carries both). The publish payload no longer carries
+`subReports.hardening.passRate`. Verify:
 `hackmyagent secure <dir> --format json | jq '{verdict, exitCode, measured, counts}'`.
 
 ### A forward-verified control now fails when its mapped check fails

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,48 @@ All notable changes to HackMyAgent are documented in this file.
 
 ## [Unreleased]
 
+### One settled outcome feeds every outbound record, and an unmeasured run sends nothing
+
+Every record that left the process about a `secure` run recomputed its own
+figures from the narrowed findings list. The Registry publish payload
+rebuilt a composite score (with a `passRate` ratio no server reads); the
+`--ci-publish` body derived `status: passed, counts all 0` for a run that
+displayed 49 findings and exited 1 (#464); the contribution event scored
+`passed/total` — 0 for any tree with one failure — under a third verdict
+ladder, with `totalChecks` as the length of whatever list it was handed
+(#519). Each was a second spelling of a settlement the CLI had already made.
+
+Now one projection — the settled outcome: score, verdict, exit code,
+measured, counts over the suppression-inclusive gate set, coverage — is
+computed at the run's single settlement point and READ by every wire: the
+publish payload (recompute and `passRate` deleted; typed
+`criticalCount/highCount/mediumCount/lowCount`, `measured`, `exitCode`,
+`coverage`, suppression rows and `schemaVersion` ride top-level), the
+remediation score, the scan/community/ci reports (`status` and counts from
+the record; `rawReport.settledOutcome` carries it whole), and the
+contribution event (`score` is the displayed 0-100; one verdict ladder;
+`totalChecks` is the completed-execution count from the run's coverage
+record, or omitted — a derived stand-in number is worse than no number).
+`secure --json`'s top level gains the record's flat keys — `verdict`,
+`exitCode`, `measured`, `counts` — and `coverage` gains
+`measured/examined/total/unit`, so `jq '.coverage.measured'` is one
+predicate across `check`, `secure` and every wire (#283).
+
+A run that settled `EXIT_UNMEASURED` (2) now posts NOTHING: `--publish`,
+`--registry-report`, `--version-id`, `--ci-publish` and the contribution are
+withheld before their own preconditions, one line says so (`Registry:
+nothing sent — ...`), and `--json` carries
+`publish: {success: false, attempted: false, reason: 'unmeasured'}`. No
+current wire can receive the disclosure honestly — the server manufactures
+`passed` from whatever counts arrive — so the smaller true statement is
+silence plus the sentence.
+
+Update pipelines: a consumer that read the ci body's `status` or the event's
+`score` gets the run's real figures now (a suppressed critical counts; the
+direction can only be toward more findings disclosed); the publish payload
+no longer carries `subReports.hardening.passRate`. Verify:
+`hackmyagent secure <dir> --format json | jq '{verdict, exitCode, measured, counts}'`.
+
 ### A forward-verified control now fails when its mapped check fails
 
 OASB-1 control 2.1 (Explicit Capability Grants) is forward-verified and also

--- a/__tests__/cli/settled-outbound-claims.test.ts
+++ b/__tests__/cli/settled-outbound-claims.test.ts
@@ -100,7 +100,48 @@ describe('#464 the --json document IS the settled record', { timeout: 300_000 },
   });
 });
 
+describe('#464 the exit precedence holds where the classes overlap', { timeout: 300_000 }, () => {
+  it('RED-ON-BASE: an unread input AND a counted critical exit 2 — the finding line RAISES, never assigns over the floor', () => {
+    const overlap = fs.mkdtempSync(path.join(os.tmpdir(), 'hma-464-overlap-'));
+    try {
+      fs.cpSync(CORPUS, overlap, { recursive: true });
+      fs.writeFileSync(path.join(overlap, 'locked.js'), 'const secret = 1;\n');
+      fs.chmodSync(path.join(overlap, 'locked.js'), 0o000);
+      const r = run(overlap, ['--format', 'json']);
+      const j = json(r.stdout);
+      expect(j.exitCode).toBe(2);
+      expect(j.verdict).toBe('fail');
+      expect(r.status).toBe(2);
+    } finally {
+      try { fs.chmodSync(path.join(overlap, 'locked.js'), 0o600); } catch { /* best effort */ }
+      try { fs.rmSync(overlap, { recursive: true, force: true }); } catch { /* best effort */ }
+    }
+  });
+});
+
 describe('#464 an unmeasured run withholds every outbound arm', { timeout: 300_000 }, () => {
+  it('RED-ON-BASE: --no-contribute beats persisted consent in the withheld line — it never claims a contribution the user disabled', () => {
+    // Consent ON in the config, disabled for this run by the flag: the line
+    // must not list `contribution`. Without the flag (consent standing) it
+    // must. This is what makes the two spellings distinguishable.
+    const home = fs.mkdtempSync(path.join(os.tmpdir(), 'hma-home-consent-'));
+    fs.mkdirSync(path.join(home, '.opena2a'), { recursive: true });
+    fs.writeFileSync(path.join(home, '.opena2a', 'config.json'), '{"contribute":{"enabled":true}}\n');
+    const spawn = (args: string[]) => {
+      const r = spawnSync(process.execPath, [CLI, 'secure', unread, '--no-machine-posture', ...args], {
+        encoding: 'utf8', timeout: 240_000, maxBuffer: 64 * 1024 * 1024,
+        env: { ...process.env, NO_COLOR: '1', OPENA2A_TELEMETRY: 'off', HOME: home },
+      });
+      return { status: r.status, stderr: r.stderr ?? '' };
+    };
+    const disabled = spawn(['--no-contribute', '--publish', '--registry-url', DEAD_REGISTRY]);
+    expect(disabled.status).toBe(2);
+    expect(disabled.stderr).toContain('Withheld: --publish');
+    expect(disabled.stderr).not.toContain('contribution');
+    const standing = spawn(['--publish', '--registry-url', DEAD_REGISTRY]);
+    expect(standing.stderr).toContain('Withheld: --publish, contribution');
+  });
+
   it('RED-ON-BASE json: --publish is withheld with the one line, and the document discloses it', () => {
     const r = run(unread, ['--format', 'json', '--publish', '--registry-url', DEAD_REGISTRY]);
     expect(r.status).toBe(2);

--- a/__tests__/cli/settled-outbound-claims.test.ts
+++ b/__tests__/cli/settled-outbound-claims.test.ts
@@ -1,0 +1,139 @@
+/**
+ * #464 #519 #283 — spawn-level: the `--json` document IS the settled record,
+ * the exit code and the document agree, and an unmeasured run withholds
+ * every outbound arm with one line saying so.
+ *
+ * Reference fixture: the corpus `repo/buggy/leaky-env-example` with an
+ * `.hmaignore` suppressing its critical (`!CONFIG-004`) — the exact tree
+ * whose suppression once moved the exit from 1 to 0 (#450) and whose
+ * outbound records carried `passed` (#464). Measured on this build:
+ * verdict fail, exitCode 1, counts {critical:1, high:0, medium:1, low:1}
+ * (the suppressed critical COUNTED), score 69, coverage 8/8 files.
+ *
+ * RED-ON-BASE cells fail on the 3570f15 build; PIN cells pass on both.
+ */
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { spawnSync } from 'node:child_process';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { assertDistFreshIfPresent, BUILT_CLI as CLI } from '../helpers/dist-freshness';
+import { pickSettledOutcome, SETTLED_OUTCOME_KEYS } from '../../src/hardening/settled-outcome';
+
+beforeAll(assertDistFreshIfPresent);
+
+const CORPUS = '/Users/ecolibria/.opena2a/corpus/repo/buggy/leaky-env-example';
+// validateRegistryUrl allows https and http://localhost only; port 9
+// (discard) refuses the connection, so an ATTEMPT fails as a network error.
+const DEAD_REGISTRY = 'http://localhost:9';
+
+let leaky: string;
+let unread: string;
+
+beforeAll(() => {
+  // The corpus tree is the shared adversarial fixture set; copy, never touch.
+  expect(fs.existsSync(CORPUS), `corpus fixture missing: ${CORPUS}`).toBe(true);
+  leaky = fs.mkdtempSync(path.join(os.tmpdir(), 'hma-464-leaky-'));
+  fs.cpSync(CORPUS, leaky, { recursive: true });
+  fs.writeFileSync(path.join(leaky, '.hmaignore'), '!CONFIG-004\n');
+
+  unread = fs.mkdtempSync(path.join(os.tmpdir(), 'hma-464-unread-'));
+  fs.writeFileSync(path.join(unread, 'index.js'), 'module.exports = 1;\n');
+  fs.writeFileSync(path.join(unread, 'locked.js'), 'const secret = 1;\n');
+  fs.chmodSync(path.join(unread, 'locked.js'), 0o000);
+});
+
+afterAll(() => {
+  try { fs.chmodSync(path.join(unread, 'locked.js'), 0o600); } catch { /* best effort */ }
+  for (const d of [leaky, unread]) { try { fs.rmSync(d, { recursive: true, force: true }); } catch { /* best effort */ } }
+});
+
+function run(dir: string, args: string[]) {
+  const r = spawnSync(process.execPath, [CLI, 'secure', dir, '--no-machine-posture', ...args], {
+    encoding: 'utf8',
+    timeout: 240_000,
+    maxBuffer: 64 * 1024 * 1024,
+    env: { ...process.env, NO_COLOR: '1', OPENA2A_TELEMETRY: 'off', HOME: fs.mkdtempSync(path.join(os.tmpdir(), 'hma-home-')) },
+  });
+  return { status: r.status, stdout: r.stdout ?? '', stderr: r.stderr ?? '' };
+}
+
+function json(stdout: string): any {
+  return JSON.parse(stdout.slice(stdout.indexOf('{')));
+}
+
+describe('#464 the --json document IS the settled record', { timeout: 300_000 }, () => {
+  it('RED-ON-BASE: flat record keys ride the top level, the exit code and the document agree, and a suppressed critical is COUNTED', () => {
+    const r = run(leaky, ['--format', 'json']);
+    const j = json(r.stdout);
+    expect(j.verdict).toBe('fail');
+    expect(j.exitCode).toBe(1);
+    expect(r.status).toBe(j.exitCode);
+    expect(j.measured).toBe(true);
+    expect(j.counts.critical).toBeGreaterThanOrEqual(1);
+    expect((j.suppressed ?? []).map((s: any) => s.checkId)).toContain('CONFIG-004');
+    expect(j.coverage).toMatchObject({ measured: true, unit: 'file' });
+    expect(j.coverage.total).toBe(j.coverage.examined);
+  });
+
+  it('RED-ON-BASE: pickSettledOutcome reconstructs a complete record from the document alone', () => {
+    const j = json(run(leaky, ['--format', 'json']).stdout);
+    const record = pickSettledOutcome(j);
+    for (const key of ['score', 'verdict', 'exitCode', 'measured', 'counts', 'coverage'] as const) {
+      expect(record[key as keyof typeof record], key).toBeDefined();
+    }
+    expect(Object.keys(record).every((k) => (SETTLED_OUTCOME_KEYS as readonly string[]).includes(k))).toBe(true);
+    expect(record.score).toBe(j.score);
+  });
+
+  it('RED-ON-BASE: an exit-2 run CARRIES its warn/fail band — the unmeasured exit hides no verdict', () => {
+    // Even this two-file tree carries counted advisories, so the band is
+    // warn; the null verdict (exit 2 with nothing counted at all) is pinned
+    // at the unit level, where the record can be built from an empty gate.
+    const r = run(unread, ['--format', 'json']);
+    const j = json(r.stdout);
+    expect(r.status).toBe(2);
+    expect(j.exitCode).toBe(2);
+    expect(j.measured).toBe(false);
+    expect(['warn', 'fail']).toContain(j.verdict);
+    expect(j.coverage.total).toBeGreaterThan(j.coverage.examined);
+  });
+});
+
+describe('#464 an unmeasured run withholds every outbound arm', { timeout: 300_000 }, () => {
+  it('RED-ON-BASE json: --publish is withheld with the one line, and the document discloses it', () => {
+    const r = run(unread, ['--format', 'json', '--publish', '--registry-url', DEAD_REGISTRY]);
+    expect(r.status).toBe(2);
+    expect(r.stderr).toContain('Registry: nothing sent —');
+    expect(r.stderr).toContain('Withheld: --publish');
+    const j = json(r.stdout);
+    expect(j.publish).toMatchObject({ success: false, attempted: false, reason: 'unmeasured' });
+  });
+
+  it('RED-ON-BASE text: the same withhold line prints on the text arm', () => {
+    const r = run(unread, ['--publish', '--registry-url', DEAD_REGISTRY]);
+    expect(r.status).toBe(2);
+    expect(r.stderr).toContain('Registry: nothing sent —');
+    expect(r.stderr).toContain('Withheld: --publish');
+    expect(r.stderr).toContain('not read');
+  });
+
+  it('RED-ON-BASE: --ci-publish is withheld before its own precondition (no HMAC error on an unmeasured run)', () => {
+    const r = run(unread, ['--ci-publish', '--registry-url', DEAD_REGISTRY]);
+    expect(r.status).toBe(2);
+    expect(r.stderr).toContain('Withheld: --ci-publish');
+    expect(r.stderr).not.toContain('CI_SCAN_HMAC_SECRET');
+  });
+
+  it('PIN: a measured run still ATTEMPTS the publish (the withhold is exit-2 only)', () => {
+    const r = run(leaky, ['--format', 'json', '--publish', '--registry-url', DEAD_REGISTRY]);
+    const j = json(r.stdout);
+    expect(r.stderr).not.toContain('Registry: nothing sent');
+    // The dead registry fails the attempt; the failure is a network failure,
+    // never the unmeasured disclosure.
+    if (j.publish) {
+      expect(j.publish.reason).not.toBe('unmeasured');
+      expect(j.publish.attempted).not.toBe(false);
+    }
+  });
+});

--- a/__tests__/cli/settled-outbound-claims.test.ts
+++ b/__tests__/cli/settled-outbound-claims.test.ts
@@ -22,7 +22,12 @@ import { pickSettledOutcome, SETTLED_OUTCOME_KEYS } from '../../src/hardening/se
 
 beforeAll(assertDistFreshIfPresent);
 
-const CORPUS = '/Users/ecolibria/.opena2a/corpus/repo/buggy/leaky-env-example';
+// The corpus is the PRIVATE shared fixture set (same idiom as
+// soul-corpus-direction.test.ts): resolve it from the running user's home
+// and SKIP the corpus-backed cells where it is absent (external CI) — the
+// unread-input cells below build their own fixtures and always run.
+const CORPUS = path.join(os.homedir(), '.opena2a', 'corpus', 'repo', 'buggy', 'leaky-env-example');
+const corpusAvailable = fs.existsSync(CORPUS);
 // validateRegistryUrl allows https and http://localhost only; port 9
 // (discard) refuses the connection, so an ATTEMPT fails as a network error.
 const DEAD_REGISTRY = 'http://localhost:9';
@@ -31,11 +36,12 @@ let leaky: string;
 let unread: string;
 
 beforeAll(() => {
-  // The corpus tree is the shared adversarial fixture set; copy, never touch.
-  expect(fs.existsSync(CORPUS), `corpus fixture missing: ${CORPUS}`).toBe(true);
-  leaky = fs.mkdtempSync(path.join(os.tmpdir(), 'hma-464-leaky-'));
-  fs.cpSync(CORPUS, leaky, { recursive: true });
-  fs.writeFileSync(path.join(leaky, '.hmaignore'), '!CONFIG-004\n');
+  if (corpusAvailable) {
+    // The corpus tree is the shared adversarial fixture set; copy, never touch.
+    leaky = fs.mkdtempSync(path.join(os.tmpdir(), 'hma-464-leaky-'));
+    fs.cpSync(CORPUS, leaky, { recursive: true });
+    fs.writeFileSync(path.join(leaky, '.hmaignore'), '!CONFIG-004\n');
+  }
 
   unread = fs.mkdtempSync(path.join(os.tmpdir(), 'hma-464-unread-'));
   fs.writeFileSync(path.join(unread, 'index.js'), 'module.exports = 1;\n');
@@ -63,7 +69,7 @@ function json(stdout: string): any {
 }
 
 describe('#464 the --json document IS the settled record', { timeout: 300_000 }, () => {
-  it('RED-ON-BASE: flat record keys ride the top level, the exit code and the document agree, and a suppressed critical is COUNTED', () => {
+  it.skipIf(!corpusAvailable)('RED-ON-BASE: flat record keys ride the top level, the exit code and the document agree, and a suppressed critical is COUNTED', () => {
     const r = run(leaky, ['--format', 'json']);
     const j = json(r.stdout);
     expect(j.verdict).toBe('fail');
@@ -76,7 +82,7 @@ describe('#464 the --json document IS the settled record', { timeout: 300_000 },
     expect(j.coverage.total).toBe(j.coverage.examined);
   });
 
-  it('RED-ON-BASE: pickSettledOutcome reconstructs a complete record from the document alone', () => {
+  it.skipIf(!corpusAvailable)('RED-ON-BASE: pickSettledOutcome reconstructs a complete record from the document alone', () => {
     const j = json(run(leaky, ['--format', 'json']).stdout);
     const record = pickSettledOutcome(j);
     for (const key of ['score', 'verdict', 'exitCode', 'measured', 'counts', 'coverage'] as const) {
@@ -101,7 +107,7 @@ describe('#464 the --json document IS the settled record', { timeout: 300_000 },
 });
 
 describe('#464 the exit precedence holds where the classes overlap', { timeout: 300_000 }, () => {
-  it('RED-ON-BASE: an unread input AND a counted critical exit 2 — the finding line RAISES, never assigns over the floor', () => {
+  it.skipIf(!corpusAvailable)('RED-ON-BASE: an unread input AND a counted critical exit 2 — the finding line RAISES, never assigns over the floor', () => {
     const overlap = fs.mkdtempSync(path.join(os.tmpdir(), 'hma-464-overlap-'));
     try {
       fs.cpSync(CORPUS, overlap, { recursive: true });
@@ -166,7 +172,7 @@ describe('#464 an unmeasured run withholds every outbound arm', { timeout: 300_0
     expect(r.stderr).not.toContain('CI_SCAN_HMAC_SECRET');
   });
 
-  it('PIN: a measured run still ATTEMPTS the publish (the withhold is exit-2 only)', () => {
+  it.skipIf(!corpusAvailable)('PIN: a measured run still ATTEMPTS the publish (the withhold is exit-2 only)', () => {
     const r = run(leaky, ['--format', 'json', '--publish', '--registry-url', DEAD_REGISTRY]);
     const j = json(r.stdout);
     expect(r.stderr).not.toContain('Registry: nothing sent');

--- a/__tests__/registry/publish-payload-not-applicable.test.ts
+++ b/__tests__/registry/publish-payload-not-applicable.test.ts
@@ -92,10 +92,12 @@ describe('#458 — not-applicable records at the publish boundary', () => {
     const hardening = payload.subReports.hardening as {
       totalChecks: number;
       failedChecks: number;
-      passRate: number;
     };
     expect(hardening.totalChecks, 'NA is in no denominator anywhere').toBe(2);
     expect(hardening.failedChecks).toBe(1);
-    expect(hardening.passRate).toBe(50);
+    // #464 deleted `passRate` — the ratio no server reads was a second
+    // spelling of the settled score. The judgment this cell carries (an NA
+    // record enters no denominator) lives on in the two counts above.
+    expect(hardening).not.toHaveProperty('passRate');
   });
 });

--- a/__tests__/registry/settled-outcome-wires.test.ts
+++ b/__tests__/registry/settled-outcome-wires.test.ts
@@ -222,6 +222,17 @@ describe('the contribution event reads the record (#519)', () => {
     expect('totalChecks' in (without.scanSummary as object)).toBe(false);
   });
 
+  it('RED-ON-BASE: the settled extras ride the summary, and an absent row list stays absent', () => {
+    const withRows = makeResult({ suppressed: [suppressedRow] } as any);
+    const s = settledOutcome(withRows, 1);
+    const event = buildScanEvent('fx', '/tmp/fx-none', withRows.findings as any, 900, s, 2);
+    expect(event.scanSummary?.exitCode).toBe(1);
+    expect(event.scanSummary?.rawScore).toBe(74);
+    expect(event.scanSummary?.scoreClamped).toBe(true);
+    expect(event.scanSummary?.suppressed).toEqual([suppressedRow]);
+    expect('outOfScope' in (event.scanSummary as object)).toBe(false);
+  });
+
   it('PIN: the no-record callers (scan-soul, detect) keep the legacy derivation', () => {
     const event = buildScanEvent('fx', '/tmp/fx-none', r.findings as any, 900);
     expect(event.scanSummary?.totalChecks).toBe(2);

--- a/__tests__/registry/settled-outcome-wires.test.ts
+++ b/__tests__/registry/settled-outcome-wires.test.ts
@@ -1,0 +1,269 @@
+/**
+ * #464 #519 #283 — one settled outcome feeds every outbound record.
+ *
+ * Before: each wire recomputed its own figures from the narrowed findings
+ * list — the publish payload rebuilt a composite (with a passRate ratio no
+ * server reads), the ci body derived `status: passed, counts all 0` for a
+ * run that displayed 49 findings and exited 1, and the contribution event
+ * scored `passed/total` (0 for any tree with one failure) under a third
+ * verdict ladder. These cells pin the projection and every builder reading
+ * it. RED-ON-BASE cells fail on the 3570f15 build; PIN cells pass on both.
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  settledOutcome,
+  settleSecureExit,
+  outboundAllowed,
+  wireStatus,
+  pickSettledOutcome,
+  SETTLED_OUTCOME_KEYS,
+  type SettledOutcome,
+} from '../../src/hardening/settled-outcome';
+import { buildPublishPayload } from '../../src/registry/publish';
+import { buildScanReport, buildCommunityReport } from '../../src/registry/client';
+import { buildScanEvent } from '../../src/telemetry/contribute';
+import { emitFindings } from '../../src/hardening/finding-emit';
+import type { ScanResult } from '../../src/hardening/security-check';
+
+function draft(checkId: string, severity: string, passed: boolean) {
+  return {
+    checkId,
+    name: checkId,
+    description: `fixture ${checkId}`,
+    category: 'config',
+    severity: severity as any,
+    passed,
+    message: 'x',
+    fixable: false,
+  };
+}
+
+const suppressedRow = { checkId: 'CONFIG-004', name: 'Leaky env', category: 'config', severity: 'critical', count: 1, suppressedBy: '.hmaignore' };
+
+function makeResult(overrides: Partial<ScanResult> = {}): ScanResult {
+  return {
+    timestamp: new Date(),
+    platform: 'test',
+    projectType: 'library',
+    findings: emitFindings([draft('ENV-001', 'high', false), draft('GIT-001', 'low', true)]),
+    score: 61,
+    maxScore: 100,
+    rawScore: 74,
+    scoreClamped: true,
+    coverage: {
+      filesExamined: 12,
+      executions: [
+        { method: 'a', prefixes: [], completed: true, filesRead: 3, pathsInspected: 3 },
+        { method: 'b', prefixes: [], completed: true, filesRead: 4, pathsInspected: 4 },
+        { method: 'c', prefixes: [], completed: false, filesRead: 0, pathsInspected: 0, skipReason: 'depth' },
+      ],
+      truncations: [],
+      unreadableInputs: { count: 0, codes: {}, directories: 0 },
+    },
+    ...overrides,
+  } as unknown as ScanResult;
+}
+
+describe('settleSecureExit — the exit ladder, spelled once', () => {
+  it('a counted critical/high is exit 1', () => {
+    expect(settleSecureExit(makeResult())).toBe(1);
+  });
+
+  it('a SUPPRESSED critical still settles exit 1 — suppression narrows the report, never the verdict', () => {
+    const r = makeResult({ findings: emitFindings([draft('GIT-001', 'low', true)]), suppressed: [suppressedRow] } as any);
+    expect(settleSecureExit(r)).toBe(1);
+  });
+
+  it('an unread input is exit 2 above everything', () => {
+    const r = makeResult({ coverage: { filesExamined: 3, executions: [], truncations: [], unreadableInputs: { count: 2, codes: { EACCES: 2 }, directories: 0 } } } as any);
+    expect(settleSecureExit(r)).toBe(2);
+  });
+
+  it('a clean measured run is exit 0', () => {
+    const r = makeResult({ findings: emitFindings([draft('GIT-001', 'low', true)]) } as any);
+    expect(settleSecureExit(r)).toBe(0);
+  });
+});
+
+describe('settledOutcome — the record', () => {
+  it('counts are over the gate set: a suppressed critical is counted, and the rows ride the record', () => {
+    const r = makeResult({ suppressed: [suppressedRow] } as any);
+    const s = settledOutcome(r, 1);
+    expect(s.counts.critical).toBe(1);
+    expect(s.counts.high).toBe(1);
+    expect(s.suppressed).toEqual([suppressedRow]);
+    expect(s.verdict).toBe('fail');
+    expect(s.schemaVersion).toBe(1);
+  });
+
+  it('coverage: total = examined + discovered-but-unread; measured flips on the record', () => {
+    const clean = settledOutcome(makeResult(), 1);
+    expect(clean.coverage).toMatchObject({ measured: true, examined: 12, total: 12, unit: 'file' });
+    const unread = makeResult({ coverage: { filesExamined: 3, executions: [], truncations: [], unreadableInputs: { count: 2, codes: { EACCES: 2 }, directories: 1 } } } as any);
+    const s = settledOutcome(unread, 2);
+    expect(s.coverage).toMatchObject({ measured: false, examined: 3, total: 5 });
+    expect(s.measured).toBe(false);
+  });
+
+  it('the verdict ladder is the wire ladder: fail on critical/high, warn on medium/low, pass on none', () => {
+    expect(settledOutcome(makeResult(), 1).verdict).toBe('fail');
+    const warn = makeResult({ findings: emitFindings([draft('LOG-001', 'medium', false)]) } as any);
+    expect(settledOutcome(warn, 0).verdict).toBe('warn');
+    const clean = makeResult({ findings: emitFindings([draft('GIT-001', 'low', true)]) } as any);
+    expect(settledOutcome(clean, 0).verdict).toBe('pass');
+  });
+
+  it('verdict is null exactly on an exit-2 run with nothing counted — a warn band at exit 2 is carried', () => {
+    const clean = makeResult({ findings: emitFindings([draft('GIT-001', 'low', true)]) } as any);
+    expect(settledOutcome(clean, 2).verdict).toBeNull();
+    const warn = makeResult({ findings: emitFindings([draft('LOG-001', 'medium', false)]) } as any);
+    expect(settledOutcome(warn, 2).verdict).toBe('warn');
+  });
+});
+
+describe('outboundAllowed and wireStatus', () => {
+  it('exit 2 or unmeasured never sends; a measured 0/1 does', () => {
+    expect(outboundAllowed(settledOutcome(makeResult(), 1))).toBe(true);
+    expect(outboundAllowed(settledOutcome(makeResult(), 2))).toBe(false);
+    const unread = makeResult({ coverage: { filesExamined: 3, executions: [], truncations: [], unreadableInputs: { count: 1, codes: { EACCES: 1 }, directories: 0 } } } as any);
+    expect(outboundAllowed(settledOutcome(unread, 1))).toBe(false);
+  });
+
+  it('wireStatus maps the band and fails closed on null', () => {
+    expect(wireStatus(settledOutcome(makeResult(), 1))).toBe('failed');
+    const warn = makeResult({ findings: emitFindings([draft('LOG-001', 'medium', false)]) } as any);
+    expect(wireStatus(settledOutcome(warn, 0))).toBe('warnings');
+    const clean = makeResult({ findings: emitFindings([draft('GIT-001', 'low', true)]) } as any);
+    expect(wireStatus(settledOutcome(clean, 0))).toBe('passed');
+    expect(() => wireStatus(settledOutcome(clean, 2))).toThrow(/EXIT_UNMEASURED/);
+  });
+});
+
+describe('the publish payload reads the record (#464)', () => {
+  const r = makeResult({ suppressed: [suppressedRow] } as any);
+  const settled = settledOutcome(r, 1);
+  const data = { packageName: 'fx', directory: '/tmp/fx', hardeningFindings: r.findings };
+
+  it('RED-ON-BASE: score and verdict are the settled figures, and the typed counts ride top-level', () => {
+    const p = buildPublishPayload(data as any, '0.33.0', settled);
+    expect(p.score).toBe(61);
+    expect(p.verdict).toBe('fail');
+    expect(p.criticalCount).toBe(1);
+    expect(p.highCount).toBe(1);
+    expect(p.measured).toBe(true);
+    expect(p.exitCode).toBe(1);
+    expect(p.schemaVersion).toBe(1);
+    expect(p.suppressed).toEqual([suppressedRow]);
+    expect(p.coverage).toMatchObject({ measured: true, examined: 12, total: 12, unit: 'file' });
+  });
+
+  it('RED-ON-BASE: subReports.hardening carries NO passRate — the ratio no server reads is deleted', () => {
+    const p = buildPublishPayload(data as any, '0.33.0', settled);
+    expect((p.subReports as any).hardening).not.toHaveProperty('passRate');
+    const legacy = buildPublishPayload(data as any, '0.33.0');
+    expect((legacy.subReports as any).hardening).not.toHaveProperty('passRate');
+  });
+
+  it('PIN: without a settled record (the attack path) the local computation stands, without the new keys', () => {
+    const legacy = buildPublishPayload(data as any, '0.33.0');
+    expect(legacy.schemaVersion).toBeUndefined();
+    expect(legacy.measured).toBeUndefined();
+    expect(typeof legacy.score).toBe('number');
+  });
+
+  it('a null-verdict record is a caller bug and throws — never a payload', () => {
+    const clean = makeResult({ findings: emitFindings([draft('GIT-001', 'low', true)]) } as any);
+    expect(() => buildPublishPayload(data as any, '0.33.0', settledOutcome(clean, 2))).toThrow(/never publishes/);
+  });
+});
+
+describe('the scan and community reports read the record (#283)', () => {
+  const r = makeResult({ suppressed: [suppressedRow] } as any);
+  const settled = settledOutcome(r, 1);
+
+  it('RED-ON-BASE: status and counts come from the record, and rawReport carries the record whole', () => {
+    const scan = buildScanReport('v-1', r.findings as any, settled);
+    expect(scan.status).toBe('failed');
+    expect(scan.criticalCount).toBe(1);
+    expect((scan.rawReport as any).settledOutcome).toEqual(settled);
+    const community = buildCommunityReport('fx', r.findings as any, {}, settled);
+    expect(community.status).toBe('failed');
+    expect(community.criticalCount).toBe(1);
+    expect((community.rawReport as any).settledOutcome).toEqual(settled);
+  });
+
+  it('PIN: without a settled record the local derivation stands and no record rides', () => {
+    const scan = buildScanReport('v-1', r.findings as any);
+    expect((scan.rawReport as any).settledOutcome).toBeUndefined();
+  });
+});
+
+describe('the contribution event reads the record (#519)', () => {
+  const r = makeResult();
+  const settled = settledOutcome(r, 1);
+
+  it('RED-ON-BASE: score is the displayed 0-100, never passed/total', () => {
+    const event = buildScanEvent('fx', '/tmp/fx-none', r.findings as any, 900, settled, 2);
+    expect(event.scanSummary?.score).toBe(61);
+  });
+
+  it('RED-ON-BASE: the verdict is the settled band — one ladder, not a third one', () => {
+    // One counted HIGH: the settled band is fail; the deleted-for-secure
+    // local ladder said warn. This cell is what makes the two spellings
+    // distinguishable.
+    const event = buildScanEvent('fx', '/tmp/fx-none', r.findings as any, 900, settled, 2);
+    expect(event.scanSummary?.verdict).toBe('fail');
+  });
+
+  it('RED-ON-BASE: totalChecks is the completed-execution count, and OMITTED when the run kept none', () => {
+    const withCount = buildScanEvent('fx', '/tmp/fx-none', r.findings as any, 900, settled, 2);
+    expect(withCount.scanSummary?.totalChecks).toBe(2);
+    const without = buildScanEvent('fx', '/tmp/fx-none', r.findings as any, 900, settled, undefined);
+    expect('totalChecks' in (without.scanSummary as object)).toBe(false);
+  });
+
+  it('PIN: the no-record callers (scan-soul, detect) keep the legacy derivation', () => {
+    const event = buildScanEvent('fx', '/tmp/fx-none', r.findings as any, 900);
+    expect(event.scanSummary?.totalChecks).toBe(2);
+    expect(event.scanSummary?.verdict).toBe('warn');
+  });
+
+  it('a null-verdict record throws — an unmeasured run never contributes', () => {
+    const clean = makeResult({ findings: emitFindings([draft('GIT-001', 'low', true)]) } as any);
+    expect(() => buildScanEvent('fx', '/tmp/fx-none', clean.findings as any, 900, settledOutcome(clean, 2), 1)).toThrow(/never contributes/);
+  });
+});
+
+describe('pickSettledOutcome — the flat document IS the record (C1/C2)', () => {
+  it('identity: picking the record keys out of a larger document returns omit(record, schemaVersion)', () => {
+    const r = makeResult({ suppressed: [suppressedRow] } as any);
+    const settled = settledOutcome(r, 1);
+    const { schemaVersion: _sv, ...recordSansVersion } = settled;
+    const document = {
+      ...r,
+      verdict: settled.verdict,
+      exitCode: settled.exitCode,
+      measured: settled.measured,
+      counts: settled.counts,
+      coverage: {
+        // The document's coverage is BIGGER (executions, truncations,
+        // categories); the picker projects it down to the record's sub-keys.
+        ...(r.coverage as object),
+        measured: settled.coverage.measured,
+        examined: settled.coverage.examined,
+        total: settled.coverage.total,
+        unit: settled.coverage.unit,
+        unreadableInputs: settled.coverage.unreadableInputs,
+      },
+      extraDocumentKey: true,
+    } as unknown as Record<string, unknown>;
+    expect(pickSettledOutcome(document)).toEqual(recordSansVersion);
+  });
+
+  it('the key list covers every record key except schemaVersion', () => {
+    const settled = settledOutcome(makeResult({ suppressed: [suppressedRow] } as any), 1);
+    const recordKeys = Object.keys(settled).filter((k) => k !== 'schemaVersion').sort();
+    const listed = [...SETTLED_OUTCOME_KEYS].filter((k) => (settled as Record<string, unknown>)[k] !== undefined).sort();
+    expect(listed).toEqual(recordKeys);
+  });
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "@opena2a/aim-sdk": "1.3.0",
         "@opena2a/check-core": "0.3.0",
         "@opena2a/cli-ui": "0.5.2",
-        "@opena2a/contribute": "^0.2.0",
+        "@opena2a/contribute": "^0.3.0",
         "@opena2a/credential-patterns": "0.1.1",
         "@opena2a/registry-client": "0.2.0",
         "@opena2a/shared": "^0.1.0",
@@ -713,9 +713,9 @@
       }
     },
     "node_modules/@opena2a/contribute": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/@opena2a/contribute/-/contribute-0.2.0.tgz",
-      "integrity": "sha512-GJUnJ4IqNBcySkvfB4oGNftmd7I8zNSV7wnCrvPwnIlEFzEngsoxWIZC7iQhVprQTa2X1gu/f9i6Z85iFY+4cw==",
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@opena2a/contribute/-/contribute-0.3.0.tgz",
+      "integrity": "sha512-KfMw7otCnzSXssjbFGB1sokaXzPmg8bmUDQDSB7ETKTTmzhd+hOXfMioq1hum9V2UxSI0YNmyMNWE7FE66aWQg==",
       "license": "Apache-2.0"
     },
     "node_modules/@opena2a/credential-patterns": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "@opena2a/aim-sdk": "1.3.0",
         "@opena2a/check-core": "0.3.0",
         "@opena2a/cli-ui": "0.5.2",
-        "@opena2a/contribute": "^0.1.0",
+        "@opena2a/contribute": "^0.2.0",
         "@opena2a/credential-patterns": "0.1.1",
         "@opena2a/registry-client": "0.2.0",
         "@opena2a/shared": "^0.1.0",
@@ -713,9 +713,9 @@
       }
     },
     "node_modules/@opena2a/contribute": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/@opena2a/contribute/-/contribute-0.1.1.tgz",
-      "integrity": "sha512-6tFVuMaAd18CzVNGEERkVzIEoiONHDOhH1KDVWa8ozWwCJqFYIw36Wmj5mtLXE5YzA2RYW8qSsXpQiACWDluJA==",
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@opena2a/contribute/-/contribute-0.2.0.tgz",
+      "integrity": "sha512-GJUnJ4IqNBcySkvfB4oGNftmd7I8zNSV7wnCrvPwnIlEFzEngsoxWIZC7iQhVprQTa2X1gu/f9i6Z85iFY+4cw==",
       "license": "Apache-2.0"
     },
     "node_modules/@opena2a/credential-patterns": {

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "@opena2a/aim-sdk": "1.3.0",
     "@opena2a/check-core": "0.3.0",
     "@opena2a/cli-ui": "0.5.2",
-    "@opena2a/contribute": "^0.2.0",
+    "@opena2a/contribute": "^0.3.0",
     "@opena2a/credential-patterns": "0.1.1",
     "@opena2a/registry-client": "0.2.0",
     "@opena2a/shared": "^0.1.0",

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "@opena2a/aim-sdk": "1.3.0",
     "@opena2a/check-core": "0.3.0",
     "@opena2a/cli-ui": "0.5.2",
-    "@opena2a/contribute": "^0.1.0",
+    "@opena2a/contribute": "^0.2.0",
     "@opena2a/credential-patterns": "0.1.1",
     "@opena2a/registry-client": "0.2.0",
     "@opena2a/shared": "^0.1.0",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -141,76 +141,12 @@ async function recordTelemetry(exitCode: number): Promise<void> {
  * exists and why #344 moved `rollback` off `process.exit` after measuring a
  * report cut at ~15% of its length on a pipe.
  */
-/**
- * The set an exit code is allowed to be derived from (#450).
- *
- * `result.findings` is what the caller asked to SEE. A check ID they suppressed
- * is not in it — deliberately, because that array also feeds the `--fix`
- * governance auto-fix, the Registry publish payload and every report format —
- * but its penalty still counts, so every gate has to add it back.
- *
- * `secure` settles its exit code in five places, one per output channel, each
- * with its own `return` (#438's shape). Until that becomes one settlement point
- * this helper is what keeps the five honest: any channel that filters
- * `result.findings` directly is laundering, and `--ignore CONFIG-004` moved the
- * leaky-env corpus fixture from exit 1 to exit 0 through exactly that gap.
- */
-function gateSet(result: { findings?: unknown[]; suppressed?: ScanResult['suppressed'] }): any[] {
-  return [...(result.findings ?? []), ...expandSuppressed(result.suppressed)] as any[];
-}
-
-/**
- * True when Layer 3 sent a file for analysis and could not read an answer back.
- *
- * #462 — a `--deep` run that could not read the analyst's answer for a file has
- * not completed a deep scan, and must not report a deep-scan PASS. Measured on
- * the branch before this: the same fixture, the same plaintext operator
- * credential and the same analyst verdict went from `69/100 exit 1` to
- * `93/100 exit 0` purely because the model wrapped its reply in prose. A CI gate
- * whose answer depends on the analyst's FORMATTING is not a gate.
- *
- * The severity of `SEM-LLM-NOT-ANALYZED` is deliberately left at medium (CISO):
- * raising it would turn every transient API hiccup into a red pipeline, which
- * makes an availability event look like a security verdict and is what pushes
- * people to bypass the gate. The verdict channel says the true thing instead —
- * this run did not finish — using the exit code this CLI already means it with.
- */
-function deepScanIncomplete(result: { findings?: unknown[]; suppressed?: ScanResult['suppressed'] }): boolean {
-  // `gateSet`, NOT `result.findings`. #450's whole point is that suppressing a
-  // check removes it from the report and not from the verdict; reading the
-  // filtered list here let `--ignore SEM-LLM-NOT-ANALYZED` turn an incomplete
-  // deep scan back into exit 0. Measured before the fix: suppressed entry
-  // present, score 93, exit 0 — the laundering this release closes elsewhere,
-  // reintroduced by the code that closes it.
-  return gateSet(result).some((f: any) => f?.checkId === 'SEM-LLM-NOT-ANALYZED');
-}
-
-/**
- * Inputs `secure` discovered inside the target and could not read (#438).
- *
- * The sibling of `deepScanIncomplete`, and the same sentence about a different
- * layer: a run that could not open a file it found has not examined that file,
- * and must not report a PASS over it. Measured on the branch before this, one
- * fixture and one `chmod`: a tree holding a benign source file and a
- * `src/secrets.js` with an `sk-` key scored `69/100 exit 1` readable and
- * `98/100 exit 0` at mode 000, on all five output channels. The score went UP
- * because the unread file left the assessment. `secure --fix` then wrote a
- * `.gitignore` into that tree and the next run scored `100/100 exit 0` with the
- * credential file still sitting there unreadable.
- *
- * The unit is inputs-discovered-but-not-read and NOT any files-read threshold.
- * A files-read gate was tried and reverted: it moved the bar from 0 files to 1,
- * and `--fix` satisfies it by writing into the target. An unread input cannot be
- * cleared that way — the `EACCES` recorded on the other file is still there.
- *
- * Which errnos count is decided in `coverage-ledger.ts` and was measured, not
- * assumed: `ENOENT`, `EISDIR` and `ENOTDIR` all mean "no file of the kind sought
- * is at that path" and are excluded, which is why this reads 0 on hackmyagent's
- * own tree, on secretless, on ai-trust and on atlas.
- */
-function unreadInputCount(result: { coverage?: { unreadableInputs?: { count: number } } }): number {
-  return result.coverage?.unreadableInputs?.count ?? 0;
-}
+// `gateSet` (#450), `deepScanIncomplete` (#462) and `unreadInputCount` (#438)
+// moved to src/hardening/settled-outcome.ts so the outbound records can read
+// the same predicates without importing this side-effectful module — the same
+// extraction `benchmark-report.ts` is. Their doc comments (the leaky-env
+// laundering, the analyst-formatting gate, the mode-000 score inflation)
+// moved with them; this file imports them back unchanged.
 
 async function finishWithFindings(code: number): Promise<void> {
   await recordTelemetry(code);
@@ -353,6 +289,7 @@ import { reconcileArtifactIntents, rawIntentDisclosureLines } from './ui/artifac
 import { describeSemanticFamilyCoverage } from './ui/semantic-coverage-labels';
 import type { SemanticFamilyCoverage } from './nanomind-core/scanner-bridge.js';
 import { clampDisclosure, clampScoreToVerdictBand, countsAgainstScore, confirmedFix, expandSuppressed, isMeasured, retainForVerdict, summarizeSuppressed, type MeasuredFinding } from './ui/verdict-band';
+import { gateSet, deepScanIncomplete, unreadInputCount, settledOutcome, settleSecureExit, outboundAllowed, wireStatus, type SettledOutcome } from './hardening/settled-outcome';
 import { shouldPrintVersionFooter } from './ui/version-footer';
 import { soulScopeDisclosureLines } from './ui/soul-scope-disclosure';
 import { fixSummaryLine } from './ui/fix-summary';
@@ -4586,6 +4523,14 @@ async function handleContribution(
   durationMs: number,
   registryUrl?: string,
   format?: string,
+  // #464/#519 — the `secure` sites pass their settled record; the event's
+  // figures then come from it, never from a recount of `findings`. The
+  // scan-soul and detect callers have no settled `secure` record and keep
+  // the legacy derivation, scoped to them inside `buildScanEvent`.
+  settled?: SettledOutcome,
+  // Completed check executions from the run's coverage record; omitted when
+  // the run kept none (the event then omits `totalChecks`, #519).
+  completedChecks?: number,
 ): Promise<void> {
   try {
     const {
@@ -4625,7 +4570,7 @@ async function handleContribution(
     const packageName = resolvePackageName(targetDir);
     if (!packageName) return;
 
-    const event = buildScanEvent(packageName, targetDir, findings, durationMs);
+    const event = buildScanEvent(packageName, targetDir, findings, durationMs, settled, completedChecks);
     await queueAndMaybeFlush(event, registryUrl, format === 'text');
     // Silent-post-consent rule (briefs/scan-result-telemetry-policy.md §5):
     // once the user has opted in (--contribute or persisted choice),
@@ -5177,6 +5122,34 @@ Examples:
         if (format !== 'text') console.error(`Score ${result.score} is below threshold ${failBelow}`);
       }
 
+      // ── The settled outcome (#464 #519 #283) ─────────────────────────────
+      //
+      // Projected ONCE, here, from the same predicates the floor above and the
+      // per-arm critical/high lines read, so every record that leaves the
+      // process — the publish payload, the remediation report, the scan/
+      // community/ci reports, the contribution event — carries the numbers
+      // this run settled, never a recomputation from the narrowed findings
+      // list. `Math.max` is the #512 precedence rule (2 outranks 1 outranks
+      // 0), spelled on the same inputs `raiseExitCode` enforces it on.
+      const settledExit = Math.max(settleSecureExit(result), thresholdBreached ? 1 : 0) as 0 | 1 | 2;
+      const settled = settledOutcome(result, settledExit);
+      // One decision, one line: no outbound arm re-discovers a reason to send.
+      const sendOutbound = outboundAllowed(settled);
+      const withheldOutbound: string[] = [];
+      // The one printed line when something outbound was withheld (#464,
+      // CISO slice A; CPO template). The reason clause is the exit-2
+      // sentence this run already prints for its cause.
+      const printWithheldLine = () => {
+        if (withheldOutbound.length === 0) return;
+        const n = unreadInputCount(result);
+        const reason =
+          n > 0
+            ? `${n} input${n === 1 ? ' was' : 's were'} discovered and not read (SCAN-UNREAD-001 above), so the score is an upper bound, not a measurement`
+            : 'the deep layer did not finish, so the run reaches no deep-scan verdict';
+        const remedy = n > 0 ? 'Make those inputs readable and re-run to publish.' : 'Re-run --deep to publish.';
+        console.error(`Registry: nothing sent — ${reason}. Withheld: ${withheldOutbound.join(', ')}. ${remedy}`);
+      };
+
       // AI Infrastructure auto-detection — scan NemoClaw, OpenClaw, etc. if present.
       //
       // [CHIEF-CA 2026-08-03] These runtimes live in $HOME, OUTSIDE the scan
@@ -5549,7 +5522,13 @@ Examples:
       if (format === 'json') {
         // Run publish in JSON mode and include result in output
         let publishStatus: Record<string, unknown> | undefined;
-        if (options.publish && options.registry !== false) {
+        // #464 — the withhold is decided BEFORE the arm's own preconditions:
+        // a run the tool could not measure publishes nothing, and the
+        // document says so instead of carrying a claim.
+        if (options.publish && options.registry !== false && !sendOutbound) {
+          withheldOutbound.push('--publish');
+          publishStatus = { success: false, attempted: false, reason: 'unmeasured' };
+        } else if (options.publish && options.registry !== false) {
           try {
             const { publishScanResults } = await import('./registry/publish');
             const registryUrl = validateRegistryUrl(options.registryUrl || process.env.REGISTRY_URL || 'https://api.oa2a.org');
@@ -5561,7 +5540,7 @@ Examples:
                 directory: displayDir,
                 hardeningFindings: result.findings,
               };
-              const publishResult = await publishScanResults(publishData, registryUrl);
+              const publishResult = await publishScanResults(publishData, registryUrl, settled);
               publishStatus = { ...publishResult, registryUrl };
 
               // Best-effort: if this scan looks like a skill or MCP artifact, also
@@ -5602,6 +5581,13 @@ Examples:
         const jsonCoverage = result.coverage
           ? {
               ...result.coverage,
+              // The settled record's coverage sub-keys (#464): one predicate —
+              // `jq '.coverage.measured'` — across `check`, `secure` and every
+              // wire; `total` = examined + discovered-but-unread.
+              measured: settled.coverage.measured,
+              examined: settled.coverage.examined,
+              total: settled.coverage.total,
+              unit: settled.coverage.unit,
               categories: summarizeCoverage(
                 result.coverage.executions,
                 nmResult.compileSetTruncated
@@ -5651,6 +5637,15 @@ Examples:
         // `evidence.lines[].content` reaches the payload.
         const jsonBase = {
           ...result,
+          // The settled record's flat keys (#464): the document's top level IS
+          // the record — no nested duplicate (CPO ruling; the spread-order
+          // collision is a compile error in settled-outcome.ts). `score`,
+          // `rawScore`, `scoreClamped`, `suppressed`, `outOfScope` already
+          // ride via `...result` and are the same values by construction.
+          verdict: settled.verdict,
+          exitCode: settled.exitCode,
+          measured: settled.measured,
+          counts: settled.counts,
           ...(jsonCoverage ? { coverage: jsonCoverage } : {}),
           ...(nmResult.analystFindings?.length ? { analystFindings: nmResult.analystFindings } : {}),
           ...(nmResult.analystEscalations?.length ? { analystEscalations: nmResult.analystEscalations } : {}),
@@ -5668,7 +5663,15 @@ Examples:
           writeJsonStdout(jsonOutput);
         }
         // Community contribution (non-blocking, runs in JSON mode too)
-        await handleContribution(options.contribute, targetDir, result.findings, scanDurationMs, options.registryUrl, format);
+        if (!sendOutbound) {
+          if (options.contribute === true || (await import('./telemetry')).isContributeEnabled() === true) {
+            withheldOutbound.push('contribution');
+          }
+        } else {
+          await handleContribution(options.contribute, targetDir, result.findings, scanDurationMs, options.registryUrl, format, settled,
+            result.coverage?.executions ? result.coverage.executions.filter((e) => e.completed).length : undefined);
+        }
+        printWithheldLine();
         // `--fail-below` is settled once at the settlement point above (#494);
         // no per-channel copy here. The copy this replaced returned before the
         // critical/high line below, and its sibling on sarif/html/asff did not
@@ -5939,7 +5942,11 @@ Examples:
 
       // Registry reporting: only when explicitly requested via --version-id (CI) or --registry-report
       // Community contributions are handled by the opena2a CLI wrapper, not HMA directly
-      if (options.versionId || options.registryReport) {
+      if ((options.versionId || options.registryReport) && !sendOutbound) {
+        // #464 — withheld before the arm's own preconditions: an unmeasured
+        // run reports nothing, and the one line below says so.
+        withheldOutbound.push(options.versionId ? '--version-id' : '--registry-report');
+      } else if (options.versionId || options.registryReport) {
         try {
           const core = await import('./index');
           const registryUrl = validateRegistryUrl(options.registryUrl || process.env.REGISTRY_URL || 'https://api.oa2a.org');
@@ -5953,7 +5960,7 @@ Examples:
             }
             const atcToken = process.env.ATC_TOKEN;
             const client = new core.RegistryClient({ registryUrl, apiKey: registryKey, atcToken });
-            const payload = core.buildScanReport(options.versionId, result.findings);
+            const payload = core.buildScanReport(options.versionId, result.findings, settled);
             await client.reportScanResult(payload);
             console.log(`Registry: scan results reported for version ${options.versionId}`);
           } else if (typeof core.buildCommunityReport === 'function') {
@@ -5967,7 +5974,7 @@ Examples:
                 : null;
               const payload = core.buildCommunityReport(packageName, result.findings, {
                 version: packageVersion ?? undefined,
-              });
+              }, settled);
               const resp = typeof client.reportCommunityResult === 'function'
                 ? await client.reportCommunityResult(payload, tokenResp?.scanToken)
                 : { status: 'skipped' };
@@ -5992,6 +5999,9 @@ Examples:
         if (format === 'text') {
           console.log('\nPublish skipped: --no-registry flag is active.');
         }
+      } else if (options.publish && !sendOutbound) {
+        // #464 — withheld before the arm's own preconditions.
+        withheldOutbound.push('--publish');
       } else if (options.publish) {
         try {
           const { publishScanResults, formatPublishOutput } = await import('./registry/publish');
@@ -6052,7 +6062,11 @@ Examples:
       }
 
       // CI publish: submit results to registry CAAT pipeline endpoint
-      if (options.ciPublish) {
+      if (options.ciPublish && !sendOutbound) {
+        // #464 — withheld before the arm's own preconditions (the HMAC check
+        // included: an unmeasured run has nothing to sign).
+        withheldOutbound.push('--ci-publish');
+      } else if (options.ciPublish) {
         const hmacSecret = process.env.CI_SCAN_HMAC_SECRET;
         if (!hmacSecret) {
           console.error('\nError: --ci-publish requires the CI_SCAN_HMAC_SECRET environment variable.');
@@ -6080,18 +6094,13 @@ Examples:
               console.error('Warning: Could not compute tree hash. Using empty hash.');
             }
 
-            // Count severity
-            const failed = result.findings.filter((f: SecurityFinding) => countsAgainstScore(f));
-            const counts = { critical: 0, high: 0, medium: 0, low: 0 };
-            for (const f of failed) {
-              if (f.severity === 'critical') counts.critical++;
-              else if (f.severity === 'high') counts.high++;
-              else if (f.severity === 'medium') counts.medium++;
-              else if (f.severity === 'low') counts.low++;
-            }
-
-            const status = (counts.critical > 0 || counts.high > 0) ? 'failed'
-              : (counts.medium > 0 || counts.low > 0) ? 'warnings' : 'passed';
+            // #464 — the counts and status READ the settled record. This
+            // very block derived them from the narrowed `result.findings`
+            // (a suppressed row cannot even appear there, #450), which
+            // published `status: passed, counts all 0` for a run that
+            // displayed 49 findings and exited 1.
+            const counts = settled.counts;
+            const status = wireStatus(settled);
 
             const client = new RegistryClient({ registryUrl, apiKey: '' });
             const scanId = `hma-ci-${Date.now()}`;
@@ -6120,8 +6129,11 @@ Examples:
               rawReport: {
                 generator: 'hackmyagent',
                 totalFindings: result.findings.length,
-                failedFindings: failed.length,
+                failedFindings: counts.critical + counts.high + counts.medium + counts.low,
                 scanDepth,
+                // #464 — the settled record rides as ONE object built from
+                // the in-memory record (carried, not yet persisted server-side).
+                settledOutcome: settled,
               },
             });
 
@@ -6142,7 +6154,15 @@ Examples:
       }
 
       // Community contribution: share anonymized findings with OpenA2A Registry
-      await handleContribution(options.contribute, targetDir, result.findings, scanDurationMs, options.registryUrl, format);
+      if (!sendOutbound) {
+        if (options.contribute === true || (await import('./telemetry')).isContributeEnabled() === true) {
+          withheldOutbound.push('contribution');
+        }
+        printWithheldLine();
+      } else {
+        await handleContribution(options.contribute, targetDir, result.findings, scanDurationMs, options.registryUrl, format, settled,
+          result.coverage?.executions ? result.coverage.executions.filter((e) => e.completed).length : undefined);
+      }
 
       // Star prompt (interactive TTY only, text format only)
       if (process.stdout.isTTY) {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -150,7 +150,13 @@ async function recordTelemetry(exitCode: number): Promise<void> {
 
 async function finishWithFindings(code: number): Promise<void> {
   await recordTelemetry(code);
-  process.exitCode = code;
+  // RAISE, never assign (#512's own precedence, previously honored only by
+  // `raiseExitCode`): a per-arm critical/high line assigning 1 trampled the
+  // EXIT_UNMEASURED floor of 2 set at the settlement point, so a run with an
+  // unread input AND a counted critical exited 1 while its settled record —
+  // honestly — said 2. Caught by the settled-outcome adversarial round.
+  const current = Number(process.exitCode ?? 0);
+  if (!(current >= code)) process.exitCode = code;
 }
 
 /**
@@ -5664,7 +5670,7 @@ Examples:
         }
         // Community contribution (non-blocking, runs in JSON mode too)
         if (!sendOutbound) {
-          if (options.contribute === true || (await import('./telemetry')).isContributeEnabled() === true) {
+          if (options.contribute !== false && (options.contribute === true || (await import('./telemetry')).isContributeEnabled() === true)) {
             withheldOutbound.push('contribution');
           }
         } else {
@@ -6022,7 +6028,9 @@ Examples:
               hardeningFindings: result.findings,
             };
 
-            const publishResult = await publishScanResults(publishData, registryUrl);
+            // The settled record rides here too — the adversarial round
+            // caught this arm recomputing while the json arm read (#464).
+            const publishResult = await publishScanResults(publishData, registryUrl, settled);
             if (format === 'text') {
               console.log(formatPublishOutput(publishResult, publishData, registryUrl));
               console.log();
@@ -6155,7 +6163,7 @@ Examples:
 
       // Community contribution: share anonymized findings with OpenA2A Registry
       if (!sendOutbound) {
-        if (options.contribute === true || (await import('./telemetry')).isContributeEnabled() === true) {
+        if (options.contribute !== false && (options.contribute === true || (await import('./telemetry')).isContributeEnabled() === true)) {
           withheldOutbound.push('contribution');
         }
         printWithheldLine();

--- a/src/hardening/settled-outcome.ts
+++ b/src/hardening/settled-outcome.ts
@@ -23,7 +23,11 @@
  * NOT nest this record: its top level IS the record (flat keys; CPO ruling,
  * CA CONFIRM-FLAT), and `pickSettledOutcome` re-derives the record from a
  * parsed document so the identity `pickSettledOutcome(json) ≡
- * omit(record, 'schemaVersion')` is testable from either side.
+ * omit(record, 'schemaVersion')` is testable from either side. The identity
+ * holds for every document the scanner emits today (its coverage record is
+ * always attached); a document with NO coverage key picks back a record
+ * without one, while the builder synthesizes an empty record — scoped here
+ * because the narrower claim is the one that is true.
  */
 import type { ScanResult } from './security-check';
 import { countsAgainstScore, expandSuppressed } from '../ui/verdict-band';

--- a/src/hardening/settled-outcome.ts
+++ b/src/hardening/settled-outcome.ts
@@ -1,0 +1,246 @@
+/**
+ * The settled outcome of a `secure` run — ONE projection every outbound
+ * record reads (#464 #519 #283).
+ *
+ * Before this module, each record that left the process about a `secure` run
+ * recomputed its own score, verdict or counts from `result.findings`: the
+ * Registry publish payload re-derived a composite from the narrowed list
+ * with a `: 100` pass-rate default, the contribution event computed
+ * `passed/total` over the list (0 with any failure) and its own severity
+ * ladder, and `--ci-publish` derived `status` from counts that disagreed
+ * with the exit code the same run returned (#464: 49 findings displayed,
+ * exit 1, `status: passed`, counts all 0). Every one of those was a second
+ * spelling of a settlement the CLI had already made once.
+ *
+ * `settledOutcome` does NO arithmetic. It reads the object the exit floor
+ * and the `--json` document already read — `ScanResult` as `applyScore`
+ * settled it — plus the exit code the one settlement point decided, and
+ * projects them into one record. `applyScore` (src/hardening/scanner.ts)
+ * stays the only place a score is computed; `gateSet` below stays the only
+ * spelling of "the findings the verdict is entitled to read".
+ *
+ * Wire consumers stamp `schemaVersion: 1`. The `secure --json` document does
+ * NOT nest this record: its top level IS the record (flat keys; CPO ruling,
+ * CA CONFIRM-FLAT), and `pickSettledOutcome` re-derives the record from a
+ * parsed document so the identity `pickSettledOutcome(json) ≡
+ * omit(record, 'schemaVersion')` is testable from either side.
+ */
+import type { ScanResult } from './security-check';
+import { countsAgainstScore, expandSuppressed } from '../ui/verdict-band';
+import { recordedCoverage, type ReadFailureRecord } from '../check/verdict';
+
+/** Identity row for a suppressed or out-of-scope check — `ScanResult['suppressed']` element VERBATIM (no path or byte can enter by construction). */
+export type SuppressionRow = NonNullable<ScanResult['suppressed']>[number];
+
+export interface SettledCoverage {
+  /** False exactly when the run discovered an input it could not read. */
+  measured: boolean;
+  /** Distinct files inside the target whose contents the scan read. */
+  examined: number;
+  /** `examined` plus what was discovered and not read (`recordedCoverage`). */
+  total: number;
+  unit: 'file';
+  unreadableInputs?: ReadFailureRecord;
+}
+
+export interface SettledOutcome {
+  /** Wires only; not part of the picker identity. */
+  schemaVersion: 1;
+  score: number;
+  rawScore?: number;
+  scoreClamped?: boolean;
+  /**
+   * `null` exactly when `exitCode === 2` and the band is pass-direction —
+   * the renderer's own rule ("No issues in what was examined — but ...");
+   * a warn/fail band at exit 2 is displayed and therefore carried.
+   */
+  verdict: 'pass' | 'warn' | 'fail' | null;
+  exitCode: 0 | 1 | 2;
+  measured: boolean;
+  /** Counts over `gateSet` — suppressed entries included, never a ratio. */
+  counts: { critical: number; high: number; medium: number; low: number };
+  coverage: SettledCoverage;
+  suppressed?: SuppressionRow[];
+  outOfScope?: SuppressionRow[];
+}
+
+/**
+ * The findings the verdict is entitled to read: the visible list PLUS the
+ * suppressed entries expanded back. #450's whole point is that suppressing a
+ * check removes it from the report and not from the verdict; any channel
+ * that filters `result.findings` directly is laundering, and
+ * `--ignore CONFIG-004` moved the leaky-env corpus fixture from exit 1 to
+ * exit 0 through exactly that gap. (Moved verbatim from `cli.ts`, which is
+ * side-effectful to import — the same reason `benchmark-report.ts` exists.)
+ */
+export function gateSet(result: { findings?: unknown[]; suppressed?: ScanResult['suppressed'] }): any[] {
+  return [...(result.findings ?? []), ...expandSuppressed(result.suppressed)] as any[];
+}
+
+/**
+ * True when Layer 3 sent a file for analysis and could not read an answer
+ * back (#462). Reads `gateSet`, NOT `result.findings`: reading the filtered
+ * list let `--ignore SEM-LLM-NOT-ANALYZED` turn an incomplete deep scan back
+ * into exit 0. (Moved verbatim from `cli.ts`.)
+ */
+export function deepScanIncomplete(result: { findings?: unknown[]; suppressed?: ScanResult['suppressed'] }): boolean {
+  return gateSet(result).some((f: any) => f?.checkId === 'SEM-LLM-NOT-ANALYZED');
+}
+
+/**
+ * Inputs `secure` discovered inside the target and could not read (#438).
+ * The unit is inputs-discovered-but-not-read, never a files-read threshold —
+ * `--fix` satisfies a files-read bar by writing into the target; it cannot
+ * clear the `EACCES` recorded on the other file. (Moved verbatim from
+ * `cli.ts`; `coverage-ledger.ts` decides which errnos count.)
+ */
+export function unreadInputCount(result: { coverage?: { unreadableInputs?: { count: number } } }): number {
+  return result.coverage?.unreadableInputs?.count ?? 0;
+}
+
+/**
+ * The exit code of a settled `secure` run, spelled once.
+ *
+ * Composes the SAME predicates the settlement point and every output arm
+ * read — the unread-input floor (#438), the critical/high direction over
+ * `gateSet` (#450) and the incomplete-deep-scan floor (#462) — so the
+ * outbound gate and the process exit cannot disagree. `--fail-below` is
+ * deliberately NOT here: a breach raises the process exit at the settlement
+ * point, and the caller passes the SETTLED code in; this function is the
+ * derivation for callers that need the code before the arms return.
+ */
+export function settleSecureExit(result: ScanResult): 0 | 1 | 2 {
+  if (unreadInputCount(result) > 0) return 2;
+  const critHigh = gateSet(result).filter(
+    (f: any) => countsAgainstScore(f) && (f.severity === 'critical' || f.severity === 'high'),
+  );
+  if (critHigh.length > 0) return 1;
+  if (deepScanIncomplete(result)) return 2;
+  return 0;
+}
+
+/**
+ * Project the settled result and the settled exit code into the one record
+ * every outbound consumer reads. No arithmetic: counts are counts over
+ * `gateSet`, the score fields are carried, coverage is
+ * `recordedCoverage(filesExamined, 'file', unreadableInputs)`.
+ */
+export function settledOutcome(result: ScanResult, exitCode: 0 | 1 | 2): SettledOutcome {
+  const gate = gateSet(result).filter((f: any) => countsAgainstScore(f));
+  const count = (sev: string) => gate.filter((f: any) => f.severity === sev).length;
+  const counts = {
+    critical: count('critical'),
+    high: count('high'),
+    medium: count('medium'),
+    low: count('low'),
+  };
+  const record: ReadFailureRecord = result.coverage?.unreadableInputs ?? { count: 0, codes: {}, directories: 0 };
+  const coverage: SettledCoverage = {
+    measured: record.count === 0,
+    ...recordedCoverage(result.coverage?.filesExamined ?? 0, 'file', record),
+  } as SettledCoverage;
+  // The wire ladder the publish payload has always spoken (#464 makes it the
+  // ONE spelling): fail on any counted critical/high, warn on any counted
+  // medium/low, pass on none. `null` only where the renderer replaces the
+  // green sentence — an exit-2 run with nothing counted at all ("No issues
+  // in what was examined — but ..."); a warn/fail band at exit 2 is
+  // displayed and therefore carried.
+  const anyCounted = counts.critical + counts.high + counts.medium + counts.low > 0;
+  const verdict: SettledOutcome['verdict'] =
+    counts.critical > 0 || counts.high > 0
+      ? 'fail'
+      : counts.medium > 0 || counts.low > 0
+        ? 'warn'
+        : exitCode === 2 && !anyCounted
+          ? null
+          : 'pass';
+  return {
+    schemaVersion: 1,
+    score: result.score,
+    ...(result.rawScore !== undefined ? { rawScore: result.rawScore } : {}),
+    ...(result.scoreClamped !== undefined ? { scoreClamped: result.scoreClamped } : {}),
+    verdict,
+    exitCode,
+    measured: coverage.measured,
+    counts,
+    coverage,
+    ...(result.suppressed?.length ? { suppressed: result.suppressed } : {}),
+    ...(result.outOfScope?.length ? { outOfScope: result.outOfScope } : {}),
+  };
+}
+
+/**
+ * May this run publish, report, or contribute ANYTHING outbound?
+ *
+ * CISO invariant: a run at `EXIT_UNMEASURED` never carries `pass`/`passed`
+ * anywhere, and the smaller true statement is that it carries nothing — the
+ * withhold is decided here, BEFORE each arm's own preconditions, so no arm
+ * can rediscover a reason to send. One line is printed at the decision site.
+ */
+export function outboundAllowed(settled: SettledOutcome): boolean {
+  return settled.measured && settled.exitCode !== 2;
+}
+
+// The `--json` document spreads `...result` and then the record's flat keys.
+// If `ScanResult` ever grows a field named like a record key, spread order
+// would silently overwrite it — this assertion turns that day into a compile
+// error instead (CPO pre-mortem (a)).
+type _RecordKeyCollision = Extract<keyof ScanResult, 'verdict' | 'exitCode' | 'measured' | 'counts'>;
+const _noRecordKeyCollision: _RecordKeyCollision extends never ? true : never = true;
+void _noRecordKeyCollision;
+
+/**
+ * The three-value status vocabulary of the scan/community/ci wires, mapped
+ * from the settled verdict: fail→failed, warn→warnings, pass→passed. Throws
+ * on the null verdict — a run at EXIT_UNMEASURED never reaches a wire
+ * (`outboundAllowed` withholds it), so a null here is a caller bug and the
+ * failure is closed, not defaulted.
+ */
+export function wireStatus(settled: SettledOutcome): 'failed' | 'warnings' | 'passed' {
+  if (settled.verdict === null) throw new Error('a run at EXIT_UNMEASURED never posts (#464)');
+  return settled.verdict === 'fail' ? 'failed' : settled.verdict === 'warn' ? 'warnings' : 'passed';
+}
+
+/** The record's keys, derived from the type — a picker that drifts from the type is a compile error, not a silent hole (C3). */
+export const SETTLED_OUTCOME_KEYS = [
+  'score',
+  'rawScore',
+  'scoreClamped',
+  'verdict',
+  'exitCode',
+  'measured',
+  'counts',
+  'coverage',
+  'suppressed',
+  'outOfScope',
+] as const satisfies ReadonlyArray<keyof Omit<SettledOutcome, 'schemaVersion'>>;
+
+/**
+ * Re-derive the record from a parsed `secure --json` document (C1/C2).
+ *
+ * The document's top level IS the record (flat placement): this picks the
+ * record keys back out, projecting the document's larger `coverage` object
+ * DOWN to the record's sub-keys, so
+ * `pickSettledOutcome(json) ≡ omit(record, 'schemaVersion')` holds and a
+ * consumer holding only the document can reconstruct exactly what the wires
+ * carried.
+ */
+export function pickSettledOutcome(json: Record<string, unknown>): Omit<SettledOutcome, 'schemaVersion'> {
+  const out: Record<string, unknown> = {};
+  for (const key of SETTLED_OUTCOME_KEYS) {
+    if (json[key] === undefined) continue;
+    if (key === 'coverage') {
+      const c = json.coverage as Record<string, unknown>;
+      out.coverage = {
+        measured: c.measured,
+        examined: c.examined,
+        total: c.total,
+        unit: c.unit,
+        ...(c.unreadableInputs !== undefined ? { unreadableInputs: c.unreadableInputs } : {}),
+      };
+    } else {
+      out[key] = json[key];
+    }
+  }
+  return out as Omit<SettledOutcome, 'schemaVersion'>;
+}

--- a/src/registry/client.ts
+++ b/src/registry/client.ts
@@ -10,6 +10,7 @@ import type { SecurityFinding, Severity } from '../hardening';
 import { assertRedactionProvenance } from '../hardening/finding-emit';
 import type { AttackReport } from '../attack';
 import { countsAgainstScore, isMeasured } from '../ui/verdict-band';
+import { wireStatus, type SettledOutcome } from '../hardening/settled-outcome';
 
 // Registry ScanResult format (must match hackmyagent_service.go:175-200)
 export interface ScanReportPayload {
@@ -117,6 +118,25 @@ export interface UnifiedPublishPayload {
   verdict: 'pass' | 'warn' | 'fail';
   type?: string;
   version?: string;
+  /**
+   * Settled-outcome extras (#464): present exactly when the publish carries a
+   * settled `secure` run behind it. Typed counts the server can trust instead
+   * of re-deriving from the narrowed `findings[]`, the measurement
+   * disclosure, and identity-only suppression rows. The server drops unknown
+   * fields today (measured: every handler binds with plain json.Unmarshal);
+   * the Registry-side typed columns and the 422 on `measured: false` are the
+   * R1 migration, owned in opena2a-registry.
+   */
+  criticalCount?: number;
+  highCount?: number;
+  mediumCount?: number;
+  lowCount?: number;
+  measured?: boolean;
+  exitCode?: number;
+  coverage?: { measured: boolean; examined: number; total: number; unit: string; unreadableInputs?: unknown };
+  suppressed?: Array<{ checkId: string; name: string; category: string; severity: string; count: number; suppressedBy: string }>;
+  outOfScope?: Array<{ checkId: string; name: string; category: string; severity: string; count: number; suppressedBy: string }>;
+  schemaVersion?: number;
   /** Ed25519 signature (base64) — moved from headers to body */
   signature?: string;
   /** Public key of the signer. PEM for the legacy claimed-agent path; raw base64 for
@@ -484,12 +504,16 @@ export class RegistryClient {
 export function buildScanReport(
   versionId: string,
   findings: SecurityFinding[],
+  settled?: SettledOutcome,
 ): ScanReportPayload {
   assertRedactionProvenance(findings, 'registry-scan-report');
   const failed = findings.filter(isMeasured).filter(f => countsAgainstScore(f));
 
-  const counts = countBySeverity(failed);
-  const status = deriveStatus(counts);
+  // #464 — with a settled record the counts and status describe the RUN and
+  // are READ from it; the local derivation over the (suppression-narrowed)
+  // list remains only for callers with no settled `secure` run behind them.
+  const counts = settled ? settled.counts : countBySeverity(failed);
+  const status = settled ? wireStatus(settled) : deriveStatus(counts);
 
   // Map failed findings to vulnerability format
   const vulnerabilities: VulnerabilityFinding[] = failed.map(f => ({
@@ -526,6 +550,9 @@ export function buildScanReport(
       generator: 'hackmyagent',
       totalFindings: findings.length,
       failedFindings: failed.length,
+      // #464 — the settled record rides as ONE object built from the
+      // in-memory record, never re-assembled from a document.
+      ...(settled ? { settledOutcome: settled } : {}),
     },
   };
 }
@@ -588,14 +615,17 @@ export function buildCommunityReport(
   packageName: string,
   findings: SecurityFinding[],
   options?: { packageType?: string; version?: string },
+  settled?: SettledOutcome,
 ): CommunityScanPayload {
   assertRedactionProvenance(findings, 'registry-community-report');
   const failed = findings.filter(isMeasured).filter(f => countsAgainstScore(f));
   // Only send package-relevant findings to registry — local dev hygiene
   // checks (git, permissions, env, IDE config) don't belong on a package page
   const registryFindings = failed.filter(isRegistryRelevant);
-  const counts = countBySeverity(registryFindings);
-  const status = deriveStatus(counts);
+  // #464 — with a settled record the counts and status describe the RUN and
+  // are READ from it; the vulnerability list above stays the display subset.
+  const counts = settled ? settled.counts : countBySeverity(registryFindings);
+  const status = settled ? wireStatus(settled) : deriveStatus(counts);
 
   const vulnerabilities: VulnerabilityFinding[] = registryFindings.map(f => ({
     id: f.checkId,
@@ -623,6 +653,9 @@ export function buildCommunityReport(
       failedFindings: failed.length,
       registryRelevantFindings: registryFindings.length,
       localOnlyFindings: localOnly,
+      // #464 — the settled record rides as ONE object built from the
+      // in-memory record, never re-assembled from a document.
+      ...(settled ? { settledOutcome: settled } : {}),
     },
   };
   payload.contentHash = computeContentHash(payload);

--- a/src/registry/publish.ts
+++ b/src/registry/publish.ts
@@ -20,6 +20,7 @@ import type { SoulScanResult } from '../soul';
 import type { BenchmarkResult } from '../benchmarks';
 import { RegistryClient, type UnifiedPublishPayload, type UnifiedFinding } from './client';
 import { reportFindings, reportRemediation } from './remediation';
+import type { SettledOutcome } from '../hardening/settled-outcome';
 import { firstPartySignerFromEnv } from '@opena2a/registry-client';
 
 /**
@@ -166,7 +167,7 @@ export function signPayload(payload: string, privateKeyPem: string): string | nu
  * Build a unified publish payload matching the POST /api/v1/trust/publish contract.
  * Combines results from hardening, attack, SOUL, and OASB scans into a single payload.
  */
-export function buildPublishPayload(data: PublishScanData, toolVersion: string): UnifiedPublishPayload {
+export function buildPublishPayload(data: PublishScanData, toolVersion: string, settled?: SettledOutcome): UnifiedPublishPayload {
   // Publish-boundary read (unit 2): every finding leaving for the Registry
   // must carry redaction provenance. The payload built below projects the
   // fields away (wire-schema carry is a separate unit), so the read runs on
@@ -240,17 +241,32 @@ export function buildPublishPayload(data: PublishScanData, toolVersion: string):
   // reveal the discrepancy. `score` is part of the signed strong canonical
   // below, so the signature would have attested a figure the tool never
   // displayed.
-  const { score: rawScore } = calculateSecurityScore(findings);
-  const { score, clamped: scoreClamped } = clampScoreToVerdictBand(rawScore, findings);
-
-  // Derive verdict
-  const failedCritical = findings.filter(f => !f.passed && f.severity === 'critical').length;
-  const failedHigh = findings.filter(f => !f.passed && f.severity === 'high').length;
-  const failedMedium = findings.filter(f => !f.passed && f.severity === 'medium').length;
-  const failedLow = findings.filter(f => !f.passed && f.severity === 'low').length;
-  let verdict: 'pass' | 'warn' | 'fail' = 'pass';
-  if (failedCritical > 0 || failedHigh > 0) verdict = 'fail';
+  // #464 — with a settled record (the `secure --publish` arms), every figure
+  // is READ from it, never recomputed here: the recomputation over the
+  // narrowed `findings` list is what published `score 100 / verdict pass /
+  // 0 failed checks` for the run the terminal reported `69/100 ... exit 1`.
+  // The local computation remains ONLY for callers with no settled `secure`
+  // run behind them (the `attack` registry arm's merged payload).
+  if (settled?.verdict === null) {
+    // Fail closed: `outboundAllowed` withholds exit-2 runs before this call;
+    // a null-verdict record reaching a wire is a caller bug, not a payload.
+    throw new Error('a run at EXIT_UNMEASURED never publishes (#464)');
+  }
+  const { score: localRawScore } = calculateSecurityScore(findings);
+  const { score: localScore, clamped: localClamped } = clampScoreToVerdictBand(localRawScore, findings);
+  const rawScore = settled ? (settled.rawScore ?? settled.score) : localRawScore;
+  const score = settled ? settled.score : localScore;
+  const scoreClamped = settled ? (settled.scoreClamped ?? false) : localClamped;
+  const failedCritical = settled ? settled.counts.critical : findings.filter(f => !f.passed && f.severity === 'critical').length;
+  const failedHigh = settled ? settled.counts.high : findings.filter(f => !f.passed && f.severity === 'high').length;
+  const failedMedium = settled ? settled.counts.medium : findings.filter(f => !f.passed && f.severity === 'medium').length;
+  const failedLow = settled ? settled.counts.low : findings.filter(f => !f.passed && f.severity === 'low').length;
+  let verdict: 'pass' | 'warn' | 'fail';
+  if (settled) {
+    verdict = settled.verdict;
+  } else if (failedCritical > 0 || failedHigh > 0) verdict = 'fail';
   else if (failedMedium > 0 || failedLow > 0) verdict = 'warn';
+  else verdict = 'pass';
 
   // Build sub-reports from each scan type
   const subReports: Record<string, unknown> = {
@@ -261,13 +277,16 @@ export function buildPublishPayload(data: PublishScanData, toolVersion: string):
   if (data.hardeningFindings) {
     // #458 — the sub-report counts measured findings only, matching the wire
     // list above: a not-applicable record is in no denominator anywhere.
+    // #464 — `passRate` is DELETED, not renamed: a second ratio beside the
+    // settled score was the recomputation class this PR removes, and no
+    // server reader exists (`hardening_pass_rate` is written by nothing in
+    // the Registry's internal/).
     const measured = data.hardeningFindings.filter(isMeasured);
     const total = measured.length;
     const failed = measured.filter(f => countsAgainstScore(f)).length;
     subReports.hardening = {
       totalChecks: total,
       failedChecks: failed,
-      passRate: total > 0 ? Math.round(((total - failed) / total) * 100) : 100,
     };
   }
 
@@ -337,6 +356,24 @@ export function buildPublishPayload(data: PublishScanData, toolVersion: string):
     verdict,
     subReports,
     contentHash,
+    // #464 — the settled record rides the wire: typed counts the server can
+    // trust instead of re-deriving from the narrowed findings[], plus the
+    // measurement disclosure. Absent on the non-settled (attack) path, so an
+    // unsettled publish stays byte-identical to what the Registry received.
+    ...(settled
+      ? {
+          criticalCount: settled.counts.critical,
+          highCount: settled.counts.high,
+          mediumCount: settled.counts.medium,
+          lowCount: settled.counts.low,
+          measured: settled.measured,
+          exitCode: settled.exitCode,
+          coverage: settled.coverage,
+          ...(settled.suppressed ? { suppressed: settled.suppressed } : {}),
+          ...(settled.outOfScope ? { outOfScope: settled.outOfScope } : {}),
+          schemaVersion: settled.schemaVersion,
+        }
+      : {}),
   };
 
   if (data.treeHash) {
@@ -358,6 +395,7 @@ export function buildPublishPayload(data: PublishScanData, toolVersion: string):
 export async function publishScanResults(
   data: PublishScanData,
   registryUrl: string,
+  settled?: SettledOutcome,
 ): Promise<PublishResult> {
   const keypair = readAgentKeypair();
 
@@ -395,7 +433,7 @@ export async function publishScanResults(
     // Fallback version
   }
 
-  const payload = buildPublishPayload(data, toolVersion);
+  const payload = buildPublishPayload(data, toolVersion, settled);
 
   // Sign and include identity in body (not headers).
   let signedFirstParty = false;
@@ -458,17 +496,20 @@ export async function publishScanResults(
 
     // Report remediation tracking (non-blocking)
     if (data.hardeningFindings) {
-      // `f.passed || f.fixed` counted a fix the verification pass disproved
-      // as a pass, so the score the Registry stored as `initialScore` /
-      // `rescanScore` credited repairs that never landed. Same predicate as
-      // every other consumer.
-      const score = data.hardeningFindings.length > 0
-        ? Math.round(
-            (data.hardeningFindings.filter(f => !countsAgainstScore(f)).length /
-              data.hardeningFindings.length) *
-              100,
-          )
-        : 100;
+      // #464 — the settled score, never a second ratio: the pass-fraction
+      // computed here was the third spelling of the run's score on one wire
+      // (`initialScore` / `rescanScore` disagreed with the published `score`
+      // and with the terminal). The ratio remains only for the non-settled
+      // (attack) path.
+      const score = settled
+        ? settled.score
+        : data.hardeningFindings.length > 0
+          ? Math.round(
+              (data.hardeningFindings.filter(f => !countsAgainstScore(f)).length /
+                data.hardeningFindings.length) *
+                100,
+            )
+          : 100;
 
       try {
         await reportFindings(registryUrl, result.scanId, data.packageName, data.hardeningFindings, score);

--- a/src/telemetry/contribute.ts
+++ b/src/telemetry/contribute.ts
@@ -26,6 +26,7 @@ import type {
   ContributionEvent,
   ContributionBatch,
 } from '@opena2a/contribute';
+import type { SettledOutcome } from '../hardening/settled-outcome';
 import { existsSync, readFileSync } from 'fs';
 import { join } from 'path';
 import { VERSION } from '../index';
@@ -90,6 +91,12 @@ function detectPackageVersion(directory: string, ecosystem: string): string {
 // Build contribution event from scan findings (HMA-specific adapter)
 // ---------------------------------------------------------------------------
 
+/**
+ * Severity ladder for callers with NO settled `secure` record behind them
+ * (scan-soul's converted controls, detect). A `secure` run never reaches
+ * this: its sites pass the settled record, and the event reads that (#519 —
+ * this ladder was the third spelling of one run's verdict across the wires).
+ */
 function computeVerdict(findings: SecurityFinding[]): string {
   const critical = findings.filter(f => !f.passed && f.severity === 'critical').length;
   const high = findings.filter(f => !f.passed && f.severity === 'high').length;
@@ -103,22 +110,28 @@ function computeVerdict(findings: SecurityFinding[]): string {
  *
  * Converts the detailed finding list into an anonymized summary:
  * only counts and severity distribution, no file paths or descriptions.
+ *
+ * #464/#519 — with a settled record, every figure is READ from it: `score`
+ * is the displayed 0-100 (never a passed/total ratio — that ratio reported
+ * 0 for any tree with one failure), `verdict` is the settled band, the
+ * severity counts are the record's, and `totalChecks` is the count of
+ * completed check executions from the run's own coverage record, or OMITTED
+ * when the run kept none — a derived stand-in number is worse than no
+ * number.
  */
 export function buildScanEvent(
   packageName: string,
   directory: string,
   findings: SecurityFinding[],
   durationMs: number,
+  settled?: SettledOutcome,
+  completedChecks?: number,
 ): ContributionEvent {
   const ecosystem = detectEcosystem(directory);
   const version = detectPackageVersion(directory, ecosystem);
 
-  const total = findings.length;
-  const passed = findings.filter(f => f.passed).length;
-  const failed = findings.filter(f => !f.passed);
-
-  return {
-    type: 'scan_result',
+  const base = {
+    type: 'scan_result' as const,
     tool: 'hackmyagent',
     toolVersion: VERSION,
     timestamp: new Date().toISOString(),
@@ -127,6 +140,36 @@ export function buildScanEvent(
       version: version || undefined,
       ecosystem,
     },
+  };
+
+  if (settled) {
+    if (settled.verdict === null) {
+      // Fail closed: `outboundAllowed` withholds exit-2 runs before this is
+      // ever built; a null verdict here is a caller bug, not an event.
+      throw new Error('a run at EXIT_UNMEASURED never contributes (#464)');
+    }
+    return {
+      ...base,
+      scanSummary: {
+        ...(completedChecks !== undefined ? { totalChecks: completedChecks } : {}),
+        passed: findings.filter(f => f.passed).length,
+        critical: settled.counts.critical,
+        high: settled.counts.high,
+        medium: settled.counts.medium,
+        low: settled.counts.low,
+        score: settled.score,
+        verdict: settled.verdict,
+        durationMs,
+      },
+    };
+  }
+
+  const total = findings.length;
+  const passed = findings.filter(f => f.passed).length;
+  const failed = findings.filter(f => !f.passed);
+
+  return {
+    ...base,
     scanSummary: {
       totalChecks: total,
       passed,

--- a/src/telemetry/contribute.ts
+++ b/src/telemetry/contribute.ts
@@ -160,6 +160,13 @@ export function buildScanEvent(
         score: settled.score,
         verdict: settled.verdict,
         durationMs,
+        // Settled-outcome extras (@opena2a/contribute 0.3.0): the exit code,
+        // the pre-clamp score, and the identity-only suppression rows.
+        exitCode: settled.exitCode,
+        ...(settled.rawScore !== undefined ? { rawScore: settled.rawScore } : {}),
+        ...(settled.scoreClamped !== undefined ? { scoreClamped: settled.scoreClamped } : {}),
+        ...(settled.suppressed ? { suppressed: settled.suppressed } : {}),
+        ...(settled.outOfScope ? { outOfScope: settled.outOfScope } : {}),
       },
     };
   }


### PR DESCRIPTION
## What

One settled outcome feeds every record that leaves the process about a `secure` run, and a run the tool could not measure sends nothing. Executes the converged three-chief design (summarized on the issues).

Before, each wire recomputed its own figures from the narrowed findings list:

- the Registry publish payload rebuilt a composite (`score 100 / verdict pass / 0 failed checks` for a run the terminal reported `69/100 ... exit 1`) with a `passRate` ratio no server reads;
- `--ci-publish` derived `status: passed, counts all 0` for a run that displayed 49 findings and exited 1 (#464);
- the contribution event scored `passed/total` — 0 for any tree with one failure — under a third verdict ladder, with `totalChecks = findings.length` (#519);
- `jq` had no one predicate for "was this measured" across `check`, `secure` and the wires (#283).

Now `settledOutcome(result, exitCode)` (NEW `src/hardening/settled-outcome.ts`) is projected once at the run's single settlement point — no arithmetic; `applyScore` remains the only score computation; `gateSet`/`deepScanIncomplete`/`unreadInputCount` moved here from `cli.ts` with their histories so the wires can share them — and every consumer reads it:

| wire | before | now |
|---|---|---|
| publish payload (json + text arms) | recomputed composite + `passRate` | settled `score/rawScore/scoreClamped/verdict`; typed `criticalCount/highCount/mediumCount/lowCount`, `measured`, `exitCode`, `coverage`, suppression rows, `schemaVersion`; `passRate` deleted |
| remediation report score | pass-fraction ratio | the settled score |
| scan / community reports | local ladder over the narrowed list | `status` = the settled band (`failed/warnings/passed`), counts from the record, `rawReport.settledOutcome` whole |
| `--ci-publish` body | `passed/0s` beside exit 1 was expressible | counts and status read the record |
| contribution event | ratio score, third ladder, `totalChecks = list length` | displayed 0-100 score, the one band, `totalChecks` = completed executions from the coverage record or OMITTED; extras `exitCode/rawScore/scoreClamped/suppressed/outOfScope` (`@opena2a/contribute` `^0.3.0`) |
| `secure --json` | — | the document's top level IS the record: flat `verdict`, `exitCode`, `measured`, `counts`; `coverage` gains `measured/examined/total/unit`; `pickSettledOutcome(json)` reconstructs the record (exported, key list derived from the type via `satisfies`) |

**Withhold:** a run that settled `EXIT_UNMEASURED` posts no outcome record — all five outbound arms are withheld before their own preconditions, one line prints (`Registry: nothing sent — <the run's own exit-2 reason>. Withheld: <arms>. <remedy>.`), and `--json` carries `publish: {success: false, attempted: false, reason: 'unmeasured'}`. `--no-contribute` wins over persisted consent in that line. (The consent-gated NanoMind classification stream flushes mid-scan and is out of scope: #655.)

**Exit precedence repaired:** `finishWithFindings` now RAISES instead of assigning, so an unread input plus a counted critical exits 2 — previously the per-arm finding line trampled the unmeasured floor to 1, against the precedence `raiseExitCode` documents.

Scan-soul and detect contributions, and the `attack` publish, carry no settled record and are byte-identical (attack payload diffed identical on both builds by the review).

## Proof

- **Unit** (`__tests__/registry/settled-outcome-wires.test.ts`, 24 cells): the exit ladder including the suppressed-critical laundering cell (a count-3 suppression row expands to 3 counted entries); the record's counts/coverage/verdict including the null rule; `outboundAllowed`; `wireStatus` fail-closed on null; every builder's settled and legacy paths; the picker identity and key-list census.
- **Spawn** (`__tests__/cli/settled-outbound-claims.test.ts`, 9 cells): the leaky-env corpus fixture with `!CONFIG-004` measured end-to-end (verdict fail, `exitCode` 1 == `$?`, the suppressed critical counted, coverage sub-keys); the picker over the real document; the exit-2 warn band carried; the unread+critical overlap exiting 2 on both channels; the withhold matrix (json/text/ci, no HMAC demand before the withhold, `--no-contribute` vs persisted consent) and the measured-run-still-attempts pin. Corpus-backed cells skip where the private corpus is absent (the repo's own idiom).
- **Red-proof** on the 3570f15 build (module kept, the four consumers reverted): 14/30 cells red — the 12 RED-marked plus the two fail-closed throw cells — every PIN green; restore identical; HEAD 30/30 (33 after the round's cells).
- **Mutations** N1-N7, each killed by name and restored identical: withhold deleted (4 kills), publish recompute restored (1), wireStatus inverted (1), event score ratio (1), counts skip suppressed (4), picker projection dropped (1), json flat key dropped (3).
- **Adversarial round** (independent agent, archive trees, no git): 1 HIGH — the text publish arm never received the record (the recompute alive on the default arm) — **fixed**, with the round's other findings: the exit-parity trample **fixed** (raise + the overlap red cell), the `--no-contribute` line corner **fixed** (+ consent-matrix cell), the community run-scoped counts disclosed in CHANGELOG per the ruling, the NanoMind stream scoped out and filed (#655), the picker identity claim narrowed, count-direction and fail-below CHANGELOG sentences narrowed. Also proven by the round: the withhold covers every outbound path (narrative publish included; a withheld run flushes no previously-queued events), `expandSuppressed` count semantics, NA exclusion, no double-print in a 10-cell matrix, attack byte-identical.
- **Gate:** full suite on the final commit: 338 files / 4782 passed / 0 failed, npm exit 0 (on f0d470a). Lint 0. Self-scan exit 0 (639 files read). /pre-push-review PASS (Effort: xhigh).

## Registry / consumers

The deployed endpoints drop unknown fields (measured); the typed columns, the 422 on `measured: false`, and the range-mark are the Registry-side R1 work owned in opena2a-registry. Production count queries (Q-A/Q-B/Q-C) run before any consumer notice, per the recorded decision. `@opena2a/contribute` 0.2.0/0.3.0 shipped earlier today with SLSA v1 provenance.

Merge != release: MINOR, rides 0.33.0 only because it is green before the tag; the token dry-run re-runs on this merge commit before tagging.

Closes #464, closes #519, closes #283
