### PR TITLE
check keeps its exit-code promise on PyPI and URL fetch failures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,11 +16,16 @@ indistinguishable (#602).
 The five endings now settle through the same unmeasured path as the other
 arms: exit 2, the `Not measured` banner in text mode, and — where `--json`
 mode previously wrote nothing at all to stdout — a document whose
-`coverage` record says `measured: false` with the reason
-(`target-not-found` for a 404/410 or a missing distribution,
-`target-unreachable` for everything that answered badly or not at all).
-The settlement is raise-only, so a verdict settled before a late error
-still holds its floor.
+`coverage` record says `measured: false` with the reason:
+`target-not-found` when the target denies existing (HTTP 404/410, a git
+clone the remote reports as not found, a distribution PyPI does not
+offer); `target-unreachable` when the fetch itself failed; `no-response`
+when the bytes arrived but produced no analyzable answer (a corrupt or
+unsupported archive). The reason is built from structured evidence — an
+HTTP status, a git exit code with its own stderr — never from substrings
+of a rendered error message, and the wire detail never embeds the raw
+message (it can carry local temp paths). The settlement is raise-only, so
+a verdict settled before a late error still holds its floor.
 
 ### Result and crash endings now emit their telemetry event
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,24 @@ All notable changes to HackMyAgent are documented in this file.
 
 ## [Unreleased]
 
+### check keeps its exit-code promise on PyPI and URL fetch failures
+
+`check --help` documents exit 2 for a target that "does not exist or could
+not be fetched", and the npm, GitHub and local-path arms keep that promise.
+The PyPI and URL arms did not: five fetch-failure endings exited 1, which
+tells a CI consumer "measured, high or critical risk" about a package or
+URL that was never fetched — a failing package and a network error were
+indistinguishable (#602).
+
+The five endings now settle through the same unmeasured path as the other
+arms: exit 2, the `Not measured` banner in text mode, and — where `--json`
+mode previously wrote nothing at all to stdout — a document whose
+`coverage` record says `measured: false` with the reason
+(`target-not-found` for a 404/410 or a missing distribution,
+`target-unreachable` for everything that answered badly or not at all).
+The settlement is raise-only, so a verdict settled before a late error
+still holds its floor.
+
 ### Result and crash endings now emit their telemetry event
 
 A hard `process.exit` ends the process before the hook that posts the

--- a/__tests__/cli/check-url-unmeasured-exit.test.ts
+++ b/__tests__/cli/check-url-unmeasured-exit.test.ts
@@ -44,6 +44,13 @@ const server = http.createServer((req, res) => {
     }
     return;
   }
+  if (req.url.startsWith('/garbage')) {
+    // Answers every request; the body is just not a tarball.
+    res.setHeader('content-type', 'application/gzip');
+    res.statusCode = 200;
+    res.end(req.method === 'HEAD' ? undefined : 'this is not a gzip archive');
+    return;
+  }
   res.statusCode = 404;
   res.end();
 });
