### PR TITLE
pull-stubs: registry owns the status vocabulary; mark-stub records lifecycle transitions with build-probed evidence (HMA-08)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,57 @@ All notable changes to HackMyAgent are documented in this file.
 
 ## [Unreleased]
 
+### The stub loop has a terminus again: `pull-stubs` drops its vocabulary, `mark-stub` writes back (HMA-08)
+
+Two defects at the same place — the point where a confirmed ARIA observation is
+supposed to become a shipped check.
+
+**`pull-stubs` held a vocabulary it did not own.** The CLI validated `--status`
+against a hardcoded `['draft','review','integrated','rejected']` and then
+filtered the response against the same list, while the database's own CHECK
+constraint held a different set. Every value except the default was unusable in
+one direction or the other: `--status review|integrated|rejected` could never
+match a row, and `--status reviewed|published` was refused client-side before
+the request was made. The pipeline's only working query was the default.
+
+Both halves are gone. `--status` is sent to the registry verbatim as
+`?status=`, the rows the registry returns are the rows that print, and a 4xx
+answer is rendered near-verbatim — no longer clipped at 200 bytes, because that
+body carries the allowed set, which is the one thing the CLI deliberately no
+longer knows. `--all` omits the parameter entirely rather than sending a magic
+word for "any", so the two sides need no agreement for the unfiltered case
+either. Each stub now leads with its **Stub ID**, and the summary closes by
+naming the command that consumes it.
+
+**Nothing marked a stub integrated.** So the transition was manual and
+unaudited, and "how many confirmed observations became a shipped check" — the
+only figure that shows the flywheel turns — had no answer. `mark-stub <id>
+<status>` is that write-back: `PATCH /internal/aria/hma-stubs/:id`, status sent
+verbatim, exit 0 recorded / 1 refused / 2 not settled.
+
+The refusals are the product. `integrated` is refused without
+`--source-commit`, and refused unless an in-process probe finds the check ID in
+the RUNNING build's coverage inventory — reading `CHECK_METHOD_PREFIXES` and
+`UNREACHABLE_PREFIXES` out of the built module rather than re-reading `src/` or
+carrying a copy. That closes the `UNREACHABLE_PREFIXES` class at write time:
+`CODEINJ`, `TMPPATH` and `ENVLEAK` are implemented, emit findings, are counted
+in the advertised suite and have no caller in `scanInner`, so a stub mapped to
+one of them would otherwise be recorded as a shipped check whose detector can
+never fire. `rejected` is refused without `--reason`.
+
+**Fabrication has no first-class UX.** There is no `--evidence`, `--reachable`
+or `--hma-version` flag: `hmaVersion` comes from the running artifact's own
+version and `reachable` is the probe's verdict. A refusal prints WHAT, a
+`Verify:` line and a `Fix:` line, and offers no flag that skips the gate —
+there isn't one. `--dry-run` runs every preflight and the probe, prints the
+exact body that would be sent, and sends nothing.
+
+The registry leg — the migration, the server-side filter and the PATCH endpoint
+— ships separately, so every test here runs against a mocked registry and the
+two land independently. `docs/release-playbook.md` gains the two release steps:
+a `--dry-run` preview for every stub a release claims, before the tag is
+pushed, and the real send afterwards from the published artifact.
+
 ### The static suite reaches where skills actually live (HMA-07)
 
 `.claude/skills/<name>/SKILL.md` is where skills sit on disk, and the scanner

