### PR TITLE
Carried P1s: source-file credential scan (CRED-005), per-instance findings, execution-sink corroborator scoped to code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,76 @@ All notable changes to HackMyAgent are documented in this file.
 
 ## [Unreleased]
 
+### The CRITICAL hardcoded-secret finding says where the secret is, and four secrets count as four (#368, #478)
+
+One cause, two symptoms, both carried since 0.28.0.
+
+`scanCanonicalCredentialFormats` knew the exact offset of every key it matched
+and threw it away. What it emitted was a CLASSIFICATION — `OpenAI legacy key:
+[REDACTED]` — which is the right thing to emit (no part of a value rides in a
+finding) but is not a substring of the file, and the only way back to a line ran
+through `extractEvidenceSpans`, which looks evidence up with `indexOf`. So:
+
+- **The CRITICAL was vaguer than the HIGH beneath it.** `AST-CRED-003` rendered
+  as `app/config.ts` with no `:N`, and with no line there is deliberately no
+  `Verify:` — directly above an `AST-CRED-001` HIGH on the same file that
+  printed both. A CRITICAL a reader cannot locate, above a HIGH they can,
+  inverts the severity signal the repo's own standard rests on (#368).
+- **Four keys in one file scored as one.** They collapsed into a single finding
+  naming the first, so removing three of the four moved the score by exactly
+  zero — which reads as "my fix did not work" (#478). Each shape was detected in
+  isolation the whole time; the loss was aggregation, not pattern coverage.
+
+The offset is now recorded at the point of the match, carried on the risk
+surface as `offset`, and turned into a line by the emit site. One finding per
+located instance, keyed on the offset rather than the line so two secrets
+sharing a line stay two secrets, and the per-file rollup in
+`deduplicateFindings` keys credential findings on their line as well — a
+hardcoded secret is a separate key to rotate, not a repetition of one issue the
+way 60 constraints in a SOUL.md are.
+
+**The detection vocabulary does not move.** The same shapes are found on the
+same files, and a file holding one secret still produces exactly one finding at
+the same severity, which a test pins beside the four-secret one.
+`MAX_FINDINGS_PER_CHECK` still caps the score contribution at three at full
+weight and 10% after, so this widens what the score can SEE without uncapping
+it. Several credential shapes remain undetected entirely — a plain
+`DB_PASSWORD`, a `postgres://` DSN, `glpat-` and `hf_` tokens still score 98/100
+at exit 0, exactly as 0.32.0 disclosed, and that is unchanged here.
+
+**Not closed by this: #497.** `AST-CRED-001` still derives its line by
+re-searching for the leftmost credential-shaped string, which is the wrong line
+whenever a digest or an `sk-EXAMPLE…` placeholder sits above the real key. The
+producer-offset route landed here for `AST-CRED-003` because the canonical scan
+records the offset of the value it matched; #497's harder half — a
+`-----BEGIN RSA PRIVATE KEY-----` match that is a good citation when a key body
+follows and a bad one when nothing does — is untouched and stays open.
+
+### `fix-all` reads the files `secure` reads before it calls credentials clean (#477)
+
+On a tree where `secure` reported a CRITICAL hardcoded secret and exited 1,
+`fix-all --scan-only` printed `Credential Protection  [+] No issues found` and
+exited 0 — while `secure --fix` routes users to `fix-all` in its own output. Two
+analyzers in one tool, opposite directions, one artifact.
+
+It was never a disagreement about which credential SHAPES count: credvault's
+catalog already carried the vendor shapes `secure` reports. It was a
+disagreement about which FILES get opened. credvault read fourteen fixed config
+paths, so an ordinary `.py` or `.ts` holding an API key was outside its
+population entirely. It now sweeps the same source extensions
+`artifact-parser.ts` classifies as `source_code`, with the same catalog and the
+same per-line ReDoS bound, and reports **CRED-005**. The sweep is bounded (depth
+8, 2000 files, no symlink traversal, the usual build and vendor directories
+skipped) and a quoted pattern in a scanner's own source does not count — source
+files legitimately hold the shapes a scanner matches with, which config files do
+not.
+
+**CRED-005 is not auto-fixable, deliberately.** `fix()` rewrites the config
+paths and nothing else, so marking it fixable would print a remedy that never
+runs and would clear the finding out of `remainingFindings` — the list the exit
+code reads. `fix-all` names the file and the line and asks the user to rotate;
+it does not rewrite source.
+
 ### The GlassWorm decoder's execution-sink corroborator reads code, and reads the same lines (#475, in part)
 
 `UNICODE-STEGO-002` lifts a decoder shape to CRITICAL when it finds an execution

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,48 @@ All notable changes to HackMyAgent are documented in this file.
 
 ## [Unreleased]
 
+### The GlassWorm decoder's execution-sink corroborator reads code, and reads the same lines (#475, in part)
+
+`UNICODE-STEGO-002` lifts a decoder shape to CRITICAL when it finds an execution
+sink in the same file. It looked for one over the whole file content, with no idea
+what was code, so two things corroborated that are not calls:
+
+- **A mention in a comment or a string literal.** `src/hardening/scanner.ts`
+  self-flagged CRITICAL on the `eval(...)` written into one of its own doc comments
+  and on the `'eval() dynamic execution'` label of a detection rule. It stayed out
+  of our own score only because `.hmaignore` excludes that path — the exemption was
+  carrying the defect, so the same file scanned anywhere else reported CRITICAL on
+  its own prose. Comments are now blanked with block state carried across the line
+  boundary (the body of a doc comment has no opener on its own line, which is why
+  the existing per-line predicate could not see this), and strings are left to
+  `isMatchInsideStringLiteral`, the predicate NEMO-009 already uses for the same
+  question. Scanned as a copy with no `.hmaignore` in reach, `scanner.ts` moves from
+  CRITICAL to a MEDIUM lead. It is still reported: the file does read codepoints in
+  the range, and saying so costs a line of output.
+- **A line the finding's own signals never read.** The presence loop skips a line
+  over `MAX_LINE_LENGTH`; the corroborator ran over whole content, so an `eval(`
+  inside a minified bundle line corroborated a `.codePointAt(` and a range literal
+  read from ordinary lines. Both now read one population in one loop, so they cannot
+  disagree about which lines exist. A pair of fixtures differing only in the length
+  of one padding string pins each direction.
+
+**The sink vocabulary is unchanged, deliberately.** `vm.runInNewContext`,
+`globalThis.eval`, `(0,eval)`, a constructor chain, `Reflect.construct`, dynamic
+`import()`, `child_process` and `module._compile` still do not corroborate, and the
+finding's guidance still says so. Widening the regex would answer a semantic
+question with a lexical test for the third time in this check; it belongs with
+#424's AST dataflow work, and the regexes themselves are byte-identical to before
+this change so that claim can be diffed rather than taken on trust.
+
+**One narrowing, disclosed:** matching per line means `eval` and `(` separated by a
+newline no longer match. That spelling is legal JavaScript and is a real loss of one
+lexical variant, on a corroborator that already misses the eight spellings above.
+
+The uncorroborated finding's own description and guidance were reworded to match:
+they used to say no `eval(` or `Function(` call "appears in this file", which is now
+false about a file that mentions one in a comment. They say "in code" and name the
+line-length limit.
+
 ### The ASP profile's credential summary no longer misses semantic secrets
 
 `secure -b oasb-1 --format asp` could report `credentials.hardcodedSecrets: 0`

--- a/__tests__/cli/cross-analyzer-credential-agreement.test.ts
+++ b/__tests__/cli/cross-analyzer-credential-agreement.test.ts
@@ -1,0 +1,199 @@
+/**
+ * HMA-01.AC4 — `fix-all --scan-only` and `secure` do not return opposite
+ * verdicts on one tree (#477, second carry).
+ *
+ * The defect: on a directory where `secure` reported a CRITICAL hardcoded
+ * secret and exited 1, `fix-all --scan-only` printed
+ * `Credential Protection  [+] No issues found` and exited 0 — and `secure --fix`
+ * routes users to `fix-all` in its own output. Two analyzers in one tool,
+ * opposite directions, same artifact.
+ *
+ * WHAT WAS ACTUALLY WRONG, and what the fix therefore is. It was never a
+ * disagreement about which credential SHAPES count: `credvault`'s catalog
+ * already carried the vendor shapes `secure` reports. It was a disagreement
+ * about which FILES get opened — `credvault` read fourteen fixed config paths,
+ * so an ordinary `.py` or `.ts` holding an API key was outside its population
+ * entirely. It now sweeps the same source extensions `artifact-parser.ts`
+ * classifies as `source_code`, with the same catalog, and reports CRED-005.
+ *
+ * CRED-005 IS NOT AUTO-FIXABLE, deliberately. `fix()` rewrites the config paths
+ * and nothing else, so marking it fixable would print a remedy that never runs
+ * and would clear the finding out of `remainingFindings`, which is the list the
+ * exit code reads.
+ *
+ * The first block runs without a build, so the plugin-level property holds in
+ * any environment. The second spawns both commands, because "the two agree" is
+ * a statement about two exit codes and only the built CLI has them.
+ */
+
+import { describe, it, expect, beforeAll } from 'vitest';
+import { spawnSync } from 'node:child_process';
+import { randomBytes } from 'node:crypto';
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
+
+import { assertDistFreshIfPresent } from '../helpers/dist-freshness';
+import { CredVaultPlugin } from '../../src/plugins/credvault';
+
+beforeAll(assertDistFreshIfPresent);
+
+const CLI_PATH = resolve(__dirname, '../../dist/cli.js');
+const STRIP_ANSI = /\x1b\[[0-9;]*m/g;
+const ARTIFACT = join('app', 'service.py');
+
+/**
+ * A key synthesized at run time, for the reason the rest of this repo
+ * synthesizes them: the detector skips any value whose own bytes carry a
+ * placeholder marker, so a fixture using the house FAKE marker would be
+ * vacuously green, and committing a credential-shaped literal is worse. Hex is
+ * a subset of the vendor character class and cannot spell a marker.
+ */
+function anthropicKey(): string {
+  return `sk-ant-api03-${randomBytes(40).toString('hex').slice(0, 40).toUpperCase()}`;
+}
+
+/** A tree whose only credential sits in an ordinary source file. */
+function treeWithSourceSecret(): string {
+  const dir = mkdtempSync(join(tmpdir(), 'hma-01-ac4-'));
+  mkdirSync(join(dir, 'app'), { recursive: true });
+  writeFileSync(
+    join(dir, ARTIFACT),
+    [
+      '# Billing worker.',
+      'import httpx',
+      '',
+      `ANTHROPIC_KEY = "${anthropicKey()}"`,
+      '',
+      'def client():',
+      '    return httpx.Client(headers={"x-api-key": ANTHROPIC_KEY})',
+      '',
+    ].join('\n'),
+    'utf-8',
+  );
+  return dir;
+}
+
+interface Run {
+  status: number | null;
+  out: string;
+}
+
+function runCli(args: string[]): Run {
+  const r = spawnSync(process.execPath, [CLI_PATH, ...args], {
+    encoding: 'utf-8',
+    timeout: 120_000,
+    env: { ...process.env, NODE_OPTIONS: '', NO_COLOR: '1' },
+  });
+  return {
+    status: r.status,
+    out: `${(r.stdout ?? '').replace(STRIP_ANSI, '')}\n${(r.stderr ?? '').replace(STRIP_ANSI, '')}`,
+  };
+}
+
+function firstJsonObject(text: string): Record<string, unknown> {
+  const start = text.indexOf('{');
+  expect(start, `no JSON object in output: ${text.slice(0, 300)}`).toBeGreaterThanOrEqual(0);
+  return JSON.parse(text.slice(start, text.lastIndexOf('}') + 1)) as Record<string, unknown>;
+}
+
+describe('HMA-01.AC4: the Credential Protection plugin reads source files', () => {
+  it('HMA-01.AC4 credvault reports a CRITICAL for a key in an ordinary source file', async () => {
+    const dir = treeWithSourceSecret();
+    const plugin = new CredVaultPlugin();
+    await plugin.init();
+    const findings = await plugin.scan(dir);
+
+    const onSource = findings.filter((f) => f.filePath === ARTIFACT);
+    expect(
+      onSource.length,
+      `credvault must not report a source file holding an API key as clean. Got: ${
+        findings.map((f) => `${f.id} ${f.filePath}`).join(', ') || '(none)'
+      }`,
+    ).toBeGreaterThan(0);
+    expect(onSource.some((f) => f.severity === 'critical')).toBe(true);
+    // Not auto-fixable, so it survives the fix pass and reaches the exit code.
+    expect(onSource.every((f) => f.autoFixable === false)).toBe(true);
+    expect(onSource.every((f) => Number.isInteger(f.line))).toBe(true);
+  });
+
+  it('HMA-01.AC4 credvault still reports nothing on a source tree with no credential', async () => {
+    // The cheapest way to pass the assertion above is to report every source
+    // file, so the negative half is pinned beside it.
+    const dir = mkdtempSync(join(tmpdir(), 'hma-01-ac4-clean-'));
+    mkdirSync(join(dir, 'app'), { recursive: true });
+    writeFileSync(
+      join(dir, ARTIFACT),
+      ['import os', '', 'KEY = os.environ["ANTHROPIC_API_KEY"]', ''].join('\n'),
+      'utf-8',
+    );
+    const plugin = new CredVaultPlugin();
+    await plugin.init();
+    expect(await plugin.scan(dir)).toEqual([]);
+  });
+});
+
+describe('HMA-01.AC4: fix-all --scan-only agrees in direction with secure', () => {
+  it('HMA-01.AC4 dist/cli.js exists', () => {
+    expect(existsSync(CLI_PATH)).toBe(true);
+  });
+
+  it('HMA-01.AC4 secure and fix-all --scan-only return the same direction on one tree', () => {
+    if (!existsSync(CLI_PATH)) return;
+    const dir = treeWithSourceSecret();
+
+    const secure = runCli(['secure', dir, '--json', '--no-machine-posture']);
+    const secureBody = firstJsonObject(secure.out);
+    const secureFindings = (secureBody.findings ?? []) as Array<{
+      severity?: string;
+      category?: string;
+      passed?: boolean;
+    }>;
+
+    // Non-vacuity: the comparison only means something while `secure` really
+    // does report a CRITICAL credential on this tree.
+    expect(
+      secureFindings.some((f) => !f.passed && f.severity === 'critical'),
+      'secure reported no CRITICAL — the adversarial fixture stopped reproducing',
+    ).toBe(true);
+    expect(secure.status, 'secure must fail the tree it calls critical').toBe(1);
+
+    const fixAll = runCli(['fix-all', dir, '--scan-only', '--json']);
+    const fixAllBody = firstJsonObject(fixAll.out);
+    const plugins = (fixAllBody.plugins ?? []) as Array<{
+      name: string;
+      findings: Array<{ severity?: string }>;
+    }>;
+    const credential = plugins.find((p) => p.name === 'Credential Protection');
+    expect(credential, 'fix-all must run the Credential Protection plugin').toBeDefined();
+
+    expect(
+      credential!.findings.length,
+      'fix-all reported Credential Protection clean on a tree secure calls CRITICAL',
+    ).toBeGreaterThan(0);
+    expect(
+      fixAll.status,
+      `direction disagreement: secure exited ${secure.status}, fix-all --scan-only exited ${fixAll.status}`,
+    ).not.toBe(0);
+  });
+
+  it('HMA-01.AC4 the text channel does not print "No issues found" for Credential Protection', () => {
+    if (!existsSync(CLI_PATH)) return;
+    const dir = treeWithSourceSecret();
+    const run = runCli(['fix-all', dir, '--scan-only']);
+
+    const block = run.out.split('> Credential Protection')[1] ?? '';
+    expect(block, 'the Credential Protection block did not render').not.toBe('');
+    expect(block.split('\n').slice(0, 4).join('\n')).not.toMatch(/No issues found/);
+    expect(run.status).not.toBe(0);
+  });
+
+  it('HMA-01.AC4 --scan-only writes nothing to the tree it reports on', () => {
+    if (!existsSync(CLI_PATH)) return;
+    const dir = treeWithSourceSecret();
+    const before = readFileSync(join(dir, ARTIFACT), 'utf-8');
+    runCli(['fix-all', dir, '--scan-only']);
+    const after = readFileSync(join(dir, ARTIFACT), 'utf-8');
+    expect(after, 'a scan-only run must not rewrite source').toBe(before);
+  });
+});

--- a/__tests__/cli/scan-soul-absent-governance.test.ts
+++ b/__tests__/cli/scan-soul-absent-governance.test.ts
@@ -1,0 +1,115 @@
+/**
+ * HMA-01.AC2 — `scan-soul --ci` over a tree with no governance file (#390,
+ * second carry).
+ *
+ * The defect: `scan-soul --ci` exited 0 and printed a full `0/100` nine-domain
+ * table, naming controls as "Missing" from a file it never found. The worst
+ * posture a target can hold was the one case CI passed.
+ *
+ * WHAT THIS FILE ADDS over `scan-soul-conformance-gate.test.ts`, which pins the
+ * same exit contract: nothing about the implementation, and that is deliberate.
+ * It states the acceptance criterion in the criterion's own terms — non-zero
+ * exit, an absence that is REPORTED rather than scored, and no fabricated band
+ * — so the criterion is checkable without reading the ruling that produced it.
+ * If the two files ever disagree, the older one is the record of the decision.
+ *
+ * ON THE WORDING. The criterion asks for a finding saying the file is ABSENT.
+ * The shipped output says `NOT MEASURED — No governance file was found, so no
+ * governance score can be reported for this target`, with the searched
+ * filenames beside it, and `--json` carries `gate.reason: 'no-governance-file'`
+ * with `score: null`. The assertions below are on that substance rather than on
+ * a literal token: renaming shipped, tested output to match a criterion's
+ * phrasing would be churn, and the `--json` reason string is a consumer
+ * contract.
+ */
+
+import { describe, it, expect, beforeAll } from 'vitest';
+import { execFileSync } from 'node:child_process';
+import { existsSync, mkdtempSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
+
+import { assertDistFreshIfPresent } from '../helpers/dist-freshness';
+import { EXIT_UNMEASURED } from '../../src/check/verdict';
+
+beforeAll(assertDistFreshIfPresent);
+
+const CLI_PATH = resolve(__dirname, '../../dist/cli.js');
+const STRIP_ANSI = /\x1b\[[0-9;]*m/g;
+
+function runScanSoul(target: string, ...flags: string[]): { out: string; status: number } {
+  try {
+    const stdout = execFileSync(process.execPath, [CLI_PATH, 'scan-soul', target, ...flags], {
+      stdio: ['ignore', 'pipe', 'pipe'],
+      encoding: 'utf8',
+      timeout: 20000,
+      env: { ...process.env, NODE_OPTIONS: '', NO_COLOR: '1' },
+    });
+    return { out: stdout.replace(STRIP_ANSI, ''), status: 0 };
+  } catch (err) {
+    const e = err as { status?: number; stdout?: Buffer | string; stderr?: Buffer | string };
+    const text = (s: Buffer | string | undefined) =>
+      (typeof s === 'string' ? s : (s?.toString() ?? '')).replace(STRIP_ANSI, '');
+    return { out: `${text(e.stdout)}\n${text(e.stderr)}`, status: e.status ?? 1 };
+  }
+}
+
+/** A directory with no SOUL.md, no CLAUDE.md, no governance file of any spelling. */
+function emptyTree(): string {
+  return mkdtempSync(join(tmpdir(), 'hma-01-ac2-'));
+}
+
+describe('HMA-01.AC2: scan-soul --ci over a tree with no governance file', () => {
+  it('HMA-01.AC2 dist/cli.js exists', () => {
+    // A spawn suite that silently skips reports success over a build that was
+    // never made. Named as its own leaf so the skip is visible.
+    expect(existsSync(CLI_PATH)).toBe(true);
+  });
+
+  it('HMA-01.AC2 --ci exits non-zero when no governance file exists at the scanned path', () => {
+    if (!existsSync(CLI_PATH)) return;
+    const { status } = runScanSoul(emptyTree(), '--ci');
+    expect(status, 'the worst posture must not be the one case CI passes').not.toBe(0);
+    // The specific code is the unmeasured arm, not a conformance failure: there
+    // is no verdict to fail, because nothing was read.
+    expect(status).toBe(EXIT_UNMEASURED);
+  });
+
+  it('HMA-01.AC2 --ci reports the governance file as absent rather than scoring it', () => {
+    if (!existsSync(CLI_PATH)) return;
+    const { out } = runScanSoul(emptyTree(), '--ci');
+    expect(out).toMatch(/NOT MEASURED/);
+    expect(out, 'the absence itself must be stated').toMatch(/no governance file was found/i);
+    // Not a dead end: the output has to say how to create one.
+    expect(out).toMatch(/harden-soul/);
+  });
+
+  it('HMA-01.AC2 --ci prints no fabricated 0/100 and no per-domain table', () => {
+    if (!existsSync(CLI_PATH)) return;
+    const { out } = runScanSoul(emptyTree(), '--ci');
+    expect(out, 'a band handed to a file that does not exist').not.toMatch(/0\/100/);
+    expect(out).not.toMatch(/Domain Scores/);
+    // Naming controls as "Missing" from a file that does not exist is the same
+    // false assertion in a different shape.
+    expect(out).not.toMatch(/SOUL-IH-003/);
+    expect(out).not.toMatch(/SOUL-HB-001/);
+  });
+
+  it('HMA-01.AC2 --ci --json withholds the score and names the reason', () => {
+    if (!existsSync(CLI_PATH)) return;
+    const { out, status } = runScanSoul(emptyTree(), '--ci', '--json');
+    expect(status).toBe(EXIT_UNMEASURED);
+    const start = out.indexOf('{');
+    expect(start, `no JSON object on stdout: ${out.slice(0, 300)}`).toBeGreaterThanOrEqual(0);
+    const body = JSON.parse(out.slice(start, out.lastIndexOf('}') + 1)) as {
+      score?: unknown;
+      conformance?: unknown;
+      gate?: { failed?: boolean; reason?: string; exitCode?: number };
+    };
+    expect(body.score ?? null, 'a consumer must not read a band this run did not earn').toBeNull();
+    expect(body.conformance ?? null).toBeNull();
+    expect(body.gate?.failed).toBe(true);
+    expect(body.gate?.reason).toBe('no-governance-file');
+    expect(body.gate?.exitCode).toBe(EXIT_UNMEASURED);
+  });
+});

--- a/__tests__/hardening/sink-corroborator-scope.test.ts
+++ b/__tests__/hardening/sink-corroborator-scope.test.ts
@@ -1,0 +1,286 @@
+/**
+ * HMA-01.AC5 — the two cheap items filed beside #475.
+ *
+ * The corroborator REGEXES ARE NOT WIDENED HERE and nothing below asserts that
+ * they are: `vm.runInNewContext`, `globalThis.eval`, `(0,eval)`, a constructor
+ * chain, `Reflect.construct`, dynamic `import()`, `child_process` and
+ * `module._compile` still do not corroborate, and closing that belongs to
+ * #424's AST dataflow unit. A semantic question answered by a lexical test is
+ * the mistake this check has already made twice.
+ *
+ * What moved is the TEXT the unchanged regexes are asked about:
+ *
+ *   1. Comments and string literals are not code. `src/hardening/scanner.ts`
+ *      self-flagged CRITICAL on the `eval(...)` in one of its own doc comments
+ *      and on the `'eval() dynamic execution'` label of a detection rule, and
+ *      stayed out of its own score only because `.hmaignore` excludes the path.
+ *      The last block below scans the real file with no `.hmaignore` in reach,
+ *      so the property is measured on the artifact the issue named rather than
+ *      on a fixture that resembles it.
+ *   2. The corroborator reads the SAME LINE POPULATION as the presence loop.
+ *      Both now skip a line over MAX_LINE_LENGTH, so an `eval(` inside a
+ *      minified bundle line cannot corroborate `.codePointAt(` and a range
+ *      literal read from ordinary lines.
+ *
+ * Every suppression block below is paired with a NON-VACUITY twin that must
+ * still reach CRITICAL, because the cheapest way to pass a "does not fire"
+ * suite is to stop the check firing at all. The minified pair differs only in
+ * the length of one padding string.
+ *
+ * No invisible codepoint is WRITTEN anywhere in this file. The one matcher that
+ * needs them builds them from numeric codepoints at run time: a file asserting
+ * that another file carries none must not carry one itself, and an editor that
+ * renders escape sequences has put ten of them into this repo once already.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { HardeningScanner } from '../../src/hardening/scanner';
+import type { SecurityFinding } from '../../src/hardening/security-check';
+import * as fs from 'fs/promises';
+import * as path from 'path';
+import * as os from 'os';
+
+/** Mirrors `MAX_LINE_LENGTH` in `src/hardening/scanner.ts`, which is module-private. */
+const MAX_LINE_LENGTH = 10000;
+
+/** The corroborator, character for character as the scanner carries it. */
+const SINK_PATTERNS = [
+  /(?:^|[^\w.$])eval\s*\(/,
+  /(?:^|[^\w.$])(?:new\s+)?Function\s*\(/,
+];
+
+/**
+ * The decoder shape the finding is actually about: reads codepoints in the
+ * variation-selector range. Carries no sink and no invisible payload of its
+ * own, so whatever a fixture adds to it is the only thing under test.
+ */
+const DECODER_SHAPE = [
+  'function read(input) {',
+  '  const out = [];',
+  '  for (let i = 0; i < input.length; i++) {',
+  '    const cp = input.codePointAt(i);',
+  '    if (cp >= 0xFE00 && cp <= 0xFE0F) out.push(cp - 0xFE00);',
+  '  }',
+  '  return out;',
+  '}',
+];
+
+describe('HMA-01.AC5: the execution-sink corroborator reads code, and reads the same lines', () => {
+  let scanner: HardeningScanner;
+  let tempDir: string;
+
+  beforeEach(async () => {
+    scanner = new HardeningScanner();
+    tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'hma-sink-scope-'));
+    await fs.writeFile(
+      path.join(tempDir, 'package.json'),
+      JSON.stringify({ name: 'sink-scope-project', version: '1.0.0' })
+    );
+  });
+
+  afterEach(async () => {
+    await fs.rm(tempDir, { recursive: true, force: true });
+  });
+
+  async function stego002For(file: string): Promise<SecurityFinding[]> {
+    const result = await scanner.scan({ targetDir: tempDir });
+    return result.findings.filter(
+      (f) => f.checkId === 'UNICODE-STEGO-002' && f.file === file
+    );
+  }
+
+  /**
+   * A fixture only measures the sink corroborator while the decoder shape is
+   * intact and the raw text still matches the unchanged regexes — otherwise a
+   * MEDIUM verdict proves the fixture stopped reaching the check, not that the
+   * sink was correctly ignored.
+   */
+  function expectFixtureStillTriggersTheOldReader(content: string): void {
+    expect(content).toContain('.codePointAt(');
+    expect(content).toMatch(/0x(?:FE0|E010)/);
+    expect(
+      SINK_PATTERNS.some((p) => p.test(content)),
+      'the fixture no longer matches the sink regexes, so this measures nothing'
+    ).toBe(true);
+  }
+
+  it('HMA-01.AC5 a doc comment naming eval( does not corroborate the decoder shape', async () => {
+    // The `eval(` sits on a CONTINUATION line of a block comment, which is the
+    // case a per-line reader cannot see: that line carries no opener of its own.
+    const content = [
+      '/**',
+      ' * Reads variation-selector codepoints for inspection.',
+      ' *',
+      ' * Never hand the result to eval(payload) — this decodes for a human,',
+      ' * not for an executor.',
+      ' */',
+      ...DECODER_SHAPE,
+      'module.exports = { read };',
+    ].join('\n');
+    expectFixtureStillTriggersTheOldReader(content);
+    await fs.writeFile(path.join(tempDir, 'doc-comment.js'), content);
+
+    const findings = await stego002For('doc-comment.js');
+    expect(findings.length).toBe(1);
+    expect(findings[0].severity).toBe('medium');
+    expect(['critical', 'high']).not.toContain(findings[0].severity);
+    expect(findings[0].message).toContain('uncorroborated');
+  });
+
+  it('HMA-01.AC5 a detection-rule label string holding eval() does not corroborate', async () => {
+    // The shape our own scanner carries: a regex literal whose escapes stop the
+    // corroborator matching, beside a human-readable label where it does match.
+    const content = [
+      'const RULES = [',
+      "  { pattern: /eval\\s*\\(/, label: 'eval() dynamic execution' },",
+      "  { pattern: /new\\s+Function\\s*\\(/, label: 'new Function() dynamic execution' },",
+      '];',
+      ...DECODER_SHAPE,
+      'module.exports = { read, RULES };',
+    ].join('\n');
+    expectFixtureStillTriggersTheOldReader(content);
+    await fs.writeFile(path.join(tempDir, 'rules.js'), content);
+
+    const findings = await stego002For('rules.js');
+    expect(findings.length).toBe(1);
+    expect(findings[0].severity).toBe('medium');
+    expect(['critical', 'high']).not.toContain(findings[0].severity);
+  });
+
+  it('HMA-01.AC5 a real call after a mention on the SAME line still corroborates', async () => {
+    // Non-vacuity for the two blocks above, and the reason the line is walked to
+    // its end rather than answered from its first match. A reader that stopped at
+    // the label would call this file a lead.
+    const content = [
+      ...DECODER_SHAPE,
+      "const label = 'eval() dynamic execution'; eval(read(process.argv[2]).join(''));",
+    ].join('\n');
+    expectFixtureStillTriggersTheOldReader(content);
+    await fs.writeFile(path.join(tempDir, 'mention-then-call.js'), content);
+
+    const findings = await stego002For('mention-then-call.js');
+    expect(findings.length).toBe(1);
+    expect(findings[0].severity).toBe('critical');
+    expect(findings[0].message).toContain('execution sink');
+  });
+
+  it('HMA-01.AC5 an eval( on a line over MAX_LINE_LENGTH does not corroborate', async () => {
+    // A minified bundle is one very long line. The presence loop has always
+    // skipped it; the corroborator used to read it anyway, so the bundle
+    // corroborated signals read from the ordinary lines above it.
+    const bundle = `const BUNDLE = "${'a'.repeat(MAX_LINE_LENGTH)}";eval(BUNDLE);`;
+    expect(bundle.length).toBeGreaterThan(MAX_LINE_LENGTH);
+    const content = [...DECODER_SHAPE, bundle].join('\n');
+    expectFixtureStillTriggersTheOldReader(content);
+    await fs.writeFile(path.join(tempDir, 'minified.js'), content);
+
+    const findings = await stego002For('minified.js');
+    expect(findings.length).toBe(1);
+    expect(findings[0].severity).toBe('medium');
+    expect(['critical', 'high']).not.toContain(findings[0].severity);
+  });
+
+  it('HMA-01.AC5 the same eval( on a line within MAX_LINE_LENGTH still corroborates', async () => {
+    // The twin of the block above, differing ONLY in the padding length. Without
+    // it, "minified.js is MEDIUM" is equally well explained by the fixture never
+    // reaching the check.
+    const short = `const BUNDLE = "${'a'.repeat(64)}";eval(BUNDLE);`;
+    expect(short.length).toBeLessThanOrEqual(MAX_LINE_LENGTH);
+    const content = [...DECODER_SHAPE, short].join('\n');
+    expectFixtureStillTriggersTheOldReader(content);
+    await fs.writeFile(path.join(tempDir, 'short-line.js'), content);
+
+    const findings = await stego002For('short-line.js');
+    expect(findings.length).toBe(1);
+    expect(findings[0].severity).toBe('critical');
+    expect(findings[0].message).toContain('execution sink');
+  });
+});
+
+/**
+ * The artifact #475 actually named. Scanned as a copy in a temp directory, so
+ * no `.hmaignore` is in reach and the exemption that has been hiding this from
+ * our own score is not available.
+ */
+describe('HMA-01.AC5: the scanner does not self-flag CRITICAL without .hmaignore', () => {
+  let scanner: HardeningScanner;
+  let tempDir: string;
+  const SOURCE = path.join(__dirname, '..', '..', 'src', 'hardening', 'scanner.ts');
+
+  const VARIATION_SELECTOR_FIRST = 0xfe00;
+  const VARIATION_SELECTOR_LAST = 0xfe0f;
+  const TAG_SUPPLEMENT_FIRST = 0xe0100;
+  const TAG_SUPPLEMENT_LAST = 0xe01ef;
+
+  /**
+   * The payload classes that DO corroborate this finding, built from codepoints
+   * so this file carries none of them. See the header.
+   */
+  const PAYLOAD_CLASS = new RegExp(
+    '['
+      + String.fromCodePoint(VARIATION_SELECTOR_FIRST)
+      + '-'
+      + String.fromCodePoint(VARIATION_SELECTOR_LAST)
+      + ']|['
+      + String.fromCodePoint(TAG_SUPPLEMENT_FIRST)
+      + '-'
+      + String.fromCodePoint(TAG_SUPPLEMENT_LAST)
+      + ']',
+    'u',
+  );
+
+  beforeEach(async () => {
+    scanner = new HardeningScanner();
+    tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'hma-self-scan-'));
+    await fs.writeFile(
+      path.join(tempDir, 'package.json'),
+      JSON.stringify({ name: 'self-scan-project', version: '1.0.0' })
+    );
+    await fs.copyFile(SOURCE, path.join(tempDir, 'scanner.ts'));
+  });
+
+  afterEach(async () => {
+    await fs.rm(tempDir, { recursive: true, force: true });
+  });
+
+  it(
+    'HMA-01.AC5 src/hardening/scanner.ts is a MEDIUM lead, not a CRITICAL, on its own text',
+    async () => {
+      const source = await fs.readFile(SOURCE, 'utf-8');
+
+      // The two presence signals are there, so the finding is reached at all.
+      expect(source).toContain('.codePointAt(');
+      expect(source).toMatch(/0x(?:FE0|E010)/);
+      // The raw text still matches the unchanged corroborator regexes — that is
+      // the whole defect: every one of those matches is a comment or a string.
+      expect(SINK_PATTERNS.some((p) => p.test(source))).toBe(true);
+      // And the OTHER corroborator must be absent, or a CRITICAL here would be
+      // correct for a reason this test is not about. The file does carry one
+      // U+200B, deliberately, escaping a globstar inside a JSDoc — a zero-width
+      // char is not a variation-selector or tag-character payload and has not
+      // corroborated this finding since #475's first half.
+      expect(PAYLOAD_CLASS.test(source)).toBe(false);
+      // Non-vacuity control: a matcher that matched nothing would satisfy the
+      // line above for the wrong reason.
+      expect(
+        PAYLOAD_CLASS.test('a' + String.fromCodePoint(VARIATION_SELECTOR_FIRST) + 'b'),
+      ).toBe(true);
+      expect(
+        PAYLOAD_CLASS.test('a' + String.fromCodePoint(TAG_SUPPLEMENT_FIRST) + 'b'),
+      ).toBe(true);
+
+      const result = await scanner.scan({ targetDir: tempDir });
+      const stego002 = result.findings.filter(
+        (f) => f.checkId === 'UNICODE-STEGO-002' && f.file === 'scanner.ts'
+      );
+
+      // Still REPORTED. Suppressing it would be the other failure mode: the file
+      // does read codepoints in the range, and saying so costs a line of output.
+      // What it must not do is fail a pipeline on its own doc comments.
+      expect(stego002.length).toBe(1);
+      expect(stego002[0].severity).toBe('medium');
+      expect(['critical', 'high']).not.toContain(stego002[0].severity);
+    },
+    180_000
+  );
+});

--- a/__tests__/nanomind-core/hardcoded-secret-instances.test.ts
+++ b/__tests__/nanomind-core/hardcoded-secret-instances.test.ts
@@ -1,0 +1,223 @@
+/**
+ * HMA-01.AC1 / HMA-01.AC3 — the CRITICAL hardcoded-secret finding is locatable,
+ * and several secrets in one file are countable (#368, #478).
+ *
+ * ONE DEFECT, TWO SYMPTOMS, ONE CAUSE. `scanCanonicalCredentialFormats` knew
+ * the exact offset of every key it matched and threw it away, emitting only a
+ * classification (`OpenAI legacy key: [REDACTED]`) that nothing downstream
+ * could search for — `extractEvidenceSpans` looks evidence up with `indexOf`,
+ * and a classification is not a quotation. So:
+ *
+ *   - the CRITICAL rendered as `app/config.ts` with no `:N` and therefore no
+ *     `Verify:`, directly above a HIGH on the same file that printed both. A
+ *     CRITICAL vaguer than the HIGH beneath it inverts the severity signal
+ *     (#368, second carry);
+ *   - four keys in one file collapsed to a single finding naming the first, and
+ *     because scoring counts findings, removing three of four moved the score
+ *     by exactly zero — which reads as "my fix did not work" (#478).
+ *
+ * The offset is now recorded where the match is made and carried on the risk
+ * surface. NO DETECTION VOCABULARY MOVES: the same shapes are found on the same
+ * files, and a file holding ONE secret still produces exactly one finding at the
+ * same severity, which the last block below pins.
+ *
+ * WHY THE KEYS ARE SYNTHESIZED AT RUN TIME rather than committed, and why the
+ * bodies are hex: the detector skips any value whose own bytes carry
+ * FAKE / EXAMPLE / PLACEHOLDER / DUMMY / YOUR_KEY / YOUR_TOKEN / REPLACE_ME /
+ * INSERT_HERE, so a fixture using the house marker would be vacuously green,
+ * and committing a credential-shaped literal to a public repo is worse. A hex
+ * body is a subset of every vendor's character class and cannot spell any of
+ * those markers, so the generator cannot accidentally suppress its own fixture.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { randomBytes } from 'node:crypto';
+import { mkdtemp, mkdir, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { runNanoMindScan } from '../../src/nanomind-core/scanner-bridge';
+import { calculateSecurityScore } from '../../src/hardening/scanner';
+import { generateVerifyCommand } from '../../src/ui/verify-command';
+
+/** Uppercase hex, which every vendor character class below admits. */
+function body(chars: number): string {
+  return randomBytes(chars).toString('hex').slice(0, chars).toUpperCase();
+}
+
+/**
+ * Four DIFFERENT vendor shapes, because #478's measurement was that each type
+ * is detected in isolation — the defect is aggregation, not pattern coverage.
+ * A four-of-one-shape fixture could not tell those apart.
+ */
+function secretLines(): string[] {
+  return [
+    `  anthropicKey: "sk-ant-api03-${body(40)}",`,
+    `  awsAccessKeyId: "AKIA${body(16)}",`,
+    `  githubToken: "ghp_${body(36)}",`,
+    `  googleApiKey: "AIza${body(35)}",`,
+  ];
+}
+
+/**
+ * `count` secrets in one source file, otherwise byte-identical. The removed
+ * lines are replaced by inert ones so the two trees differ only in how many
+ * credentials they hold, not in how long the file is.
+ */
+function sourceWithSecrets(count: number): string {
+  const secrets = secretLines();
+  const rows = secrets.map((line, i) =>
+    i < count ? line : `  setting${i}: "us-east-1",`,
+  );
+  return [
+    '// Runtime configuration for the billing worker.',
+    "import { createClient } from './client';",
+    '',
+    'export const settings = {',
+    ...rows,
+    "  endpoint: 'https://api.openai.com/v1',",
+    '};',
+    '',
+    'export const client = createClient(settings);',
+    '',
+  ].join('\n');
+}
+
+const ARTIFACT = join('app', 'config.ts');
+
+describe('HMA-01.AC1 / HMA-01.AC3: hardcoded secrets are locatable and countable', () => {
+  /** Write the fixture into a fresh tree and run the real semantic pipeline. */
+  async function scanWith(count: number) {
+    const dir = await mkdtemp(join(tmpdir(), 'hma-01-cred-tree-'));
+    await mkdir(join(dir, 'app'), { recursive: true });
+    await writeFile(join(dir, ARTIFACT), sourceWithSecrets(count), 'utf-8');
+    const result = await runNanoMindScan(dir, []);
+    return { dir, result };
+  }
+
+  it('HMA-01.AC1 the CRITICAL hardcoded-secret finding carries a line and a runnable Verify', async () => {
+    const { dir, result } = await scanWith(1);
+    try {
+      const cred = result.mergedFindings.filter(
+        (f) => !f.passed && f.checkId === 'AST-CRED-003',
+      );
+      expect(
+        cred.length,
+        'AST-CRED-003 must fire on the planted key, or nothing below measures anything',
+      ).toBeGreaterThan(0);
+
+      for (const f of cred) {
+        expect(
+          f.line,
+          `AST-CRED-003 reported no line on ${f.file}, so the renderer prints no ":N" and no Verify`,
+        ).toBeGreaterThanOrEqual(1);
+        // The renderer's own two conditions, evaluated here: `f.line` gates the
+        // `<file>:<line>` line and `generateVerifyCommand` gates the `Verify:`
+        // line (src/cli.ts, both finding-render sites).
+        expect(generateVerifyCommand(f, dir)).toMatch(/^sed -n '\d+p' /);
+      }
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('HMA-01.AC1 no CRITICAL is less locatable than a HIGH rendered beside it', async () => {
+    const { dir, result } = await scanWith(1);
+    try {
+      const onArtifact = result.mergedFindings.filter(
+        (f) => !f.passed && f.file === ARTIFACT,
+      );
+      const criticals = onArtifact.filter((f) => f.severity === 'critical');
+
+      // Two non-vacuity floors. Without a CRITICAL the assertion below is free,
+      // and without a located finding of any severity the artifact simply has
+      // no citations to be less specific than.
+      expect(
+        criticals.length,
+        'no CRITICAL on the artifact — the fixture stopped reaching the credential checks',
+      ).toBeGreaterThan(0);
+      expect(
+        onArtifact.filter((f) => Number.isInteger(f.line)).length,
+        `nothing on ${ARTIFACT} carried a line — there is no citation to compare against`,
+      ).toBeGreaterThan(0);
+
+      // The property #368 is about, stated without assuming which severity the
+      // sibling finding lands on: whatever else the report locates on this file,
+      // the CRITICAL is located too. A CRITICAL a reader cannot open, printed
+      // above a finding they can, inverts the severity signal.
+      expect(
+        criticals.filter((f) => !Number.isInteger(f.line)).map((f) => f.checkId),
+        'a CRITICAL with no line renders vaguer than the findings beside it',
+      ).toEqual([]);
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('HMA-01.AC3 four secrets in one file are four countable findings, at four lines', async () => {
+    const { dir, result } = await scanWith(4);
+    try {
+      const cred = result.mergedFindings.filter(
+        (f) => !f.passed && f.checkId === 'AST-CRED-003' && f.file === ARTIFACT,
+      );
+      expect(
+        cred.length,
+        `four keys must be countable in the output, one per instance. Got ${cred.length}`,
+      ).toBe(4);
+
+      const lines = cred.map((f) => f.line);
+      expect(new Set(lines).size, `four instances must carry four distinct lines: ${lines.join(', ')}`)
+        .toBe(4);
+
+      // The alternative the criterion allows — one finding carrying a count —
+      // must never be reported as null when instances were measured.
+      for (const f of cred) {
+        const details = (f as { details?: { instanceCount?: unknown } }).details;
+        expect(details?.instanceCount ?? null, 'instanceCount must not be null').not.toBeNull();
+      }
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('HMA-01.AC3 removing three of the four secrets moves the score up', async () => {
+    const four = await scanWith(4);
+    const one = await scanWith(1);
+    try {
+      const credCount = (r: Awaited<ReturnType<typeof scanWith>>['result']) =>
+        r.mergedFindings.filter((f) => !f.passed && f.checkId === 'AST-CRED-003').length;
+
+      // Non-vacuity floor: the score comparison below is only meaningful while
+      // the two trees genuinely differ in how many credentials were found.
+      expect(credCount(four.result)).toBe(4);
+      expect(credCount(one.result)).toBe(1);
+
+      const scoreFour = calculateSecurityScore(four.result.mergedFindings).score;
+      const scoreOne = calculateSecurityScore(one.result.mergedFindings).score;
+
+      expect(
+        scoreOne,
+        `removing three of four secrets must move the score. four=${scoreFour} one=${scoreOne}`,
+      ).toBeGreaterThan(scoreFour);
+    } finally {
+      await rm(four.dir, { recursive: true, force: true });
+      await rm(one.dir, { recursive: true, force: true });
+    }
+  });
+
+  it('HMA-01.AC3 a file holding one secret still produces exactly one finding', async () => {
+    // The rollup this widens exists for a real reason. A "fix" that simply
+    // stopped grouping would pass the two assertions above and flood every
+    // report that fires a check repeatedly inside one artifact.
+    const { dir, result } = await scanWith(1);
+    try {
+      const cred = result.mergedFindings.filter(
+        (f) => !f.passed && f.checkId === 'AST-CRED-003' && f.file === ARTIFACT,
+      );
+      expect(cred).toHaveLength(1);
+      expect(cred[0].severity).toBe('critical');
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+});

--- a/__tests__/repo/carried-p1-release-record.test.ts
+++ b/__tests__/repo/carried-p1-release-record.test.ts
@@ -64,11 +64,18 @@ describe('HMA-01.AC6: no third carry, no widened corroborator, no publish', () =
     expect(cut, 'the 0.29.0 heading moved — this slice no longer means what it says')
       .toBeGreaterThan(0);
 
+    // A CARRY is a Known-issues ENTRY whose subject is the issue — the bullet's first
+    // issue reference names it. A later bullet about a different issue may legitimately
+    // REFERENCE "#390's change" while describing its own defect; a bare includes() cannot
+    // tell the two apart and failed on exactly that (the 0.30.0 #503 bullet references
+    // #390's fix). Key each bullet on its first #NNN.
     for (const block of knownIssueBlocks(CHANGELOG.slice(0, cut))) {
-      for (const issue of ['#368', '#390']) {
+      const bullets = block.split(/^- /m).slice(1);
+      for (const bullet of bullets) {
+        const subject = bullet.match(/#\d+/)?.[0];
         expect(
-          block.includes(issue),
-          `${issue} is on its third carry — the recorded rule is a maximum of two:\n${block.trim().slice(0, 400)}`,
+          subject === '#368' || subject === '#390',
+          `a Known issues entry whose subject is ${subject} would be a third carry — the recorded rule is a maximum of two:\n${bullet.trim().slice(0, 400)}`,
         ).toBe(false);
       }
     }

--- a/__tests__/repo/carried-p1-release-record.test.ts
+++ b/__tests__/repo/carried-p1-release-record.test.ts
@@ -1,0 +1,119 @@
+/**
+ * HMA-01.AC6 — the negative criterion: no third carry, no widened corroborator,
+ * and the release record updated without publishing.
+ *
+ * Three properties, all checkable from the tree:
+ *
+ *   1. #368 and #390 are on their SECOND carry and the recorded rule is a
+ *      maximum of two. No `Known issues` block from 0.30.0 — the release that
+ *      closed them — onward may name either again. A third listing is the
+ *      failure this criterion exists to catch, and it is the kind of thing that
+ *      gets added by hand at release time, so it is pinned rather than trusted.
+ *   2. The #475 execution-sink corroborator regexes are BYTE-IDENTICAL. The
+ *      semantic half of #475 belongs to #424's AST dataflow unit; answering a
+ *      semantic question with a wider lexical test would be the third instance
+ *      of one mistake in this check. The claim "the regexes did not move" is
+ *      only worth making if it can be diffed, so the exact bytes are pinned
+ *      here as well as mirrored in `sink-corroborator-scope.test.ts`.
+ *   3. `package.json` carries the LAST RELEASED version, and new work lands
+ *      under `## [Unreleased]`. That is this repo's convention — the huge
+ *      Unreleased section sitting above a `0.32.0` package version is what it
+ *      looks like — and it is what keeps `hackmyagentVersion` in every JSON
+ *      report from claiming a version that was never published. Publishing,
+ *      tagging and cutting the dated section are the release seat's, not this
+ *      unit's.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { join, resolve } from 'node:path';
+
+const REPO_ROOT = resolve(__dirname, '..', '..');
+const CHANGELOG = readFileSync(join(REPO_ROOT, 'CHANGELOG.md'), 'utf-8');
+const SCANNER = readFileSync(join(REPO_ROOT, 'src', 'hardening', 'scanner.ts'), 'utf-8');
+const PKG = JSON.parse(readFileSync(join(REPO_ROOT, 'package.json'), 'utf-8')) as { version: string };
+
+/** The Unreleased section, up to the first dated release heading. */
+function unreleasedSection(): string {
+  const start = CHANGELOG.indexOf('## [Unreleased]');
+  expect(start, 'the changelog has no [Unreleased] section').toBeGreaterThanOrEqual(0);
+  const next = CHANGELOG.indexOf('\n## [', start + 1);
+  return next < 0 ? CHANGELOG.slice(start) : CHANGELOG.slice(start, next);
+}
+
+/** Every `### Known issues` block in `text`, body only. */
+function knownIssueBlocks(text: string): string[] {
+  const blocks: string[] = [];
+  const heading = /^### Known issues.*$/gim;
+  let m: RegExpExecArray | null;
+  while ((m = heading.exec(text)) !== null) {
+    const from = m.index + m[0].length;
+    const nextHeading = text.slice(from).search(/^#{2,3} /m);
+    blocks.push(nextHeading < 0 ? text.slice(from) : text.slice(from, from + nextHeading));
+  }
+  return blocks;
+}
+
+describe('HMA-01.AC6: no third carry, no widened corroborator, no publish', () => {
+  it('HMA-01.AC6 no Known issues block from 0.30.0 onward names #368 or #390', () => {
+    // 0.30.0 is where both were closed — `Findings are locatable, and their
+    // Verify: commands run (#368, #286)` and `Breaking: scan-soul exit codes
+    // now follow the conformance verdict (#390)`. Everything above it in this
+    // newest-first file is 0.30.0 or later.
+    const cut = CHANGELOG.indexOf('## [0.29.0]');
+    expect(cut, 'the 0.29.0 heading moved — this slice no longer means what it says')
+      .toBeGreaterThan(0);
+
+    for (const block of knownIssueBlocks(CHANGELOG.slice(0, cut))) {
+      for (const issue of ['#368', '#390']) {
+        expect(
+          block.includes(issue),
+          `${issue} is on its third carry — the recorded rule is a maximum of two:\n${block.trim().slice(0, 400)}`,
+        ).toBe(false);
+      }
+    }
+  });
+
+  it('HMA-01.AC6 the Unreleased section records the carried P1s as fixed', () => {
+    // The other direction: a suite that only forbids a Known issues entry
+    // passes on a release that says nothing about them at all.
+    const unreleased = unreleasedSection();
+    for (const issue of ['#368', '#477', '#478']) {
+      expect(unreleased, `the Unreleased section does not name ${issue}`).toContain(issue);
+    }
+    expect(knownIssueBlocks(unreleased), 'the Unreleased section carries a Known issues block')
+      .toHaveLength(0);
+  });
+
+  it('HMA-01.AC6 the #475 execution-sink corroborator regexes are byte-identical', () => {
+    const open = SCANNER.indexOf('const EXECUTION_SINK_PATTERNS = [');
+    expect(open, 'EXECUTION_SINK_PATTERNS is gone — the corroborator was restructured')
+      .toBeGreaterThan(0);
+    const close = SCANNER.indexOf('];', open);
+    const body = SCANNER.slice(open, close + 2);
+
+    // The two patterns this check has always carried, character for character.
+    // `vm.runInNewContext`, `globalThis.eval`, `(0,eval)`, a constructor chain,
+    // `Reflect.construct`, dynamic `import()`, `child_process` and
+    // `module._compile` are still absent, deliberately (#424 owns that work).
+    const lines = body
+      .split('\n')
+      .map((l) => l.trim())
+      .filter((l) => l.startsWith('/'));
+
+    expect(lines).toEqual([
+      String.raw`/(?:^|[^\w.$])eval\s*\(/,`,
+      String.raw`/(?:^|[^\w.$])(?:new\s+)?Function\s*\(/,`,
+    ]);
+  });
+
+  it('HMA-01.AC6 package.json carries the last released version, not an unpublished one', () => {
+    const newestDated = /^## \[(\d+\.\d+\.\d+)\] - /m.exec(CHANGELOG);
+    expect(newestDated, 'the changelog carries no dated release heading').not.toBeNull();
+    expect(
+      PKG.version,
+      'package.json names a version with no dated changelog section — cutting the release '
+        + 'and publishing belong to the release seat, not to a fix unit',
+    ).toBe(newestDated![1]);
+  });
+});

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -11090,6 +11090,10 @@ program
       'CRED-002': 'OpenAI API key detected (sk-proj-... or sk-...). Run: opena2a protect . — removes the key from source and stores it in your secure vault.',
       'CRED-003': 'Anthropic API key detected (sk-ant-...). Run: opena2a protect . — removes the key from source and stores it in your secure vault.',
       'CRED-004': 'AWS credential pattern detected (AKIA...). Run: opena2a protect . — removes the key from source and stores it in your secure vault.',
+      // #477 — fix-all reads source files now, and a finding it can report has
+      // to be a finding it can explain. Says plainly that this one is not
+      // rewritten for you: fix-all edits config files, never source.
+      'CRED-005': 'Hardcoded credential in a source file. fix-all reports it but does not rewrite source. Rotate the credential at the provider, then read it from the environment or a secrets manager. Run: opena2a protect . — migrates hardcoded secrets into the Secretless vault so source files reference them by name only.',
       'MCP-001': 'MCP server running without TLS. Agent-to-server communication is unencrypted. Enable TLS on the MCP server or use a reverse proxy with TLS termination.',
       'SKILL-005': 'External endpoint in skill capability declaration. Verify the endpoint is trusted and uses HTTPS.',
       'GOV-001': 'No governance policy found. Agents should declare behavioral constraints in a SOUL.md or governance file. Create a SOUL.md with mission, boundaries, and allowed actions.',

--- a/src/hardening/scanner.ts
+++ b/src/hardening/scanner.ts
@@ -1633,6 +1633,87 @@ export function isMatchInsideStringLiteral(line: string, matchIndex: number): bo
 }
 
 /**
+ * Blank the comment regions of ONE line, carrying block-comment state across the
+ * line boundary in `state`, and return a line of the same length with every
+ * comment character replaced by a space.
+ *
+ * `isMatchInsideStringLiteral` above already answers this for strings and for a
+ * block comment that opens and closes on the line it is asked about, which is
+ * all its four NEMO-009 call sites need: they ask about one line at a time and
+ * about code they were already walking line by line. A FILE-WIDE reader sees
+ * something they do not — the body of a doc comment, where every line after the
+ * first carries no opener. `src/hardening/scanner.ts` self-flagged CRITICAL on
+ * the `eval(...)` written in the doc comment above that very helper (#475), so
+ * the block state has to survive the line boundary. Kept as a separate function
+ * rather than folded into the predicate, whose signature is per-line and whose
+ * existing callers pass no state.
+ *
+ * SAME LENGTH IN, SAME LENGTH OUT. A caller can measure an offset on the
+ * returned line and hand it straight back to `isMatchInsideStringLiteral`, which
+ * is the point: comments are handled here, strings there, and neither function
+ * grows a second job.
+ *
+ * Quote-aware, so `"http://example"` is not read as a line comment and `'/*'` is
+ * not read as a comment opener. Quote state does NOT carry across lines: a
+ * template literal spanning lines is read as code on its continuation lines.
+ * That direction over-reports rather than under-reports, and it is the same
+ * limit the per-line predicate already has, stated rather than silently shared.
+ * Regex literals are likewise not lexed — a `/don't/` toggles quote state, as
+ * documented on the predicate above.
+ */
+function blankCommentRegions(line: string, state: { inBlockComment: boolean }): string {
+  let out = '';
+  let quote: string | null = null;
+  let i = 0;
+  while (i < line.length) {
+    const c = line[i];
+    if (state.inBlockComment) {
+      if (c === '*' && line[i + 1] === '/') {
+        state.inBlockComment = false;
+        out += '  ';
+        i += 2;
+        continue;
+      }
+      out += ' ';
+      i += 1;
+      continue;
+    }
+    if (quote !== null) {
+      // A backslash consumes the next character if one exists. A trailing
+      // backslash at end of line consumes only itself, same as the predicate.
+      if (c === '\\' && i + 1 < line.length) {
+        out += line.slice(i, i + 2);
+        i += 2;
+        continue;
+      }
+      if (c === quote) quote = null;
+      out += c;
+      i += 1;
+      continue;
+    }
+    if (c === "'" || c === '"' || c === '`') {
+      quote = c;
+      out += c;
+      i += 1;
+      continue;
+    }
+    if (c === '/' && line[i + 1] === '/') {
+      out += ' '.repeat(line.length - i);
+      return out;
+    }
+    if (c === '/' && line[i + 1] === '*') {
+      state.inBlockComment = true;
+      out += '  ';
+      i += 2;
+      continue;
+    }
+    out += c;
+    i += 1;
+  }
+  return out;
+}
+
+/**
  * Parsed .hmaignore rules split into path patterns and check ID patterns.
  * Check ID patterns start with `!` and support trailing `*` wildcards.
  * Example: `!SANDBOX-*` suppresses all SANDBOX checks.
@@ -14261,6 +14342,55 @@ dist/
 
       const hexPattern = /0x(?:FE0[0-9A-Fa-f]|fe0[0-9a-f]|E010[0-9A-Fa-f]|e010[0-9a-f]|E01[0-9A-Ea-e][0-9A-Fa-f]|e01[0-9a-e][0-9a-f])/;
 
+      // #475, the execution-sink corroborator. BOTH PATTERNS ARE THE ONES THIS
+      // CHECK HAS ALWAYS USED, character for character. What moved is the text
+      // they are asked about, and only in the two directions the issue names:
+      //
+      //  1. THE SAME LINE POPULATION AS THE PRESENCE LOOP. The two signals below
+      //     skip a line over MAX_LINE_LENGTH; the corroborator used to run over
+      //     whole file content, so an `eval(` inside a minified bundle line
+      //     corroborated `.codePointAt(` and a range literal read from ordinary
+      //     lines the bundle had nothing to do with. One loop now reads one
+      //     population, so the two cannot disagree about which lines exist.
+      //  2. COMMENTS AND STRING LITERALS ARE NOT CODE. `src/hardening/scanner.ts`
+      //     self-flagged CRITICAL on the `eval(...)` in a doc comment and the
+      //     `'eval() dynamic execution'` label of a detection rule, and stayed
+      //     out of its own score only because `.hmaignore` excludes the path.
+      //     Comments are blanked by `blankCommentRegions` (block state carried
+      //     across lines); strings are left to `isMatchInsideStringLiteral`, the
+      //     predicate NEMO-009 already uses for the same question one line at a
+      //     time.
+      //
+      // WHAT THIS IS NOT: the sink VOCABULARY is unchanged and deliberately so.
+      // `vm.runInNewContext`, `globalThis.eval`, `(0,eval)`, a constructor chain,
+      // `Reflect.construct`, dynamic `import()`, `child_process` and
+      // `module._compile` still do not corroborate. Widening the regex is a
+      // semantic question answered by a lexical test for the third time; it
+      // belongs with #424's AST dataflow work, and the finding's own guidance
+      // already tells the reader which sinks it cannot see.
+      //
+      // ONE NARROWING, DISCLOSED: matching per line means `eval` and `(`
+      // separated by a NEWLINE (`\s` spans one) no longer match. That spelling
+      // is legal JavaScript and is not detected any more, which is a loss of
+      // exactly one lexical variant on a corroborator that already misses the
+      // eight spellings above.
+      const EXECUTION_SINK_PATTERNS = [
+        /(?:^|[^\w.$])eval\s*\(/,
+        /(?:^|[^\w.$])(?:new\s+)?Function\s*\(/,
+      ];
+      // Scanned with `g` so a line can be walked past a mention and still reach a
+      // real call after it — `const label = 'eval() docs'; eval(payload);` has
+      // both, and a first-match-only reader would answer for the label and stop.
+      // Built from `.source`, so the patterns above stay the literal bytes this
+      // check has always carried and a reader can diff them without reading here.
+      // `^` still anchors to index 0 only (no `m`), which is what makes the
+      // second and later matches on a line require the `[^\w.$]` arm.
+      const executionSinkScanners = EXECUTION_SINK_PATTERNS.map(
+        (pattern) => new RegExp(pattern.source, 'g'),
+      );
+      const sinkCommentState = { inBlockComment: false };
+      let hasExecutionSink = false;
+
       for (let i = 0; i < lines.length; i++) {
         const line = lines[i];
         if (line.length > MAX_LINE_LENGTH) continue;
@@ -14271,6 +14401,42 @@ dist/
         if (!hasHexLiteral && hexPattern.test(line)) {
           hasHexLiteral = true;
           hexLiteralLine = i + 1;
+        }
+        // A line that carries neither sink token and cannot open or close a
+        // block comment leaves both the state and the answer unchanged, so the
+        // character walk is skipped rather than run over every line of every
+        // scanned file. `inBlockComment` forces the walk because only the walk
+        // can find the closing delimiter.
+        const mayAffectSink =
+          !hasExecutionSink &&
+          (sinkCommentState.inBlockComment ||
+            line.includes('/*') ||
+            line.includes('*/') ||
+            line.includes('eval') ||
+            line.includes('Function'));
+        if (!mayAffectSink) continue;
+        const codeLine = blankCommentRegions(line, sinkCommentState);
+        for (const sinkScanner of executionSinkScanners) {
+          sinkScanner.lastIndex = 0;
+          let m: RegExpExecArray | null;
+          while ((m = sinkScanner.exec(codeLine)) !== null) {
+            // The patterns open with `(?:^|[^\w.$])`, so `m.index` is the
+            // character BEFORE the token — and when that character is the
+            // opening quote of a string, asking the predicate about it answers
+            // for a position that is not yet inside the string. Ask about the
+            // token.
+            const tokenOffset = m[0].search(/eval|Function/);
+            const tokenIndex = m.index + (tokenOffset >= 0 ? tokenOffset : 0);
+            if (!isMatchInsideStringLiteral(codeLine, tokenIndex)) {
+              hasExecutionSink = true;
+              break;
+            }
+            // A zero-length match cannot happen here (both patterns require a
+            // token and a paren), but advancing explicitly keeps the loop
+            // terminating on any future edit to them.
+            if (sinkScanner.lastIndex <= m.index) sinkScanner.lastIndex = m.index + 1;
+          }
+          if (hasExecutionSink) break;
         }
       }
 
@@ -14326,9 +14492,10 @@ dist/
       //      it just does not lift THIS decoder finding to CRITICAL.
       // Neither corroborator holds for a test that builds a payload and asserts a
       // sanitiser escapes it — a correct DEFENCE against this technique.
-      const hasExecutionSink =
-        /(?:^|[^\w.$])eval\s*\(/.test(content) ||
-        /(?:^|[^\w.$])(?:new\s+)?Function\s*\(/.test(content);
+      //
+      // `hasExecutionSink` is settled in the presence loop above, over the same
+      // lines and with comments and string literals excluded — see the block
+      // there for what did and did not change about it.
       const hasDecodablePayload = hasVariationSelectors || hasTagCharsIn001;
       const corroborated = hasExecutionSink || hasDecodablePayload;
 
@@ -14354,7 +14521,7 @@ dist/
           name: 'GlassWorm Decoder Pattern Detected',
           description: corroboration
             ? `Source file ${act} Unicode variation selector or tag character codepoints AND carries corroborating evidence - this is the decoder half of a GlassWorm attack`
-            : `Source file ${act} Unicode variation selector or tag character codepoints. This is the shape of a GlassWorm decoder, but neither corroborator this check recognises is present - no literal eval( or Function( call, and no variation-selector or tag-character payload`,
+            : `Source file ${act} Unicode variation selector or tag character codepoints. This is the shape of a GlassWorm decoder, but neither corroborator this check recognises is present - no literal eval( or Function( call in code, and no variation-selector or tag-character payload`,
           category: 'unicode-stego',
           severity: corroborated ? 'critical' : 'medium',
           passed: false,
@@ -14369,7 +14536,7 @@ dist/
             : `sed -n '${Math.max(1, reportedLine - 5)},${reportedLine + 20}p' ${shellEscape(relativePath)}   # confirm this decodes for inspection, not for execution`,
           guidance: corroboration
             ? `The GlassWorm attack hides a payload in invisible Unicode characters and rebuilds it at runtime from their codepoints. This file ${act} those codepoints AND carries corroborating evidence, so treat it as live until traced. Follow the value from the range literal to whatever consumes it.`
-            : `This file ${act} codepoints in the variation selector or tag range. Sanitisers, linters, width calculators and tests for this attack all legitimately do the same thing, which is why this is a lead rather than a verdict. What was actually checked, stated narrowly on purpose: no literal eval( or Function( call appears in this file, and no variation-selector or tag-character payload - the invisible classes this shape decodes - is present (a lone zero-width char or a mid-file BOM, which UNICODE-STEGO-001 may still report on its own, does not corroborate this finding). Neither is a statement about the class. A decoded string can reach an executor through vm, child_process, a dynamic import(), a member expression such as globalThis.eval, or the Function constructor reached through a prototype chain, and this check recognises none of those - so read the file rather than trusting this line. Reconstitution likewise has many spellings (an alias, a destructured binding, .map, Buffer.from, TextDecoder), so its absence from the message above is not proof the file does not rebuild a string.`,
+            : `This file ${act} codepoints in the variation selector or tag range. Sanitisers, linters, width calculators and tests for this attack all legitimately do the same thing, which is why this is a lead rather than a verdict. What was actually checked, stated narrowly on purpose: no literal eval( or Function( call appears in this file's CODE - one written inside a comment or a string literal is a mention rather than a call site and is not counted, and a line longer than the scanner's per-line limit is not read here any more than it is by the two signals this finding is built from - and no variation-selector or tag-character payload - the invisible classes this shape decodes - is present (a lone zero-width char or a mid-file BOM, which UNICODE-STEGO-001 may still report on its own, does not corroborate this finding). Neither is a statement about the class. A decoded string can reach an executor through vm, child_process, a dynamic import(), a member expression such as globalThis.eval, or the Function constructor reached through a prototype chain, and this check recognises none of those - so read the file rather than trusting this line. Reconstitution likewise has many spellings (an alias, a destructured binding, .map, Buffer.from, TextDecoder), so its absence from the message above is not proof the file does not rebuild a string.`,
         });
       }
 

--- a/src/nanomind-core/analyzers/credential-analyzer.ts
+++ b/src/nanomind-core/analyzers/credential-analyzer.ts
@@ -512,16 +512,8 @@ function checkHardcodedSecrets(ast: SecurityAST, artifactContent?: string): ASTF
       ? credentialEvidence[0].text.slice(0, 120)
       : credentialRisks[0]?.evidence ?? 'Credential pattern detected';
 
-  // Prefer the EvidenceSpan's character offset (signed AST data) — it's
-  // exact and local. Fall back to substring search on the unsigned content
-  // when only a RiskSurface evidence string is available.
-  const spanStart = credentialEvidence[0]?.start;
-  const lineFromSpan = artifactContent !== undefined && spanStart !== undefined
-    ? lineFromOffset(artifactContent, spanStart)
-    : undefined;
-  const fallbackLine = lineFromSpan ?? findLineFromString(artifactContent, evidenceSummary);
-
-  findings.push({
+  /** Everything but the two per-instance fields, which every emit below shares. */
+  const emit = (summary: string, line: number | undefined): ASTFinding => ({
     checkId: 'AST-CRED-003',
     name: 'Hardcoded Secret Detected',
     description:
@@ -531,10 +523,10 @@ function checkHardcodedSecrets(ast: SecurityAST, artifactContent?: string): ASTF
     category: 'Credential Security',
     severity,
     passed: false,
-    message: `Hardcoded secret: ${evidenceSummary.slice(0, 80)}`,
+    message: `Hardcoded secret: ${summary.slice(0, 80)}`,
     fixable: false,
     file: ast.artifactPath,
-    line: fallbackLine,
+    line,
     fix:
       'opena2a protect .  — migrates hardcoded secrets into the Secretless vault (local, keychain, 1Password, or HashiCorp Vault). Keys are injected at runtime; source files reference them by name only. ' +
       'Rotate any credentials that were committed to version control.',
@@ -543,8 +535,53 @@ function checkHardcodedSecrets(ast: SecurityAST, artifactContent?: string): ASTF
       'The old values may already be in git history or build caches.',
     attackClass: 'CRED-HARDCODED',
     confidence: allTestFixtures ? 0.3 : maxConfidence,
-    evidence: evidenceSummary,
+    evidence: summary,
   });
+
+  // ── One finding per credential the producer LOCATED (#478, #368) ──────────
+  //
+  // The canonical credential scan records the offset of every match it makes,
+  // so four keys in one file are four known positions. Collapsing them into a
+  // single finding naming the first cost two things at once: the CRITICAL had
+  // no line and therefore no `Verify:` while the HIGH beside it had both
+  // (#368), and removing three of the four moved the score by zero, because
+  // scoring counts findings and there was one either way (#478).
+  //
+  // Keyed on OFFSET, not on line: two distinct patterns cannot match at one
+  // offset (the vendor shapes are mutually exclusive at their prefixes — see
+  // CANONICAL_CREDENTIAL_PATTERNS), so this counts secrets rather than
+  // collapsing two secrets that happen to share a line.
+  //
+  // NOTHING ELSE ABOUT THE FINDING MOVES. Severity, confidence and the
+  // suppression gates above are computed once, over the whole artifact, and
+  // read by every instance — so a file with exactly one secret produces
+  // exactly the finding it produced before, at the same severity, plus the
+  // line it always had the data for.
+  if (artifactContent !== undefined) {
+    const located = new Map<number, string>();
+    for (const r of credentialRisks) {
+      if (typeof r.offset === 'number' && r.offset >= 0 && !located.has(r.offset)) {
+        located.set(r.offset, r.evidence);
+      }
+    }
+    if (located.size > 0) {
+      for (const [offset, summary] of [...located.entries()].sort((a, b) => a[0] - b[0])) {
+        findings.push(emit(summary, lineFromOffset(artifactContent, offset)));
+      }
+      return findings;
+    }
+  }
+
+  // Prefer the EvidenceSpan's character offset (signed AST data) — it's
+  // exact and local. Fall back to substring search on the unsigned content
+  // when only a RiskSurface evidence string is available.
+  const spanStart = credentialEvidence[0]?.start;
+  const lineFromSpan = artifactContent !== undefined && spanStart !== undefined
+    ? lineFromOffset(artifactContent, spanStart)
+    : undefined;
+  const fallbackLine = lineFromSpan ?? findLineFromString(artifactContent, evidenceSummary);
+
+  findings.push(emit(evidenceSummary, fallbackLine));
 
   return findings;
 }

--- a/src/nanomind-core/compiler/semantic-compiler.ts
+++ b/src/nanomind-core/compiler/semantic-compiler.ts
@@ -190,6 +190,10 @@ export class SemanticCompiler {
           attackClass: 'CRED-HARVEST',
           confidence: 0.9,
           evidence: hit.evidence,
+          // Against `content`, which is what this scan read — not the stripped
+          // analysis view `mapRiskSurfaces` above works from. Every consumer
+          // that turns this back into a line is handed the same `content`.
+          offset: hit.index,
         });
         declaredDataAccess.push({
           dataType: 'credentials',
@@ -1396,6 +1400,16 @@ function hasCanonicalCredentialFormat(content: string): boolean {
 interface CanonicalCredentialHit {
   label: string;
   evidence: string;
+  /**
+   * Character offset of the matched SECRET BYTES in the content that was
+   * scanned — for the name-gated arm, of the captured value rather than of the
+   * name anchor in front of it.
+   *
+   * Recorded here because it cannot be recovered later: `evidence` is a
+   * classification, not a quotation, so nothing downstream can search for it
+   * (#368). It carries no part of the value, only where the value is.
+   */
+  index: number;
 }
 
 /**
@@ -1611,6 +1625,7 @@ function scanCanonicalCredentialFormats(content: string): CanonicalCredentialHit
         // stamped `redactionStatus: 'clean'`. `label` already carries everything the user
         // acts on (which vendor), and `file`/`line` carry where.
         evidence: `${label}: [REDACTED]`,
+        index: match.index,
       });
     }
   }
@@ -1652,6 +1667,12 @@ function scanCanonicalCredentialFormats(content: string): CanonicalCredentialHit
         // Same rule as the canonical arm above. This is a SEPARATE producer with its own
         // truncation width, so fixing only the canonical one leaves the class open.
         evidence: `${label}: [REDACTED]`,
+        // The VALUE's offset, not the match's. `match[0]` opens with the name
+        // anchor (`AWS_SECRET_ACCESS_KEY=`), which can carry the match across a
+        // line boundary from the secret it names; every pattern in this list
+        // captures the value as its final segment, so the value ends where the
+        // match does.
+        index: match.index + match[0].length - value.length,
       });
     }
   }

--- a/src/nanomind-core/scanner-bridge.ts
+++ b/src/nanomind-core/scanner-bridge.ts
@@ -945,6 +945,28 @@ function runCodeAnalyzers(
 // ============================================================================
 
 /**
+ * The part of a rollup key that comes AFTER (checkId, file), which is empty for
+ * every check but one.
+ *
+ * A hardcoded secret is not a repetition of one issue the way 60 constraints in
+ * a SOUL.md are: each match is a separate key, at a separate line, with a
+ * separate rotation to perform. Rolling four of them up reported one finding
+ * naming the first, and — because scoring counts findings — made a fix that
+ * removed three of the four move the score by exactly zero, which reads as "my
+ * fix did not work" (#478). Keying those on their LINE as well keeps them
+ * countable and lets the score follow the tree.
+ *
+ * Deliberately not a general rule for any finding that carries a line. The cap
+ * that bounds a check firing broadly is `MAX_FINDINGS_PER_CHECK` in
+ * `calculateSecurityScore` (3 at full weight, the rest at 10%), and it applies
+ * here too — this widens what the score can SEE, it does not uncap it.
+ */
+function rollupSuffix(f: ASTFinding): string {
+  if (f.attackClass !== 'CRED-HARDCODED') return '';
+  return `\x00${f.line ?? ''}`;
+}
+
+/**
  * Deduplicate AST findings per (checkId, file). When the same check fires many
  * times within ONE artifact (e.g. AST-GOV-002 on 60 constraints in a single
  * SOUL.md), keep one representative for that artifact with the highest
@@ -958,6 +980,8 @@ function runCodeAnalyzers(
  * checkId at MAX_FINDINGS_PER_CHECK at full weight and discounts the rest.
  *
  * Passed findings are kept as-is (they don't affect scoring).
+ *
+ * `rollupSuffix` widens the key for credential findings — see its own note.
  */
 function deduplicateFindings(findings: ASTFinding[]): ASTFinding[] {
   const failed: ASTFinding[] = [];
@@ -980,7 +1004,7 @@ function deduplicateFindings(findings: ASTFinding[]): ASTFinding[] {
   // of its own. Which file survived was decided by walk order (#535).
   const groups = new Map<string, ASTFinding[]>();
   for (const f of failed) {
-    const key = `${f.checkId}\x00${f.file ?? ''}`;
+    const key = `${f.checkId}\x00${f.file ?? ''}${rollupSuffix(f)}`;
     const group = groups.get(key) ?? [];
     group.push(f);
     groups.set(key, group);

--- a/src/nanomind-core/types.ts
+++ b/src/nanomind-core/types.ts
@@ -164,6 +164,19 @@ export interface RiskSurface {
   confidence: number;
   /** Specific text that creates this risk */
   evidence: string;
+  /**
+   * Character offset, in the ORIGINAL artifact content, of the bytes this risk
+   * was raised on. Present only where the producer recorded one.
+   *
+   * `evidence` is not always a substring of the artifact — the canonical
+   * credential scan emits a CLASSIFICATION (`OpenAI legacy key: [REDACTED]`)
+   * rather than the matched value, deliberately, so no part of a secret rides
+   * in a finding. That made the risk unlocatable by search: `extractEvidenceSpans`
+   * looks the evidence up with `indexOf` and finds nothing, so the finding
+   * built from it carried no line and therefore no `Verify:` (#368). The offset
+   * is recorded at the point of the match instead, where it is exact.
+   */
+  offset?: number;
   /** How to mitigate */
   mitigation?: string;
 }

--- a/src/plugins/credvault.ts
+++ b/src/plugins/credvault.ts
@@ -48,6 +48,33 @@ const CONFIG_FILES = [
 
 const KEY_FILE_EXTENSIONS = ['.key', '.pem', '.p12', '.pfx'];
 
+/**
+ * Source extensions this plugin reads for CRED-005.
+ *
+ * Character for character the list `artifact-parser.ts` classifies as
+ * `source_code`, and deliberately so: #477 was not a disagreement about which
+ * credential SHAPES count — the catalog above already carries the ones `secure`
+ * reports — it was a disagreement about which FILES get opened. `fix-all` read
+ * fourteen fixed config paths, so a `.py` or `.ts` holding an API key was
+ * "Credential Protection [+] No issues found" at exit 0 while `secure` exited 1
+ * with a CRITICAL on the same tree. Reading the same population is what makes
+ * the two verdicts comparable; keep this list in step with that one.
+ */
+const SOURCE_EXTENSIONS = new Set([
+  '.ts', '.tsx', '.js', '.jsx', '.mjs', '.cjs', '.py', '.pyi', '.go', '.rs', '.java', '.rb',
+]);
+
+/** Directories a source sweep never descends into. */
+const SKIPPED_DIRS = new Set([
+  'node_modules', '.git', 'dist', 'build', 'out', 'coverage', '.next', '.nuxt',
+  'vendor', '__pycache__', '.venv', 'venv', 'target', '.tox', '.mypy_cache',
+  '.hackmyagent-backup', '.opena2a',
+]);
+
+/** Bounds on the sweep, so a large tree cannot turn `fix-all` into a full crawl. */
+const SOURCE_SWEEP_MAX_DEPTH = 8;
+const SOURCE_SWEEP_MAX_FILES = 2000;
+
 // --- Types ---
 
 export interface SecretEntry {
@@ -130,6 +157,111 @@ function scanFileForCredentials(filePath: string, agentDir: string): Finding[] {
           oasbControl: '1.1',
           autoFixable: true,
         });
+      }
+    }
+  }
+
+  return findings;
+}
+
+/**
+ * Collect source files under `agentDir`, breadth-bounded and depth-bounded.
+ * Unreadable directories are skipped rather than raised: this sweep widens what
+ * the plugin can see and must not be able to fail a run that used to work.
+ */
+function collectSourceFiles(agentDir: string): string[] {
+  const out: string[] = [];
+  const queue: Array<{ dir: string; depth: number }> = [{ dir: agentDir, depth: 0 }];
+
+  while (queue.length > 0 && out.length < SOURCE_SWEEP_MAX_FILES) {
+    const { dir, depth } = queue.shift()!;
+    let entries: fs.Dirent[];
+    try {
+      entries = fs.readdirSync(dir, { withFileTypes: true });
+    } catch {
+      continue;
+    }
+    for (const entry of entries) {
+      if (out.length >= SOURCE_SWEEP_MAX_FILES) break;
+      const full = path.join(dir, entry.name);
+      // Symlinks are not followed: a link out of the tree would report a
+      // finding against a path the user did not ask this command to scan.
+      if (entry.isSymbolicLink()) continue;
+      if (entry.isDirectory()) {
+        if (SKIPPED_DIRS.has(entry.name)) continue;
+        if (depth + 1 <= SOURCE_SWEEP_MAX_DEPTH) queue.push({ dir: full, depth: depth + 1 });
+        continue;
+      }
+      if (!entry.isFile()) continue;
+      if (!SOURCE_EXTENSIONS.has(path.extname(entry.name).toLowerCase())) continue;
+      // Already read, by name, in the config-file pass above. Reporting it
+      // twice would inflate the count without naming a second credential.
+      if (CONFIG_FILES.includes(path.relative(agentDir, full))) continue;
+      out.push(full);
+    }
+  }
+
+  return out;
+}
+
+/**
+ * CRED-005 — a hardcoded credential in an ordinary source file (#477).
+ *
+ * NOT auto-fixable, and that is a statement about this plugin rather than about
+ * the credential: `fix()` rewrites the fourteen config paths and nothing else,
+ * so marking these fixable would print a remedy that never runs and would clear
+ * the finding out of `remainingFindings` — the list the exit code reads. The
+ * finding names the file and the line; rotating the key is the user's move.
+ */
+function scanSourceFilesForCredentials(agentDir: string): Finding[] {
+  const findings: Finding[] = [];
+  const maxSize = 10 * 1024 * 1024;
+  // A pattern QUOTED in source is not a key. Config files hold values; source
+  // files legitimately hold the shapes a scanner matches with, which is why
+  // this guard is on this arm and not on the config-file one above.
+  const regexContextMarker = /\\d|\\w|\\s|\[a-z|\[A-Z|\[0-9|\{\d+,/;
+  const placeholderMarker = /FAKE|EXAMPLE|PLACEHOLDER|DUMMY|YOUR_?KEY|YOUR_?TOKEN|REPLACE_ME|INSERT_HERE/i;
+
+  for (const filePath of collectSourceFiles(agentDir)) {
+    try {
+      if (fs.statSync(filePath).size > maxSize) continue;
+    } catch {
+      continue;
+    }
+
+    let content: string;
+    try {
+      content = fs.readFileSync(filePath, 'utf-8');
+    } catch {
+      continue;
+    }
+
+    const relativePath = path.relative(agentDir, filePath);
+    const lines = content.split('\n');
+
+    for (let i = 0; i < lines.length; i++) {
+      const line = lines[i];
+      if (line.length > 4096) continue; // Same ReDoS bound as the config pass.
+      for (const pattern of CREDENTIAL_PATTERNS) {
+        const m = pattern.regex.exec(line);
+        if (!m) continue;
+        // `continue`, not `break`: a filtered match from one pattern must not
+        // hide a real key another pattern finds on the same line.
+        if (regexContextMarker.test(m[0]) || placeholderMarker.test(m[0])) continue;
+        findings.push({
+          id: 'CRED-005',
+          title: `Exposed ${pattern.name} in source`,
+          description:
+            `${pattern.name} found in ${relativePath} at line ${i + 1}. ` +
+            'Rotate the credential, then read it from the environment or a secrets manager. ' +
+            'fix-all does not rewrite source files.',
+          severity: 'critical',
+          filePath: relativePath,
+          line: i + 1,
+          oasbControl: '1.1',
+          autoFixable: false,
+        });
+        break; // One finding per line, as the config pass does.
       }
     }
   }
@@ -264,7 +396,7 @@ export const metadata: PluginMetadata = {
   displayName: 'Credential Protection',
   description: 'Scan for hardcoded secrets and replace with environment variable references',
   version: VERSION,
-  findings: ['CRED-001', 'CRED-002', 'CRED-003', 'CRED-004'],
+  findings: ['CRED-001', 'CRED-002', 'CRED-003', 'CRED-004', 'CRED-005'],
   scoreImprovement: 25,
 };
 
@@ -286,6 +418,11 @@ export class CredVaultPlugin implements OpenA2APlugin {
         findings.push(...scanFileForCredentials(filePath, agentDir));
       }
     }
+
+    // Scan ordinary source files for the same credential shapes (CRED-005).
+    // Without this arm `fix-all` and `secure` returned opposite verdicts on one
+    // tree — see the note on SOURCE_EXTENSIONS (#477).
+    findings.push(...scanSourceFilesForCredentials(agentDir));
 
     // Scan for private key files (CRED-002)
     findings.push(...scanForKeyFiles(agentDir));


### PR DESCRIPTION
Three carried P1 fixes in the hardening/credential path:

- **CRED-005 — fix-all now reads source files.** `fix-all` scanned only 14 fixed config paths, so a .py/.ts holding an API key reported "No issues found" at exit 0 while `secure` exited 1 with a CRITICAL on the same tree (#477). A bounded, depth/breadth-capped source sweep closes that gap; the finding names file:line and states plainly that fix-all reports but does not rewrite source (rotate + move to env/secrets manager). Regex-context and placeholder guards keep scanner-source pattern definitions from self-flagging.

- **One finding per located credential (#478, #368).** The canonical scan records each match's offset, so four keys in one file are four findings at four lines — not one naming the first. Collapsing them cost the CRITICAL its line (and its Verify command) while the HIGH beside it had both, and made a fix that removed three of four move the score by zero (scoring counts findings). Keyed on offset, deduped per (checkId, file, line); severity/confidence/suppression are computed once over the artifact, so a single-secret file is unchanged.

- **Execution-sink corroborator reads code, not comments/strings.** scanner.ts self-flagged CRITICAL on the `eval(` written inside its own doc comment and the `'eval() dynamic execution'` rule label. The corroborator now runs over the same line population as the presence loop (per-line length cap) with comments blanked (block state carried across lines) and string literals excluded via the existing predicate. Sink vocabulary is unchanged and deliberately so; one disclosed narrowing (eval + `(` split by a newline no longer matches).

QA: blind gate PASS 6/6 (subject-keyed third-carry predicate mutation-proven twice; full vitest 4859 passed in isolation). An adversarial round found one MEDIUM (sink-corroborator quote-lexer desync) — filed to CSR, recorded to next version per the stopping rule.