@@ -111,6 +118,34 @@ describe('#602 check URL fetch failures are unmeasured, exit 2', { timeout: 300_
     const r = run('http://127.0.0.1:9/pkg.tar.gz', false);
     expect(r.status, r.stderr).toBe(2);
     expect(r.stderr).toMatch(/not measured|Not measured/i);
+  });
+
+  it('a target that answered every request is not called unreachable — bad bytes are no-response, and the wire detail carries no raw message', () => {
+    // Adversarial round 2 measured the arm-wide catch claiming "could not
+    // be fetched" / target-unreachable for a 200-everything server whose
+    // body simply is not an archive — false on both machine-readable
+    // claims — and embedding the raw error (with local temp paths) in the
+    // persistent detail. The fetched-stage flag decides the claim now.
+    const r = run(`${base}/garbage/pkg.tar.gz`, true);
+    expect(r.status, r.stderr).toBe(2);
+    const c = coverage(r.stdout);
+    expect(c.measured).toBe(false);
+    expect(c.reason).toBe('no-response');
+    expect(c.detail).not.toMatch(/hma-check-url|\/tmp\/|\/var\/folders|Command failed/);
+  });
+
+  it("the wire reason cannot be steered by '128' in the URL itself", () => {
+    // Round 2's exact repro pair: the old substring sniff mapped ANY
+    // message containing "128" to target-not-found, so two identical
+    // connection refusals disagreed based on the repo NAME. The reason is
+    // structured-evidence-only now: same failure, same reason, whatever
+    // the path spells.
+    const a = run('http://127.0.0.1:9/repo128.git', true);
+    const b = run('http://127.0.0.1:9/repoxyz.git', true);
+    expect(a.status, a.stderr).toBe(2);
+    expect(b.status, b.stderr).toBe(2);
+    expect(coverage(a.stdout).reason).toBe(coverage(b.stdout).reason);
+    expect(coverage(a.stdout).reason).toBe('target-unreachable');
   });
 
   it('PIN: the --help table and the behavior agree on exit 2', () => {

--- a/__tests__/cli/check-url-unmeasured-exit.test.ts
+++ b/__tests__/cli/check-url-unmeasured-exit.test.ts
@@ -1,0 +1,124 @@
+/**
+ * #602 — `check`'s URL arm keeps the documented exit-code contract on fetch
+ * failure: exit 2 ("does not exist or could not be fetched", the #508 table),
+ * never 1, which told a CI consumer "measured, high risk" about a target
+ * that was never fetched.
+ *
+ * RED-ON-BASE: on c9d18b7 all three failure cells exit 1 and `--json` mode
+ * writes NOTHING to stdout. Now they settle through `unmeasured(...)` /
+ * `settleCheckVerdict` like the npm and local arms: exit 2, the unmeasured
+ * banner in text mode, and a coverage document in json mode.
+ *
+ * The PyPI arm's two sibling sites (no-dist, fetch catch) share the same
+ * settlement but have no deterministic offline trigger (the PyPI base URL is
+ * hardcoded); they are held by the exit-surface ratchet — their bare exits
+ * are GONE from the baseline (the first shrink), so a revert reintroduces a
+ * bare site and fails the ratchet, not this file.
+ *
+ * All fixtures are local: an in-test HTTP server on an ephemeral port, and
+ * the discard port for connection refusal. Nothing reaches the network.
+ */
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { spawnSync, spawn, type ChildProcess } from 'node:child_process';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { assertDistFreshIfPresent, BUILT_CLI as CLI } from '../helpers/dist-freshness';
+
+beforeAll(assertDistFreshIfPresent);
+
+// The fixture server runs in a CHILD process: `spawnSync` blocks this
+// worker's event loop for the whole CLI run, so an in-process server could
+// never accept the connection (measured as a 120s deadlock on first write).
+const SERVER_SRC = `
+const http = require('node:http');
+const server = http.createServer((req, res) => {
+  if (req.url.startsWith('/flaky')) {
+    if (req.method === 'HEAD') {
+      res.setHeader('content-type', 'application/gzip');
+      res.statusCode = 200;
+      res.end();
+    } else {
+      res.statusCode = 500;
+      res.end();
+    }
+    return;
+  }
+  res.statusCode = 404;
+  res.end();
+});
+server.listen(0, '127.0.0.1', () => {
+  process.stdout.write(String(server.address().port) + '\\n');
+});
+`;
+
+let serverProc: ChildProcess;
+let base = '';
+
+beforeAll(async () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'hma-602-srv-'));
+  const file = path.join(dir, 'server.js');
+  fs.writeFileSync(file, SERVER_SRC);
+  serverProc = spawn(process.execPath, [file], { stdio: ['ignore', 'pipe', 'ignore'] });
+  const port = await new Promise<string>((resolve, reject) => {
+    const t = setTimeout(() => reject(new Error('fixture server did not start')), 10_000);
+    serverProc.stdout!.once('data', (d) => { clearTimeout(t); resolve(String(d).trim()); });
+    serverProc.once('exit', () => { clearTimeout(t); reject(new Error('fixture server exited')); });
+  });
+  base = `http://127.0.0.1:${port}`;
+});
+
+afterAll(() => {
+  serverProc?.kill();
+});
+
+function run(target: string, json: boolean) {
+  const args = [CLI, 'check', target, '--offline', ...(json ? ['--json'] : [])];
+  const r = spawnSync(process.execPath, args, {
+    encoding: 'utf8',
+    timeout: 120_000,
+    maxBuffer: 64 * 1024 * 1024,
+    env: { ...process.env, NO_COLOR: '1', OPENA2A_TELEMETRY: 'off', HOME: fs.mkdtempSync(path.join(os.tmpdir(), 'hma-602-home-')) },
+  });
+  return { status: r.status, stdout: r.stdout ?? '', stderr: r.stderr ?? '' };
+}
+
+function coverage(stdout: string): any {
+  const doc = JSON.parse(stdout.slice(stdout.indexOf('{'), stdout.lastIndexOf('}') + 1));
+  return doc.coverage;
+}
+
+describe('#602 check URL fetch failures are unmeasured, exit 2', { timeout: 300_000 }, () => {
+  it('RED-ON-BASE: HTTP 404 on HEAD → exit 2, target-not-found, a json document exists', () => {
+    const r = run(`${base}/missing/pkg.tar.gz`, true);
+    expect(r.status, r.stderr).toBe(2);
+    const c = coverage(r.stdout);
+    expect(c.measured).toBe(false);
+    expect(c.reason).toBe('target-not-found');
+  });
+
+  it('RED-ON-BASE: download failing after a good HEAD → exit 2, target-unreachable', () => {
+    const r = run(`${base}/flaky/pkg.tar.gz`, true);
+    expect(r.status, r.stderr).toBe(2);
+    const c = coverage(r.stdout);
+    expect(c.measured).toBe(false);
+    expect(c.reason).toBe('target-unreachable');
+  });
+
+  it('RED-ON-BASE: connection refused → exit 2 with the unmeasured banner in text mode', () => {
+    // The discard port refuses instantly, so the fetch throws into the URL
+    // arm's catch — the site that used to exit 1 with only an error line.
+    const r = run('http://127.0.0.1:9/pkg.tar.gz', false);
+    expect(r.status, r.stderr).toBe(2);
+    expect(r.stderr).toMatch(/not measured|Not measured/i);
+  });
+
+  it('PIN: the --help table and the behavior agree on exit 2', () => {
+    const r = spawnSync(process.execPath, [CLI, 'check', '--help'], {
+      encoding: 'utf8',
+      timeout: 60_000,
+      env: { ...process.env, NO_COLOR: '1', OPENA2A_TELEMETRY: 'off', HOME: fs.mkdtempSync(path.join(os.tmpdir(), 'hma-602-help-')) },
+    });
+    expect(r.stdout + r.stderr).toMatch(/2.*(not exist|could not be fetched|not measured)/i);
+  });
+});