--- a/__tests__/cli/hma08-mark-stub.test.ts
+++ b/__tests__/cli/hma08-mark-stub.test.ts
@@ -1,0 +1,497 @@
+/**
+ * HMA-08.AC3 – HMA-08.AC6 — `mark-stub`, the write-back half of the
+ * observation -> shipped-check loop.
+ *
+ * DEFECT 2 of `todo/roadmap/hackmyagent-pull-stubs-status-vocabulary-mismatch.md`:
+ * nothing in HMA marked a stub integrated, so the transition was manual and
+ * unaudited and nobody could answer "how many confirmed observations became a
+ * shipped check". [CHIEF-CPO] 2026-08-31 ruled the UX; [CHIEF-CA] 2026-08-31
+ * ruled that `integrated` is REFUSED without evidence probed from the BUILT
+ * artifact.
+ *
+ * The refusals are what is under test here, because they are what makes the
+ * resulting number mean anything. `UNREACHABLE_PREFIXES` is the precedent:
+ * `CODEINJ`, `TMPPATH` and `ENVLEAK` are implemented, emit findings, are
+ * counted in the advertised suite and have no caller in `scanInner`. A stub
+ * mapped to one of them, marked integrated, would record a shipped check
+ * whose detector can never fire — worse than having no check, because the
+ * ledger now says it is covered.
+ *
+ * The fixture for that case is therefore DERIVED, by importing
+ * `UNREACHABLE_PREFIXES` from `dist/` — the same built module the probe reads.
+ * A hardcoded `'CODEINJ-001'` would keep passing on the day CODEINJ is wired
+ * in, asserting a refusal the product should no longer make.
+ *
+ * The registry leg ships separately as REG-10, so every request here goes to
+ * the in-process mock and nothing needs a live registry.
+ */
+import { describe, it, expect, beforeAll, afterEach } from 'vitest';
+import { spawn, spawnSync } from 'node:child_process';
+import { existsSync, readFileSync } from 'node:fs';
+import path from 'node:path';
+import { assertDistFreshIfPresent, BUILT_CLI as CLI } from '../helpers/dist-freshness';
+import {
+  startMockRegistry,
+  closedPortUrl,
+  stubRow,
+  type MockRegistry,
+  type RecordedRequest,
+} from '../helpers/hma08-stub-registry';
+
+beforeAll(assertDistFreshIfPresent);
+
+const REPO_ROOT = path.resolve(__dirname, '..', '..');
+const canRun = () => existsSync(CLI);
+const VERSION = JSON.parse(
+  readFileSync(path.join(REPO_ROOT, 'package.json'), 'utf8'),
+).version as string;
+
+const STUB_ID = 'stub-0001';
+const RECORDED_CHECK_ID = 'CRED-001';
+const COMMIT = 'a1b2c3d';
+
+let registry: MockRegistry | undefined;
+afterEach(async () => { await registry?.close(); registry = undefined; });
+
+/**
+ * Spawn the built CLI WITHOUT blocking this process's event loop — the mock
+ * registry runs in-process, so a `spawnSync` would hold the loop until the
+ * child gave up on its own 15s timeout and never answer it.
+ */
+function run(args: string[], env: NodeJS.ProcessEnv = {}): Promise<{ status: number | null; stdout: string; stderr: string }> {
+  return new Promise((resolve, reject) => {
+    const child = spawn(process.execPath, [CLI, ...args], {
+      env: { ...process.env, NO_COLOR: '1', INTERNAL_API_KEY: 'test-key', NODE_OPTIONS: '', ...env },
+    });
+    let stdout = '';
+    let stderr = '';
+    child.stdout.on('data', (c: Buffer) => { stdout += c.toString('utf8'); });
+    child.stderr.on('data', (c: Buffer) => { stderr += c.toString('utf8'); });
+    child.on('error', reject);
+    child.on('close', (status) => resolve({ status, stdout, stderr }));
+  });
+}
+
+function help(...argv: string[]): string {
+  const r = spawnSync(process.execPath, [CLI, ...argv, '--help'], {
+    encoding: 'utf8', timeout: 30_000, env: { ...process.env, NO_COLOR: '1', NODE_OPTIONS: '' },
+  });
+  return (r.stdout ?? '').replace(/\x1b\[[0-9;]*m/g, '');
+}
+
+/** The coverage inventory of the RUNNING build — never a copy, never a re-read of src/. */
+function builtInventory(): {
+  CHECK_METHOD_PREFIXES: Record<string, readonly string[]>;
+  UNREACHABLE_PREFIXES: readonly string[];
+} {
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
+  return require(path.join(REPO_ROOT, 'dist', 'hardening', 'coverage-ledger.js'));
+}
+
+/** A registry that lists one stub and accepts the PATCH. */
+async function happyRegistry(over: Partial<Record<string, string>> = {}): Promise<MockRegistry> {
+  return startMockRegistry((req) => {
+    if (req.method === 'GET') {
+      return { status: 200, body: JSON.stringify({ stubs: [stubRow({ id: STUB_ID, checkId: RECORDED_CHECK_ID, ...over })], total: 1 }) };
+    }
+    return { status: 200, body: JSON.stringify({ ok: true }) };
+  });
+}
+
+const patches = (reqs: RecordedRequest[]) => reqs.filter(r => r.method === 'PATCH');
+
+describe('HMA-08.AC3 the command surface', () => {
+  it('HMA-08.AC3 registers mark-stub <id> <status> as a visible top-level command', () => {
+    if (!canRun()) return;
+    expect(help()).toContain('mark-stub');
+    expect(help('mark-stub')).toContain('Usage: hackmyagent mark-stub [options] <id> <status>');
+  });
+
+  it('HMA-08.AC3 opens its long description with the INTERNAL_API_KEY requirement', () => {
+    if (!canRun()) return;
+    const text = help('mark-stub');
+    const afterUsage = text.split('\n').slice(1).map(l => l.trim()).filter(Boolean);
+    expect(afterUsage[0]).toMatch(/^Requires INTERNAL_API_KEY/);
+  });
+
+  it('HMA-08.AC3 carries --registry-url and --json in exact parity with pull-stubs', () => {
+    if (!canRun()) return;
+    const optionLine = (command: string, flag: string): string => {
+      const text = help(command);
+      const options = text.slice(text.indexOf('\nOptions:'));
+      const line = options.split('\n').find(l => l.trim().startsWith(flag));
+      expect(line, `${command} does not register ${flag}`).toBeDefined();
+      return line!.replace(/\s+/g, ' ').trim();
+    };
+    // Same declaration, same default, same wording — a write-back that talks
+    // to a different registry than the read it followed is the one failure
+    // this parity is for.
+    expect(optionLine('mark-stub', '--registry-url')).toBe(optionLine('pull-stubs', '--registry-url'));
+    expect(optionLine('mark-stub', '--json')).toContain('--json');
+    expect(help('mark-stub')).toContain('--dry-run');
+    expect(help('mark-stub')).toContain('--reason <text>');
+    expect(help('mark-stub')).toContain('--source-commit <sha>');
+    expect(help('mark-stub')).toContain('--check-id <id>');
+  });
+
+  it('HMA-08.AC3 PATCHes /internal/aria/hma-stubs/:id with the camelCase body', async () => {
+    if (!canRun()) return;
+    registry = await happyRegistry();
+
+    const res = await run(['mark-stub', STUB_ID, 'reviewed', '--registry-url', registry.url]);
+
+    expect(res.status, res.stderr).toBe(0);
+    const sent = patches(registry.requests);
+    expect(sent).toHaveLength(1);
+    expect(sent[0].url).toBe(`/internal/aria/hma-stubs/${STUB_ID}`);
+    expect(JSON.parse(sent[0].body)).toEqual({ status: 'reviewed' });
+  });
+
+  it('HMA-08.AC3 carries reason and evidence in the same camelCase body', async () => {
+    if (!canRun()) return;
+    registry = await happyRegistry();
+
+    const res = await run([
+      'mark-stub', STUB_ID, 'integrated',
+      '--source-commit', COMMIT, '--reason', 'shipped as CRED-001',
+      '--registry-url', registry.url,
+    ]);
+
+    expect(res.status, res.stderr).toBe(0);
+    expect(JSON.parse(patches(registry.requests)[0].body)).toEqual({
+      status: 'integrated',
+      reason: 'shipped as CRED-001',
+      evidence: { checkId: RECORDED_CHECK_ID, hmaVersion: VERSION, sourceCommit: COMMIT, reachable: true },
+    });
+  });
+
+  it('HMA-08.AC3 validates --source-commit as 7-40 hex', async () => {
+    if (!canRun()) return;
+    registry = await happyRegistry();
+
+    const tooShort = await run(['mark-stub', STUB_ID, 'integrated', '--source-commit', 'a1b2c3', '--registry-url', registry.url, '--json']);
+    const notHex = await run(['mark-stub', STUB_ID, 'integrated', '--source-commit', 'zzzzzzzz', '--registry-url', registry.url, '--json']);
+    const tooLong = await run(['mark-stub', STUB_ID, 'integrated', '--source-commit', 'a'.repeat(41), '--registry-url', registry.url, '--json']);
+    const fullSha = await run(['mark-stub', STUB_ID, 'integrated', '--source-commit', 'a'.repeat(40), '--registry-url', registry.url, '--json']);
+
+    for (const bad of [tooShort, notHex, tooLong]) {
+      expect(bad.status).toBe(1);
+      expect(JSON.parse(bad.stdout).refusal.code).toBe('source-commit-shape');
+    }
+    expect(fullSha.status, fullSha.stderr).toBe(0);
+  });
+
+  it('HMA-08.AC3 defaults --check-id to the stub\'s own recorded checkId via the existing GET', async () => {
+    if (!canRun()) return;
+    registry = await startMockRegistry((req) => {
+      if (req.method === 'GET') {
+        return { status: 200, body: JSON.stringify({ stubs: [stubRow({ id: STUB_ID, checkId: 'MCP-014' })], total: 1 }) };
+      }
+      return { status: 200, body: '{}' };
+    });
+
+    const res = await run(['mark-stub', STUB_ID, 'integrated', '--source-commit', COMMIT, '--registry-url', registry.url, '--json']);
+
+    expect(res.status, res.stderr).toBe(0);
+    expect(registry.requests[0].method).toBe('GET');
+    expect(registry.requests[0].url).toBe('/internal/aria/hma-stubs');
+    expect(JSON.parse(res.stdout).evidence.checkId).toBe('MCP-014');
+  });
+});
+
+describe('HMA-08.AC4 the evidence is honest by construction', () => {
+  it('HMA-08.AC4 refuses integrated without --source-commit, and sends nothing', async () => {
+    if (!canRun()) return;
+    registry = await happyRegistry();
+
+    const res = await run(['mark-stub', STUB_ID, 'integrated', '--registry-url', registry.url, '--json']);
+
+    expect(res.status).toBe(1);
+    expect(JSON.parse(res.stdout).refusal.code).toBe('source-commit-required');
+    expect(patches(registry.requests)).toHaveLength(0);
+  });
+
+  it('HMA-08.AC4 refuses rejected without --reason, and sends nothing', async () => {
+    if (!canRun()) return;
+    registry = await happyRegistry();
+
+    const res = await run(['mark-stub', STUB_ID, 'rejected', '--registry-url', registry.url, '--json']);
+
+    expect(res.status).toBe(1);
+    expect(JSON.parse(res.stdout).refusal.code).toBe('reason-required');
+    expect(patches(registry.requests)).toHaveLength(0);
+  });
+
+  it('HMA-08.AC4 refuses an unreachable-class checkId, on a fixture derived from the built UNREACHABLE_PREFIXES', async () => {
+    if (!canRun()) return;
+    const { UNREACHABLE_PREFIXES } = builtInventory();
+    // Non-vacuity: if the list is ever emptied — which is what wiring all
+    // three checks in would mean — this test has no subject and must say so
+    // rather than pass over an absence.
+    expect(UNREACHABLE_PREFIXES.length, 'the built module lists no unreachable prefixes').toBeGreaterThan(0);
+    const fixture = `${UNREACHABLE_PREFIXES[0]}-001`;
+    registry = await happyRegistry();
+
+    const res = await run([
+      'mark-stub', STUB_ID, 'integrated', '--source-commit', COMMIT,
+      '--check-id', fixture, '--registry-url', registry.url, '--json',
+    ]);
+
+    expect(res.status).toBe(1);
+    const envelope = JSON.parse(res.stdout);
+    expect(envelope.refusal.code).toBe('check-unreachable');
+    expect(envelope.refusal.what).toContain(UNREACHABLE_PREFIXES[0]);
+    expect(patches(registry.requests)).toHaveLength(0);
+  });
+
+  it('HMA-08.AC4 refuses a checkId absent from the built coverage inventory', async () => {
+    if (!canRun()) return;
+    const { CHECK_METHOD_PREFIXES, UNREACHABLE_PREFIXES } = builtInventory();
+    const known = new Set([...Object.values(CHECK_METHOD_PREFIXES).flat(), ...UNREACHABLE_PREFIXES]);
+    const absent = 'NOSUCHFAMILY';
+    expect(known.has(absent), 'the fixture prefix is registered after all').toBe(false);
+    registry = await happyRegistry();
+
+    const res = await run([
+      'mark-stub', STUB_ID, 'integrated', '--source-commit', COMMIT,
+      '--check-id', `${absent}-001`, '--registry-url', registry.url, '--json',
+    ]);
+
+    expect(res.status).toBe(1);
+    expect(JSON.parse(res.stdout).refusal.code).toBe('check-absent');
+    expect(patches(registry.requests)).toHaveLength(0);
+  });
+
+  it('HMA-08.AC4 derives hmaVersion only from the running artifact\'s own version', async () => {
+    if (!canRun()) return;
+    registry = await happyRegistry();
+
+    // A version the environment offers loudly, which the evidence must ignore.
+    const res = await run(
+      ['mark-stub', STUB_ID, 'integrated', '--source-commit', COMMIT, '--registry-url', registry.url, '--json'],
+      { npm_package_version: '99.99.99', HMA_VERSION: '99.99.99' },
+    );
+
+    expect(res.status, res.stderr).toBe(0);
+    expect(JSON.parse(res.stdout).evidence.hmaVersion).toBe(VERSION);
+    expect(JSON.parse(patches(registry.requests)[0].body).evidence.hmaVersion).toBe(VERSION);
+  });
+
+  it('HMA-08.AC4 offers no --evidence, --reachable or --hma-version flag anywhere on the option surface', async () => {
+    if (!canRun()) return;
+    const text = help('mark-stub');
+    for (const flag of ['--evidence', '--reachable', '--hma-version']) {
+      expect(text, `${flag} is on the option surface`).not.toContain(flag);
+      const res = await run(['mark-stub', STUB_ID, 'reviewed', flag, 'x']);
+      expect(res.stderr).toContain(`unknown option '${flag}'`);
+    }
+  });
+});
+
+describe('HMA-08.AC5 exit codes and output contracts', () => {
+  it('HMA-08.AC5 exits 0 when the transition is recorded', async () => {
+    if (!canRun()) return;
+    registry = await happyRegistry();
+    const res = await run(['mark-stub', STUB_ID, 'reviewed', '--registry-url', registry.url]);
+    expect(res.status, res.stderr).toBe(0);
+    expect(res.stdout).toContain('Recorded');
+  });
+
+  it('HMA-08.AC5 exits 1 when the local preflight refuses', async () => {
+    if (!canRun()) return;
+    registry = await happyRegistry();
+    const res = await run(['mark-stub', STUB_ID, 'rejected', '--registry-url', registry.url]);
+    expect(res.status).toBe(1);
+  });
+
+  it('HMA-08.AC5 exits 1 when the registry answers 4xx', async () => {
+    if (!canRun()) return;
+    registry = await startMockRegistry((req) => {
+      if (req.method === 'GET') return { status: 200, body: JSON.stringify({ stubs: [stubRow({ id: STUB_ID })], total: 1 }) };
+      return { status: 409, body: '{"error":"illegal transition draft -> reviewed"}' };
+    });
+
+    const res = await run(['mark-stub', STUB_ID, 'reviewed', '--registry-url', registry.url]);
+
+    expect(res.status).toBe(1);
+    expect(res.stderr).toContain('illegal transition');
+  });
+
+  it('HMA-08.AC5 exits 2 when the registry answers 5xx — the run cannot tell whether it landed', async () => {
+    if (!canRun()) return;
+    registry = await startMockRegistry((req) => {
+      if (req.method === 'GET') return { status: 200, body: JSON.stringify({ stubs: [stubRow({ id: STUB_ID })], total: 1 }) };
+      return { status: 503, body: 'upstream unavailable' };
+    });
+
+    const res = await run(['mark-stub', STUB_ID, 'reviewed', '--registry-url', registry.url]);
+
+    expect(res.status).toBe(2);
+    expect(res.stderr).toContain('Not settled');
+  });
+
+  it('HMA-08.AC5 exits 2 when the registry cannot be reached at all', async () => {
+    if (!canRun()) return;
+    const dead = await closedPortUrl();
+    const res = await run(['mark-stub', STUB_ID, 'reviewed', '--registry-url', dead]);
+    expect(res.status).toBe(2);
+    expect(res.stderr).toContain('Not settled');
+  });
+
+  it('HMA-08.AC5 emits the camelCase envelope under --json on both the recorded and refused paths', async () => {
+    if (!canRun()) return;
+    registry = await happyRegistry();
+
+    const ok = JSON.parse((await run([
+      'mark-stub', STUB_ID, 'integrated', '--source-commit', COMMIT,
+      '--reason', 'shipped', '--registry-url', registry.url, '--json',
+    ])).stdout);
+    expect(ok.ok).toBe(true);
+    expect(ok.stubId).toBe(STUB_ID);
+    expect(ok.status).toBe('integrated');
+    expect(ok.checkId).toBe(RECORDED_CHECK_ID);
+    expect(ok.reason).toBe('shipped');
+    expect(ok.evidence).toEqual({ checkId: RECORDED_CHECK_ID, hmaVersion: VERSION, sourceCommit: COMMIT, reachable: true });
+    expect(ok.refusal).toBeUndefined();
+
+    const refused = JSON.parse((await run(['mark-stub', STUB_ID, 'rejected', '--registry-url', registry.url, '--json'])).stdout);
+    expect(refused.ok).toBe(false);
+    expect(refused.stubId).toBe(STUB_ID);
+    expect(refused.status).toBe('rejected');
+    expect(Object.keys(refused.refusal).sort()).toEqual(['code', 'fix', 'verify', 'what']);
+    expect(refused).toHaveProperty('checkId');
+  });
+
+  it('HMA-08.AC5 renders a refusal as WHAT + Verify: + Fix: with no bypass flag offered', async () => {
+    if (!canRun()) return;
+    registry = await happyRegistry();
+
+    const res = await run(['mark-stub', STUB_ID, 'integrated', '--registry-url', registry.url]);
+
+    const lines = res.stderr.split('\n').filter(Boolean);
+    expect(lines[0]).toMatch(/^Refused: \S/);
+    expect(lines[1]).toMatch(/^\s+Verify: \S/);
+    expect(lines[2]).toMatch(/^\s+Fix: \S/);
+    // A gate with a bypass measures how many people found the bypass.
+    for (const bypass of ['--force', '--no-verify', '--skip', '--yes', '--evidence', '--reachable']) {
+      expect(res.stderr, `the refusal offers ${bypass}`).not.toContain(bypass);
+    }
+  });
+
+  it('HMA-08.AC5 cites only flags that resolve against the registered Commander surface', async () => {
+    if (!canRun()) return;
+    // Phase 7c cross-reference, scoped to this command: `--dry-run` printed as
+    // advice is a dead end unless `mark-stub` registers it. The repo-wide
+    // walker (__tests__/ui/printed-flag-citations.test.ts) enforces the same
+    // rule over every string in src/ and docs/; this asserts it where the new
+    // strings are, so a break here names the command that broke.
+    const registered = (command: string): Set<string> => {
+      const text = help(command);
+      const options = text.slice(text.indexOf('\nOptions:'));
+      return new Set([...options.matchAll(/--[a-z][\w-]*/g)].map(m => m[0]));
+    };
+    const markStubFlags = registered('mark-stub');
+    const pullStubsFlags = registered('pull-stubs');
+    const secureFlags = registered('secure');
+    const checkMetadataFlags = registered('check-metadata');
+    expect(markStubFlags.size).toBeGreaterThan(4);
+
+    registry = await happyRegistry();
+    const refusals = [
+      await run(['mark-stub', STUB_ID, 'integrated', '--registry-url', registry.url]),
+      await run(['mark-stub', STUB_ID, 'rejected', '--registry-url', registry.url]),
+      await run(['mark-stub', STUB_ID, 'integrated', '--source-commit', 'zzz', '--registry-url', registry.url]),
+      await run(['mark-stub', STUB_ID, 'integrated', '--source-commit', COMMIT, '--check-id', 'NOSUCHFAMILY-001', '--registry-url', registry.url]),
+    ];
+
+    const unresolved: string[] = [];
+    for (const text of [help('mark-stub'), ...refusals.map(r => r.stderr)]) {
+      for (const segment of text.split('\n')) {
+        // The command a flag is attributed to is the one named on its own
+        // line; a line naming none is prose about this command.
+        const owner = /\bpull-stubs\b/.test(segment) ? pullStubsFlags
+          : /\bcheck-metadata\b/.test(segment) ? checkMetadataFlags
+            : /\bsecure\b/.test(segment) ? secureFlags
+              : markStubFlags;
+        for (const m of segment.matchAll(/(?<![\w-])--[a-z][\w-]*/g)) {
+          if (!owner.has(m[0])) unresolved.push(`${m[0]} in: ${segment.trim()}`);
+        }
+      }
+    }
+    expect(unresolved, unresolved.join('\n')).toEqual([]);
+  });
+});
+
+describe('HMA-08.AC6 --dry-run runs every gate and sends nothing', () => {
+  it('HMA-08.AC6 makes zero HTTP calls when it needs no lookup', async () => {
+    if (!canRun()) return;
+    registry = await happyRegistry();
+
+    const res = await run([
+      'mark-stub', STUB_ID, 'integrated', '--source-commit', COMMIT,
+      '--check-id', RECORDED_CHECK_ID, '--dry-run', '--registry-url', registry.url,
+    ]);
+
+    expect(res.status, res.stderr).toBe(0);
+    expect(registry.requests, 'a dry run touched the network').toHaveLength(0);
+  });
+
+  it('HMA-08.AC6 prints the exact PATCH body it would have sent', async () => {
+    if (!canRun()) return;
+    registry = await happyRegistry();
+
+    const preview = await run([
+      'mark-stub', STUB_ID, 'integrated', '--source-commit', COMMIT, '--reason', 'shipped',
+      '--check-id', RECORDED_CHECK_ID, '--dry-run', '--registry-url', registry.url,
+    ]);
+    const real = await run([
+      'mark-stub', STUB_ID, 'integrated', '--source-commit', COMMIT, '--reason', 'shipped',
+      '--check-id', RECORDED_CHECK_ID, '--registry-url', registry.url,
+    ]);
+
+    expect(preview.stdout).toContain('nothing was sent');
+    const previewed = JSON.parse(preview.stdout.slice(preview.stdout.indexOf('{')));
+    // "Exact" means byte-for-byte the same object the real run puts on the
+    // wire, not a summary of it.
+    expect(previewed).toEqual(JSON.parse(patches(registry.requests)[0].body));
+    expect(real.status, real.stderr).toBe(0);
+  });
+
+  it('HMA-08.AC6 still runs the reachability probe, and its exit code reflects the local verdict', async () => {
+    if (!canRun()) return;
+    const { UNREACHABLE_PREFIXES } = builtInventory();
+    expect(UNREACHABLE_PREFIXES.length).toBeGreaterThan(0);
+    registry = await happyRegistry();
+
+    const refused = await run([
+      'mark-stub', STUB_ID, 'integrated', '--source-commit', COMMIT,
+      '--check-id', `${UNREACHABLE_PREFIXES[0]}-001`, '--dry-run', '--registry-url', registry.url, '--json',
+    ]);
+    const passes = await run([
+      'mark-stub', STUB_ID, 'integrated', '--source-commit', COMMIT,
+      '--check-id', RECORDED_CHECK_ID, '--dry-run', '--registry-url', registry.url, '--json',
+    ]);
+
+    expect(refused.status).toBe(1);
+    expect(JSON.parse(refused.stdout).refusal.code).toBe('check-unreachable');
+    expect(passes.status, passes.stderr).toBe(0);
+    expect(registry.requests).toHaveLength(0);
+  });
+
+  it('HMA-08.AC6 warns on an obviously illegal source transition and defers to the registry as the authority', async () => {
+    if (!canRun()) return;
+    // The stub is already settled as `integrated`; moving it back to `draft`
+    // is the fat-finger this warns about. It is a WARNING, not a refusal —
+    // the registry owns the transition table, and a CLI holding its own copy
+    // is the second vocabulary this whole unit deletes.
+    registry = await happyRegistry({ status: 'integrated' });
+
+    const res = await run(['mark-stub', STUB_ID, 'draft', '--registry-url', registry.url]);
+
+    expect(res.status, res.stderr).toBe(0);
+    expect(res.stderr).toContain('Warning');
+    expect(res.stderr).toMatch(/registry decides which transitions are legal/);
+    expect(res.stderr).not.toContain('Refused');
+    expect(patches(registry.requests)).toHaveLength(1);
+  });
+});

--- a/__tests__/cli/hma08-pull-stubs.test.ts
+++ b/__tests__/cli/hma08-pull-stubs.test.ts
@@ -1,0 +1,203 @@
+/**
+ * HMA-08.AC1 / HMA-08.AC2 — `pull-stubs` stops holding an opinion about the
+ * status vocabulary, and starts printing the identifier its own next step
+ * needs.
+ *
+ * DEFECT 1 of `todo/roadmap/hackmyagent-pull-stubs-status-vocabulary-mismatch.md`:
+ * the CLI validated `--status` against a hardcoded
+ * `['draft','review','integrated','rejected']` AND filtered the response
+ * against the same list, while the DB CHECK constraint held a different set.
+ * Every value except the default was unusable in one direction or the other,
+ * so the pipeline's only working query was the default — the loop's terminus,
+ * untraversable. [CHIEF-CA] 2026-08-31 ruled ONE vocabulary owned by the DB
+ * and the Go domain constants, with the CLI array and the client filter
+ * DELETED.
+ *
+ * The registry leg is REG-10; this suite runs against the in-process mock, so
+ * neither leg waits for the other. Spawn-based like its siblings in this
+ * directory, and gated on a built CLI through `assertDistFreshIfPresent`
+ * (#285) so it can never measure a stale binary and report a pass.
+ */
+import { describe, it, expect, beforeAll, afterEach } from 'vitest';
+import { spawn, spawnSync } from 'node:child_process';
+import { existsSync, readFileSync } from 'node:fs';
+import path from 'node:path';
+import { assertDistFreshIfPresent, BUILT_CLI as CLI } from '../helpers/dist-freshness';
+import { startMockRegistry, stubRow, type MockRegistry } from '../helpers/hma08-stub-registry';
+
+beforeAll(assertDistFreshIfPresent);
+
+const REPO_ROOT = path.resolve(__dirname, '..', '..');
+const canRun = () => existsSync(CLI);
+
+let registry: MockRegistry | undefined;
+afterEach(async () => { await registry?.close(); registry = undefined; });
+
+/**
+ * Spawn the built CLI WITHOUT blocking this process's event loop.
+ *
+ * `spawnSync` cannot be used here: the mock registry runs in-process, and a
+ * synchronous spawn holds the loop until the child exits — so the child's
+ * request sits in the socket buffer unanswered until its own 15s timeout
+ * fires. Every test in the first draft of this file failed that way, with the
+ * request recorded and the answer never sent.
+ */
+function run(args: string[]): Promise<{ status: number | null; stdout: string; stderr: string }> {
+  return new Promise((resolve, reject) => {
+    const child = spawn(process.execPath, [CLI, ...args], {
+      env: { ...process.env, NO_COLOR: '1', INTERNAL_API_KEY: 'test-key', NODE_OPTIONS: '' },
+    });
+    let stdout = '';
+    let stderr = '';
+    child.stdout.on('data', (c: Buffer) => { stdout += c.toString('utf8'); });
+    child.stderr.on('data', (c: Buffer) => { stderr += c.toString('utf8'); });
+    child.on('error', reject);
+    child.on('close', (status) => resolve({ status, stdout, stderr }));
+  });
+}
+
+/** `--help` text, ANSI-stripped. */
+function help(command: string): string {
+  const r = spawnSync(process.execPath, [CLI, command, '--help'], {
+    encoding: 'utf8', timeout: 30_000, env: { ...process.env, NO_COLOR: '1', NODE_OPTIONS: '' },
+  });
+  return (r.stdout ?? '').replace(/\x1b\[[0-9;]*m/g, '');
+}
+
+describe('HMA-08.AC1 the status vocabulary belongs to the registry', () => {
+  it('HMA-08.AC1 passes an arbitrary unknown status through to the server as ?status=, unvalidated', async () => {
+    if (!canRun()) return;
+    // Not a word any vocabulary this project has ever held. On the pre-fix
+    // build this exited 1 before a socket was opened.
+    const arbitrary = 'wibble-wobble-9000';
+    registry = await startMockRegistry(() => ({
+      status: 200,
+      body: JSON.stringify({ stubs: [stubRow({ status: arbitrary })], total: 1 }),
+    }));
+
+    const res = await run(['pull-stubs', '--status', arbitrary, '--registry-url', registry.url, '--json']);
+
+    expect(res.status, res.stderr).toBe(0);
+    expect(registry.requests).toHaveLength(1);
+    expect(registry.requests[0].url).toBe(
+      `/internal/aria/hma-stubs?status=${encodeURIComponent(arbitrary)}`,
+    );
+    // And no client-side filter ate the answer on the way back.
+    const payload = JSON.parse(res.stdout) as { stubs: unknown[]; filtered: number };
+    expect(payload.filtered).toBe(1);
+    expect(payload.stubs).toHaveLength(1);
+  });
+
+  it('HMA-08.AC1 renders rows the registry returned even when their status differs from the one asked for', async () => {
+    if (!canRun()) return;
+    // The registry is the authority on what matched. A client that re-filters
+    // can only ever disagree with it, and disagreeing silently is what made
+    // `--status review` return nothing against rows that existed.
+    registry = await startMockRegistry(() => ({
+      status: 200,
+      body: JSON.stringify({ stubs: [stubRow({ id: 'kept-me', status: 'something-else' })], total: 1 }),
+    }));
+
+    const res = await run(['pull-stubs', '--status', 'reviewed', '--registry-url', registry.url]);
+
+    expect(res.status, res.stderr).toBe(0);
+    expect(res.stdout).toContain('kept-me');
+  });
+
+  it('HMA-08.AC1 renders a 4xx body near-verbatim, because that body carries the allowed set', async () => {
+    if (!canRun()) return;
+    // Deliberately longer than the 200-byte clip the pre-fix build applied:
+    // the allowed set is the one thing the CLI no longer knows, so truncating
+    // the answer that carries it defeats the whole ruling.
+    const allowed = 'status must be one of: draft, reviewed, integrated, rejected';
+    const filler = 'x'.repeat(240);
+    const body = `{"error":"invalid status","detail":"${filler}","allowed":"${allowed}"}`;
+    expect(body.length).toBeGreaterThan(200);
+    registry = await startMockRegistry(() => ({ status: 400, body }));
+
+    const res = await run(['pull-stubs', '--status', 'nope', '--registry-url', registry.url]);
+
+    expect(res.status).toBe(1);
+    expect(res.stderr).toContain(allowed);
+    expect(res.stderr).toContain(filler);
+  });
+
+  it('HMA-08.AC1 carries no client-side status vocabulary in the source', () => {
+    const src = readFileSync(path.join(REPO_ROOT, 'src', 'cli.ts'), 'utf8');
+    const start = src.indexOf(".command('pull-stubs')");
+    const end = src.indexOf(".command('mark-stub')");
+    expect(start, 'pull-stubs registration not found').toBeGreaterThan(-1);
+    expect(end, 'mark-stub registration not found').toBeGreaterThan(start);
+    const region = src.slice(start, end);
+    expect(region).not.toContain('validStatuses');
+    expect(region, 'the client-side status filter is back').not.toMatch(/\.filter\([^)]*\.status\s*===/);
+  });
+
+  it('HMA-08.AC1 lists the four ruled words in --status help as examples of the current vocabulary', () => {
+    if (!canRun()) return;
+    const text = help('pull-stubs');
+    // Sliced out of the Options block, not the whole page: `--all` and
+    // `--json` appear in the Examples above it, so an unanchored slice reads
+    // backwards and passes over an empty string.
+    const options = text.slice(text.indexOf('\nOptions:'));
+    const statusHelp = options.slice(options.indexOf('--status <status>'), options.indexOf('--all'));
+    expect(statusHelp, 'the --status option block was not found').not.toBe('');
+    for (const word of ['draft', 'reviewed', 'integrated', 'rejected']) {
+      expect(statusHelp, `--status help does not name ${word}`).toContain(word);
+    }
+  });
+});
+
+describe('HMA-08.AC2 the report leads with the identifier its next step needs', () => {
+  it('HMA-08.AC2 leads each formatted stub with a Stub ID field', async () => {
+    if (!canRun()) return;
+    registry = await startMockRegistry(() => ({
+      status: 200,
+      body: JSON.stringify({ stubs: [stubRow({ id: 'stub-abc-123' })], total: 1 }),
+    }));
+
+    const res = await run(['pull-stubs', '--registry-url', registry.url]);
+
+    expect(res.status, res.stderr).toBe(0);
+    expect(res.stdout).toContain('Stub ID:');
+    expect(res.stdout).toContain('stub-abc-123');
+    // FIRST field of the block, ahead of the Check ID that used to lead it.
+    expect(res.stdout.indexOf('Stub ID:')).toBeLessThan(res.stdout.indexOf('Check ID:'));
+  });
+
+  it('HMA-08.AC2 closes the summary with one next-step line naming mark-stub', async () => {
+    if (!canRun()) return;
+    registry = await startMockRegistry(() => ({
+      status: 200,
+      body: JSON.stringify({ stubs: [stubRow()], total: 1 }),
+    }));
+
+    const res = await run(['pull-stubs', '--registry-url', registry.url]);
+
+    const naming = res.stdout.split('\n').filter(l => l.includes('mark-stub'));
+    expect(naming, 'expected exactly one next-step line naming mark-stub').toHaveLength(1);
+    expect(naming[0]).toMatch(/Next step/);
+    expect(res.stdout.indexOf('Summary')).toBeLessThan(res.stdout.indexOf('mark-stub'));
+  });
+
+  it('HMA-08.AC2 --all omits the status parameter from the request entirely', async () => {
+    if (!canRun()) return;
+    registry = await startMockRegistry(() => ({
+      status: 200,
+      body: JSON.stringify({ stubs: [stubRow(), stubRow({ id: 'two', status: 'integrated' })], total: 2 }),
+    }));
+
+    const res = await run(['pull-stubs', '--all', '--registry-url', registry.url, '--json']);
+
+    expect(res.status, res.stderr).toBe(0);
+    expect(registry.requests).toHaveLength(1);
+    // A request-shape switch, not a magic vocabulary value: no `status` key
+    // reaches the wire at all, so the registry needs no word for "any".
+    expect(registry.requests[0].url).toBe('/internal/aria/hma-stubs');
+    expect(registry.requests[0].url).not.toContain('status');
+    const payload = JSON.parse(res.stdout) as { filtered: number; status: string | null; all: boolean };
+    expect(payload.filtered).toBe(2);
+    expect(payload.status).toBeNull();
+    expect(payload.all).toBe(true);
+  });
+});

--- a/__tests__/cli/json-exit-code-parity.test.ts
+++ b/__tests__/cli/json-exit-code-parity.test.ts
@@ -108,6 +108,14 @@ const JSON_EXIT_PARITY: Record<string, Parity> = {
     kind: 'unrunnable-offline',
     reason: 'fetches pending check stubs from the registry; no local target, no findings verdict',
   },
+  'mark-stub': {
+    kind: 'unrunnable-offline',
+    reason:
+      'writes a stub status transition to the registry; there is no local target and no '
+      + 'findings verdict. Its own exit contract (0 recorded / 1 refused / 2 not settled) is '
+      + 'asserted against a mocked registry in __tests__/cli/hma08-mark-stub.test.ts, one '
+      + 'test per class, on both channels',
+  },
 };
 
 /** Commands registering `--json`, read from the CLI source. */

--- a/__tests__/hardening/redaction-provenance-boundaries.test.ts
+++ b/__tests__/hardening/redaction-provenance-boundaries.test.ts
@@ -108,12 +108,20 @@ describe('cli.ts JSON-serialization tripwire', () => {
   // (route through writeJsonStdout, add an assert, or record why neither),
   // then update the count. It does not prove coverage; the injections above
   // and the healthy e2e runs do that for the known set.
+  // HMA-08 added two, both classified here rather than routed: `mark-stub`
+  // serializes its PATCH body twice — once into the request and once into the
+  // `--dry-run` preview, which must print the SAME bytes to be worth reading.
+  // Neither carries a `SecurityFinding`: the body is `{status, reason?,
+  // evidence?}` where `evidence` is four measured scalars, so the
+  // publish-boundary read has nothing to cover on either. The `--json`
+  // envelope, which is the finding-adjacent channel, does go through
+  // `writeJsonStdout`.
   it('the number of JSON.stringify sites in cli.ts is accounted for', () => {
     const cli = readFileSync(join(__dirname, '..', '..', 'src', 'cli.ts'), 'utf8');
     const count = (cli.match(/JSON\.stringify\(/g) ?? []).length;
     expect(
       count,
       'cli.ts gained or lost a JSON.stringify site — classify it against the publish-boundary read (unit 2) before updating this pin',
-    ).toBe(18);
+    ).toBe(20);
   });
 });

--- a/__tests__/helpers/exit-surface-baseline.ts
+++ b/__tests__/helpers/exit-surface-baseline.ts
@@ -14,11 +14,16 @@
  * regenerate it mechanically.
  */
 export const UNSETTLED_EXIT_IDS: ReadonlySet<string> = new Set([
-  // Pre-work refusals (Class R) — events await the schema reason field (#525):
+  // Pre-work refusals (Class R) — events await the schema reason field (#525).
+  // S042 (pull-stubs' client-side `--status` vocabulary refusal) is GONE: the
+  // validStatuses array it guarded was deleted with the rest of the client
+  // vocabulary, so the site it annotated no longer exists. A shrink, which is
+  // the only direction this list moves.
+
   'S001', 'S002', 'S003', 'S004', 'S005', 'S006', 'S007', 'S008', 'S009', 'S010',
   'S012', 'S013', 'S014', 'S016', 'S017', 'S018', 'S019', 'S020', 'S021', 'S022',
   'S023', 'S024', 'S025', 'S026', 'S027', 'S031', 'S035', 'S037', 'S039', 'S041',
-  'S042', 'S043', 'S044', 'S045',
+  'S043', 'S044', 'S045',
   // Bare `process.exitCode` assignments outside the funnel — migrate to raiseExitCode.
   // (S050-S054, check's PyPI and URL fetch-failure exits, settled via
   // settleCheckVerdict under #602 — the first baseline shrink.)

--- a/__tests__/helpers/hma08-stub-registry.ts
+++ b/__tests__/helpers/hma08-stub-registry.ts
@@ -1,0 +1,91 @@
+/**
+ * An in-process stand-in for the registry's HMA-stub endpoints (HMA-08).
+ *
+ * The registry leg of this unit — the migration, the server-side `?status=`
+ * filter and `PATCH /internal/aria/hma-stubs/:id` — ships separately as
+ * REG-10. Every HMA-08 test therefore runs against this, so the two legs land
+ * independently and no test in this repo needs a live registry.
+ *
+ * It RECORDS as much as it answers. Half of what this unit promises is about
+ * requests that must not happen (`--dry-run` sends nothing) or about the
+ * exact shape of one that does (`?status=` verbatim, a camelCase PATCH body),
+ * and neither is observable from the CLI's own output.
+ */
+import * as http from 'node:http';
+import type { AddressInfo } from 'node:net';
+
+export interface RecordedRequest {
+  method: string;
+  /** Path plus query, exactly as it arrived. */
+  url: string;
+  /** Request body as UTF-8; empty string for a GET. */
+  body: string;
+}
+
+export interface MockRegistry {
+  /** Base URL to hand `--registry-url`. `localhost`, which the CLI's HTTPS rule allows. */
+  url: string;
+  /** Every request that reached the socket, in order. */
+  requests: RecordedRequest[];
+  close(): Promise<void>;
+}
+
+export type Responder = (req: RecordedRequest) => { status: number; body: string };
+
+/** A stub row shaped like the one `pull-stubs` renders. */
+export function stubRow(over: Partial<Record<string, string>> = {}): Record<string, string> {
+  return {
+    id: 'stub-0001',
+    ariaFindingId: 'aria-9001',
+    checkId: 'CRED-001',
+    series: 'CRED',
+    name: 'Hardcoded credential in agent config',
+    description: 'ARIA observed a credential literal in an agent manifest.',
+    severity: 'high',
+    detectionLogic: 'match a credential literal in the manifest',
+    status: 'draft',
+    createdAt: '2026-08-01T00:00:00Z',
+    updatedAt: '2026-08-02T00:00:00Z',
+    ...over,
+  };
+}
+
+export async function startMockRegistry(respond: Responder): Promise<MockRegistry> {
+  const requests: RecordedRequest[] = [];
+  const server = http.createServer((req, res) => {
+    const chunks: Buffer[] = [];
+    req.on('data', (c: Buffer) => chunks.push(c));
+    req.on('end', () => {
+      const recorded: RecordedRequest = {
+        method: req.method ?? '',
+        url: req.url ?? '',
+        body: Buffer.concat(chunks).toString('utf8'),
+      };
+      requests.push(recorded);
+      const answer = respond(recorded);
+      res.writeHead(answer.status, { 'Content-Type': 'application/json' });
+      res.end(answer.body);
+    });
+  });
+  await new Promise<void>((resolve) => server.listen(0, resolve));
+  const { port } = server.address() as AddressInfo;
+  return {
+    url: `http://localhost:${port}`,
+    requests,
+    close: () => new Promise<void>((resolve) => { server.close(() => resolve()); }),
+  };
+}
+
+/**
+ * A port nothing is listening on.
+ *
+ * Bound and released, so it is a port the OS just handed out rather than a
+ * guess that could collide with a real service on the developer's machine.
+ */
+export async function closedPortUrl(): Promise<string> {
+  const server = http.createServer();
+  await new Promise<void>((resolve) => server.listen(0, resolve));
+  const { port } = server.address() as AddressInfo;
+  await new Promise<void>((resolve) => { server.close(() => resolve()); });
+  return `http://localhost:${port}`;
+}

--- a/__tests__/helpers/render-safety.ts
+++ b/__tests__/helpers/render-safety.ts
@@ -111,6 +111,7 @@ export const COMMAND_CLASSIFICATION: Record<string, 'renders-paths' | string> = 
   nanomind: 'renders model identifiers and local model state',
   'mcp-serve': 'a server, not a report',
   'pull-stubs': 'downloads model stubs; renders the tool\'s own cache paths',
+  'mark-stub': 'renders a stub id, a status word and the PATCH body it would send; no filesystem path reaches its output',
 };
 
 /**

--- a/__tests__/nanomind-core/deterministic-floor-census.test.ts
+++ b/__tests__/nanomind-core/deterministic-floor-census.test.ts
@@ -35,11 +35,20 @@ function sourceFiles(dir: string, acc: string[] = []): string[] {
  * Every `-x` / `--flag` token registered through commander's
  * `.option` / `.requiredOption` / `.addOption` anywhere under `src/`, on
  * origin/main c2a9c2f. 88 tokens.
+ *
+ * HMA-08 adds four, deliberately, exactly as the assertion message below
+ * prescribes: `--all` on `pull-stubs` (a request-shape switch that omits the
+ * `?status=` filter) and `--reason`, `--source-commit`, `--check-id` on the
+ * new `mark-stub` command. None of them touches the semantic layer, and none
+ * is an opt-out of anything — `--source-commit` and `--reason` are GATES that
+ * make a write-back refuse without them, which is the opposite direction to
+ * the flag this invariant exists to forbid.
  */
 const COMMAND_SURFACE = [
   '--a2a-recipient', '--a2a-sender', '--analm', '--api-format', '--at', '--atx',
   '--audit', '--aws-account-id', '--aws-region', '--batch', '--benchmark',
   '--broker-socket', '--broker-token', '--category', '--ci', '--ci-publish',
+  '--all', '--check-id', '--reason', '--source-commit',        // HMA-08, see note below
   '--contribute', '--deep', '--delay', '--directory', '--dry-run', '--explain',
   '--export-csv', '--export-training', '--fail-below', '--fail-on-gate',
   '--fail-on-vulnerable', '--fix', '--format', '--grant', '--grant-agent-id',

--- a/__tests__/repo/hma07-scope-invariant.test.ts
+++ b/__tests__/repo/hma07-scope-invariant.test.ts
@@ -55,11 +55,24 @@ const REPO_ROOT = path.resolve(__dirname, '..', '..');
 /** Recorded at HMA-07 intake, against origin/main 957bb65. */
 const TRACKED_FS_SHA256 = 'bf6566fa2dfab6877ebed88b67b0d28e518e013d2ca164d5640aa5c472586389';
 
-/** Long flags registered anywhere under `src/`, recorded at HMA-07 intake. */
+/**
+ * Long flags registered anywhere under `src/`, recorded at HMA-07 intake.
+ *
+ * SCOPE DECISION, taken with HMA-08 (the `pull-stubs` / `mark-stub` unit),
+ * following the rule in the docblock above: that change legitimately adds four
+ * flags, so they are recorded here rather than the assertion being retired.
+ * Recording is the stronger option and it is available BECAUSE the invariant
+ * HMA-07 needs is narrower than "no flag ever" — it is "the wider skills walk
+ * is not opt-in". `--all` (pull-stubs, omits the `?status=` filter),
+ * `--reason`, `--source-commit` and `--check-id` (mark-stub, the registry
+ * write-back) are on two registry commands that never reach the scanner walk,
+ * and two of them are refusal GATES rather than escape hatches. A flag that
+ * did make the walk opt-in would still turn this red.
+ */
 const REGISTERED_LONG_FLAGS = [
-  '--a2a-recipient', '--a2a-sender', '--analm', '--api-format', '--at', '--atx',
-  '--audit', '--aws-account-id', '--aws-region', '--batch', '--benchmark',
-  '--broker-socket', '--broker-token', '--category', '--ci', '--ci-publish',
+  '--a2a-recipient', '--a2a-sender', '--all', '--analm', '--api-format', '--at',
+  '--atx', '--audit', '--aws-account-id', '--aws-region', '--batch', '--benchmark',
+  '--broker-socket', '--broker-token', '--category', '--check-id', '--ci', '--ci-publish',
   '--contribute', '--deep', '--delay', '--directory', '--dry-run', '--explain',
   '--export-csv', '--export-training', '--fail-below', '--fail-on-gate',
   '--fail-on-vulnerable', '--fix', '--format', '--grant', '--grant-agent-id',
@@ -67,9 +80,9 @@ const REGISTERED_LONG_FLAGS = [
   '--local', '--mcp-tool', '--min-trust', '--model', '--name', '--nanomind',
   '--no-color', '--no-contribute', '--no-machine-posture', '--no-registry',
   '--no-scan', '--offline', '--output', '--payload-file', '--ports', '--profile',
-  '--publish', '--registry-key', '--registry-report', '--registry-url',
-  '--rescan', '--root', '--scan-depth', '--scan-only', '--static-only',
-  '--status', '--stop-on-success', '--surface', '--system-prompt',
+  '--publish', '--reason', '--registry-key', '--registry-report', '--registry-url',
+  '--rescan', '--root', '--scan-depth', '--scan-only', '--source-commit',
+  '--static-only', '--status', '--stop-on-success', '--surface', '--system-prompt',
   '--target-type', '--tier', '--timeout', '--tool', '--type', '--verbose',
   '--version', '--version-id', '--with-aim',
 ];

--- a/docs/release-playbook.md
+++ b/docs/release-playbook.md
@@ -367,6 +367,50 @@ Failures:
   but generic. Does NOT block current release; fix before next.
 - **LOW**: polish. Batch.
 
+## Stub write-back — two steps, non-skippable
+
+`mark-stub` is the terminus of the observation -> shipped-check loop: it is
+the only place a stub the release actually implemented gets recorded as
+`integrated`, and the only place an authored-but-never-wired check is caught
+(`integrated` is refused when the check ID names a family this build ships and
+never calls). A release that ships checks and records none of them leaves the
+question "how many confirmed observations became a shipped check" unanswerable
+for that version.
+
+Both steps require `INTERNAL_API_KEY`. Neither is skippable, and neither runs
+against a fixture registry.
+
+**1. Before the tag is pushed — preview every stub the release claims.**
+
+Run a preview for each stub this release says it implemented. It runs every
+preflight and the reachability probe, prints the exact body that would be
+sent, and sends nothing, so a stub whose check was authored but never wired
+into `scanInner` fails HERE rather than after publish.
+
+```bash
+node dist/cli.js pull-stubs --status reviewed
+node dist/cli.js mark-stub <stub-id> integrated --source-commit $(git rev-parse HEAD) --dry-run
+```
+
+Exit 0 means the transition would be recorded. Exit 1 is a refusal and blocks
+the tag push — read the `Fix:` line, it names the real remedy. Exit 2 means the
+registry could not be reached, so nothing was determined; resolve that and
+re-run rather than proceeding.
+
+**2. After publish — send it for real, from the RELEASED artifact.**
+
+Run the real send from the published package, not from the working tree. The
+evidence carries the version of the artifact that produced it, and the whole
+point of the record is that it describes what users can install:
+
+```bash
+npx hackmyagent@<version> mark-stub <stub-id> integrated --source-commit <sha>
+```
+
+Record the stub ids and the exit code of each send in `briefs/release-findings.md`
+alongside the rest of the run. A stub that refuses at this step after passing
+step 1 is a finding: the published artifact and the working tree disagree.
+
 ## Self-learning loop (MANDATORY — this is how the playbook grows)
 
 Five mechanisms, none optional:

--- a/src/cli-prefix.ts
+++ b/src/cli-prefix.ts
@@ -76,7 +76,7 @@ export const RAW_CLI_PREFIX = resolveRawCliPrefix();
 const HMA_VERBS = [
   'secure-openclaw', 'secure-nemoclaw', 'harden-soul', 'harden-skill',
   'scan-soul', 'scan-history', 'fix-all', 'init-mcp', 'check-metadata',
-  'pull-stubs', 'secure', 'scan', 'check', 'attack', 'detect', 'wild',
+  'pull-stubs', 'mark-stub', 'secure', 'scan', 'check', 'attack', 'detect', 'wild',
   'rollback', 'trust', 'telemetry', 'nanomind', 'harden', 'review',
   'protect', 'benchmark', 'oracle', 'init', 'verify',
 ] as const;

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -371,6 +371,16 @@ import { generateBenchmarkReport } from './benchmarks/benchmark-report';
 import { UsageError, usageError, isRefusal, networkTimeoutError } from './checker/errors';
 import { RootRefusalError } from './mcp/roots';
 import { shellQuote, citationPath, citationTarget, commandNaming } from './ui/shell-quote';
+import {
+  preflight,
+  probeReachability,
+  settledSourceWarning,
+  buildEvidence,
+  buildPatchBody,
+  EVIDENCE_GATED_STATUS,
+  type StubRefusal,
+  type StubEvidence,
+} from './registry/stub-writeback';
 import { CONCEPT_EXPLAINERS, inferConceptFromFix } from './ui/concept-explainers';
 import type { ConceptId } from './types/finding-evidence';
 import { trustAapGate } from './aap';
@@ -11727,6 +11737,18 @@ Examples:
   });
 
 // pull-stubs: fetch pending HMA check stubs from the registry
+//
+// The status vocabulary is the REGISTRY'S, not this CLI's (DEFECT 1 of
+// `todo/roadmap/hackmyagent-pull-stubs-status-vocabulary-mismatch.md`, ruled
+// by [CHIEF-CA] 2026-08-31). This command used to validate against a
+// hardcoded `['draft','review','integrated','rejected']` and then filter the
+// response client-side against the same list, while the DB CHECK constraint
+// held a different set — so every value except the default `draft` was
+// unusable in one direction or the other and the pipeline's only working
+// query was the default. Both halves are gone: `--status` rides to the
+// registry verbatim as `?status=`, and a 4xx answer is printed as it came
+// back, because that body is what carries the allowed set. A CLI that
+// re-states a vocabulary it does not own can only ever be wrong later.
 program
   .command('pull-stubs')
   .description(`Fetch pending HMA check stubs from the registry for review.
@@ -11735,27 +11757,26 @@ The ARIA pipeline discovers new attack patterns and creates stub definitions
 for checks that HMA doesn't yet implement. This command pulls those stubs
 so you can review, refine, and integrate them.
 
+--status is sent to the registry verbatim; the registry owns the vocabulary
+and answers with the allowed set when it does not recognise a word.
+
 Requires INTERNAL_API_KEY environment variable for registry authentication.
 
 Examples:
   $ ${CLI_PREFIX} pull-stubs
-  $ ${CLI_PREFIX} pull-stubs --status review
+  $ ${CLI_PREFIX} pull-stubs --status reviewed
+  $ ${CLI_PREFIX} pull-stubs --all
   $ ${CLI_PREFIX} pull-stubs --json`)
-  .option('--status <status>', 'Filter by stub status (draft, review, integrated, rejected)', 'draft')
+  .option('--status <status>', 'Filter by stub status, sent verbatim to the registry (current vocabulary: draft, reviewed, integrated, rejected)', 'draft')
+  .option('--all', 'Every stub, whatever its status (omits the status filter from the request)')
   .option('--registry-url <url>', 'Registry base URL', validateRegistryUrl(process.env.REGISTRY_URL || 'https://api.oa2a.org'))
   .option('--json', 'Output raw JSON instead of formatted table')
   .action(async (opts: {
     status: string;
+    all?: boolean;
     registryUrl: string;
     json?: boolean;
-  }) => {
-    const validStatuses = ['draft', 'review', 'integrated', 'rejected'];
-    if (!validStatuses.includes(opts.status)) {
-      process.stderr.write(`Error: --status must be one of: ${validStatuses.join(', ')}\n`);
-      process.stderr.write(`  Got: ${opts.status}\n`);
-      process.exit(1); // exit-unsettled(#350/S042): pre-work refusal; events await the schema reason field (#525)
-    }
-
+  }, command: Command) => {
     const apiKey = process.env.INTERNAL_API_KEY;
     // HTTP header values are ByteStrings (Latin-1). A key carrying anything
     // outside that range — most often U+FFFD after a bad copy-paste or a
@@ -11785,7 +11806,18 @@ Examples:
     }
 
     const registryUrl = validateRegistryUrl(opts.registryUrl).replace(/\/+$/, '');
-    const endpoint = `${registryUrl}/internal/aria/hma-stubs`;
+    // `--all` is a REQUEST-SHAPE switch, not a magic status word: it omits
+    // `?status=` entirely rather than sending a value the registry would then
+    // have to know about. A vocabulary the two sides have to agree on is the
+    // defect this unit closes, so the "no filter" case must not need one.
+    if (opts.all && command.getOptionValueSource('status') === 'cli') {
+      process.stderr.write('Note: --all omits the status filter, so --status is not sent.\n');
+    }
+    const endpoint = opts.all
+      ? `${registryUrl}/internal/aria/hma-stubs`
+      : `${registryUrl}/internal/aria/hma-stubs?status=${encodeURIComponent(opts.status)}`;
+    /** What this request asked for, for the labels and the JSON echo. */
+    const filterLabel = opts.all ? 'all' : opts.status;
 
     let responseData: { stubs: Array<{
       id: string;
@@ -11819,7 +11851,16 @@ Examples:
         if (res.status === 401 || res.status === 403) {
           process.stderr.write('  Your INTERNAL_API_KEY may be invalid or expired.\n');
         }
-        if (body) process.stderr.write(`  ${body.slice(0, 200)}\n`);
+        // Near-verbatim, and no longer clipped at 200 bytes: a 400 here
+        // carries the allowed status set, which is the ONE thing the CLI no
+        // longer knows and the reader most needs. Escaped per line because
+        // these are registry bytes reaching a terminal (#601), and bounded
+        // only against a pathological body.
+        if (body) {
+          for (const line of body.slice(0, 4000).split('\n')) {
+            process.stderr.write(`  ${escapeForDisplay(line)}\n`);
+          }
+        }
         await exitRecorded(1, 'error');
       }
 
@@ -11838,16 +11879,20 @@ Examples:
       return;
     }
 
-    // Filter by status
-    const stubs = responseData.stubs.filter(s => s.status === opts.status);
+    // No client-side filter. The rows the registry returned ARE the answer;
+    // re-filtering them here is what made `--status reviewed` return nothing
+    // on a registry that had rows in exactly that state.
+    const stubs = responseData.stubs;
 
     if (stubs.length === 0) {
       if (opts.json) {
-        writeJsonStdout({ stubs: [], total: responseData.total, filtered: 0, status: opts.status });
+        writeJsonStdout({ stubs: [], total: responseData.total, filtered: 0, status: opts.all ? null : opts.status, all: opts.all === true });
       } else {
-        console.log(`No stubs with status "${opts.status}" found.`);
+        console.log(opts.all
+          ? 'No stubs found.'
+          : `No stubs with status "${escapeForDisplay(opts.status)}" found.`);
         if (responseData.total > 0) {
-          console.log(`  Registry has ${responseData.total} total stub(s). Try a different --status filter.`);
+          console.log(`  Registry has ${responseData.total} total stub(s). Try a different --status filter, or --all.`);
         }
       }
       return;
@@ -11855,7 +11900,7 @@ Examples:
 
     // JSON output mode
     if (opts.json) {
-      writeJsonStdout({ stubs, total: responseData.total, filtered: stubs.length, status: opts.status });
+      writeJsonStdout({ stubs, total: responseData.total, filtered: stubs.length, status: opts.all ? null : opts.status, all: opts.all === true });
       return;
     }
 
@@ -11868,7 +11913,7 @@ Examples:
       info: colors.dim,
     };
 
-    console.log(`\nHMA Check Stubs (status: ${opts.status})\n`);
+    console.log(`\nHMA Check Stubs (status: ${escapeForDisplay(filterLabel)})\n`);
 
     for (const stub of stubs) {
       // #601 — every field here is bytes from the Registry JSON response; a
@@ -11878,6 +11923,9 @@ Examples:
       // yields no color, never renders).
       const sc = severityColor[stub.severity?.toLowerCase()] || '';
       console.log(`${'='.repeat(60)}`);
+      // Stub ID leads: it is the argument `mark-stub` takes, and a report
+      // whose next step needs an identifier it never printed is a dead end.
+      console.log(`  Stub ID:    ${escapeForDisplay(String(stub.id))}`);
       console.log(`  Check ID:   ${escapeForDisplay(String(stub.checkId))}`);
       console.log(`  Series:     ${escapeForDisplay(String(stub.series))}`);
       console.log(`  Name:       ${escapeForDisplay(String(stub.name))}`);
@@ -11900,7 +11948,7 @@ Examples:
     console.log('='.repeat(60));
     console.log(`\nSummary`);
     console.log(`  Total in registry:  ${responseData.total}`);
-    console.log(`  Matching "${opts.status}":  ${stubs.length}`);
+    console.log(`  Matching "${escapeForDisplay(filterLabel)}":  ${stubs.length}`);
 
     // By series
     const bySeries: Record<string, number> = {};
@@ -11916,10 +11964,253 @@ Examples:
     console.log(`\n  By severity:`);
     for (const [sev, count] of Object.entries(bySeverity).sort((a, b) => b[1] - a[1])) {
       const sc = severityColor[sev?.toLowerCase()] || '';
-      console.log(`    ${sc}${sev}${colors.reset}: ${count}`);
+      console.log(`    ${sc}${escapeForDisplay(sev)}${colors.reset}: ${count}`);
     }
 
+    console.log(`\n  Next step: record a transition with ${CLI_PREFIX} mark-stub <stub-id> <status> (add --dry-run to preview it)`);
+
     console.log('');
+  });
+
+// mark-stub: the write-back half of the observation -> shipped-check loop.
+//
+// DEFECT 2 of the same roadmap unit, UX ruled verbatim by [CHIEF-CPO]
+// 2026-08-31. Nothing in HMA marked a stub integrated, so nobody could answer
+// "how many confirmed observations became a shipped check" — the only figure
+// that proves the flywheel turns. The registry endpoint this PATCHes ships
+// separately (REG-10); every test here runs against a mocked registry so the
+// two legs land independently.
+//
+// The refusals are the product. A write-back that records whatever it is told
+// measures how often someone typed the command, not how often a check
+// shipped, and the manual authoring path has a step (`scanInner` wiring)
+// whose omission leaves a check counted and unable to fire — which is exactly
+// what the reachability probe reads the built inventory to catch.
+program
+  .command('mark-stub')
+  .argument('<id>', 'Stub id, as printed by pull-stubs under "Stub ID"')
+  .argument('<status>', 'Status to record. Sent verbatim; the registry owns the vocabulary')
+  .description(`Requires INTERNAL_API_KEY: record an HMA check-stub status transition in the registry.
+
+Sends PATCH /internal/aria/hma-stubs/:id. The status word is sent verbatim —
+the registry owns the vocabulary and answers with the allowed set when it does
+not recognise one.
+
+Two transitions carry a local gate, because both are claims somebody will be
+asked to defend later:
+
+  integrated  refused without --source-commit, and refused unless the check ID
+              names a family THIS build both ships and calls. The evidence
+              recorded alongside it (check id, this artifact's version, the
+              commit, the probe verdict) is measured here, never supplied.
+  rejected    refused without --reason.
+
+Examples:
+  $ ${CLI_PREFIX} mark-stub 7f3c1d2e reviewed
+  $ ${CLI_PREFIX} mark-stub 7f3c1d2e integrated --source-commit 1a2b3c4 --dry-run
+  $ ${CLI_PREFIX} mark-stub 7f3c1d2e rejected --reason "duplicate of CRED-014"`)
+  .option('--reason <text>', 'Why this transition is being recorded. Required for rejected.')
+  .option('--source-commit <sha>', 'Commit carrying the shipped check, 7-40 hex. Required for integrated.')
+  .option('--check-id <id>', 'Check ID to probe. Defaults to the checkId the registry already records for this stub.')
+  .option('--dry-run', 'Run every preflight and the reachability probe, print the exact PATCH body, and send nothing')
+  .option('--registry-url <url>', 'Registry base URL', validateRegistryUrl(process.env.REGISTRY_URL || 'https://api.oa2a.org'))
+  .option('--json', 'Output raw JSON instead of formatted text')
+  .action(async (id: string, status: string, opts: {
+    reason?: string;
+    sourceCommit?: string;
+    checkId?: string;
+    dryRun?: boolean;
+    registryUrl: string;
+    json?: boolean;
+  }) => {
+    /** 1 — the run refused. 2 — the run could not tell whether it landed. */
+    const EXIT_REFUSED = 1;
+    const EXIT_NOT_SETTLED = 2;
+
+    /** The one place a refusal ends, on both channels. */
+    const refuse = async (refusal: StubRefusal, checkId: string | null): Promise<never> => {
+      if (opts.json) {
+        writeJsonStdout({ ok: false, stubId: id, status, checkId, refusal });
+      } else {
+        // WHAT it refused, how to check that for yourself, and the way
+        // forward. No fourth line offering a flag that skips the gate: there
+        // isn't one, and a refusal that hints at one teaches the bypass.
+        // Escaped at the printing line as well as at construction (#601).
+        // Every field is authored, and `registry-refused` splices a Registry
+        // body into `what` — already escaped where it enters, and escaping is
+        // idempotent, so the second pass costs nothing and keeps the property
+        // true on the line a reader checks it on.
+        process.stderr.write(`Refused: ${escapeForDisplay(refusal.what)}\n`);
+        process.stderr.write(`  Verify: ${escapeForDisplay(refusal.verify)}\n`);
+        process.stderr.write(`  Fix: ${escapeForDisplay(refusal.fix)}\n`);
+      }
+      return exitRecorded(EXIT_REFUSED, 'refused');
+    };
+
+    const apiKey = process.env.INTERNAL_API_KEY;
+    // Parity with pull-stubs (#253.4): a header value outside Latin-1 makes
+    // fetch() throw a raw internal ByteString exception.
+    if (apiKey) {
+      const badIndex = [...apiKey].findIndex(ch => ch.codePointAt(0)! > 0xff);
+      if (badIndex !== -1) {
+        await refuse({
+          code: 'api-key-not-latin1',
+          what: `INTERNAL_API_KEY contains a non-Latin1 character at index ${badIndex} and cannot be sent as an HTTP header.`,
+          verify: 'printf %s "$INTERNAL_API_KEY" | LC_ALL=C grep -n "[^ -~]"',
+          fix: 'Re-copy the key as plain ASCII: export INTERNAL_API_KEY=<your-key>',
+        }, opts.checkId ?? null);
+      }
+    }
+    if (!apiKey) {
+      await refuse({
+        code: 'api-key-missing',
+        what: 'INTERNAL_API_KEY is not set, and this command writes to the registry under it.',
+        verify: 'env | grep -c INTERNAL_API_KEY',
+        fix: 'export INTERNAL_API_KEY=<your-key>',
+      }, opts.checkId ?? null);
+      return;
+    }
+
+    const localRefusal = preflight({ stubId: id, status, reason: opts.reason, sourceCommit: opts.sourceCommit });
+    if (localRefusal) await refuse(localRefusal, opts.checkId ?? null);
+
+    const registryUrl = validateRegistryUrl(opts.registryUrl).replace(/\/+$/, '');
+    const collection = `${registryUrl}/internal/aria/hma-stubs`;
+    // NOT named `target`: the render-source gate reads that spelling as a
+    // filesystem path, and this is a registry URL. Renaming keeps the gate
+    // measuring what it is for instead of taking an exemption.
+    const stubEndpoint = `${collection}/${encodeURIComponent(id)}`;
+
+    /**
+     * Read the stub the registry already holds.
+     *
+     * Only when `--check-id` was not given: the flag names the check to probe,
+     * which is the ONLY thing this read supplies that the run cannot do
+     * without. That is what lets `--dry-run --check-id <id>` make zero HTTP
+     * calls while still running every gate.
+     */
+    let recorded: { id: string; checkId: string; status: string } | undefined;
+    if (!opts.checkId) {
+      try {
+        const controller = new AbortController();
+        const timeout = setTimeout(() => controller.abort(), 15_000);
+        const res = await fetch(collection, {
+          headers: { 'Authorization': `Bearer ${apiKey}`, 'Accept': 'application/json' },
+          signal: controller.signal,
+        });
+        clearTimeout(timeout);
+        if (res.status >= 500) {
+          process.stderr.write(`Not settled: the registry returned ${res.status} ${res.statusText} reading the stub; nothing was sent.\n`);
+          await exitRecorded(EXIT_NOT_SETTLED, 'unmeasured');
+        }
+        if (!res.ok) {
+          const body = await res.text().catch(() => '');
+          await refuse({
+            code: 'registry-rejected-read',
+            what: `The registry answered ${res.status} ${res.statusText} reading the stub list: ${escapeForDisplay(body.slice(0, 2000))}`,
+            verify: `${CLI_PREFIX} pull-stubs --json`,
+            fix: 'Resolve what the registry reported above, then re-run.',
+          }, null);
+        }
+        const listed = await res.json() as { stubs?: Array<{ id: string; checkId: string; status: string }> };
+        recorded = (listed.stubs ?? []).find(s => String(s.id) === id);
+      } catch (err: unknown) {
+        const cause = err instanceof Error && err.name === 'AbortError'
+          ? 'the read timed out after 15s'
+          : escapeForDisplay(err instanceof Error ? err.message : String(err));
+        process.stderr.write(`Not settled: could not reach the registry (${cause}); nothing was sent.\n`);
+        await exitRecorded(EXIT_NOT_SETTLED, 'unmeasured');
+        return;
+      }
+
+      if (!recorded) {
+        await refuse({
+          code: 'stub-not-found',
+          what: `The registry lists no stub with id ${escapeForDisplay(id)}, so there is nothing to transition.`,
+          verify: `${CLI_PREFIX} pull-stubs --all --json`,
+          fix: 'Take the Stub ID from a pull-stubs run against this same registry.',
+        }, null);
+      }
+    }
+
+    const checkId = opts.checkId ?? recorded!.checkId;
+
+    // Live data, so the heads-up is worth printing. Never a refusal — the
+    // registry owns the transition table (see `settledSourceWarning`).
+    if (recorded) {
+      const warning = settledSourceWarning(String(recorded.status), status);
+      // stderr on BOTH channels: a `--json` consumer that suppressed this
+      // would be the one reader most likely to be scripting the transition
+      // that triggers it, and stderr cannot corrupt the stdout document.
+      if (warning) process.stderr.write(`${warning}\n`);
+    }
+
+    let evidence: StubEvidence | undefined;
+    if (status === EVIDENCE_GATED_STATUS) {
+      const probeRefusal = probeReachability(String(checkId));
+      if (probeRefusal) await refuse(probeRefusal, String(checkId));
+      // `opts.sourceCommit` is non-null here: `preflight` refuses `integrated`
+      // without it, above, and nothing between reassigns it.
+      evidence = buildEvidence(String(checkId), opts.sourceCommit!);
+    }
+
+    const body = buildPatchBody({ status, reason: opts.reason, evidence });
+
+    if (opts.dryRun) {
+      if (opts.json) {
+        writeJsonStdout({ ok: true, stubId: id, status, checkId, evidence, reason: opts.reason, dryRun: true });
+      } else {
+        console.log(`Dry run — nothing was sent. PATCH ${escapeForDisplay(stubEndpoint)} would carry:`);
+        console.log(JSON.stringify(body, null, 2));
+      }
+      return;
+    }
+
+    try {
+      const controller = new AbortController();
+      const timeout = setTimeout(() => controller.abort(), 15_000);
+      const res = await fetch(stubEndpoint, {
+        method: 'PATCH',
+        headers: {
+          'Authorization': `Bearer ${apiKey}`,
+          'Accept': 'application/json',
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify(body),
+        signal: controller.signal,
+      });
+      clearTimeout(timeout);
+
+      if (res.status >= 500) {
+        process.stderr.write(`Not settled: the registry returned ${res.status} ${res.statusText}; whether the transition was recorded is unknown.\n`);
+        await exitRecorded(EXIT_NOT_SETTLED, 'incomplete');
+      }
+      if (!res.ok) {
+        const answer = await res.text().catch(() => '');
+        await refuse({
+          code: 'registry-refused',
+          what: `The registry refused the transition with ${res.status} ${res.statusText}: ${escapeForDisplay(answer.slice(0, 2000))}`,
+          verify: `${CLI_PREFIX} pull-stubs --all --json`,
+          fix: 'Resolve what the registry reported above, then re-run.',
+        }, String(checkId));
+      }
+    } catch (err: unknown) {
+      const cause = err instanceof Error && err.name === 'AbortError'
+        ? 'the request timed out after 15s'
+        : escapeForDisplay(err instanceof Error ? err.message : String(err));
+      process.stderr.write(`Not settled: the PATCH did not complete (${cause}); whether the transition was recorded is unknown.\n`);
+      await exitRecorded(EXIT_NOT_SETTLED, 'incomplete');
+      return;
+    }
+
+    if (opts.json) {
+      writeJsonStdout({ ok: true, stubId: id, status, checkId, evidence, reason: opts.reason });
+    } else {
+      console.log(`Recorded: stub ${escapeForDisplay(id)} is now "${escapeForDisplay(status)}".`);
+      if (evidence) {
+        console.log(`  Evidence: ${escapeForDisplay(evidence.checkId)} reachable in v${evidence.hmaVersion}, commit ${escapeForDisplay(evidence.sourceCommit)}`);
+      }
+    }
   });
 
 // create-skill: generate best-practice, secured skills from plain English

--- a/src/registry/stub-writeback.ts
+++ b/src/registry/stub-writeback.ts
@@ -1,0 +1,249 @@
+/**
+ * `mark-stub`'s honesty half — every decision that can refuse a write-back,
+ * and the evidence a recorded `integrated` carries.
+ *
+ * The CLI leg of DEFECT 2 in
+ * `todo/roadmap/hackmyagent-pull-stubs-status-vocabulary-mismatch.md`: nothing
+ * in HMA marked a stub integrated, so the observation -> shipped-check
+ * transition was manual and unaudited. The value of a write-back is entirely
+ * in whether the record it writes is TRUE, which is why the refusals live
+ * here rather than inline in `src/cli.ts` — a predicate that can only be
+ * exercised by spawning a binary is a predicate nobody adds a case to.
+ *
+ * The reachability probe reads `CHECK_METHOD_PREFIXES` and
+ * `UNREACHABLE_PREFIXES` out of the RUNNING build's coverage inventory — the
+ * same two tables `secure --json` reports from — rather than re-reading
+ * `src/` or carrying a copy of either list. `UNREACHABLE_PREFIXES` is the
+ * precedent the whole gate exists for: `CODEINJ`, `TMPPATH` and `ENVLEAK` are
+ * implemented, emit findings, are counted in the advertised static suite, and
+ * have no caller in `scanInner`, so a stub mapped to one of them would be
+ * recorded as a shipped check whose detector can never fire. A copied list
+ * would go stale the day one of them is wired in, and it would go stale
+ * SILENTLY, in the direction that over-claims.
+ *
+ * Nothing here reads a flag that could supply evidence. `hmaVersion` comes
+ * from the artifact's own `VERSION` and `reachable` is the probe's verdict,
+ * so the only fabricable field is `sourceCommit` — which is a claim about a
+ * repository the registry can check, not about this build.
+ */
+import { CHECK_METHOD_PREFIXES, UNREACHABLE_PREFIXES } from '../hardening/coverage-ledger';
+import { VERSION } from '../index';
+import { CLI_PREFIX } from '../cli-prefix';
+import { citationPath } from '../ui/shell-quote';
+import { escapeForDisplay } from '../ui/display-safe';
+
+/**
+ * A refusal, rendered as WHAT / Verify: / Fix: for a person and carried
+ * verbatim in the `--json` envelope for a machine.
+ *
+ * There is no fourth field offering a way past the refusal, and there is no
+ * flag that supplies one. A gate with a bypass is a gate that reports the
+ * number of people who found the bypass.
+ */
+export interface StubRefusal {
+  /** Stable machine code. Never derived from user input. */
+  code: string;
+  /** What was refused, and why it would not have been true. */
+  what: string;
+  /** A command the reader can run to check the claim for themselves. */
+  verify: string;
+  /** The way forward. Always the real remedy, never a bypass. */
+  fix: string;
+}
+
+/** The evidence an `integrated` transition carries. Every field is measured. */
+export interface StubEvidence {
+  checkId: string;
+  hmaVersion: string;
+  sourceCommit: string;
+  reachable: true;
+}
+
+/** The PATCH body, camelCase, exactly as it goes on the wire. */
+export interface StubPatchBody {
+  status: string;
+  reason?: string;
+  evidence?: StubEvidence;
+}
+
+/**
+ * `--source-commit` shape. Seven is git's own short-SHA floor and forty is a
+ * full SHA-1; anything outside that is not a commit the registry could
+ * resolve, so it is refused here rather than recorded and disbelieved later.
+ */
+export const SOURCE_COMMIT_SHAPE = /^[0-9a-fA-F]{7,40}$/;
+
+/**
+ * The two statuses this command gates on, named because the CPO ruling names
+ * them: `integrated` is the claim that a check SHIPPED, and `rejected` is the
+ * claim that a human decided against one. Both are assertions somebody will
+ * later be asked to defend.
+ *
+ * This is NOT a vocabulary check. Every other word — and these two — go to
+ * the registry verbatim; the registry owns which words are legal. These two
+ * only decide which local gate applies.
+ */
+export const EVIDENCE_GATED_STATUS = 'integrated';
+export const REASON_GATED_STATUS = 'rejected';
+
+/**
+ * Source states out of which a transition is obviously questionable.
+ *
+ * Used for a WARNING only. The registry is the authority on which
+ * transitions are legal — this exists so a fat-fingered re-run of an already
+ * settled stub says something before the request goes out, not so the CLI can
+ * hold an opinion the registry has to agree with.
+ */
+const SETTLED_SOURCE_STATES: ReadonlySet<string> = new Set(['integrated', 'rejected']);
+
+/**
+ * The longest prefix in `prefixes` that `checkId` belongs to, or null.
+ *
+ * Longest wins because the registered prefixes are not disjoint by spelling:
+ * `SKILL` and `SKILL-MEM` are both registered, and `SKILL-MEM-001` belongs to
+ * the second. A first-match walk credits it to `SKILL`, which is a different
+ * category with a different method behind it.
+ */
+export function checkIdPrefix(checkId: string, prefixes: readonly string[]): string | null {
+  let best: string | null = null;
+  for (const prefix of prefixes) {
+    if (checkId !== prefix && !checkId.startsWith(`${prefix}-`)) continue;
+    if (best === null || prefix.length > best.length) best = prefix;
+  }
+  return best;
+}
+
+/**
+ * Every check-ID prefix a registered `check*` method in THIS build emits.
+ *
+ * `CHECK_METHOD_PREFIXES` only — deliberately NOT widened with
+ * `SEMANTIC_PREFIXES`. The semantic layer is not a `check*` method and its
+ * evidence enters the rollup through a different door, so this probe cannot
+ * say from the inventory alone that a `SEM-*` / `AST-*` id is called. A stub
+ * carrying one is therefore refused as absent rather than recorded on a
+ * lookup that proves nothing — a refusal in the honest direction, and one a
+ * later unit can lift by proving the semantic side the same way.
+ */
+export function reachablePrefixes(): string[] {
+  return [...new Set(Object.values(CHECK_METHOD_PREFIXES).flat())].sort();
+}
+
+/**
+ * In-process reachability probe against the running build's inventory.
+ *
+ * Returns the refusal, or null when the check ID names a family this build
+ * both ships and calls.
+ */
+export function probeReachability(checkId: string): StubRefusal | null {
+  const shown = escapeForDisplay(checkId);
+  const unreachable = checkIdPrefix(checkId, UNREACHABLE_PREFIXES);
+  if (unreachable) {
+    return {
+      code: 'check-unreachable',
+      what:
+        `${shown} belongs to the ${escapeForDisplay(unreachable)} family, which this build (v${VERSION}) `
+        + 'counts in its advertised suite and never calls. The detector cannot fire, so "integrated" '
+        + 'would not be a true statement about this artifact.',
+      verify: `${CLI_PREFIX} secure . --json   (the coverage block names this family under unreachableCheckPrefixes)`,
+      fix: 'Wire the check into the scan orchestration, publish that build, and record the transition from it.',
+    };
+  }
+  if (!checkIdPrefix(checkId, reachablePrefixes())) {
+    return {
+      code: 'check-absent',
+      what:
+        `No check method in this build (v${VERSION}) registers a prefix for ${shown}, so this artifact `
+        + 'cannot show that the check exists at all.',
+      verify: `${CLI_PREFIX} check-metadata --json   (the check catalogue this build ships)`,
+      fix: 'Record the transition from a build that ships the check, or correct the check ID the stub carries.',
+    };
+  }
+  return null;
+}
+
+/**
+ * Every local gate, in the order a reader would apply them.
+ *
+ * Runs before any request is built, so a refusable invocation never reaches
+ * the network — including under `--dry-run`, where the refusal IS the answer.
+ */
+export function preflight(input: {
+  stubId: string;
+  status: string;
+  reason?: string;
+  sourceCommit?: string;
+}): StubRefusal | null {
+  const citedId = citationPath(input.stubId) ?? '<stub-id>';
+  if (input.sourceCommit !== undefined && !SOURCE_COMMIT_SHAPE.test(input.sourceCommit)) {
+    return {
+      code: 'source-commit-shape',
+      what:
+        '--source-commit must be 7 to 40 hexadecimal characters (a git short SHA or a full one); '
+        + `got ${escapeForDisplay(input.sourceCommit)}.`,
+      verify: 'git rev-parse HEAD',
+      fix: `${CLI_PREFIX} mark-stub ${citedId} integrated --source-commit <7-40 hex>`,
+    };
+  }
+  if (input.status === EVIDENCE_GATED_STATUS && !input.sourceCommit) {
+    return {
+      code: 'source-commit-required',
+      what:
+        'Recording "integrated" claims a check shipped, and the commit that carries it is the part '
+        + 'of that claim this build cannot derive for itself.',
+      verify: 'git rev-parse HEAD',
+      fix: `${CLI_PREFIX} mark-stub ${citedId} integrated --source-commit <7-40 hex>`,
+    };
+  }
+  if (input.status === REASON_GATED_STATUS && !input.reason) {
+    return {
+      code: 'reason-required',
+      what:
+        'Recording "rejected" closes a confirmed observation, and a closed observation with no '
+        + 'recorded reason cannot be reviewed or reopened by anyone later.',
+      verify: `${CLI_PREFIX} pull-stubs --status rejected --json`,
+      fix: `${CLI_PREFIX} mark-stub ${citedId} rejected --reason "<why this stub is not becoming a check>"`,
+    };
+  }
+  return null;
+}
+
+/**
+ * The warning for a transition out of an already-settled source state.
+ *
+ * Returns null when there is nothing to say. Deliberately NOT a refusal: the
+ * registry owns the transition table, and a CLI that refuses on its own
+ * reading of it is a second vocabulary — the exact defect the pull-stubs half
+ * of this unit deletes.
+ */
+export function settledSourceWarning(from: string, to: string): string | null {
+  if (!SETTLED_SOURCE_STATES.has(from) || from === to) return null;
+  return (
+    `Warning: the registry records this stub as "${escapeForDisplay(from)}" and this would move it to `
+    + `"${escapeForDisplay(to)}". The registry decides which transitions are legal — this is a heads-up `
+    + 'before the request goes out, not a verdict, and it will answer for itself.'
+  );
+}
+
+/**
+ * The evidence for an `integrated` transition.
+ *
+ * `hmaVersion` is the running artifact's own version and `reachable` is the
+ * probe's verdict; neither is reachable from the option surface. Call only
+ * after `probeReachability` has returned null for this same `checkId` — the
+ * `reachable: true` literal is what that call earns.
+ */
+export function buildEvidence(checkId: string, sourceCommit: string): StubEvidence {
+  return { checkId, hmaVersion: VERSION, sourceCommit, reachable: true };
+}
+
+/** The exact PATCH body, with absent fields omitted rather than sent as null. */
+export function buildPatchBody(input: {
+  status: string;
+  reason?: string;
+  evidence?: StubEvidence;
+}): StubPatchBody {
+  const body: StubPatchBody = { status: input.status };
+  if (input.reason) body.reason = input.reason;
+  if (input.evidence) body.evidence = input.evidence;
+  return body;
+}


### PR DESCRIPTION
CLI half of the pull-stubs status-vocabulary fix (the registry half — migration, server-side ?status= filter, evidence-gated PATCH — ships separately; all tests here run against a mocked registry so the legs land independently).

- **pull-stubs**: the client-side `validStatuses` list and post-fetch `.filter()` are deleted — the `--status` value goes through verbatim and a registry 400 (which carries the allowed set) renders near-verbatim. Stub ID now leads each stub in the formatted output; the summary names the next step; new `--all` omits the server-side `?status=` param entirely.
- **new `mark-stub <id> <status>`**: records a stub lifecycle transition. `--reason` required preflight for `rejected`; `--source-commit` (7-40 hex) required for `integrated`; `--check-id` override (default: the stub's own recorded checkId); `--dry-run` runs every preflight plus the reachability probe, prints the exact PATCH body, and sends nothing; `--registry-url`/`--json` in parity with pull-stubs.
- **Evidence is honest by construction**: `hmaVersion` comes only from the running artifact; reachability is probed in-process against the built module's own coverage inventory (an UNREACHABLE_PREFIXES-class check cannot be attested as integrated); no manual evidence flag exists.
- **Exit codes**: 0 recorded / 1 refused (preflight, probe, 4xx) / 2 not settled (timeout, network, 5xx). Refusals render WHAT + Verify + Fix with no bypass flag.
- release-playbook gains the pre-tag `--dry-run` step and the post-publish send from the released artifact.

Full suite 372/372 files green; independent blind QA verified all seven acceptance criteria on a byte-identical tree (records in the internal ledger).