### PR TITLE
Rename review check to 'Automated code review'

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -7,7 +7,7 @@
 ---
 
 If you opened this from a fork: the checks do not start until a maintainer approves the run, and
-`Claude Code Review` will then report failure with no comment explaining it. That check needs a
+`Automated code review` will then report failure with no comment explaining it. That check needs a
 repository secret, and GitHub does not pass secrets to workflows triggered from a fork, so its
 result is not a judgement about this change. Its text is in the check's own summary. The other
 required checks are the ones to read. A maintainer picks the change up from there:

--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -1,5 +1,5 @@
 name: PR Review
-# Runs on every PR to main — calls the Claude API for a security-focused code review.
+# Runs on every PR to main — an automated code review (calls the Claude API).
 #
 # The gate fails CLOSED. There are three verdicts: APPROVE passes,
 # REQUEST_CHANGES fails, INCONCLUSIVE fails. Inconclusive covers a missing key,
@@ -33,7 +33,7 @@ permissions:
 
 jobs:
   review:
-    name: Claude Code Review
+    name: Automated code review
     runs-on: ubuntu-latest
     env:
       PR_NUMBER: ${{ github.event.pull_request.number }}
@@ -144,12 +144,14 @@ jobs:
           # standalone because gh rejects --slurp combined with --jq.
           #
           # The login filter is the security half: any commenter who quotes
-          # "Claude Code Review" would otherwise be fed back to the model under
+          # "Automated code review" (or the pre-rename header) would otherwise
+          # be fed back to the model under
           # a PREVIOUS REVIEW heading the system prompt instructs it to trust,
           # as the gate's own prior verdict.
           gh api --paginate --slurp "repos/${{ github.repository }}/issues/$PR_NUMBER/comments?per_page=100" 2>/dev/null \
-            | jq -r '[.[][] | select(.user.login == "github-actions[bot]") | select(.body | test("Claude Code Review")) | .body] | last // ""' \
+            | jq -r '[.[][] | select(.user.login == "github-actions[bot]") | select(.body | test("Claude Code Review|Automated code review")) | .body] | last // ""' \
             | sed -e '/^## Claude Code Review/d' \
+                  -e '/^## Automated code review/d' \
                   -e '/^[[:space:]]*VERDICT:/d' \
                   -e '/VERDICT-[0-9A-Za-z_-]\{8,\}[[:space:]]*:/d' \
                   -e '/^\[redacted: this line matched the gate/d' \
@@ -387,7 +389,7 @@ jobs:
             echo "::error::$1"
             # Exit 0 on purpose: the refusal is a REVIEW OUTCOME, not a step
             # crash, and the difference decides which message a blocked author
-            # reads. `Run Claude review` is skipped, the verdict is therefore
+            # reads. `Run automated review` is skipped, the verdict is therefore
             # absent, and absent is INCONCLUSIVE, which does not pass.
             exit 0
           }
@@ -927,7 +929,7 @@ jobs:
           printf 'batches=%s\n' "$NBATCH" >> "$GITHUB_OUTPUT"
           echo "Partitioned into $NBATCH batches; every byte of the diff accounted for."
 
-      - name: Run Claude review
+      - name: Run automated review
         id: review
         # `success() &&` is load-bearing and not decoration. An `if:` REPLACES
         # the implicit success() check, so `if: steps.partition.outputs.refused
@@ -1112,7 +1114,7 @@ jobs:
           fi
 
           {
-            echo "## Claude Code Review — $VERDICT"
+            echo "## Automated code review — $VERDICT"
             echo ""
             [ -z "$FORK_NOTE" ] || printf '%s\n' "$FORK_NOTE"
             cat "$REVIEW_FILE"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -61,7 +61,7 @@ cheaper to read now than to work out from a red check later.
 workflow runs for contributors outside the organization. Until someone does, your pull request
 reports no checks at all, passing or failing.
 
-**One required check cannot pass from a fork, ever.** `Claude Code Review` calls a model API
+**One required check cannot pass from a fork, ever.** `Automated code review` calls a model API
 using a repository secret. GitHub does not pass repository secrets to a workflow triggered from
 a fork: "With the exception of `GITHUB_TOKEN`, secrets are not passed to the runner when a
 workflow is triggered from a forked repository"
@@ -73,23 +73,23 @@ your change.
 
 **No comment will appear explaining it.** The workflow posts its result as a pull request
 comment, and on a fork run its token is read only, so the post fails. The result is written to
-the check's own summary instead. Open `Claude Code Review` from the checks list and read the
+the check's own summary instead. Open `Automated code review` from the checks list and read the
 summary there.
 
-`Claude Code Review` is the only required check in that position. You can confirm that in your
+`Automated code review` is the only required check in that position. You can confirm that in your
 own clone:
 
 ```bash
 grep -rn "secrets\." .github/workflows/
 ```
 
-Every match is in `pr-review.yml`, the workflow behind `Claude Code Review`. The workflows behind
+Every match is in `pr-review.yml`, the workflow behind `Automated code review`. The workflows behind
 the other required checks reference no secret. Those are the checks to read on your change. No
 pull request has been opened from a fork on this repository yet, so you would be the first.
 
 We do not merge past a failing required check. The route is:
 
-1. Open the pull request from your fork. Leave `Claude Code Review` alone.
+1. Open the pull request from your fork. Leave `Automated code review` alone.
 2. A maintainer reviews the change and replies on your pull request.
 3. When it is ready, a maintainer pushes your commits to a branch in this repository and opens a
    pull request from there. The review runs on that one with the key available, and the change

--- a/__tests__/gate/pr-review-partition.test.ts
+++ b/__tests__/gate/pr-review-partition.test.ts
@@ -574,7 +574,7 @@ describe('PR review gate: the partition step is executable and self-describing',
 
   it('keeps the job name the required status checks are keyed on', () => {
     const wf = loadWorkflow() as unknown as { jobs: { review: { name: string } } };
-    expect(wf.jobs.review.name).toBe('Claude Code Review');
+    expect(wf.jobs.review.name).toBe('Automated code review');
   });
 });
 


### PR DESCRIPTION
Renames the PR review check from `Claude Code Review` to `Automated code review` — one string for the job name (which is the required status-check context), the posted comment header (`## Automated code review — VERDICT`), and the contributor docs that name the check (`CONTRIBUTING.md`, the PR template).

The name states what the green tick is: a machine-produced review. It is "code review", not "security review", because the check blocks on correctness and quality defects too.

**Transition mechanics** (so prior reviews are still recognized while both names exist):

- The previous-review matcher now matches either header: `test("Claude Code Review|Automated code review")`.
- The strip pipeline gains one expression, `-e '/^## Automated code review/d'`, rather than switching to `sed -E`: two sibling expressions (`\{8,\}` interval, literal `(s)`) are BRE and would silently go dead under `-E` — verified by executing the pipeline both ways.
- Both transitional branches should be removed once no open PR carries an old-name comment.

**Merge coordination — read before merging.** The job name is the required status-check context, so this PR's run reports under the NEW context and the OLD required context `Claude Code Review` will never report here. Merging requires a repo admin to update branch protection in one atomic call that replaces the contexts array — dropping the old name and adding `Automated code review` together. Never drop the old context without adding the new one in the same call: a check that is not required does not block, and the gate would silently become advisory.

The behavior of the gate is otherwise unchanged: partitioning, verdict handling (APPROVE / REQUEST_CHANGES / INCONCLUSIVE, fail-closed), and the fork path are untouched, and the job-name pin test now pins the new name.
