### PR TITLE
A contradiction between --json and --format is named, not resolved silently

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to HackMyAgent are documented in this file.
 
 ## [Unreleased]
 
+### A contradiction between --json and --format is named, not resolved silently
+
+`--json` is the deprecated alias of `--format json`. Given together with a
+different format — `secure --ci --json --format sarif` — the alias won
+silently: the json report printed at exit 0 and nothing said the requested
+format was discarded. Both commands that carry the two flags (`secure` and
+`attack`) now refuse the contradiction where their other format errors are
+raised, before any scan: exit 1, naming the alias and both flags. Bare
+`--json` and the redundant agreement (`--json --format json`) are
+untouched. `attack --format ''` also now reaches the invalid-format
+refusal instead of falling to the text report (#605).
+
 ### check keeps its exit-code promise on PyPI and URL fetch failures
 
 `check --help` documents exit 2 for a target that "does not exist or could

--- a/__tests__/cli/json-format-contradiction.test.ts
+++ b/__tests__/cli/json-format-contradiction.test.ts
@@ -43,7 +43,7 @@ describe('#605 --json contradicting --format refuses, pre-scan', { timeout: 300_
   it('RED-ON-BASE: secure --json --format sarif refuses at exit 1, naming the alias, with no report on stdout', () => {
     const r = run(['secure', dir(), '--json', '--format', 'sarif', '--no-machine-posture']);
     expect(r.status).toBe(1);
-    expect(r.stderr).toMatch(/deprecated alias.*--format sarif.*Drop one/s);
+    expect(r.stderr).toMatch(/deprecated alias.*sarif.*Drop one/s);
     expect(r.stdout).not.toContain('{');
   });
 
@@ -66,7 +66,7 @@ describe('#605 --json contradicting --format refuses, pre-scan', { timeout: 300_
     // contacted — the cell completes fast on a port nothing listens on.
     const r = run(['attack', 'http://127.0.0.1:9', '--json', '--format', 'sarif']);
     expect(r.status).toBe(1);
-    expect(r.stderr).toMatch(/deprecated alias.*--format sarif.*Drop one/s);
+    expect(r.stderr).toMatch(/deprecated alias.*sarif.*Drop one/s);
   });
 
   it("RED-ON-BASE: attack --format '' reaches the invalid-format refusal instead of falling to text", () => {

--- a/__tests__/cli/json-format-contradiction.test.ts
+++ b/__tests__/cli/json-format-contradiction.test.ts
@@ -1,0 +1,77 @@
+/**
+ * #605 — `--json` is the deprecated alias of `--format json`; given together
+ * with a DIFFERENT format the two contradict, and the contradiction used to
+ * resolve silently in --json's favor: `secure --ci --json --format sarif`
+ * printed the json report at exit 0 with nothing to say the requested
+ * format was discarded. Now both commands that carry the two flags (secure
+ * and attack — `eval` has --format but no --json; scan-soul has --json but
+ * no --format) refuse the contradiction where their other format errors are
+ * raised, pre-scan.
+ *
+ * The check keys on Commander's option-value SOURCE, because --format has a
+ * 'text' DEFAULT: bare `--json` sees format='text' from the default and
+ * must stay untouched, and the redundant agreement (`--json --format
+ * json`) has nothing to resolve and stays allowed — a refusal there would
+ * break scripts that spell the same thing twice.
+ *
+ * RED-ON-BASE: contradiction cells exit 0/ran on 203356c; the attack
+ * `--format ''` cell documents the `?? 'text'` fix (#632's truthiness
+ * class, previously fixed on secure only).
+ */
+import { describe, it, expect, beforeAll } from 'vitest';
+import { spawnSync } from 'node:child_process';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { assertDistFreshIfPresent, BUILT_CLI as CLI } from '../helpers/dist-freshness';
+
+beforeAll(assertDistFreshIfPresent);
+
+function run(args: string[]) {
+  const r = spawnSync(process.execPath, [CLI, ...args], {
+    encoding: 'utf8',
+    timeout: 120_000,
+    maxBuffer: 64 * 1024 * 1024,
+    env: { ...process.env, NO_COLOR: '1', OPENA2A_TELEMETRY: 'off', HOME: fs.mkdtempSync(path.join(os.tmpdir(), 'hma-605-home-')) },
+  });
+  return { status: r.status, stdout: r.stdout ?? '', stderr: r.stderr ?? '' };
+}
+
+const dir = () => fs.mkdtempSync(path.join(os.tmpdir(), 'hma-605-'));
+
+describe('#605 --json contradicting --format refuses, pre-scan', { timeout: 300_000 }, () => {
+  it('RED-ON-BASE: secure --json --format sarif refuses at exit 1, naming the alias, with no report on stdout', () => {
+    const r = run(['secure', dir(), '--json', '--format', 'sarif', '--no-machine-posture']);
+    expect(r.status).toBe(1);
+    expect(r.stderr).toMatch(/deprecated alias.*--format sarif.*Drop one/s);
+    expect(r.stdout).not.toContain('{');
+  });
+
+  it('secure --json --format json is the redundant agreement and still runs', () => {
+    const r = run(['secure', dir(), '--json', '--format', 'json', '--no-machine-posture']);
+    expect(r.stderr).not.toMatch(/deprecated alias|contradicts/);
+    // An empty temp dir settles unmeasured; the point is the run HAPPENED
+    // and produced the json document the flags agree on.
+    expect(() => JSON.parse(r.stdout.slice(r.stdout.indexOf('{'), r.stdout.lastIndexOf('}') + 1))).not.toThrow();
+  });
+
+  it("bare --json is untouched — Commander's 'text' default is not an explicit --format", () => {
+    const r = run(['secure', dir(), '--json', '--no-machine-posture']);
+    expect(r.stderr).not.toMatch(/deprecated alias|contradicts/);
+    expect(() => JSON.parse(r.stdout.slice(r.stdout.indexOf('{'), r.stdout.lastIndexOf('}') + 1))).not.toThrow();
+  });
+
+  it('RED-ON-BASE: attack --json --format sarif refuses before any connection', () => {
+    // The refusal fires at flag validation, so the dead target is never
+    // contacted — the cell completes fast on a port nothing listens on.
+    const r = run(['attack', 'http://127.0.0.1:9', '--json', '--format', 'sarif']);
+    expect(r.status).toBe(1);
+    expect(r.stderr).toMatch(/deprecated alias.*--format sarif.*Drop one/s);
+  });
+
+  it("RED-ON-BASE: attack --format '' reaches the invalid-format refusal instead of falling to text", () => {
+    const r = run(['attack', 'http://127.0.0.1:9', '--format', '']);
+    expect(r.status).toBe(1);
+    expect(r.stderr).toMatch(/Invalid format ''/);
+  });
+});

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -4744,7 +4744,7 @@ Examples:
   .option('--no-contribute', 'Do not share findings for this scan (overrides config)')
   .option('--ci', 'CI mode: suppress interactive prompts and disable contribution. Does not change the exit code')
   .option('--no-machine-posture', 'Skip the advisory scan of AI runtimes installed outside the target (~/.openclaw, ~/.nemoclaw)')
-  .action(async (directory: string, options: { fix?: boolean; dryRun?: boolean; ignore?: string; json?: boolean; format?: string; output?: string; failBelow?: string; verbose?: boolean; benchmark?: string; level?: string; category?: string; deep?: boolean; nanomind?: boolean; analm?: boolean; scanDepth?: string; ciPublish?: boolean; publish?: boolean; registryReport?: boolean; registry?: boolean; versionId?: string; registryUrl?: string; registryKey?: string; contribute?: boolean; ci?: boolean; machinePosture?: boolean }) => {
+  .action(async (directory: string, options: { fix?: boolean; dryRun?: boolean; ignore?: string; json?: boolean; format?: string; output?: string; failBelow?: string; verbose?: boolean; benchmark?: string; level?: string; category?: string; deep?: boolean; nanomind?: boolean; analm?: boolean; scanDepth?: string; ciPublish?: boolean; publish?: boolean; registryReport?: boolean; registry?: boolean; versionId?: string; registryUrl?: string; registryKey?: string; contribute?: boolean; ci?: boolean; machinePosture?: boolean }, cmd: Command) => {
     try {
       const originalTarget = require("path").resolve(directory);
       let targetDir = originalTarget;
@@ -4859,8 +4859,21 @@ Examples:
       // fall to the text report silently (#632's class). `??` keeps '' as
       // given so it reaches the invalid-format error below.
       const format = options.json ? 'json' : (options.format ?? 'text');
-      if (!validFormats.includes(format)) {
-        console.error(`Error: Invalid format '${escapeForDisplay(String(format))}'. Use: ${validFormats.join(', ')}`);
+      // #605 — `--json` given together with a DIFFERENT `--format` is a
+      // contradiction, and it used to resolve silently in --json's favor: a
+      // CI job asking for sarif got the json report at exit 0 with nothing
+      // to say so. The source check distinguishes an explicit flag from
+      // Commander's 'text' default, so bare `--json` is untouched, and the
+      // redundant agreement (--json --format json) has nothing to resolve
+      // and stays allowed. One refusal site serves both messages so the
+      // exit-surface baseline holds its count.
+      const formatContradiction = options.json
+        && cmd.getOptionValueSource('format') === 'cli'
+        && options.format !== 'json';
+      if (formatContradiction || !validFormats.includes(format)) {
+        console.error(formatContradiction
+          ? `Error: --json is the deprecated alias of --format json and contradicts --format ${escapeForDisplay(String(options.format))}. Drop one of the two flags.`
+          : `Error: Invalid format '${escapeForDisplay(String(format))}'. Use: ${validFormats.join(', ')}`);
         process.exit(1); // exit-unsettled(#350/S006): pre-work refusal; events await the schema reason field (#525)
       }
       // #563 — the Agent Security Profile is rendered only by the OASB-1
@@ -7469,7 +7482,7 @@ Examples:
     registryUrl?: string;
     registryKey?: string;
     json?: boolean;
-  }) => {
+  }, cmd: Command) => {
     try {
       // Validate target
       if (!targetUrl && !options.local) {
@@ -7557,9 +7570,21 @@ Examples:
 
       // Validate format (--json is shorthand for --format json)
       const validFormats = ['text', 'json', 'sarif', 'html'];
-      const format = options.json ? 'json' : (options.format || 'text');
-      if (!validFormats.includes(format)) {
-        console.error(`Error: Invalid format '${escapeForDisplay(String(format))}'. Use: ${validFormats.join(', ')}`);
+      // `??`, not `||`: `--format ''` fell to the text report silently
+      // (#632's class, fixed on secure earlier); '' now reaches the
+      // invalid-format refusal below.
+      const format = options.json ? 'json' : (options.format ?? 'text');
+      // #605 — same contradiction as secure's: `--json --format sarif` used
+      // to resolve silently in --json's favor. Source check spares bare
+      // --json (Commander's 'text' default) and the redundant agreement;
+      // one refusal site serves both messages (baseline count unchanged).
+      const formatContradiction = options.json
+        && cmd.getOptionValueSource('format') === 'cli'
+        && options.format !== 'json';
+      if (formatContradiction || !validFormats.includes(format)) {
+        console.error(formatContradiction
+          ? `Error: --json is the deprecated alias of --format json and contradicts --format ${escapeForDisplay(String(options.format))}. Drop one of the two flags.`
+          : `Error: Invalid format '${escapeForDisplay(String(format))}'. Use: ${validFormats.join(', ')}`);
         process.exit(1); // exit-unsettled(#350/S020): pre-work refusal; events await the schema reason field (#525)
       }
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -4872,7 +4872,7 @@ Examples:
         && options.format !== 'json';
       if (formatContradiction || !validFormats.includes(format)) {
         console.error(formatContradiction
-          ? `Error: --json is the deprecated alias of --format json and contradicts --format ${escapeForDisplay(String(options.format))}. Drop one of the two flags.`
+          ? `Error: --json is the deprecated alias of --format json and contradicts --format '${escapeForDisplay(String(options.format))}'. Drop one of the two flags.`
           : `Error: Invalid format '${escapeForDisplay(String(format))}'. Use: ${validFormats.join(', ')}`);
         process.exit(1); // exit-unsettled(#350/S006): pre-work refusal; events await the schema reason field (#525)
       }
@@ -7445,7 +7445,7 @@ Examples:
   .option('--stop-on-success', 'Stop after first successful attack')
   .option('--payload-file <path>', 'JSON file with custom attack payloads')
   .option('--fail-on-vulnerable [severity]', 'Exit code 1 if vulnerabilities found (optional: critical/high/medium/low)')
-  .option('--json', 'Output as JSON (shorthand for --format json)')
+  .option('--json', 'Output as JSON (deprecated alias of --format json)')
   .option('-f, --format <format>', 'Output format: text, json, sarif, html', 'text')
   .option('-o, --output <file>', 'Write output to file')
   .option('-v, --verbose', 'Show detailed output for each payload')
@@ -7568,7 +7568,7 @@ Examples:
         a2aRecipient: options.a2aRecipient,
       };
 
-      // Validate format (--json is shorthand for --format json)
+      // Validate format (--json is the deprecated alias of --format json)
       const validFormats = ['text', 'json', 'sarif', 'html'];
       // `??`, not `||`: `--format ''` fell to the text report silently
       // (#632's class, fixed on secure earlier); '' now reaches the
@@ -7583,7 +7583,7 @@ Examples:
         && options.format !== 'json';
       if (formatContradiction || !validFormats.includes(format)) {
         console.error(formatContradiction
-          ? `Error: --json is the deprecated alias of --format json and contradicts --format ${escapeForDisplay(String(options.format))}. Drop one of the two flags.`
+          ? `Error: --json is the deprecated alias of --format json and contradicts --format '${escapeForDisplay(String(options.format))}'. Drop one of the two flags.`
           : `Error: Invalid format '${escapeForDisplay(String(format))}'. Use: ${validFormats.join(', ')}`);
         process.exit(1); // exit-unsettled(#350/S020): pre-work refusal; events await the schema reason field (#525)
       }


### PR DESCRIPTION
Closes #605.

`--json` is the deprecated alias of `--format json`. Given together with a different format — `secure --ci --json --format sarif` — the alias won silently: the json report printed at exit 0 and nothing said the requested format was discarded, so a CI job that asked for sarif consumed json without a word.

Both commands that carry the two flags refuse the contradiction where their other format errors are raised, pre-scan, at exit 1, naming the alias and both flags. The class ends there: `eval oracle` has `--format` but no `--json`, `scan-soul` the reverse (verified by the round across all three `--format` registrations in the tree).

Design points, each proven by a named cell and a killed mutation:
- The check keys on Commander's option-value **source**, because `--format` carries a `'text'` default — bare `--json` sees the default and must stay untouched (the widened-predicate mutation breaks exactly that cell). The redundant agreement `--json --format json` has nothing to resolve and stays allowed.
- Each command's **existing** format-refusal site serves both messages, so the exit-surface baseline holds its count (the ratchet suite runs green in the same battery).
- `attack`'s format resolution moves from `||` to `??` (#632's truthiness class, previously fixed on `secure` only), so `--format ''` reaches the invalid-format refusal instead of silently falling to the text report.
- The refusal fires before any connection: with the predicate mutated dead, the attack cell takes 111s reaching the dead target; live, 140ms.

Adversarial round: SHIP, zero blocking — it verified the commander v12 action contract (`cmd` is always the parameter after options), all flag spellings (`-f`, `--format=`, order), the refusal ordering against the neighboring S-sites, and every CHANGELOG claim. Its three cosmetic findings are fixed (help/refusal wording agreement, the quoted format value); its one pre-existing out-of-diff finding is filed as #660 (`-H` repeats overwrite). Full suite 343 files / 4814 tests green.