--- a/__tests__/hardening/provenance-abort-survives-catches.test.ts
+++ b/__tests__/hardening/provenance-abort-survives-catches.test.ts
@@ -71,9 +71,12 @@ describe('every swallowing catch around a publish boundary calls the helper', ()
     // Blunt on purpose, like the JSON.stringify tripwire: it does not prove
     // coverage, it forces the author of a NEW publish catch to classify it.
     const calls = (src.match(/rethrowIfRedactionProvenance\(/g) ?? []).length;
+    // 9 → 10 under #602: checkPyPiPackage's arm-wide catch gained the guard
+    // its URL sibling already had — an adversarial round measured it
+    // swallowing a provenance abort and relabeling it a network error.
     expect(
       calls,
       'cli.ts gained or lost a rethrowIfRedactionProvenance call — a new catch around a publish boundary must call it, then update this pin',
-    ).toBe(9);
+    ).toBe(10);
   });
 });

--- a/__tests__/helpers/exit-surface-baseline.ts
+++ b/__tests__/helpers/exit-surface-baseline.ts
@@ -19,9 +19,11 @@ export const UNSETTLED_EXIT_IDS: ReadonlySet<string> = new Set([
   'S012', 'S013', 'S014', 'S016', 'S017', 'S018', 'S019', 'S020', 'S021', 'S022',
   'S023', 'S024', 'S025', 'S026', 'S027', 'S031', 'S035', 'S037', 'S039', 'S041',
   'S042', 'S043', 'S044', 'S045',
-  // Bare `process.exitCode` assignments outside the funnel — migrate to raiseExitCode:
+  // Bare `process.exitCode` assignments outside the funnel — migrate to raiseExitCode.
+  // (S050-S054, check's PyPI and URL fetch-failure exits, settled via
+  // settleCheckVerdict under #602 — the first baseline shrink.)
   'S011', 'S015', 'S028', 'S029', 'S030', 'S032', 'S033', 'S034', 'S036', 'S038',
-  'S040', 'S046', 'S047', 'S048', 'S049', 'S050', 'S051', 'S052', 'S053', 'S054',
+  'S040', 'S046', 'S047', 'S048', 'S049',
   'S055',
   // benchmark-report.ts's category refusal (reached from the tracked benchmark command):
   'S056',

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -13033,6 +13033,9 @@ async function checkPyPiPackage(
   }
 
   const tempDir = await mkdtemp(join(tmpdir(), 'hma-check-pypi-'));
+  // What the catch below may truthfully claim (#602, adversarial round 2):
+  // false until the distribution's bytes have fully arrived.
+  let fetched = false;
 
   try {
     // Fetch package metadata from PyPI JSON API
@@ -13098,6 +13101,7 @@ async function checkPyPiPackage(
       throw new Error(`Failed to download ${dist.filename}: HTTP ${archiveRes.status}`);
     }
     const archiveBuffer = Buffer.from(await archiveRes.arrayBuffer());
+    fetched = true;
     const archivePath = join(tempDir, dist.filename);
     const { writeFileSync } = await import('node:fs');
     writeFileSync(archivePath, archiveBuffer);
@@ -13207,9 +13211,12 @@ async function checkPyPiPackage(
 
     // Exit code settled above, before the `--json` branch.
   } catch (err: unknown) {
+    // A redaction-provenance failure is a security invariant, not a fetch
+    // problem — never relabel it as a network error (adversarial round 2;
+    // the URL arm's catch already had this guard).
+    rethrowIfRedactionProvenance(err);
     const message = err instanceof Error ? err.message : String(err);
-    const pypiNotFound = message.includes('not found on PyPI');
-    if (pypiNotFound) {
+    if (message.includes('not found on PyPI')) {
       console.error(`Error: ${escapeForDisplay(String(message))}`);
     } else {
       console.error(`Error scanning PyPI package "${escapeForDisplay(name)}": ${escapeForDisplay(String(message))}`);
@@ -13217,12 +13224,14 @@ async function checkPyPiPackage(
     // #602 — the run reached no verdict: exit 2 per the documented table,
     // never 1, which told a CI consumer "high risk" about a package that was
     // never scanned. Raise-only, so a verdict settled before a late error
-    // still holds its floor.
+    // still holds its floor. `fetched` decides which claim is true (the
+    // catch spans the whole arm); the raw message stays on stderr and out
+    // of the wire detail (it embeds local temp paths).
     const verdict = unmeasured(
-      pypiNotFound ? 'target-not-found' : 'target-unreachable',
-      pypiNotFound
-        ? `${escapeForDisplay(name)} was not found on PyPI, so nothing was scanned.`
-        : `${escapeForDisplay(name)} could not be fetched from PyPI (${escapeForDisplay(String(message))}), so no verdict was measured.`,
+      fetched ? 'no-response' : 'target-unreachable',
+      fetched
+        ? `${escapeForDisplay(name)} was fetched from PyPI but could not be analyzed, so no verdict was measured.`
+        : `${escapeForDisplay(name)} could not be fetched from PyPI, so nothing was scanned.`,
     );
     await settleCheckVerdict(verdict);
     if (options.json) {
@@ -13253,6 +13262,11 @@ async function checkRawUrl(
   const tempDir = await mkdtemp(join(tmpdir(), 'hma-check-url-'));
   let scanDir = tempDir;
   let displayName = url;
+  // What the catch below may truthfully claim (#602, adversarial round 2):
+  // false until the bytes have fully arrived. A failure after this flips is
+  // an analysis failure, not a fetch failure — the two are different
+  // sentences for the user and different reasons on the wire.
+  let fetched = false;
 
   try {
     // Git clone for known forge URLs and .git suffix
@@ -13271,6 +13285,7 @@ async function checkRawUrl(
         'git', ['clone', '--depth', '1', '--single-branch', url, join(tempDir, repoName)],
         { timeout: 120_000 },
       );
+      fetched = true;
       scanDir = join(tempDir, repoName);
     } else {
       // HTTP fetch — use HEAD to determine content type
@@ -13324,6 +13339,7 @@ async function checkRawUrl(
         return;
       }
       const buffer = Buffer.from(await bodyRes.arrayBuffer());
+      fetched = true;
 
       if (isArchive) {
         const archivePath = join(tempDir, fileName);
@@ -13463,8 +13479,7 @@ async function checkRawUrl(
   } catch (err: unknown) {
     rethrowIfRedactionProvenance(err);
     const message = err instanceof Error ? err.message : String(err);
-    const urlNotFound = message.includes('128') || message.includes('not found') || message.includes('Repository not found');
-    if (urlNotFound) {
+    if (message.includes('128') || message.includes('not found') || message.includes('Repository not found')) {
       console.error(`Error: Could not clone repository from "${escapeForDisplay(String(url))}".`);
       console.error(`\nVerify the URL is accessible and contains a git repository.`);
     } else if (message.includes('timeout') || message.includes('Timeout')) {
@@ -13477,9 +13492,23 @@ async function checkRawUrl(
     // #602 — the run reached no verdict: exit 2 per the documented table,
     // never 1 about a URL that was never fetched. Raise-only, so a verdict
     // settled before a late error still holds its floor.
+    //
+    // The wire reason is built from STRUCTURED evidence only (adversarial
+    // round 2): the message-substring sniff above is display-only, because
+    // "128" anywhere in the URL itself would steer it. And the catch spans
+    // the whole arm, so `fetched` decides which claim is true — a target
+    // that answered every request was not "unreachable"; its bytes just
+    // produced no analyzable answer. The raw message stays on stderr and
+    // out of the wire detail (it embeds local temp paths).
+    const gitErr = err as { code?: unknown; stderr?: unknown };
+    const urlNotFound = gitErr?.code === 128 && /repository not found|not found/i.test(String(gitErr.stderr ?? ''));
     const verdict = unmeasured(
-      urlNotFound ? 'target-not-found' : 'target-unreachable',
-      `${escapeForDisplay(String(url))} could not be fetched (${escapeForDisplay(String(message))}), so no verdict was measured.`,
+      fetched ? 'no-response' : urlNotFound ? 'target-not-found' : 'target-unreachable',
+      fetched
+        ? `${escapeForDisplay(String(url))} was fetched but could not be analyzed, so no verdict was measured.`
+        : urlNotFound
+          ? `${escapeForDisplay(String(url))} was not found, so nothing was scanned.`
+          : `${escapeForDisplay(String(url))} could not be fetched, so nothing was scanned.`,
     );
     await settleCheckVerdict(verdict);
     if (options.json) {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -13076,7 +13076,19 @@ async function checkPyPiPackage(
 
     if (!dist) {
       console.error(`Error: No downloadable distribution found for "${escapeForDisplay(String(name))}" on PyPI.`);
-      process.exitCode = 1; // exit-unsettled(#350/S050): bare assignment outside the funnel; migrate to raiseExitCode
+      // #602 — nothing was fetched, so nothing was measured: exit 2 per the
+      // documented table, never 1 ("measured, high risk") about a package
+      // that was never scanned. Same settlement as the npm and local arms.
+      const verdict = unmeasured(
+        'target-not-found',
+        `${escapeForDisplay(String(name))} has no downloadable distribution on PyPI, so nothing was scanned.`,
+      );
+      await settleCheckVerdict(verdict);
+      if (options.json) {
+        writeJsonStdout({ hackmyagentVersion: VERSION, target: name, type: 'pypi-package', coverage: coverageJson(verdict) });
+      } else {
+        console.error(unmeasuredBanner(verdict));
+      }
       return;
     }
 
@@ -13196,12 +13208,28 @@ async function checkPyPiPackage(
     // Exit code settled above, before the `--json` branch.
   } catch (err: unknown) {
     const message = err instanceof Error ? err.message : String(err);
-    if (message.includes('not found on PyPI')) {
+    const pypiNotFound = message.includes('not found on PyPI');
+    if (pypiNotFound) {
       console.error(`Error: ${escapeForDisplay(String(message))}`);
     } else {
       console.error(`Error scanning PyPI package "${escapeForDisplay(name)}": ${escapeForDisplay(String(message))}`);
     }
-    process.exitCode = 1; // exit-unsettled(#350/S051): bare assignment outside the funnel; migrate to raiseExitCode
+    // #602 — the run reached no verdict: exit 2 per the documented table,
+    // never 1, which told a CI consumer "high risk" about a package that was
+    // never scanned. Raise-only, so a verdict settled before a late error
+    // still holds its floor.
+    const verdict = unmeasured(
+      pypiNotFound ? 'target-not-found' : 'target-unreachable',
+      pypiNotFound
+        ? `${escapeForDisplay(name)} was not found on PyPI, so nothing was scanned.`
+        : `${escapeForDisplay(name)} could not be fetched from PyPI (${escapeForDisplay(String(message))}), so no verdict was measured.`,
+    );
+    await settleCheckVerdict(verdict);
+    if (options.json) {
+      writeJsonStdout({ hackmyagentVersion: VERSION, target: name, type: 'pypi-package', coverage: coverageJson(verdict) });
+    } else {
+      console.error(unmeasuredBanner(verdict));
+    }
   } finally {
     await rm(tempDir, { recursive: true, force: true });
   }
@@ -13253,10 +13281,19 @@ async function checkRawUrl(
       const headRes = await fetch(url, { method: 'HEAD', redirect: 'follow' });
       if (!headRes.ok) {
         console.error(`Error: HTTP ${headRes.status} fetching "${escapeForDisplay(String(url))}".`);
-        // Set exit code and return so `finally` can clean up tempDir (was
-        // already allocated above). process.exit() would skip the cleanup
-        // and orphan the /tmp/hma-check-url-* directory.
-        process.exitCode = 1; // exit-unsettled(#350/S052): bare assignment outside the funnel; migrate to raiseExitCode
+        // #602 — nothing was fetched, so nothing was measured: exit 2 per
+        // the documented table. Settle-and-return (not process.exit) so
+        // `finally` can clean up the already-allocated tempDir.
+        const verdict = unmeasured(
+          headRes.status === 404 || headRes.status === 410 ? 'target-not-found' : 'target-unreachable',
+          `HTTP ${headRes.status} fetching ${escapeForDisplay(String(url))}, so nothing was scanned.`,
+        );
+        await settleCheckVerdict(verdict);
+        if (options.json) {
+          writeJsonStdout({ hackmyagentVersion: VERSION, target: url, type: 'raw-url', coverage: coverageJson(verdict) });
+        } else {
+          console.error(unmeasuredBanner(verdict));
+        }
         return;
       }
 
@@ -13273,7 +13310,17 @@ async function checkRawUrl(
       const bodyRes = await fetch(finalUrl, { redirect: 'follow' });
       if (!bodyRes.ok || !bodyRes.body) {
         console.error(`Error: Failed to download "${escapeForDisplay(String(url))}" (HTTP ${bodyRes.status}).`);
-        process.exitCode = 1; // exit-unsettled(#350/S053): bare assignment outside the funnel; migrate to raiseExitCode
+        // #602 — same settlement as the HEAD failure above: unmeasured, 2.
+        const verdict = unmeasured(
+          'target-unreachable',
+          `Failed to download ${escapeForDisplay(String(url))} (HTTP ${bodyRes.status}), so nothing was scanned.`,
+        );
+        await settleCheckVerdict(verdict);
+        if (options.json) {
+          writeJsonStdout({ hackmyagentVersion: VERSION, target: url, type: 'raw-url', coverage: coverageJson(verdict) });
+        } else {
+          console.error(unmeasuredBanner(verdict));
+        }
         return;
       }
       const buffer = Buffer.from(await bodyRes.arrayBuffer());
@@ -13416,7 +13463,8 @@ async function checkRawUrl(
   } catch (err: unknown) {
     rethrowIfRedactionProvenance(err);
     const message = err instanceof Error ? err.message : String(err);
-    if (message.includes('128') || message.includes('not found') || message.includes('Repository not found')) {
+    const urlNotFound = message.includes('128') || message.includes('not found') || message.includes('Repository not found');
+    if (urlNotFound) {
       console.error(`Error: Could not clone repository from "${escapeForDisplay(String(url))}".`);
       console.error(`\nVerify the URL is accessible and contains a git repository.`);
     } else if (message.includes('timeout') || message.includes('Timeout')) {
@@ -13426,7 +13474,19 @@ async function checkRawUrl(
     } else {
       console.error(`Error scanning URL: ${escapeForDisplay(String(message))}`);
     }
-    process.exitCode = 1; // exit-unsettled(#350/S054): bare assignment outside the funnel; migrate to raiseExitCode
+    // #602 — the run reached no verdict: exit 2 per the documented table,
+    // never 1 about a URL that was never fetched. Raise-only, so a verdict
+    // settled before a late error still holds its floor.
+    const verdict = unmeasured(
+      urlNotFound ? 'target-not-found' : 'target-unreachable',
+      `${escapeForDisplay(String(url))} could not be fetched (${escapeForDisplay(String(message))}), so no verdict was measured.`,
+    );
+    await settleCheckVerdict(verdict);
+    if (options.json) {
+      writeJsonStdout({ hackmyagentVersion: VERSION, target: url, type: 'raw-url', coverage: coverageJson(verdict) });
+    } else {
+      console.error(unmeasuredBanner(verdict));
+    }
   } finally {
     await rm(tempDir, { recursive: true, force: true });
   }


### PR DESCRIPTION
Closes #602.

`check --help` documents exit 2 for a target that "does not exist or could not be fetched", and the npm, GitHub and local-path arms keep that promise. The PyPI and URL arms did not: five fetch-failure endings exited 1 — "measured, high or critical risk" about a package or URL that was never fetched — so a CI consumer could not tell a failing package from a network error, and `--json` mode wrote nothing to stdout at all on these paths.

**The fix.** The five endings settle through the same `unmeasured()` / `settleCheckVerdict` path as the other arms: exit 2 (raise-only, so a verdict settled before a late error holds its floor), the `Not measured` banner in text mode, and a coverage document in json mode. Their five ids leave the exit-surface baseline — the ratchet's first shrink, so a revert reintroduces a bare site and fails the bijection (proven: the PyPI-revert mutation is killed by the ratchet, not by a spawn cell).

**The wire reason states only what the arm actually knows** (adversarial round findings, both live-reproduced by the reviewer and fixed here):
- A fetched-stage flag decides the claim: `target-not-found` when the target denies existing (HTTP 404/410, a git clone the remote reports as not found, a distribution PyPI does not offer); `target-unreachable` when the fetch itself failed; `no-response` when the bytes arrived but produced no analyzable answer. The first cut called a 200-everything server with a corrupt archive "could not be fetched".
- The git not-found verdict keys on structured evidence only (exit code 128 plus git's own stderr); the first cut's substring sniff let `"128"` anywhere in the URL flip the reason — two identical connection refusals disagreed based on the repository name. The message sniff stays display-only.
- No wire detail embeds a raw error message (it can carry local temp paths); the raw message stays on stderr.
- The PyPI catch gains the provenance rethrow its URL sibling already had (the guard-count pin updated with the classification recorded), and its unreachable not-found branch is out of the verdict construction.

**Evidence.** Red-proofs: each of the four conversions reverted singly is killed by its cell (the PyPI one by the ratchet); the fetched-flag and substring mutations are killed by the two round-2 cells; pristine green with identical restores. Spawn cells run against a child-process fixture server (`spawnSync` blocks the worker's event loop, so an in-process server deadlocks — measured) plus the discard port; nothing reaches the network. Full suite 342 files / 4809 tests green. Follow-up filed: #658 (late error after a measured settle prints an unmeasured banner under a rendered report — pre-existing class, surfaced by the round).