### PR TITLE
Wire the gate-file approval check + raise the CLI scan-test timeout

### DIFF
--- a/.github/workflows/gate-file-approval.yml
+++ b/.github/workflows/gate-file-approval.yml
@@ -1,0 +1,149 @@
+# Gate file approval — a path-scoped merge gate for this repository's own CI,
+# review, and release configuration.
+#
+# Any pull request that changes a file under .github/ must carry an approving
+# review from a listed approver, given on the pull request's current head
+# commit. Pull requests that touch nothing under .github/ pass immediately, so
+# ordinary changes stay gated by status checks alone.
+#
+# Why pull_request_target: the workflow definition is read from the BASE
+# branch, so a pull request that modifies this file is judged by the unmodified
+# copy — the gate cannot be weakened by the change it is judging. This job
+# reads only API data (the changed-file list and the review list). It must
+# never check out or execute pull request head content, must never reference a
+# repository secret, and must keep its token read-only apart from checks:write.
+# A tripwire below fails the check if a pull request tries to change that.
+#
+# The verdict is carried twice on purpose: as an explicit check run named
+# "Gate file approval" posted against the head commit (the context branch
+# protection must require), and as the job's own exit status, so that even a
+# misconfigured protection rule that requires the job context instead of the
+# check run still carries the real verdict rather than an always-green job.
+name: Gate file approval
+
+on:
+  pull_request_target:
+    # edited is required: retargeting the base branch recomputes the diff
+    # without changing the head commit, so the verdict must be re-evaluated.
+    types: [opened, synchronize, reopened, edited]
+  pull_request_review:
+    types: [submitted, dismissed, edited]
+
+permissions:
+  contents: read
+  pull-requests: read
+  checks: write
+
+concurrency:
+  group: gate-file-approval-${{ github.event.pull_request.number }}
+  cancel-in-progress: false
+
+jobs:
+  evaluate:
+    name: Evaluate gate-file approval
+    runs-on: ubuntu-latest
+    env:
+      GH_TOKEN: ${{ github.token }}
+      REPO: ${{ github.repository }}
+      PR_NUMBER: ${{ github.event.pull_request.number }}
+      HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+    steps:
+      - name: Evaluate and post the check run
+        run: |
+          set -euo pipefail
+          # The approver set. Changing it is itself a gate-file change, so the
+          # change is judged by the current set.
+          approvers="thebenignhacker"
+
+          # The files listing endpoint is capped at 3000 entries; a gate file
+          # hidden past the cap would otherwise pass unseen. Refuse to evaluate
+          # oversized pull requests instead of failing open.
+          changed_count=$(gh api "repos/$REPO/pulls/$PR_NUMBER" --jq .changed_files)
+          if [ "$changed_count" -ge 3000 ]; then
+            conclusion="failure"
+            title="Too many changed files to evaluate"
+            summary="This pull request changes $changed_count files, at or beyond the 3000-entry listing cap, so the gate cannot see every path. Split the pull request."
+          else
+            conclusion=""
+            title=""
+            summary=""
+          fi
+
+          # Both sides of a rename count: a pull request that renames a file OUT
+          # of .github/ reports the old path only in previous_filename, and a
+          # rename is as much a gate-file change as an edit.
+          files=$(gh api "repos/$REPO/pulls/$PR_NUMBER/files" --paginate \
+            --jq '.[] | .filename, (.previous_filename // empty)')
+
+          # grep exit 1 means no match; anything above 1 is an execution error
+          # and must abort rather than read as "no gate files" (fail closed).
+          set +e
+          printf '%s\n' "$files" | grep -q '^\.github/'
+          gate_rc=$?
+          set -e
+          [ "$gate_rc" -le 1 ]
+
+          if [ -z "$conclusion" ] && [ "$gate_rc" -eq 1 ]; then
+            conclusion="success"
+            title="No gate files touched"
+            summary="This pull request changes nothing under .github/, so no gate-file approval is required."
+          fi
+
+          if [ -z "$conclusion" ]; then
+            # Tripwire: if this pull request modifies this workflow, inspect the
+            # proposed copy AS DATA (never executed) and refuse patterns that
+            # would re-arm the pull_request_target attack surface. The patterns
+            # are split so this file cannot match itself. An unreadable proposed
+            # copy is refused too, never waved through.
+            if printf '%s\n' "$files" | grep -qx '\.github/workflows/gate-file-approval\.yml'; then
+              p_checkout='actions/''checkout'
+              p_secret='secrets''[.]'
+              p_write='contents:''[[:space:]]*write'
+              p_writeall='write-''all'
+              head_copy=$(gh api "repos/$REPO/contents/.github/workflows/gate-file-approval.yml?ref=$HEAD_SHA" --jq .content | base64 -d)
+              if [ -z "$head_copy" ]; then
+                conclusion="failure"
+                title="Gate workflow copy unreadable"
+                summary="The proposed gate-file-approval.yml could not be read for inspection (empty contents response). Refused rather than waved through."
+              elif printf '%s\n' "$head_copy" | grep -Eq "$p_checkout|$p_secret|$p_write|$p_writeall"; then
+                conclusion="failure"
+                title="Gate workflow hardening violated"
+                summary="The proposed gate-file-approval.yml checks out head content, references a secret, or widens write permissions. Those are refused regardless of approval."
+              fi
+            fi
+          fi
+
+          if [ -z "$conclusion" ]; then
+            # Latest state-changing review from an approver. A stale approval
+            # (older head commit) does not count: approval must be on the
+            # current head, so it cannot survive a later push.
+            latest=$(gh api "repos/$REPO/pulls/$PR_NUMBER/reviews" --paginate \
+              | jq -s -c --arg u "$approvers" 'add
+                  | [.[] | select(.state == "APPROVED" or .state == "CHANGES_REQUESTED" or .state == "DISMISSED")
+                         | select(.user.login == $u)]
+                  | last // empty')
+            state=$(printf '%s' "$latest" | jq -r '.state // empty')
+            commit=$(printf '%s' "$latest" | jq -r '.commit_id // empty')
+            if [ "$state" = "APPROVED" ] && [ "$commit" = "$HEAD_SHA" ]; then
+              conclusion="success"
+              title="Gate-file change approved"
+              summary="This pull request changes files under .github/ and carries an approving review from $approvers on the current head commit."
+            else
+              conclusion="failure"
+              title="Gate-file change needs approval"
+              summary="This pull request changes files under .github/. It requires an approving review from $approvers on the current head commit ($HEAD_SHA). Automation can author gate-file changes; it cannot approve them."
+            fi
+          fi
+
+          gh api -X POST "repos/$REPO/check-runs" \
+            -f name='Gate file approval' \
+            -f head_sha="$HEAD_SHA" \
+            -f status=completed \
+            -f conclusion="$conclusion" \
+            -f 'output[title]'="$title" \
+            -f 'output[summary]'="$summary" \
+            --jq '"check_run id=" + (.id|tostring) + " conclusion=" + .conclusion'
+
+          # Mirror the verdict in the job status so an accidentally required
+          # job context is never an always-green bypass.
+          [ "$conclusion" = "success" ]

--- a/.github/workflows/gate-file-approval.yml
+++ b/.github/workflows/gate-file-approval.yml
@@ -14,11 +14,20 @@
 # repository secret, and must keep its token read-only apart from checks:write.
 # A tripwire below fails the check if a pull request tries to change that.
 #
-# The verdict is carried twice on purpose: as an explicit check run named
-# "Gate file approval" posted against the head commit (the context branch
-# protection must require), and as the job's own exit status, so that even a
-# misconfigured protection rule that requires the job context instead of the
-# check run still carries the real verdict rather than an always-green job.
+# The verdict lives in the check run named "Gate file approval" posted against
+# the head commit — that is the context branch protection must require, never
+# this job's own context. The states are encoded asymmetrically on purpose:
+# awaiting-owner-approval is the EXPECTED state of a gate-file pull request,
+# so it posts conclusion=action_required, which blocks a required check
+# exactly like failure while the run itself succeeds — the run evaluated and
+# posted its verdict, and the run record says so, with no failure email for a
+# routine state. Only genuine failures (tripwire violation, oversized pull
+# request, unreadable proposed copy) post conclusion=failure AND fail the job,
+# so a workflow-failure email from this workflow always means anomaly or
+# attack, never routine. The job-exit mirror below keeps an accidentally
+# required job context from ever being an always-green bypass; the conclusion
+# "neutral" is forbidden for any blocking state because required checks treat
+# it as passing.
 name: Gate file approval
 
 on:
@@ -40,20 +49,36 @@ concurrency:
 
 jobs:
   evaluate:
-    name: Evaluate gate-file approval
+    name: 'Evaluate gate-file approval (require the "Gate file approval" check, not this job)'
     runs-on: ubuntu-latest
     env:
       GH_TOKEN: ${{ github.token }}
       REPO: ${{ github.repository }}
       PR_NUMBER: ${{ github.event.pull_request.number }}
       HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+      EVENT_NAME: ${{ github.event_name }}
+      REVIEW_AUTHOR: ${{ github.event.review.user.login }}
     steps:
       - name: Evaluate and post the check run
         run: |
           set -euo pipefail
           # The approver set. Changing it is itself a gate-file change, so the
-          # change is judged by the current set.
+          # change is judged by the current set. This ONE variable feeds both
+          # the review-event early exit and the evaluation filter below — the
+          # two predicates cannot diverge because they share it.
           approvers="thebenignhacker"
+
+          # A review from anyone but the approver is not an input to the
+          # verdict, so re-evaluating on it would produce nothing new. Early
+          # exit posts nothing; the standing check run against the head commit
+          # remains the verdict. Only pull_request_review events may exit
+          # here — every pull_request_target event still evaluates. The
+          # approver's own events (including dismissal of their approval,
+          # whose review author is the approver) always evaluate.
+          if [ "$EVENT_NAME" = "pull_request_review" ] && [ "$REVIEW_AUTHOR" != "$approvers" ]; then
+            echo "Review by $REVIEW_AUTHOR is not an input to the verdict; nothing posted."
+            exit 0
+          fi
 
           # The files listing endpoint is capped at 3000 entries; a gate file
           # hidden past the cap would otherwise pass unseen. Refuse to evaluate
@@ -129,7 +154,11 @@ jobs:
               title="Gate-file change approved"
               summary="This pull request changes files under .github/ and carries an approving review from $approvers on the current head commit."
             else
-              conclusion="failure"
+              # The expected state of a gate-file pull request: evaluated,
+              # verdict posted, a human must act. action_required blocks a
+              # required check like failure, but the run itself succeeds, so
+              # no failure email fires for a routine state.
+              conclusion="action_required"
               title="Gate-file change needs approval"
               summary="This pull request changes files under .github/. It requires an approving review from $approvers on the current head commit ($HEAD_SHA). Automation can author gate-file changes; it cannot approve them."
             fi
@@ -144,6 +173,12 @@ jobs:
             -f 'output[summary]'="$summary" \
             --jq '"check_run id=" + (.id|tostring) + " conclusion=" + .conclusion'
 
-          # Mirror the verdict in the job status so an accidentally required
-          # job context is never an always-green bypass.
-          [ "$conclusion" = "success" ]
+          # Mirror only genuine failures in the job status: exit 0 iff the
+          # conclusion is in the explicit two-value allowlist, so any future
+          # state defaults loud, an accidentally required job context is never
+          # an always-green bypass, and a failure email from this workflow is
+          # a high-signal anomaly, never routine.
+          case "$conclusion" in
+            success|action_required) exit 0 ;;
+            *) exit 1 ;;
+          esac

