### PR TITLE
Registry check-stub output is escaped against terminal control bytes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to HackMyAgent are documented in this file.
 
 ## [Unreleased]
 
+### Registry check-stub output is escaped against terminal control bytes
+
+`hackmyagent stubs` printed every field of the Registry JSON response — check id, series, name, severity, description, detection logic — without a display escape, so a stub carrying a raw ESC byte could steer the reader's terminal (#601). Each field now escapes on its printing line. A census of the same class across `secure`/`check`/`attack`/`scan-soul` output found no other live hole: the remaining field interpolations render tool-authored constants or analyst strings already stripped of control bytes at their IPC boundary, and a dead `displayRegistryResult` function was removed. A structural tripwire pins the property so a new raw field-print fails the build until it is escaped or classified.
+
 ### The fix marker no longer depends on how the tool was invoked
 
 Under a parent CLI that sets `HMA_CLI_PREFIX`, fix citations are rewritten

--- a/__tests__/cli/field-interpolation-render-source.test.ts
+++ b/__tests__/cli/field-interpolation-render-source.test.ts
@@ -1,0 +1,133 @@
+/**
+ * Structural tripwire (#601): a print in src/cli.ts that interpolates one of
+ * the non-path finding/registry FIELD names must escape it on the printing
+ * line — unless the line is on the allowlist below, which records (with a
+ * verified source classification) that the value there is a tool-authored
+ * constant or an already-sanitized analyst string, not raw bytes from a
+ * scanned tree, a Registry/HTTP response, or an LLM.
+ *
+ * WHY A SEPARATE TRIPWIRE. The render-source gate (render-source.ts) keys on
+ * PATH-NAMED expressions; a raw `${finding.description}` carrying an ESC byte
+ * from a scanned artifact, or `${stub.name}` from a Registry response, is
+ * invisible to it. A census on main found 34 field-interpolating prints; the
+ * Registry `stubs` render (now escaped) was the one live hole, plus a dead
+ * `displayRegistryResult` (now deleted). The analyst-channel prints are
+ * stripped of control bytes once at their IPC boundary
+ * (`shapeResultForTask` → `sanitizeAnalystString`, verified this session),
+ * so they carry no per-line escape and are allowlisted with that reason.
+ *
+ * WHY EXACT-LINE, NOT BY object.field TOKEN. The receiver name `r` is
+ * overloaded — `r.evidence` is an attack result, `r.impact`/`r.description`
+ * are analyst output — so a token key would conflate distinct sources. The
+ * line is the unambiguous key, at the cost that an EDIT to a listed line must
+ * re-justify it here: the deliberate-edit contract, same as the exit-surface
+ * baseline.
+ *
+ * SCOPE, stated honestly (as error-render-idiom.test.ts): the predicate is
+ * line-based. A field copied into a local and printed on another line evades
+ * it. It is a tripwire against the observed failure mode — a raw
+ * `${obj.field}` inside a print call for one of these field names — so the
+ * class cannot REGROW silently, not a taint analysis.
+ */
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+
+const src = readFileSync(path.join(__dirname, '..', '..', 'src', 'cli.ts'), 'utf8');
+const lines = src.split('\n');
+
+const PRINT = /console\.(log|error|warn)\(|process\.std(out|err)\.write\(/;
+// The non-path fields a finding / registry / analyst object carries that can
+// hold attacker-influenced bytes. These field names ALSO name authored
+// constants throughout this file — hence the classified allowlist, not a ban.
+const FIELD = /\$\{[^}]*\.(evidence|message|fix|guidance|description|impact|remediation|reason|value|attemptedValue|name|title)\b[^}]*\}/;
+const ESCAPED = /escapeForDisplay\(|escapePathForDisplay\(|escapeForTerminal\(|sanitizeAnalystString\(/;
+
+/**
+ * Allowlisted print lines: trimmed source line → why its interpolated field
+ * is safe without a per-line escape (a tool-authored constant, or an analyst
+ * string already sanitized at its IPC boundary). Verified by the #601 source
+ * classification; each entry is a claim reviewed as a gate change.
+ */
+const AUTHORED_ALLOW: ReadonlyArray<readonly [string, string]> = [
+  ["console.log(`Publisher: @${result.publisher.name}`);", "authored: publisher parsed from the user CLI arg"],
+  ["console.log(`└─ [!!] Revoked: ${result.revocation.reason}`);", "authored: hardcoded revocation reason string"],
+  ["console.log(`  ${borderColor}│${RESET()} ${colors.cyan}${colors.bold}━━ ${explainer.title} ━━${RESET()} ${colors.dim}(shown once per scan)${RESET()}`);", "authored: CONCEPT_EXPLAINERS[].title catalog"],
+  ["console.log(`  ${colors.bold}${colors.white}${block.header.name}${RESET()}${metaSuffix}`);", "authored: registry-only header name = user identifier"],
+  ["console.log(`  ${colors.dim}${label}${RESET()}${paintCheckTone(line.tone, line.value)}`);", "authored: check meter/label/count lines (registry-only)"],
+  ["console.log(`  ${colors.dim}${labelPad}${RESET()}${toneColor(line.tone)}${line.value}${RESET()}`);", "authored: surfaces/checks labels + counts + project kind enum"],
+  ["console.log(`  ${' '.repeat(LABEL_WIDTH)}${colors.dim}${tag} — ${c.reason ?? 'not examined'}${RESET()}`);", "authored: coverage-ledger reasons (templates + skip strings)"],
+  ["console.log(`  ${colors.dim}${labelPad}${RESET()}${color}${accent}${line.value}${RESET()}`);", "authored: categories/verdict labels + counts + kind"],
+  ["if (r.impact) console.log(`  ${colors.yellow}Impact:${RESET()} ${r.impact}`);", "llm: analyst impact = sanitizeAnalystString(verdict) at the IPC boundary"],
+  ["if (r.description) console.log(`  ${r.description}`);", "llm: analyst description = sanitized analysis (unreachable default branch aside)"],
+  ["console.log(`     [-] ${ctrl.controlId}: ${ctrl.name}`);", "authored: OASB control.name"],
+  ["console.log(`     [+] ${ctrl.controlId}: ${ctrl.name}`);", "authored: OASB control.name"],
+  ["console.log(`     [?] ${ctrl.controlId}: ${ctrl.name} (${reason})`);", "authored: OASB control.name"],
+  ["console.log(`  ${verifyIcon} [${finding.checkId}] ${location} - ${finding.name}`);", "authored: scanner check-def name"],
+  ["console.log(`${risk.description}\\n`);", "authored: assessRiskLevel templates + counts"],
+  ["console.log(`   ${finding.description}`);", "authored: openclaw check description constants"],
+  ["console.log(`  ${colors.green}✓${RESET()} [${finding.checkId}] ${finding.name}`);", "authored: scanner check-def name"],
+  ["console.log(`  ${colors.green}✓${RESET()} [${finding.checkId}] ${finding.name}`);", "authored: scanner check-def name"],
+  ["console.log(`${risk.description}\\n`);", "authored: assessNemoClawRiskLevel templates + counts"],
+  ["console.log(`   ${finding.description}`);", "authored: nemoclaw check description constants (scanned bytes go to .message)"],
+  ["console.log(`  ${colors.green}[ok]${RESET()} [${finding.checkId}] ${finding.name}`);", "authored: scanner check-def name"],
+  ["console.log(`  ${icon} ${catInfo.name}: ${stats.successful}/${stats.total} successful`);", "authored: ATTACK_CATEGORIES[].name"],
+  ["console.log(`  ${sevColor}[${r.payload.severity.toUpperCase()}]${RESET()} ${r.payload.id}: ${r.payload.name}`);", "authored: payload catalog / local --payloads file (user config, not a scan channel)"],
+  ["console.log(`       Evidence: ${r.evidence}`);", "authored: analysis.evidence = pattern-match templates; raw target response is stored separately"],
+  ["console.log(`       Remediation: ${r.payload.remediation}`);", "authored: payload catalog / local --payloads file remediation"],
+  ["console.log(`  [+] ${r.payload.id}: ${r.payload.name}`);", "authored: payload catalog / local --payloads file name"],
+  ["console.log(`  ${colors.brightRed}${colors.bold}HIGH${RESET()}  ${colors.bold}${v.id}${RESET()}  ${colors.dim}${v.name}${RESET()}`);", "authored: SoulViolation.name = VIOLATION_PATTERNS[].name"],
+  ["console.log(`    ${colors.dim}${ctrl.id}:${RESET()} ${status}  ${colors.dim}${ctrl.name}${RESET()}`);", "authored: soul DomainResult control.name = CONTROL_DEFS"],
+  ["console.log(`  ${label} ${colors.bold}${c.id}${RESET()}  ${colors.dim}${c.name} (${c.domain})${RESET()}`);", "authored: missingCritical name from CONTROL_DEFS"],
+  ["console.log(`            ${colors.dim}${c.remediation}${RESET()}`);", "authored: CONTROL_DEFS remediation"],
+  ["console.log(`  No agent was executed${result.evaluation.reason ? ` — ${result.evaluation.reason}` : ''}.`);", "authored: NOT_EXECUTED_REASON constant"],
+  ["console.error(`  ${colors.dim}${l.label.padEnd(LABEL_WIDTH)}${RESET()}${paintNotFoundTone(l.tone, l.value)}`);", "authored: not-found meter lines (user arg, regex-constrained)"],
+  ["console.error(`  ${paintNotFoundTone(l.tone, l.value)}`);", "authored: not-found meter lines (user arg, regex-constrained)"],
+  ["process.stderr.write(`  Failed: ${check.name} -- ${check.reason}\\n`);", "authored: integrity check names are literals; reasons interpolate the tool own signed manifest"],
+];
+const ALLOW = new Map(AUTHORED_ALLOW);
+
+const analystSrc = readFileSync(
+  path.join(__dirname, '..', '..', 'src', 'nanomind-core', 'inference', 'security-analyst.ts'),
+  'utf8',
+);
+
+describe('#601 field-interpolation render source (src/cli.ts)', () => {
+  it('every print interpolating an attacker-channel field escapes it, or is an allowlisted authored/sanitized constant', () => {
+    const offenders: string[] = [];
+    lines.forEach((l) => {
+      if (!PRINT.test(l)) return;
+      if (!FIELD.test(l)) return;
+      if (ESCAPED.test(l)) return;
+      const key = l.trim();
+      if (ALLOW.has(key)) return;
+      offenders.push(key);
+    });
+    expect(
+      offenders,
+      'A print in src/cli.ts interpolates a finding/registry/analyst field with no display escape. If the value is ' +
+        'bytes from a scanned tree, a Registry/HTTP response, or an unsanitized LLM string, wrap it in ' +
+        'escapeForDisplay(...) on this line. If it is a tool-authored constant (or already sanitized at a boundary), ' +
+        'add the trimmed line to AUTHORED_ALLOW with its source classification:\n\n' + offenders.join('\n'),
+    ).toEqual([]);
+  });
+
+  it('the allowlist has no dead entries — every allowlisted line still exists verbatim', () => {
+    const present = new Set(lines.map((l) => l.trim()));
+    const dead = [...ALLOW.keys()].filter((k) => !present.has(k));
+    expect(dead, 'allowlisted lines no longer in src/cli.ts (delete the stale entry): ' + dead.join(' | ')).toEqual([]);
+  });
+
+  it('the analyst boundary sanitizer still strips terminal control bytes', () => {
+    // The analyst-block prints are allowlisted on the strength of THIS
+    // function; if it stops stripping, they become live holes. Pin its
+    // existence, its CSI + bare-ESC strips, and that it is applied at the
+    // shaping boundary rather than merely defined.
+    // Matched as literal source substrings (the file contains these exact
+    // characters) rather than regexes-about-regexes, which are unreadable.
+    expect(analystSrc.includes('function sanitizeAnalystString')).toBe(true);
+    expect(analystSrc.includes('\\x1b\\['), 'CSI strip removed from sanitizeAnalystString').toBe(true);
+    expect(analystSrc.includes('\\x00-\\x08'), 'C0 strip removed from sanitizeAnalystString').toBe(true);
+    expect(analystSrc).toMatch(/=\s*sanitizeAnalystString\(response\.(analysis|verdict|evidence|remediation)\)/);
+  });
+});

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -11762,21 +11762,26 @@ Examples:
     console.log(`\nHMA Check Stubs (status: ${opts.status})\n`);
 
     for (const stub of stubs) {
+      // #601 — every field here is bytes from the Registry JSON response; a
+      // raw ESC in any of them steers the terminal, so each is escaped on
+      // its printing line. `severity` is escaped for display but the raw
+      // value still keys the color map (a control byte there just misses and
+      // yields no color, never renders).
       const sc = severityColor[stub.severity?.toLowerCase()] || '';
       console.log(`${'='.repeat(60)}`);
-      console.log(`  Check ID:   ${stub.checkId}`);
-      console.log(`  Series:     ${stub.series}`);
-      console.log(`  Name:       ${stub.name}`);
-      console.log(`  Severity:   ${sc}${stub.severity}${colors.reset}`);
-      console.log(`  ARIA ID:    ${stub.ariaFindingId}`);
-      console.log(`  Status:     ${stub.status}`);
+      console.log(`  Check ID:   ${escapeForDisplay(String(stub.checkId))}`);
+      console.log(`  Series:     ${escapeForDisplay(String(stub.series))}`);
+      console.log(`  Name:       ${escapeForDisplay(String(stub.name))}`);
+      console.log(`  Severity:   ${sc}${escapeForDisplay(String(stub.severity))}${colors.reset}`);
+      console.log(`  ARIA ID:    ${escapeForDisplay(String(stub.ariaFindingId))}`);
+      console.log(`  Status:     ${escapeForDisplay(String(stub.status))}`);
       if (stub.description) {
-        console.log(`  Description: ${stub.description}`);
+        console.log(`  Description: ${escapeForDisplay(String(stub.description))}`);
       }
       if (stub.detectionLogic) {
         console.log(`  Detection logic:`);
-        for (const line of stub.detectionLogic.split('\n')) {
-          console.log(`    ${line}`);
+        for (const line of String(stub.detectionLogic).split('\n')) {
+          console.log(`    ${escapeForDisplay(line)}`);
         }
       }
       console.log('');
@@ -11793,7 +11798,7 @@ Examples:
     for (const s of stubs) { bySeries[s.series] = (bySeries[s.series] || 0) + 1; }
     console.log(`\n  By series:`);
     for (const [series, count] of Object.entries(bySeries).sort((a, b) => b[1] - a[1])) {
-      console.log(`    ${series}: ${count}`);
+      console.log(`    ${escapeForDisplay(series)}: ${count}`);
     }
 
     // By severity
@@ -12292,25 +12297,6 @@ async function publishToRegistry(
   } catch {
     return false;
   }
-}
-
-/**
- * Display registry trust data in the terminal.
- */
-function displayRegistryResult(data: RegistryTrustData): void {
-  const scoreRatio = data.trustScore;
-  const scoreColor = scoreRatio >= 0.7 ? colors.green : scoreRatio >= 0.4 ? colors.yellow : colors.red;
-  const score = Math.round(scoreRatio * 100);
-
-  console.log(`\n  ${data.name}`);
-  console.log(`  Type:       ${data.packageType ?? 'unknown'}`);
-  console.log(`  Score:      ${scoreColor}${score}/100${RESET()}  (registry)`);
-  console.log(`  Verdict:    ${data.verdict}`);
-  if (data.lastScannedAt) {
-    const days = Math.floor((Date.now() - new Date(data.lastScannedAt).getTime()) / (1000 * 60 * 60 * 24));
-    console.log(`  Scanned:    ${days === 0 ? 'today' : days + ' day(s) ago'}`);
-  }
-  printCheckNextSteps(data.name);
 }
 
 /**


### PR DESCRIPTION
Closes #601.

`hackmyagent stubs` printed every field of the Registry JSON response — check id, series, name, severity, description, detection logic, and the by-series summary key — with no display escape, so a stub carrying a raw ESC byte could steer the reader's terminal. Each field escapes on its printing line now.

**The census, and what it found.** The render-source gate keys on path-named expressions, so a raw `${finding.description}` from a scanned artifact or `${stub.name}` from a Registry response is invisible to it. A sweep of the 34 prints in `src/cli.ts` that interpolate a non-path finding/registry/analyst field name found the `stubs` render was the one **live** hole. The rest were verified safe and are held by a tripwire, not hand-waved:

- **Authored constants** (check-def names, OASB/CONTROL_DEFS names and remediation, ATTACK_CATEGORIES, assessRiskLevel templates, the hardcoded revocation reason, etc.).
- **Analyst output**, stripped of control bytes once at its IPC boundary — I verified `shapeResultForTask` passes every shaped field through `sanitizeAnalystString` (CSI/OSC/DCS/bare-ESC/C0/C1), so the render sites need no per-line escape.
- The one site the issue flagged as an attack-target response, `r.evidence`, I traced to `analysis.evidence` (authored pattern-match templates interpolating catalog `pattern.source`); the raw target `response` is stored separately and truncated, never spliced into evidence.
- A dead `displayRegistryResult` (zero callers; a latent registry-name hole if ever revived) is **deleted** rather than escaped — its type and `printCheckNextSteps` helper are used elsewhere, so nothing else moved.

**The tripwire** (`field-interpolation-render-source.test.ts`) pins the property so the class cannot regrow silently: a print interpolating one of these field names must escape it, or be an allowlisted line carrying a verified source classification — a deliberate-edit contract keyed on the exact line (not an `object.field` token, because the receiver name `r` is overloaded between attack results and analyst output). It also pins the analyst boundary sanitizer the allowlist rests on, so a regression there fails here rather than silently opening ~16 holes. Red-proofs: reverting a stub escape, dropping an allowlist entry, and breaking the sanitizer strip each fail their cell.

Runtime coverage of the escape itself rests on `escapeForDisplay`'s own display-safe tests plus the tripwire; `stubs` is Registry- and internal-key-gated, so there is no cheap end-to-end spawn. Full suite 345 files / 4820 tests green. Phase 4.5 (adversarial self-review) skipped under its condition: output-escaping only, no detection rule, scoring weight, or severity threshold changed.