### PR TITLE
HMA_CLI_PREFIX is inserted literally into rebranded citations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to HackMyAgent are documented in this file.
 
 ## [Unreleased]
 
+### HMA_CLI_PREFIX is inserted literally into rebranded citations
+
+A parent CLI sets `HMA_CLI_PREFIX` to rename the tool in command citations,
+and the rebrander built its replacement with an interpolated string. In a
+`String.replace` replacement string, `$&`, `$1`, `` $` ``, `$'` and `$$` are
+patterns, not text, so a prefix containing one rewrote the citation instead
+of prefixing it. The rebrander now uses a replacer function, whose return is
+inserted verbatim (#600). The vector is the environment, not a scanned
+target, so the exposure is a garbled citation, not an injection.
+
 ### Registry check-stub output is escaped against terminal control bytes
 
 `hackmyagent stubs` printed every field of the Registry JSON response — check id, series, name, severity, description, detection logic — without a display escape, so a stub carrying a raw ESC byte could steer the reader's terminal (#601). Each field now escapes on its printing line. A census of the same class across `secure`/`check`/`attack`/`scan-soul` output found no other live hole: the remaining field interpolations render tool-authored constants or analyst strings already stripped of control bytes at their IPC boundary, and a dead `displayRegistryResult` function was removed. A structural tripwire pins the property so a new raw field-print fails the build until it is escaped or classified.

--- a/__tests__/cli-prefix-replacement-patterns.test.ts
+++ b/__tests__/cli-prefix-replacement-patterns.test.ts
@@ -1,0 +1,65 @@
+/**
+ * #600 — HMA_CLI_PREFIX is inserted LITERALLY into rebranded citations, even
+ * when it contains String.replace replacement patterns.
+ *
+ * `rebrandCommandCitations` rewrote citations with an interpolated replacement
+ * STRING (`\`${CLI_PREFIX} $1\``). In a replacement string, `$&`, `$1`,
+ * `` $` ``, `$'` and `$$` are patterns, not text — so an env-set prefix
+ * carrying one rewrote the citation instead of prefixing it. Measured on the
+ * base build:
+ *
+ *   HMA_CLI_PREFIX='opena2a $& $1 $` x'  →
+ *   rebrand('Run hackmyagent secure --fix now')
+ *   = 'Run opena2a hackmyagent secure secure Run  x secure --fix now'
+ *
+ * The fix uses a replacer FUNCTION, whose return is inserted verbatim. The
+ * vector is the environment (a parent CLI's own prefix), so this is a
+ * correctness bug, not an injection from a scanned target — but a garbled
+ * citation is a garbled citation.
+ *
+ * CLI_PREFIX is frozen at module load (`const CLI_PREFIX = resolveCliPrefix()`),
+ * so each case sets the env and imports the module fresh via resetModules.
+ */
+import { describe, it, expect, vi, afterEach } from 'vitest';
+
+async function rebrandWithPrefix(prefix: string, text: string): Promise<string> {
+  const prev = process.env.HMA_CLI_PREFIX;
+  process.env.HMA_CLI_PREFIX = prefix;
+  vi.resetModules();
+  try {
+    const mod = await import('../src/cli-prefix');
+    // Guard: the module actually picked up our prefix (resolveCliPrefix passes
+    // printable ASCII through unchanged), so a case can't pass vacuously
+    // against a stale hackmyagent default.
+    expect(mod.CLI_PREFIX).toBe(prefix);
+    return mod.rebrandCommandCitations(text);
+  } finally {
+    if (prev === undefined) delete process.env.HMA_CLI_PREFIX;
+    else process.env.HMA_CLI_PREFIX = prev;
+  }
+}
+
+afterEach(() => vi.resetModules());
+
+describe('#600 rebrandCommandCitations inserts the prefix literally', () => {
+  it('RED-ON-BASE: a prefix of replacement patterns is not interpreted', async () => {
+    const out = await rebrandWithPrefix('opena2a $& $1 $` x', 'Run hackmyagent secure --fix now');
+    // The whole prefix appears verbatim before the verb; none of $&/$1/$` is expanded.
+    expect(out).toBe('Run opena2a $& $1 $` x secure --fix now');
+  });
+
+  it("RED-ON-BASE: a `$$` in the prefix stays `$$`, not collapsed to `$`", async () => {
+    const out = await rebrandWithPrefix('opena2a $$', 'hackmyagent scan-soul');
+    expect(out).toBe('opena2a $$ scan-soul');
+  });
+
+  it('a plain prefix still rebrands (regression)', async () => {
+    const out = await rebrandWithPrefix('opena2a', 'Run hackmyagent secure --fix now');
+    expect(out).toBe('Run opena2a secure --fix now');
+  });
+
+  it('the default prefix is still a no-op', async () => {
+    const out = await rebrandWithPrefix('hackmyagent', 'Run hackmyagent secure --fix');
+    expect(out).toBe('Run hackmyagent secure --fix');
+  });
+});

--- a/src/cli-prefix.ts
+++ b/src/cli-prefix.ts
@@ -281,10 +281,15 @@ export function rebrandCommandCitations(text: string): string {
   if (!text) return text;
   let out = text;
   if (CLI_PREFIX !== 'hackmyagent') {
-    out = out.replace(CITATION_RE, `${CLI_PREFIX} $1`);
+    // Replacer FUNCTION, not an interpolated string (#600): CLI_PREFIX is
+    // environment-derived (HMA_CLI_PREFIX), and a `$&` / `$1` / `` $` `` / `$'`
+    // inside a String.replace replacement STRING is a pattern, not text — so a
+    // prefix carrying one rewrote the citation instead of prefixing it. A
+    // function return is inserted literally; `verb` is the one capture group.
+    out = out.replace(CITATION_RE, (_m, verb: string) => `${CLI_PREFIX} ${verb}`);
   }
   if (!opena2aIsOnPath()) {
-    out = out.replace(OPENA2A_CITATION_RE, `npx ${OPENA2A_PACKAGE} $1`);
+    out = out.replace(OPENA2A_CITATION_RE, (_m, verb: string) => `npx ${OPENA2A_PACKAGE} ${verb}`);
   }
   // Pass 3 runs LAST, on purpose: passes 1 and 2 have already normalised the
   // tool name, so this only has to recognise `${CLI_PREFIX}` and


### PR DESCRIPTION
Closes #600.

A parent CLI sets `HMA_CLI_PREFIX` to rename the tool in command citations, and `rebrandCommandCitations` built its replacement with an interpolated string (`` `${CLI_PREFIX} $1` ``). In a `String.replace` replacement string, `$&`, `$1`, `` $` ``, `$'` and `$$` are patterns, not text — so a prefix carrying one rewrote the citation instead of prefixing it. Measured on the base build:

```
HMA_CLI_PREFIX='opena2a $& $1 $` x'  →  rebrand('Run hackmyagent secure --fix now')
= 'Run opena2a hackmyagent secure secure Run  x secure --fix now'
```

Both rebrand passes now use a replacer **function**, whose return is inserted verbatim; the `$1` was the single capture group (the verb), passed as a plain string. The `opena2a`-package pass was already safe (`OPENA2A_PACKAGE` is a constant) and is converted for consistency, and the sibling `completeTargetlessCitations` already used a replacer function and `escapeRegExp`s the prefix — so the file's whole interpolated-replacement surface is closed.

The vector is the environment (a parent CLI's own prefix), not a scanned target, so the exposure is a garbled citation rather than an injection.

**Tests.** `CLI_PREFIX` is frozen at module load, so the new cells set `HMA_CLI_PREFIX` and import the module fresh (`vi.resetModules`), with a guard that the fresh module actually picked up the prefix so a case can't pass vacuously. Red-on-base: the base build fails both pattern cells (`$& $1 $\``, and `$$` collapsing to `$`) and passes the two regression cells, which is the correct split. Full suite 346 files / 4824 tests green. Phase 4.5 skipped under its condition: a string-handling helper, no detection rule, scoring, or severity changed.