--- a/__tests__/cli/secure-unread-input-gate.test.ts
+++ b/__tests__/cli/secure-unread-input-gate.test.ts
@@ -110,7 +110,7 @@ afterAll(() => {
   try { fs.rmSync(root, { recursive: true, force: true }); } catch { /* best effort */ }
 });
 
-describe('#438 secure settles one verdict over a tree it could not read', () => {
+describe('#438 secure settles one verdict over a tree it could not read', { timeout: 300_000 }, () => {
   // Each output channel is its own `return` inside the action, and each one
   // shipped its own copy of the exit rule. `--fail-below` is already silently
   // inert on three of them (#494) for exactly that reason, so the channels are
@@ -177,7 +177,7 @@ describe('#438 secure settles one verdict over a tree it could not read', () => 
   });
 });
 
-describe('#438 the run says which input it could not read', () => {
+describe('#438 the run says which input it could not read', { timeout: 300_000 }, () => {
   it('names the file in a finding and offers a runnable fix', () => {
     const dir = makeTree('discloses');
     if (!makeUnreadable(path.join(dir, 'src', 'secrets.js'))) {
@@ -216,7 +216,7 @@ describe('#438 the run says which input it could not read', () => {
   });
 });
 
-describe('#438 the gate is deterministic and names every path', () => {
+describe('#438 the gate is deterministic and names every path', { timeout: 300_000 }, () => {
   it('returns 2 on every one of N consecutive runs', () => {
     // A gate that fires most of the time is not a gate, and the miss is a
     // silent pass on exactly the defect. 60 runs were measured by hand at 0
@@ -252,7 +252,7 @@ describe('#438 the gate is deterministic and names every path', () => {
   }, 240_000);
 });
 
-describe('#438 the gate cannot be satisfied by writing into the target', () => {
+describe('#438 the gate cannot be satisfied by writing into the target', { timeout: 300_000 }, () => {
   it('--fix writing a .gitignore does not clear an unread input', () => {
     // The hazard that killed the reverted files-read gate: `secure --fix`
     // wrote a `.gitignore`, re-read it, and thereby satisfied its own coverage
@@ -274,7 +274,7 @@ describe('#438 the gate cannot be satisfied by writing into the target', () => {
   });
 });
 
-describe('#438 the unit counts only paths the scan is responsible for', () => {
+describe('#438 the unit counts only paths the scan is responsible for', { timeout: 300_000 }, () => {
   it('a symlink whose target escapes the tree is not a lost input', () => {
     // Found by adversarial review. `src/evil.js -> /etc/master.passwd` needs no
     // chmod and no privileges — any contributor can commit it — and the read
@@ -377,7 +377,7 @@ describe('#438 the unit counts only paths the scan is responsible for', () => {
   }, 240_000);
 });
 
-describe('#438 --fail-below cannot bypass the settlement', () => {
+describe('#438 --fail-below cannot bypass the settlement', { timeout: 300_000 }, () => {
   it('a threshold that passes does not restore exit 0 over an unread input', () => {
     // The #390 round-1 shape, and the reason the settlement is above the
     // channel branch: both `--fail-below` early returns sit ABOVE each
@@ -437,7 +437,7 @@ const VALID_DEPTHS: string[] = (() => {
   return depths;
 })();
 
-describe('#499 the completeness floor holds at every scan depth', () => {
+describe('#499 the completeness floor holds at every scan depth', { timeout: 300_000 }, () => {
   it.each(VALID_DEPTHS)('%s: an unreadable input is not a pass', (depth) => {
     const dir = makeTree(`depth-${depth}`);
     if (!makeUnreadable(path.join(dir, 'src', 'secrets.js'))) {
@@ -508,7 +508,7 @@ describe('#499 the completeness floor holds at every scan depth', () => {
  * Measured on the broken build: quick `unread 3`, standard `unread 4` — the one
  * real obstruction counted a second, third and fourth time.
  */
-describe('#499 a probe miss is not an unread input', () => {
+describe('#499 a probe miss is not an unread input', { timeout: 300_000 }, () => {
   function probeTree(name: string): string {
     const dir = path.join(root, name);
     fs.mkdirSync(path.join(dir, 'src'), { recursive: true });

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -31,13 +31,23 @@ export default defineConfig({
     // `spawnSync` blocks the event loop, so vitest cannot interrupt one. A cap
     // under the spawn budget still waits out the whole spawn and only then
     // reports an unhelpful "Test timed out", which is how the layering was
-    // inverted here. 60s covers the spawn tests with several times the
-    // headroom they need — a CLI scan that runs longer than that is broken,
-    // not slow — while staying tight enough that a genuinely hung unit test
-    // still fails quickly. The handful of files whose own spawn budgets
-    // exceed 60s carry an explicit higher `{ timeout }` on their describe.
-    testTimeout: 60_000,
-    hookTimeout: 60_000,
+    // inverted here.
+    //
+    // 60s was the previous cap, on the claim that a longer scan is broken
+    // rather than slow. Measured false under full-suite parallelism
+    // (2026-08-29): the suite packs ~5600s of test time into ~660s wall, and
+    // scans that take 13-20s in isolation contend past 60s — three different
+    // spawn-test files flaked at exactly 60000ms across three otherwise-green
+    // full-suite runs on an idle machine. 180s covers a contended scan with
+    // headroom while a genuinely hung unit test still fails in minutes, not
+    // hours. A file whose own spawn budget meets or exceeds this cap carries
+    // an explicit higher `{ timeout }` on its describe (secure-unread-input-
+    // gate: spawn budget 240s, describe timeout 300s).
+    // hookTimeout matches testTimeout for the same reason: several files run
+    // their scan spawns in beforeAll (fix-marker-under-prefix timed out its
+    // hook at exactly 60000ms in the run after testTimeout alone was raised).
+    testTimeout: 180_000,
+    hookTimeout: 180_000,
     // The OPENA2A_CORPUS_DETERMINISTIC default that used to sit here as
     // `env: { ... }` now lives in vitest.setup.ts, which sets it only when it is
     // unset. That conditional form is the reason it moved: a deliberate


### PR DESCRIPTION
Adds `.github/workflows/gate-file-approval.yml` (byte-identical to the amended `action_required` encoding now on the five other wired repos, sha256 `03e7a2b20ef53042`): a gate-file change under `.github/` needs an approving review from the listed approver on the current head; awaiting-approval posts `action_required` (blocks like failure, no false failure email), genuine failures still fail loud. Also raises the vitest testTimeout/hookTimeout 60s to 180s (measured: 60s flaked contended spawn tests under full-suite parallelism) and adds explicit describe-level timeouts to the secure-unread gate suite. Branch protection adds `Gate file approval` to required contexts after merge.