### PR TITLE
The ASP credential summary no longer misses semantic secrets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,21 @@ All notable changes to HackMyAgent are documented in this file.
 
 ## [Unreleased]
 
+### The ASP profile's credential summary no longer misses semantic secrets
+
+`secure -b oasb-1 --format asp` could report `credentials.hardcodedSecrets: 0`
+with "No hardcoded credentials detected" while its own `failedControls`
+listed control 5.1 failing on a hardcoded secret — two sections of one
+signed-shaped document contradicting each other. The summary counted only
+`CRED-*` findings by prefix, missing the semantic `SEM-CRED-*` family, so a
+dotenv secret that failed control 5.1 on `SEM-CRED-002` was reported as
+zero. The summary now counts the static `CRED-*` and semantic `SEM-CRED-*`
+credential findings, so it no longer misses the semantic family a control
+fails on (#606). It stays a per-finding count, so it can exceed the number
+of distinct checks a control cites; it never reports fewer than it counts.
+(It is not yet every hardcoded-secret check — `AST-CRED-*`/`WEBCRED-*` stay
+uncounted; #666 tracks widening it, and control 5.1's own CRED-001 gap.)
+
 ### secure --format asff carries each finding's remediation
 
 The ASFF emitter read a `recommendation` field that findings do not have

--- a/__tests__/cli/asp-credentials-control-parity.test.ts
+++ b/__tests__/cli/asp-credentials-control-parity.test.ts
@@ -1,0 +1,123 @@
+/**
+ * #606 — the ASP profile's `credentials` summary counts the static CRED-*
+ * and semantic SEM-CRED-* credential findings, so it no longer misses the
+ * semantic family a control fails on.
+ *
+ * The summary counted `checkId.startsWith('CRED-')`, which matched the static
+ * CRED-001..004 checks but NOT the semantic `SEM-CRED-*` family. So a dotenv
+ * secret that failed OASB-1 control 5.1 on `SEM-CRED-002` was reported as
+ * `hardcodedSecrets: 0` with "No hardcoded credentials detected" in the very
+ * same signed-shaped document that listed control 5.1 as failed — the summary
+ * and the failed-control list contradicting each other. The predicate now
+ * matches both prefixes — the CRED-* and SEM-CRED-* families.
+ *
+ * NOTE (tracked separately, a benchmark-mapping gap): OASB-1 control 5.1's
+ * `checkIds` include `CRED-002/003/004` and `SEM-CRED-*` but not the generic
+ * `CRED-001` key detector, though 5.1's audit text expects it. The summary
+ * counts CRED-001 (it is a hardcoded secret), so the summary is a SUPERSET of
+ * control 5.1's cited findings until CRED-001 is mapped — filed for the
+ * benchmark owner. The equality cell below is scoped to a semantic-only tree,
+ * where CRED-001 does not fire and the two coincide.
+ */
+import { describe, it, expect, beforeAll } from 'vitest';
+import { spawnSync } from 'node:child_process';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { assertDistFreshIfPresent, BUILT_CLI as CLI } from '../helpers/dist-freshness';
+
+// Filenames and a high-entropy synthetic value assembled at runtime from
+// fragments, so no blocked-file path literal and no KEY=value secret shape
+// sits in this source (the repo idiom; see fix-all-key-material.test.ts).
+// FAKE-marked, never real.
+const DOTENV = ['', 'env'].join('.');
+const VAR = ['OPENAI', 'API', 'KEY'].join('_');
+// A generic hardcoded key the STATIC CRED-001 detector catches (its OpenAI
+// pattern is /sk-[A-Za-z0-9]{48,}/).
+function providerKey(): string {
+  const alpha = 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789';
+  let seed = 7;
+  let body = '';
+  for (let i = 0; i < 48; i++) {
+    seed = (seed * 1103515245 + 12345) % 2147483648;
+    body += alpha[seed % alpha.length];
+  }
+  return ['sk', body].join('-');
+}
+
+
+describe('#606 ASP credential summary counts the CRED- and SEM-CRED- families', { timeout: 300_000 }, () => {
+  beforeAll(assertDistFreshIfPresent);
+
+  function asp(dir: string, extra: string[] = []): any {
+    const r = spawnSync(process.execPath, [CLI, 'secure', dir, '-b', 'oasb-1', '--format', 'asp', '--no-machine-posture', ...extra], {
+      encoding: 'utf8',
+      timeout: 240_000,
+      maxBuffer: 64 * 1024 * 1024,
+      env: { ...process.env, NO_COLOR: '1', OPENA2A_TELEMETRY: 'off', HOME: fs.mkdtempSync(path.join(os.tmpdir(), 'hma-606-home-')) },
+    });
+    const out = r.stdout ?? '';
+    return JSON.parse(out.slice(out.indexOf('{'), out.lastIndexOf('}') + 1));
+  }
+
+  let dotenvTree: string;   // a semantic secret (SEM-CRED-*), no static CRED
+  let configTree: string;   // a generic key in config.json (CRED-*), for --static-only
+  let cleanTree: string;
+  beforeAll(() => {
+    dotenvTree = fs.mkdtempSync(path.join(os.tmpdir(), 'hma-606-dotenv-'));
+    fs.writeFileSync(path.join(dotenvTree, 'package.json'), '{ "name": "fx606", "version": "1.0.0", "private": true }\n');
+    fs.writeFileSync(path.join(dotenvTree, DOTENV), VAR + '=' + providerKey() + '\n');
+
+    configTree = fs.mkdtempSync(path.join(os.tmpdir(), 'hma-606-config-'));
+    fs.writeFileSync(path.join(configTree, 'package.json'), '{ "name": "fx606c", "version": "1.0.0", "private": true }\n');
+    fs.writeFileSync(path.join(configTree, 'config.json'), JSON.stringify({ apiKey: providerKey() }, null, 2) + '\n');
+
+    cleanTree = fs.mkdtempSync(path.join(os.tmpdir(), 'hma-606-clean-'));
+    fs.writeFileSync(path.join(cleanTree, 'package.json'), '{ "name": "fx606x", "version": "1.0.0", "private": true }\n');
+  });
+
+  it('RED-ON-BASE: the SEM-CRED-* finding is counted alongside the static one', () => {
+    // A provider key in .env fires BOTH the static CRED-001 and the semantic
+    // SEM-CRED-002; control 5.1 fails and cites SEM-CRED-002. The old
+    // startsWith('CRED-')-only predicate counted CRED-001 (1) and MISSED
+    // SEM-CRED-002 — the #606 undercount. Counting both requires the
+    // SEM-CRED- clause, so hardcodedSecrets >= 2 is red on the base build.
+    const j = asp(dotenvTree);
+    const c51 = (j.failedControls ?? []).find((c: any) => c.id === '5.1');
+    expect(c51, 'control 5.1 should fail on a tree with a hardcoded secret').toBeTruthy();
+    expect(c51.findings.some((f: string) => f.startsWith('SEM-CRED-002')), 'the semantic secret is detected and cited by 5.1').toBe(true);
+    expect(j.credentials.hardcodedSecrets).toBeGreaterThanOrEqual(2);
+    expect(j.credentials.recommendation).not.toMatch(/No hardcoded credentials detected/);
+  });
+
+  it('the summary is a superset of what control 5.1 cites — it never underreports', () => {
+    // The two counts are NOT equal in general: the summary counts per finding
+    // over the CRED-*/SEM-CRED-* families, while the control
+    // cites one entry per distinct failed checkId in its own (CRED-001-less)
+    // set. The invariant that matters for #606 is that the summary never
+    // reports FEWER secrets than a failed control lists — the direction that
+    // produced the false "0" contradiction.
+    const j = asp(dotenvTree);
+    const c51 = (j.failedControls ?? []).find((c: any) => c.id === '5.1');
+    expect(c51, 'control 5.1 must fail here, or the >= degrades to >= 0').toBeTruthy();
+    expect(j.credentials.hardcodedSecrets).toBeGreaterThanOrEqual((c51?.findings ?? []).length);
+    expect(j.credentials.hardcodedSecrets).toBeGreaterThan(0);
+  });
+
+  it('REGRESSION GUARD: a generic hardcoded key is still counted under --static-only', () => {
+    // The first cut of this fix sourced the count from control 5.1 alone,
+    // which drops CRED-001 (the generic key detector, mapped to no control):
+    // under --static-only (semantic checks off) a real key then reported 0.
+    // The two-prefix predicate keeps it counted.
+    const j = asp(configTree, ['--static-only']);
+    expect(j.credentials.hardcodedSecrets).toBeGreaterThan(0);
+    expect(j.credentials.recommendation).not.toMatch(/No hardcoded credentials detected/);
+  });
+
+  it('a clean tree reports zero and control 5.1 does not fail', () => {
+    const j = asp(cleanTree);
+    expect((j.failedControls ?? []).some((c: any) => c.id === '5.1')).toBe(false);
+    expect(j.credentials.hardcodedSecrets).toBe(0);
+    expect(j.credentials.recommendation).toMatch(/No hardcoded credentials detected/);
+  });
+});

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -4156,7 +4156,18 @@ function generateAspOutput(benchmarkResult: BenchmarkResult, scanResult: { findi
   capabilities['shell'] = hasShellAccess ? 'detected' : 'none';
 
   // Credential hygiene
-  const credentialFindings = scanResult.findings.filter(f => f.checkId.startsWith('CRED-'));
+  // #606 — count the static CRED-* AND semantic SEM-CRED-* credential
+  // findings. The old `startsWith('CRED-')` matched CRED-001..004 but not the
+  // SEM-CRED-* family, so a dotenv secret that failed OASB-1 control 5.1 on
+  // SEM-CRED-002 was reported here as `hardcodedSecrets: 0` — the summary and
+  // the failed-control list contradicting each other in one document.
+  // `SEM-CRED-` does not start with `CRED-`, so it needs its own clause; the
+  // clause also keeps the generic CRED-001 detector counted. (This is not
+  // every hardcoded-secret check in the tool — AST-CRED-*/WEBCRED-* also
+  // detect secrets and are still uncounted here; #666 tracks widening it.)
+  const credentialFindings = scanResult.findings.filter(
+    f => f.checkId.startsWith('CRED-') || f.checkId.startsWith('SEM-CRED-'),
+  );
   const hardcodedCreds = credentialFindings.filter(f => !f.passed).length;
 
   // Supply chain status


### PR DESCRIPTION
Closes #606.

`secure -b oasb-1 --format asp` could report `credentials.hardcodedSecrets: 0` with "No hardcoded credentials detected" while its own `failedControls` listed control 5.1 failing on a hardcoded secret — two sections of one signed-shaped document contradicting each other. The summary counted only `checkId.startsWith('CRED-')`, missing the semantic `SEM-CRED-*` family, so a dotenv secret that failed control 5.1 on `SEM-CRED-002` was reported as zero.

The predicate now matches both `CRED-*` and `SEM-CRED-*` (the second clause is needed — `SEM-CRED-` does not start with `CRED-`), which also keeps the generic `CRED-001` detector counted.

**Two adversarial rounds shaped this** (both findings fixed, verified):
- Round 1 caught a HIGH regression in the first cut, which sourced the count from control 5.1's checkIds alone — that **dropped `CRED-001`** (mapped to no control), so a generic key under `--static-only` reported 0. The two-prefix predicate fixes it; the benchmark-touching accessor was fully reverted, so the diff is `cli.ts` + test + CHANGELOG only and the 0.33.0 tag's frozen dry-run is unaffected.
- Round 2 caught two honesty defects: the "RED-ON-BASE" cell was vacuous (its provider-key fixture fires `CRED-001` too, so it passed on base), and "complete detection set" overclaimed. The cell now uses a dotenv provider key that fires **both** `CRED-001` and `SEM-CRED-002`, asserts `hardcodedSecrets >= 2` and that 5.1 cites `SEM-CRED-002` — removing the `SEM-CRED-` clause drops it to 1, so it is genuinely red on base. The claim is scoped to the two families it counts.

**Scoped honestly:** this is not every hardcoded-secret check — `AST-CRED-*` / `WEBCRED-*` also detect secrets and stay uncounted, and control 5.1's own checkIds omit `CRED-001` though its audit text expects it. Both are benchmark/summary-widening work filed as **#666** (a CA-domain spec-mapping change that must land with a dry-run re-verify, after the tag), deliberately kept out of this PR.

The summary is a per-finding count and stays a superset of what any one control cites; it never underreports what it counts. Full suite 348 files / 4831 tests green.
