### PR TITLE
Require an out-of-fleet approval for changes to the merge gate's own config

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,16 @@
+# Ownership of the merge gate's own configuration.
+#
+# Everything under .github/ is covered: the review workflow, the release
+# workflow, the pinned review action reference, and this file itself. A change
+# to any of them needs an approving review from an account the automation does
+# not hold. Automation can author changes here; it cannot approve them.
+#
+# Why this path and no other: the review workflow runs from the pull request
+# head on same-repo branches, so without this rule a pull request that weakens
+# the reviewing logic is judged by the weakened logic it just introduced.
+#
+# This is the ONLY path in the repository that requires a human approval.
+# Ordinary pull requests are gated by checks alone, and that is deliberate: a
+# reviewer who has to approve everything approves nothing.
+
+/.github/ @thebenignhacker


### PR DESCRIPTION
## What this adds

A `.github/CODEOWNERS` file covering `/.github/` — the review workflow, the release workflow, the
pinned review action reference, and the CODEOWNERS file itself — owned by `@thebenignhacker`.

## Why

The review workflow runs from the pull request head on same-repo branches, so a pull request that
weakens the reviewing logic is judged by the weakened logic it just introduced. Until now nothing
prevented that: this repository had no CODEOWNERS file and required no human review, so the
automated check was the only merge gate, and a change to that check reviewed itself.

With this file (and `require_code_owner_reviews` enabled on `main` — a separate repo-admin step),
a change to the gate's own configuration needs an approving review from an account the automation
does not hold. Automation can still author changes to these paths; it cannot approve them.

## What this deliberately does NOT do

This is the **only** path in the repository requiring human approval. Ordinary pull requests stay
gated by checks alone. That is the design, not an oversight: a reviewer who has to approve
everything approves nothing, and the point of the automated review is that it is not a
bottleneck. The follow-up verification includes a negative control asserting exactly this — a PR
touching a non-gate path must not require review.

## Sequencing

The rule is inert until `require_code_owner_reviews` is enabled on the branch, so merging this PR
changes nothing by itself. The toggle, the enforcement proof (a benign gate-file PR that stays
blocked while all checks are green, cannot be self-approved by its author, and unblocks on a code
owner's approval), and the negative control all follow after this lands in all six repositories.
