### PR TITLE
Redact credential values at the producer, and prove it with a matrix that cannot pass vacuously

### DIFF
--- a/__tests__/cli/hma15-credential-render-property.test.ts
+++ b/__tests__/cli/hma15-credential-render-property.test.ts
@@ -1,0 +1,220 @@
+/**
+ * HMA-15.AC3 — the credential-byte render class, closed across the full
+ * matrix and held closed by property rather than by producer.
+ *
+ * Runtime-minted synthetic values are planted in a fixture of EVERY
+ * ArtifactType the classifier can return — one COVERED control the report
+ * boundary removes, and one UNCOVERED value it provably does not (HMA-15.AC5
+ * r2) — BOTH user-facing commands run over each fixture tree (`secure` in its
+ * five non-benchmark output formats: text, json, sarif, html, asff; `check`
+ * in its two: default text, `--json`), and every cell asserts that no byte of
+ * stdout, no byte of an `-o` output file, and no string leaf of the emitted
+ * JSON holds a contiguous run of ANY planted value longer than that cell's
+ * own measured noise floor (HMA-15.AC4: at least 200 never-planted values
+ * drawn per planted form family, the maximum of their runs in the same output
+ * IS the threshold — no literal).
+ *
+ * THE UNCOVERED PREDICATE IS PROVEN IN THIS RUN (HMA-15.AC5 r2): for every
+ * fixture, `redactSecretsForReport` is called on the exact planted lines —
+ * the uncovered probe must come back UNCHANGED (the day a shape rule covers
+ * that form, this fails and forces a new form: a predicate, not a list) and
+ * the covered probe must come back CHANGED with its value gone (the control
+ * that a future fix did not delete the boundary). The r1 matrix planted only
+ * covered shapes and passed 73/73 on a build rendering a complete credential.
+ *
+ * Two ordered gates per cell (HMA-15.AC5): the cell must DETECT (produce at
+ * least one credential-class finding) before non-render is asserted, and an
+ * unreached cell FAILS the run naming itself.
+ *
+ * THIS SUITE NEVER SKIPS (HMA-15.AC11, CISO Binding Decision 12): a security
+ * gate that skips is a failing gate. `release.yml` — the tag-triggered
+ * publish workflow — runs `npm test`, and under the r1 `describe.skipIf`
+ * guard this matrix executed ZERO cells at the exact moment of publish. A
+ * precondition the matrix needs and cannot find (the built CLI) is an ERROR:
+ * the first assertion below fails naming the missing artifact, and every cell
+ * after it fails rather than skipping.
+ *
+ * PRODUCER-AGNOSTIC (HMA-15.AC6): the harness imports nothing from `src/`;
+ * this file imports exactly ONE src symbol — `redactSecretsForReport`, the
+ * redaction boundary the AC5 r2 predicate is required to interrogate in the
+ * same run. No semantic-compiler internal, no producer function, no check id.
+ * The tool is exercised exclusively through the built CLI at `dist/cli.js`
+ * (override with HMA15_CLI to point the SAME unmodified test at another
+ * build — the AC10 verifier runs it against the pre-fix baseline and must
+ * see this file go red).
+ *
+ * The run artifact (HMA-15.AC3/AC5/AC9/AC10 evidence) records the exercised
+ * CLI's path, its sha256, and the sha256 of the WHOLE dist tree (AC10 r2:
+ * cli.js alone hashes identical across the builds this test distinguishes);
+ * per fixture, the planted forms and boundary-predicate outcomes; per cell,
+ * exit code, detection, the credential-class finding count (the AC9
+ * not-narrowed comparison reads these against the same fixtures on the
+ * pre-fix baseline), the measured floor, and the planted runs by kind. Its
+ * default location is an OS temp dir, printed at the end of the run; QA pins
+ * it with HMA15_RUN_ARTIFACT.
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { existsSync, rmSync } from 'node:fs';
+import { mkdtempSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { assertDistFreshIfPresent } from '../helpers/dist-freshness';
+import { redactSecretsForReport } from '../../src/nanomind-core/security/defense-in-depth';
+import {
+  CELL_ARTIFACT_TYPES,
+  type CellEvaluation,
+  type Fixture,
+  type FixtureEvidence,
+  allCellSpecs,
+  assessMatrix,
+  evaluateCell,
+  formatCellFailure,
+  mintNullControl,
+  runArtifactPath,
+  runCliCell,
+  sha256Dir,
+  sha256File,
+  writeFixtureTree,
+  writeRunArtifact,
+} from '../helpers/hma15-render-harness';
+
+const REPO_ROOT = join(__dirname, '..', '..');
+const CLI = process.env.HMA15_CLI ?? join(REPO_ROOT, 'dist', 'cli.js');
+const usingDefaultCli = process.env.HMA15_CLI === undefined;
+
+interface FixtureState {
+  treeDir: string;
+  fixture: Fixture;
+}
+
+const fixtures = new Map<(typeof CELL_ARTIFACT_TYPES)[number], FixtureState>();
+const fixtureEvidence: FixtureEvidence[] = [];
+const evaluations: CellEvaluation[] = [];
+let scratch = '';
+const startedAt = new Date().toISOString();
+
+beforeAll(() => {
+  // A stale build would measure code that is no longer under test. Only
+  // enforced for this tree's own dist — an HMA15_CLI override deliberately
+  // points at a DIFFERENT tree's build (the AC10 baseline run). A MISSING
+  // dist is not handled here at all: the first test below fails on it,
+  // because a missing precondition is an error, never a skip (HMA-15.AC11).
+  if (usingDefaultCli) assertDistFreshIfPresent();
+  scratch = mkdtempSync(join(tmpdir(), 'hma15-scratch-'));
+  for (const artifactType of CELL_ARTIFACT_TYPES) {
+    const { treeDir, fixture } = writeFixtureTree(artifactType);
+    fixtures.set(artifactType, { treeDir, fixture });
+    // The AC5 r2 predicate, against the real boundary, in this run.
+    const covered = fixture.planted.filter((p) => p.kind === 'covered');
+    const uncovered = fixture.planted.filter((p) => p.kind === 'uncovered');
+    const coveredRemoved = covered.every((p) => {
+      const out = redactSecretsForReport(p.probe);
+      return out !== p.probe && !out.includes(p.value);
+    });
+    const uncoveredUnchanged = uncovered.every((p) => redactSecretsForReport(p.probe) === p.probe);
+    fixtureEvidence.push({
+      artifactType,
+      plantedForms: fixture.planted.map((p) => ({ kind: p.kind, form: p.form })),
+      boundary: { coveredRemoved, uncoveredUnchanged },
+    });
+  }
+});
+
+afterAll(() => {
+  const artifactPath = runArtifactPath();
+  writeRunArtifact(artifactPath, {
+    task: 'HMA-15',
+    startedAt,
+    finishedAt: new Date().toISOString(),
+    cli: {
+      path: CLI,
+      sha256: existsSync(CLI) ? sha256File(CLI) : 'missing',
+      distTreeSha256: existsSync(dirname(CLI)) ? sha256Dir(dirname(CLI)) : 'missing',
+    },
+    fixtures: fixtureEvidence,
+    cells: evaluations,
+    verdict: {
+      ok: assessMatrix(evaluations).ok,
+      failedCells: assessMatrix(evaluations).failures.map((f) => f.cell),
+    },
+  });
+  // Path only — the artifact itself carries kinds, forms, lengths and hashes,
+  // never values.
+  console.log(`HMA-15 run artifact: ${artifactPath}`);
+  for (const { treeDir } of fixtures.values()) {
+    rmSync(treeDir, { recursive: true, force: true });
+  }
+  if (scratch) rmSync(scratch, { recursive: true, force: true });
+});
+
+describe('HMA-15.AC3 credential-byte render property matrix', () => {
+  it('HMA-15.AC11 the built CLI precondition holds — a miss is this failure, never a skip', () => {
+    expect(existsSync(CLI), `built CLI missing at ${CLI} — build before testing; this gate does not skip`).toBe(true);
+    expect(sha256File(CLI)).toMatch(/^[0-9a-f]{64}$/);
+    // AC10 r2: identity is the whole tree, not one file that never changes.
+    expect(sha256Dir(dirname(CLI))).toMatch(/^[0-9a-f]{64}$/);
+  });
+
+  it('HMA-15.AC5 every fixture proves its uncovered plant against the boundary, in this run', () => {
+    expect(fixtureEvidence.length).toBe(CELL_ARTIFACT_TYPES.length);
+    for (const evidence of fixtureEvidence) {
+      expect(
+        evidence.boundary.uncoveredUnchanged,
+        `${evidence.artifactType}: an uncovered probe came back CHANGED from redactSecretsForReport — ` +
+          `the boundary now covers this form; the predicate demands a form it does not remove`,
+      ).toBe(true);
+      expect(
+        evidence.boundary.coveredRemoved,
+        `${evidence.artifactType}: the covered control was NOT removed by redactSecretsForReport — ` +
+          `the boundary this matrix controls for is gone`,
+      ).toBe(true);
+    }
+  });
+
+  it('HMA-15.AC5 the minimum uncovered set is planted across the matrix', () => {
+    const uncoveredForms = new Set(
+      fixtureEvidence.flatMap((e) => e.plantedForms.filter((p) => p.kind === 'uncovered').map((p) => p.form)),
+    );
+    for (const form of ['jwt', 'entropy-blob', 'json-quoted-token', 'yaml-unquoted-token', 'env-unquoted-token']) {
+      expect(uncoveredForms.has(form as never), `uncovered form ${form} is planted nowhere in the matrix`).toBe(true);
+    }
+  });
+
+  for (const spec of allCellSpecs()) {
+    it(`HMA-15.AC3 ${spec.cell} holds no planted run above its measured floor`, () => {
+      const state = fixtures.get(spec.artifactType)!;
+      const output = runCliCell(CLI, spec, state.treeDir, scratch);
+      const nulls = mintNullControl(state.fixture.planted);
+      const evaluation = evaluateCell(spec, output, state.fixture.planted, nulls);
+      evaluations.push(evaluation);
+      // Both gates, in order, through the harness's own formatter — which is
+      // pinned elsewhere to emit no byte of any planted value (HMA-15.AC7).
+      expect(evaluation.status, formatCellFailure(evaluation)).toBe('pass');
+    });
+  }
+
+  it('HMA-15.AC5 every cell of the matrix was reached — none skipped silently', () => {
+    // 10 artifact types x (5 secure formats + 2 check formats). A cell that
+    // never even ran (crashed before evaluation) must fail the run exactly
+    // like an unreached one.
+    expect(evaluations.length).toBe(CELL_ARTIFACT_TYPES.length * 7);
+    const unreached = evaluations.filter((e) => !e.detected).map((e) => e.cell);
+    expect(unreached, `cells with no credential-class finding: ${unreached.join(', ')}`).toEqual([]);
+  });
+
+  it('HMA-15.AC9 machine cells record credential-class finding counts for the baseline comparison', () => {
+    // The not-narrowed half of AC9 is a two-build comparison the verifier
+    // performs against the pre-fix baseline using these recorded counts; the
+    // floor asserted here is that every countable cell counted at least one,
+    // so the recorded numbers can never satisfy ">= baseline" vacuously.
+    const countable = evaluations.filter((e) => e.credentialFindingCount >= 0);
+    expect(countable.length).toBeGreaterThan(0);
+    for (const e of countable) {
+      expect(
+        e.credentialFindingCount,
+        `${e.cell} recorded no countable credential-class finding`,
+      ).toBeGreaterThan(0);
+    }
+  });
+});

--- a/__tests__/hardening/hma15-shipped-declaration-claims.test.ts
+++ b/__tests__/hardening/hma15-shipped-declaration-claims.test.ts
@@ -1,0 +1,161 @@
+/**
+ * HMA-15.AC12 — no shipped type declaration asserts a redaction guarantee
+ * that measurement does not support.
+ *
+ * A `.d.ts` renders in the consumer's editor at the moment they use the
+ * field, so it outranks a README. The r1 delivery would have published
+ * "emitFinding redacts it IN FULL and derives `redactionStatus`/
+ * `redactedShapes` from that actual removal" into `capability-analyzer.d.ts`
+ * — measured FALSE for every shape the redactor's table does not cover.
+ * Precedent: the secretless-ai `grant-policy.d.ts` "Enforced in v1." claim.
+ *
+ * Mechanism: `npm pack` the artifact exactly as a release would, extract it,
+ * and grep the extracted dist's declaration files. Two layers:
+ *
+ *   1. The measured-false r1 claim family must be ABSENT everywhere.
+ *   2. Any OTHER guarantee-strength redaction claim must appear in the
+ *      allowlist below, where each entry NAMES the committed measurement
+ *      backing it — and the test asserts that measurement file exists. A new
+ *      strong claim without a measurement fails here, which is the point:
+ *      wording it down or measuring it are the only ways to ship it.
+ *
+ * A precondition this gate needs and cannot find — an unbuilt tree, a pack
+ * with no declarations — is an ERROR, never a skip (HMA-15.AC11, CISO
+ * Binding Decision 12).
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { spawnSync } from 'node:child_process';
+import { existsSync, mkdtempSync, readdirSync, readFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+const REPO_ROOT = join(__dirname, '..', '..');
+
+/**
+ * Guarantee-strength redaction claims. Deliberately narrow: ordinary
+ * descriptive uses of "redact" (what a function does, which marker a shape
+ * maps to, what a status VALUE means) are not guarantees. What this hunts is
+ * the absolute form — the wording that tells a consumer they need no other
+ * control.
+ */
+const STRONG_CLAIM_PATTERNS: readonly RegExp[] = [
+  /redact\w*[^.\n]{0,60}\bin full\b/i,
+  /\bin full\b[^.\n]{0,60}redact\w*/i,
+  /derives?[^.\n]{0,80}redactionStatus[^.\n]{0,120}actual removal/is,
+  // Adjacency, not proximity: "always redacts" is a guarantee; "stamp the
+  // two always-present fields" is a sentence that happens to contain both
+  // words. The first draft of this list used a 60-char proximity window and
+  // flagged exactly that benign line in finding-emit.d.ts.
+  /\balways\s+redact/i,
+  /redact\w*\s+(?:always|everything|all\s+shapes)\b/i,
+  /guarantee[ds]?\s+(?:that\s+)?[^.\n]{0,40}redact/i,
+  /redact\w*[^.\n]{0,30}\bguarantee[ds]?\b(?!\s+point)/i,
+  /\b(?:never|cannot)\s+leak/i,
+  /Enforced in v\d/,
+];
+
+/**
+ * Strong claims that ARE allowed to ship, each backed by a named committed
+ * measurement. Empty today — the r2 wording states mechanisms and recorded
+ * facts, not guarantees — and an addition here must name the test that
+ * measures the claim, which the assertion below requires to exist.
+ */
+const MEASURED_CLAIM_ALLOWLIST: readonly {
+  file: RegExp;
+  claim: RegExp;
+  measurement: string;
+}[] = [];
+
+let packDir = '';
+let declarationFiles: string[] = [];
+
+function walkDts(dir: string, out: string[]): void {
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    const p = join(dir, entry.name);
+    if (entry.isDirectory()) walkDts(p, out);
+    else if (entry.isFile() && entry.name.endsWith('.d.ts')) out.push(p);
+  }
+}
+
+beforeAll(() => {
+  packDir = mkdtempSync(join(tmpdir(), 'hma15-pack-'));
+  const pack = spawnSync('npm', ['pack', '--silent', '--pack-destination', packDir], {
+    cwd: REPO_ROOT,
+    encoding: 'utf8',
+    timeout: 170_000,
+    maxBuffer: 16 * 1024 * 1024,
+  });
+  if (pack.status !== 0) {
+    throw new Error(`npm pack failed (exit ${pack.status}): ${pack.stderr}`);
+  }
+  const tgz = pack.stdout.trim().split('\n').pop() ?? '';
+  const tgzPath = join(packDir, tgz);
+  if (!existsSync(tgzPath)) throw new Error(`npm pack produced no tarball at ${tgzPath}`);
+  const tar = spawnSync('tar', ['-xzf', tgzPath, '-C', packDir], {
+    encoding: 'utf8',
+    timeout: 170_000,
+  });
+  if (tar.status !== 0) throw new Error(`tar extraction failed: ${tar.stderr}`);
+  const distDir = join(packDir, 'package', 'dist');
+  // ERROR, never a skip: a pack with no declarations means the gate cannot
+  // see what would ship, which is a failing precondition of the gate.
+  if (!existsSync(distDir)) {
+    throw new Error('packed artifact carries no dist/ — build before testing; this gate does not skip');
+  }
+  walkDts(distDir, declarationFiles);
+});
+
+afterAll(() => {
+  if (packDir) rmSync(packDir, { recursive: true, force: true });
+});
+
+describe('HMA-15.AC12 shipped declaration claims', () => {
+  it('HMA-15.AC12 the packed artifact ships type declarations to audit', () => {
+    expect(declarationFiles.length, 'no .d.ts in the packed dist — nothing was audited').toBeGreaterThan(0);
+  });
+
+  it('HMA-15.AC12 the measured-false r1 claim ships nowhere', () => {
+    // The named instance, checked by content rather than by file name, so a
+    // moved declaration cannot carry it back in.
+    const r1Claim = /redacts it IN FULL|from\s+that actual removal/i;
+    for (const file of declarationFiles) {
+      const text = readFileSync(file, 'utf8');
+      expect(
+        r1Claim.test(text),
+        `${file.slice(packDir.length)} still ships the r1 claim measured false on 2026-08-31`,
+      ).toBe(false);
+    }
+  });
+
+  it('HMA-15.AC12 every guarantee-strength redaction claim in shipped declarations is measured', () => {
+    const unmeasured: string[] = [];
+    for (const file of declarationFiles) {
+      const rel = file.slice(packDir.length);
+      const text = readFileSync(file, 'utf8');
+      for (const pattern of STRONG_CLAIM_PATTERNS) {
+        const match = pattern.exec(text);
+        if (!match) continue;
+        const allowed = MEASURED_CLAIM_ALLOWLIST.some(
+          (entry) => entry.file.test(rel) && entry.claim.test(match[0]),
+        );
+        if (!allowed) {
+          unmeasured.push(`${rel}: ${JSON.stringify(match[0].slice(0, 120))}`);
+        }
+      }
+    }
+    expect(
+      unmeasured,
+      'guarantee-strength redaction claims with no named measurement — measure them or word them down',
+    ).toEqual([]);
+  });
+
+  it('HMA-15.AC12 every allowlisted claim names a measurement that exists', () => {
+    for (const entry of MEASURED_CLAIM_ALLOWLIST) {
+      expect(
+        existsSync(join(REPO_ROOT, entry.measurement)),
+        `allowlist entry ${entry.claim} names a measurement that does not exist: ${entry.measurement}`,
+      ).toBe(true);
+    }
+  });
+});

--- a/__tests__/harness/hma15-harness-honesty.test.ts
+++ b/__tests__/harness/hma15-harness-honesty.test.ts
@@ -1,0 +1,262 @@
+/**
+ * HMA-15.AC4 / AC5 / AC7 — the property harness is honest about itself.
+ *
+ * The property test's power rests on claims about the HARNESS, not the
+ * scanner, and each is proven here by driving the exported evaluation logic
+ * with stubbed cell output:
+ *
+ *   AC4 — the render threshold is the measured null-control maximum, computed
+ *   per run. Same output, same planted value, different null control ⇒
+ *   different verdict; and the gate-two comparison in the source is pinned to
+ *   the measured floor, with no numeric literal in its place.
+ *
+ *   AC5 — a cell that yields zero credential-class findings is UNREACHABLE
+ *   and fails the run naming the cell, instead of passing vacuously; value
+ *   construction is pinned per form family; and (r2) every fixture plants a
+ *   covered control AND an uncovered value, with the minimum uncovered set
+ *   present across the matrix. The boundary predicate itself — uncovered
+ *   probes UNCHANGED by `redactSecretsForReport`, covered probes changed —
+ *   is asserted in the property run, against the real boundary, because a
+ *   copy of the boundary here would be the table-trusting design r2 rejects.
+ *
+ *   AC7 — the failure formatter emits the cell name, the surface, the
+ *   planted KIND, and observed run LENGTHS — and can never emit a byte of
+ *   any planted value, covered or uncovered.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import {
+  type CellSpec,
+  type PlantedValue,
+  CELL_ARTIFACT_TYPES,
+  assessMatrix,
+  buildFixture,
+  evaluateCell,
+  formatCellFailure,
+  longestSharedRun,
+  mintJwtValue,
+  mintNullControl,
+  mintSyntheticValue,
+  NULL_CONTROL_DRAWS,
+} from '../helpers/hma15-render-harness';
+
+const TEXT_SPEC: CellSpec = {
+  cell: 'unknown/secure/text',
+  artifactType: 'unknown',
+  command: 'secure',
+  format: 'text',
+  jsonOutput: false,
+};
+
+const JSON_SPEC: CellSpec = {
+  cell: 'unknown/secure/json',
+  artifactType: 'unknown',
+  command: 'secure',
+  format: 'json',
+  jsonOutput: true,
+};
+
+function planted(value: string, kind: PlantedValue['kind'] = 'covered'): PlantedValue {
+  return { kind, form: kind === 'covered' ? 'name-gated-quoted' : 'entropy-blob', value, probe: value };
+}
+
+/** A stub output whose only credential vocabulary is tool-authored. */
+function detectedOutput(stdout: string) {
+  return { exitCode: 1, stdout, stderr: '' };
+}
+
+describe('HMA-15 harness honesty', () => {
+  it('HMA-15.AC5 the planted value construction is pinned, not left to chance', () => {
+    for (let i = 0; i < 100; i++) {
+      const v = mintSyntheticValue();
+      // Exactly 40 — the one length the name-gated detector can see; longer
+      // is never detected at all and would green every assertion vacuously.
+      expect(v).toMatch(/^[A-Za-z0-9]{40}$/);
+      expect(v).not.toMatch(/FAKE|EXAMPLE|PLACEHOLDER|DUMMY|REPLACE|INSERT|TEST|SAMPLE|XXX|CRED/i);
+      expect(new Set(v).size).toBeGreaterThan(6);
+    }
+    for (let i = 0; i < 100; i++) {
+      const j = mintJwtValue();
+      // The exact three-segment base64url geometry the JWT scan accepts.
+      expect(j).toMatch(/^eyJ[A-Za-z0-9_-]{17}\.[A-Za-z0-9_-]{24}\.[A-Za-z0-9_-]{21}$/);
+      expect(j).not.toMatch(/FAKE|EXAMPLE|PLACEHOLDER|DUMMY|REPLACE|INSERT|TEST|SAMPLE|XXX|CRED/i);
+    }
+  });
+
+  it('HMA-15.AC5 every fixture plants a covered control and an uncovered value, with probe lines (r2)', () => {
+    const uncoveredForms = new Set<string>();
+    for (const artifactType of CELL_ARTIFACT_TYPES) {
+      const fixture = buildFixture(artifactType);
+      const kinds = new Set(fixture.planted.map((p) => p.kind));
+      expect(kinds.has('covered'), `${artifactType}: no covered control planted`).toBe(true);
+      expect(kinds.has('uncovered'), `${artifactType}: no uncovered value planted`).toBe(true);
+      for (const p of fixture.planted) {
+        expect(p.probe.includes(p.value), `${artifactType}/${p.kind}: probe line misses its value`).toBe(true);
+        expect(fixture.content.includes(p.probe), `${artifactType}/${p.kind}: probe is not a fixture line`).toBe(true);
+        if (p.kind === 'uncovered') uncoveredForms.add(p.form);
+      }
+    }
+    // The measured minimum uncovered set (2026-08-31), present ACROSS the
+    // matrix: the quoting axis and the two table-omitted shapes.
+    for (const form of ['jwt', 'entropy-blob', 'json-quoted-token', 'yaml-unquoted-token', 'env-unquoted-token']) {
+      expect(uncoveredForms.has(form), `uncovered form ${form} planted nowhere`).toBe(true);
+    }
+  });
+
+  it('HMA-15.AC4 the threshold is the measured null-control maximum of the same output', () => {
+    const value = mintSyntheticValue();
+    // The output carries a 5-character fragment of the planted value beside
+    // tool-authored credential vocabulary (gate one), and nothing else of it.
+    const output = detectedOutput('Credential Security !!! ' + value.slice(0, 5));
+
+    // Null control A: one value sharing exactly that same 5-char window with
+    // the output — its measured run is >= 5, so the floor absorbs the
+    // planted fragment and the cell passes.
+    const nullHigh = value.slice(0, 5) + mintSyntheticValue().slice(5);
+    const passEval = evaluateCell(TEXT_SPEC, output, [planted(value)], [nullHigh]);
+    expect(passEval.plantedRun).toBeGreaterThanOrEqual(5);
+    expect(passEval.nullFloor).toBeGreaterThanOrEqual(5);
+    expect(passEval.status).toBe('pass');
+
+    // Null control B: a value measurably sharing LESS than 5 with the output.
+    // Identical output, identical planted value — only the null control
+    // moved, and the verdict flips. The threshold therefore came from the
+    // null control, not from any constant.
+    let nullLow = mintSyntheticValue();
+    while (longestSharedRun([nullLow], output.stdout) >= 5) nullLow = mintSyntheticValue();
+    const redEval = evaluateCell(TEXT_SPEC, output, [planted(value)], [nullLow]);
+    expect(redEval.plantedRun).toBe(passEval.plantedRun);
+    expect(redEval.nullFloor).toBeLessThan(5);
+    expect(redEval.status).toBe('rendered');
+  });
+
+  it('HMA-15.AC4 the gate-two comparison is the measured floor — no numeric literal threshold', () => {
+    const src = readFileSync(join(__dirname, '..', 'helpers', 'hma15-render-harness.ts'), 'utf8');
+    // The assertion the whole matrix hangs on, pinned by source: the planted
+    // run is compared against the measured floor variable...
+    expect(src).toContain('plantedRun > nullFloor');
+    // ...and never against a number.
+    expect(src).not.toMatch(/plantedRun\s*>\s*\d/);
+    expect(src).not.toMatch(/plantedRun\s*>=\s*\d/);
+  });
+
+  it('HMA-15.AC4 the null control draws at least 200 values per planted form family', () => {
+    expect(NULL_CONTROL_DRAWS).toBeGreaterThanOrEqual(200);
+    const blobOnly = [planted(mintSyntheticValue())];
+    const blobNulls = mintNullControl(blobOnly);
+    expect(blobNulls.length).toBeGreaterThanOrEqual(NULL_CONTROL_DRAWS);
+    expect(blobNulls).not.toContain(blobOnly[0].value);
+
+    const withJwt = [planted(mintSyntheticValue()), { ...planted(mintJwtValue(), 'uncovered'), form: 'jwt' as const }];
+    const jwtNulls = mintNullControl(withJwt);
+    // A family the fixture plants draws its own 200 — a jwt's `eyJ` prefix
+    // and dot geometry must land in the floor, not read as planted material.
+    expect(jwtNulls.length).toBeGreaterThanOrEqual(2 * NULL_CONTROL_DRAWS);
+    expect(jwtNulls.some((v) => v.startsWith('eyJ'))).toBe(true);
+    for (const p of withJwt) expect(jwtNulls).not.toContain(p.value);
+  });
+
+  it('HMA-15.AC5 a cell with zero credential-class findings is UNREACHABLE and fails the run', () => {
+    const values = [planted(mintSyntheticValue())];
+    const nulls = mintNullControl(values);
+
+    // Unstructured cell whose output carries no credential-class vocabulary.
+    const textEval = evaluateCell(
+      TEXT_SPEC,
+      { exitCode: 0, stdout: 'Scan complete. 0 issues.\n', stderr: '' },
+      values,
+      nulls,
+    );
+    expect(textEval.status).toBe('unreachable');
+    expect(textEval.detected).toBe(false);
+
+    // Structured cell whose JSON parses but holds zero credential-class
+    // findings — the exact shape of a scan that silently never looked.
+    const jsonEval = evaluateCell(
+      JSON_SPEC,
+      {
+        exitCode: 0,
+        stdout: '',
+        stderr: '',
+        outputFile: JSON.stringify({ findings: [{ checkId: 'X', category: 'network' }] }),
+      },
+      values,
+      nulls,
+    );
+    expect(jsonEval.status).toBe('unreachable');
+
+    // The run verdict over a matrix containing an unreached cell is FAILURE,
+    // and the failure names the cell.
+    const verdict = assessMatrix([textEval, jsonEval]);
+    expect(verdict.ok).toBe(false);
+    expect(verdict.failures.map((f) => f.cell)).toContain(TEXT_SPEC.cell);
+    expect(formatCellFailure(textEval)).toContain(TEXT_SPEC.cell);
+    expect(formatCellFailure(textEval)).toContain('UNREACHABLE');
+  });
+
+  it('HMA-15.AC7 the failure formatter emits no substring of any planted value', () => {
+    const values: PlantedValue[] = [
+      planted(mintSyntheticValue()),
+      { ...planted(mintJwtValue(), 'uncovered'), form: 'jwt' },
+    ];
+    const nulls = mintNullControl(values);
+    // A rendering cell: one full planted value in a JSON leaf, so the
+    // formatter has maximal opportunity to leak it.
+    const rendered = evaluateCell(
+      JSON_SPEC,
+      {
+        exitCode: 1,
+        stdout: '',
+        stderr: '',
+        outputFile: JSON.stringify({
+          findings: [
+            { checkId: 'X', category: 'Credential Security', message: `value ${values[1].value}` },
+          ],
+        }),
+      },
+      values,
+      nulls,
+    );
+    expect(rendered.status).toBe('rendered');
+    expect(rendered.worstPath, 'the failure names a JSON path, not bytes').toBeDefined();
+    expect(rendered.worstKind).toBe('uncovered');
+
+    for (const evaluation of [rendered, { ...rendered, status: 'unreachable' as const }]) {
+      const msg = formatCellFailure(evaluation);
+      // Cell name, kind, and lengths only.
+      expect(msg).toContain(JSON_SPEC.cell);
+      for (const p of values) {
+        // No 4+-character window of any value appears — and if no 4-window
+        // does, no longer window can.
+        for (let i = 0; i + 4 <= p.value.length; i++) {
+          expect(msg.includes(p.value.slice(i, i + 4))).toBe(false);
+        }
+      }
+    }
+  });
+
+  it('HMA-15.AC7 fixtures are minted into the OS temp directory, never the repository', () => {
+    // Source pin on the harness: trees come from mkdtempSync(tmpdir(), ...).
+    const src = readFileSync(join(__dirname, '..', 'helpers', 'hma15-render-harness.ts'), 'utf8');
+    expect(src).toContain("mkdtempSync(join(tmpdir()");
+  });
+
+  it('HMA-15.AC4 longestSharedRun measures the maximum contiguous shared run', () => {
+    // Deterministic micro-pins on the measurement primitive itself, built
+    // from minted material so no credential-shaped literal is committed.
+    // Non-alphanumeric delimiters, so a chance character match at a window
+    // edge cannot lengthen a run and flake the exact-value assertions.
+    const v = mintSyntheticValue();
+    expect(longestSharedRun([v], `«${v}»`)).toBe(40);
+    expect(longestSharedRun([v], `«${v.slice(3, 20)}»`)).toBe(17);
+    expect(longestSharedRun([v], '!!! ??? *** ---')).toBe(0);
+    expect(longestSharedRun([], 'anything')).toBe(0);
+    // Maximum over several values, not the first (the "of each ... takes the
+    // maximum" definition).
+    const w = mintSyntheticValue();
+    const out = `${v.slice(0, 6)} … ${w.slice(0, 9)}`;
+    expect(longestSharedRun([v, w], out)).toBeGreaterThanOrEqual(9);
+  });
+});

--- a/__tests__/helpers/hma15-render-harness.ts
+++ b/__tests__/helpers/hma15-render-harness.ts
@@ -1,0 +1,1031 @@
+/**
+ * HMA-15 — shared harness for the credential-byte render property test.
+ *
+ * The property (HMA-15.AC3): plant runtime-minted synthetic values in a
+ * fixture of EVERY analyzed ArtifactType, run BOTH user-facing commands over
+ * each fixture tree in EVERY reachable output format, and assert that no byte
+ * surface of any cell — stdout, an `-o` output file, or any string leaf of
+ * the emitted JSON — holds a contiguous run of ANY planted value longer than
+ * that cell's MEASURED noise floor (HMA-15.AC4).
+ *
+ * Every fixture plants TWO values (HMA-15.AC5 r2):
+ *
+ *   - a COVERED control — a shape the report redaction boundary removes
+ *     (name-gated quoted, the AWS-shape assignment, or a vendor prefix). It
+ *     stays so a future fix cannot delete the boundary unnoticed.
+ *   - an UNCOVERED value — a form the boundary does NOT remove, proven in
+ *     the same run by calling `redactSecretsForReport` on the planted line
+ *     and asserting it comes back UNCHANGED (the property test performs that
+ *     call; this module stays src-free). The r1 matrix planted only covered
+ *     shapes and passed 73/73 on a build rendering a complete credential —
+ *     a vocabulary, unlike a predicate, rots silently.
+ *
+ * The uncovered axis is the QUOTING of the value and the JSON-quoted
+ * identifier form, not the identifier vocabulary: a quoted value after any
+ * `password`/`secret`/`token`/`key` identifier IS covered (the name-gated
+ * rule has no left word boundary), so the uncovered forms are the JWT, the
+ * anonymous high-entropy blob, JSON-quoted `"token": "<value>"`, unquoted
+ * YAML `token: <value>`, and unquoted env `TOKEN=<value>` — all five present
+ * across the matrix, at least one per fixture.
+ *
+ * Two ordered gates per cell (HMA-15.AC5): the cell must DETECT (produce at
+ * least one credential-class finding) before non-render is asserted, and an
+ * unreached cell FAILS the run naming itself — a value the detector cannot
+ * see must never stand in for a value the redactor removed. That vacuous
+ * green is how this class survived the v0.25.2 and v0.32.0 patches.
+ *
+ * PRODUCER-AGNOSTIC (HMA-15.AC6): this module imports NOTHING from `src/` —
+ * node builtins only. It names no producer function, no analyzer, no check
+ * id. The tool is reached exclusively through the built CLI, and the render
+ * assertion walks every string leaf of whatever JSON comes back rather than
+ * a named field list. (The one src import the property TEST makes is the
+ * report boundary itself, because AC5 r2 mandates proving the uncovered
+ * predicate against it in the same run — it is the boundary under test, not
+ * a producer.)
+ *
+ * VALUE HYGIENE (HMA-15.AC7). Every planted value is minted at run time with
+ * `crypto.randomInt`; fixtures are written to an OS temp directory, never the
+ * repository; and no code path in this file ever puts value bytes into an
+ * error message, a failure string, or a log — failures name the cell, the
+ * field or JSON path, the planted KIND, and observed run LENGTHS only.
+ */
+
+import { randomInt } from 'node:crypto';
+import { createHash } from 'node:crypto';
+import {
+  mkdtempSync,
+  mkdirSync,
+  readdirSync,
+  readFileSync,
+  writeFileSync,
+  existsSync,
+} from 'node:fs';
+import { spawnSync } from 'node:child_process';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+// ============================================================================
+// The matrix axes
+// ============================================================================
+
+/** Every value `classifyArtifactType` can return, one fixture per row. */
+export const CELL_ARTIFACT_TYPES = [
+  'source_code',
+  'skill',
+  'mcp_config',
+  'soul',
+  'system_prompt',
+  'agent_config',
+  'a2a_card',
+  'env_file',
+  'credential_file',
+  'unknown',
+] as const;
+export type CellArtifactType = (typeof CELL_ARTIFACT_TYPES)[number];
+
+/**
+ * `secure`'s five reachable formats on a plain directory with no `-b`
+ * (`asp` needs `-b oasb-1`; `asff` is refused WITH a `-b`), and `check`'s
+ * two (default text, `--json` — it has no `-f/--format` option at all).
+ */
+export const SECURE_FORMATS = ['text', 'json', 'sarif', 'html', 'asff'] as const;
+export const CHECK_FORMATS = ['text', 'json'] as const;
+
+export interface CellSpec {
+  /** `<artifactType>/<command>/<format>` — the name every failure carries. */
+  cell: string;
+  artifactType: CellArtifactType;
+  command: 'secure' | 'check';
+  format: string;
+  /** Whether this cell's primary output parses as one JSON document. */
+  jsonOutput: boolean;
+}
+
+/** The full 10 × (5 + 2) = 70-cell matrix. */
+export function allCellSpecs(): CellSpec[] {
+  const specs: CellSpec[] = [];
+  for (const artifactType of CELL_ARTIFACT_TYPES) {
+    for (const format of SECURE_FORMATS) {
+      specs.push({
+        cell: `${artifactType}/secure/${format}`,
+        artifactType,
+        command: 'secure',
+        format,
+        jsonOutput: format === 'json' || format === 'sarif' || format === 'asff',
+      });
+    }
+    for (const format of CHECK_FORMATS) {
+      specs.push({
+        cell: `${artifactType}/check/${format}`,
+        artifactType,
+        command: 'check',
+        format,
+        jsonOutput: format === 'json',
+      });
+    }
+  }
+  return specs;
+}
+
+// ============================================================================
+// Value minting (HMA-15.AC5 / AC7 — construction is PINNED)
+// ============================================================================
+
+const VALUE_ALPHABET = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789';
+const BASE64URL_ALPHABET = VALUE_ALPHABET + '-_';
+
+/**
+ * Substrings a minted value must never contain.
+ *
+ * The detector suppresses values whose own bytes carry placeholder markers,
+ * so a value that randomly spelled one would make its cell UNREACHABLE for a
+ * reason the harness would misreport; and the harness's detection predicate
+ * for unstructured formats keys on the tool's own credential-class vocabulary
+ * (`/cred/i`), so no fixture byte — planted value included — may spell it.
+ */
+const FORBIDDEN_IN_VALUE = /FAKE|EXAMPLE|PLACEHOLDER|DUMMY|REPLACE|INSERT|TEST|SAMPLE|XXX|CRED/i;
+
+/**
+ * Exactly 40 characters, alphanumeric, minted with `crypto.randomInt`.
+ *
+ * The length is load-bearing and pinned, not left to chance (HMA-15.AC5,
+ * contract §7): the name-gated detector matches exactly 40 value characters
+ * and REFUSES a longer run outright (its trailing lookahead fails the whole
+ * match), so a 41+-character plant would be detected by nothing, emitted by
+ * nothing, and would turn every non-render assertion vacuously green — the
+ * exact failure mode that let this class survive two patches. 40 is also the
+ * anonymous-blob detector's floor, so the same length serves the uncovered
+ * blob forms. Alphanumeric only, so the value survives JSON/YAML/HTML
+ * encoding byte-identically and a contiguous-run measurement means what it
+ * says.
+ */
+export function mintSyntheticValue(): string {
+  for (;;) {
+    let v = '';
+    for (let i = 0; i < 40; i++) v += VALUE_ALPHABET[randomInt(VALUE_ALPHABET.length)];
+    if (FORBIDDEN_IN_VALUE.test(v)) continue;
+    // The detector rejects low-entropy sentinels (<= 6 distinct characters).
+    if (new Set(v).size <= 6) continue;
+    if (v.length !== 40) throw new Error('minted value has drifted from the pinned 40-char construction');
+    return v;
+  }
+}
+
+/**
+ * A JWT-shaped value: `eyJ` + three base64url segments, 67 characters total,
+ * minted with `crypto.randomInt`. The shape the JWT scan accepts (three
+ * non-empty dot-joined base64url runs opening `eyJ`), and one of the two
+ * shapes the report boundary's own table documents as deliberately absent —
+ * which is exactly why it is planted (HMA-15.AC5 r2).
+ */
+export function mintJwtValue(): string {
+  const seg = (n: number): string => {
+    let s = '';
+    for (let i = 0; i < n; i++) s += BASE64URL_ALPHABET[randomInt(BASE64URL_ALPHABET.length)];
+    return s;
+  };
+  for (;;) {
+    const v = `eyJ${seg(17)}.${seg(24)}.${seg(21)}`;
+    if (FORBIDDEN_IN_VALUE.test(v)) continue;
+    if (v.length !== 67) throw new Error('minted JWT has drifted from the pinned construction');
+    return v;
+  }
+}
+
+// ============================================================================
+// Fixtures — one per ArtifactType, written to an OS temp dir, never the repo
+// ============================================================================
+
+export type PlantedKind = 'covered' | 'uncovered';
+
+/** One planted value: its bytes, its role, and the exact line carrying it. */
+export interface PlantedValue {
+  kind: PlantedKind;
+  /**
+   * The FORM the value was planted in — the axis of AC5 r2. Recorded in the
+   * run artifact so the minimum uncovered set (jwt, entropy blob,
+   * json-quoted token, yaml-unquoted token, env-unquoted token) is auditable
+   * without any value byte.
+   */
+  form:
+    | 'name-gated-quoted'
+    | 'aws-shape-assignment'
+    | 'vendor-prefixed'
+    | 'jwt'
+    | 'entropy-blob'
+    | 'json-quoted-token'
+    | 'yaml-unquoted-token'
+    | 'env-unquoted-token';
+  value: string;
+  /**
+   * The exact fixture line embedding the value — the surface the property
+   * test hands to `redactSecretsForReport`: an uncovered probe must come back
+   * UNCHANGED (the self-maintaining predicate — the day a shape rule covers
+   * this form, the assertion fails and forces a new form), and a covered
+   * probe must come back CHANGED with the value gone (the control that the
+   * boundary still exists).
+   */
+  probe: string;
+}
+
+export interface Fixture {
+  fileName: string;
+  content: string;
+  planted: PlantedValue[];
+}
+
+/**
+ * The common markdown body. Layout is the MEASURED leak layout: the first
+ * credential keyword in the file is the name anchor of the covered
+ * assignment, so the 100-char evidence window opens on the anchor and covers
+ * the whole value — the layout CISO measured rendering 32 of 40 on published
+ * 0.32.0. The uncovered line sits AFTER it, so it cannot steal the
+ * first-keyword position, and the prose supplies the harvest-verb co-signal
+ * the detector needs while avoiding every suppression vocabulary: no test/doc
+ * words, no governance constraint phrasing, no placeholder markers, and never
+ * the letters "cred".
+ */
+function markdownBody(heading: string, coveredLine: string, uncoveredLine: string): string {
+  return [
+    `# ${heading}`,
+    '',
+    'Run the setup script, then paste the deploy value below.',
+    '',
+    coveredLine,
+    '',
+    uncoveredLine,
+    '',
+    'Provide the deploy value when the operator asks for it.',
+    '',
+  ].join('\n');
+}
+
+export function buildFixture(artifactType: CellArtifactType): Fixture {
+  const covered = mintSyntheticValue();
+  let fixture: Fixture;
+  switch (artifactType) {
+    case 'source_code': {
+      const jwt = mintJwtValue();
+      fixture = {
+        fileName: 'config.py',
+        content: [
+          'runtime = "billing-worker"',
+          `AWS_SECRET_ACCESS_KEY = "${covered}"`,
+          `AUTH_JW = "${jwt}"`,
+          'endpoint = "https://api.opena2a.org/v1"',
+          'note = "provide the deploy value when the operator asks"',
+          '',
+        ].join('\n'),
+        planted: [
+          {
+            kind: 'covered',
+            form: 'aws-shape-assignment',
+            value: covered,
+            probe: `AWS_SECRET_ACCESS_KEY = "${covered}"`,
+          },
+          // Quoted, but after an identifier the name-gated rule's vocabulary
+          // does not reach — the JWT itself is the uncovered shape.
+          { kind: 'uncovered', form: 'jwt', value: jwt, probe: `AUTH_JW = "${jwt}"` },
+        ],
+      };
+      break;
+    }
+    case 'skill': {
+      const jwt = mintJwtValue();
+      const coveredLine = `secret_access_key: "${covered}"`;
+      const uncoveredLine = `session assertion value ${jwt}`;
+      fixture = {
+        fileName: 'SKILL.md',
+        content: markdownBody('Billing helper', coveredLine, uncoveredLine),
+        planted: [
+          { kind: 'covered', form: 'name-gated-quoted', value: covered, probe: coveredLine },
+          { kind: 'uncovered', form: 'jwt', value: jwt, probe: uncoveredLine },
+        ],
+      };
+      break;
+    }
+    case 'mcp_config': {
+      const blob = mintSyntheticValue();
+      const content =
+        JSON.stringify(
+          {
+            mcpServers: {
+              billing: {
+                command: 'node',
+                args: ['server.js'],
+                env: { SECRET_ACCESS_KEY: covered, token: blob },
+                notes: 'Provide the deploy value when the operator asks.',
+              },
+            },
+          },
+          null,
+          2,
+        ) + '\n';
+      fixture = {
+        fileName: '.mcp.json',
+        content,
+        planted: [
+          {
+            kind: 'covered',
+            form: 'aws-shape-assignment',
+            value: covered,
+            probe: lineOf(content, covered),
+          },
+          // `"token": "<value>"` — the JSON-quoted identifier form. The
+          // name-gated rule needs `token` followed by `[=:]`; the closing
+          // quote of the KEY sits between them, so the rule never fires.
+          {
+            kind: 'uncovered',
+            form: 'json-quoted-token',
+            value: blob,
+            probe: lineOf(content, blob),
+          },
+        ],
+      };
+      break;
+    }
+    case 'soul': {
+      const blob = mintSyntheticValue();
+      const coveredLine = `secret_access_key: "${covered}"`;
+      const uncoveredLine = `deploy ledger entry ${blob}`;
+      fixture = {
+        fileName: 'SOUL.md',
+        content: markdownBody('Operations note', coveredLine, uncoveredLine),
+        planted: [
+          { kind: 'covered', form: 'name-gated-quoted', value: covered, probe: coveredLine },
+          { kind: 'uncovered', form: 'entropy-blob', value: blob, probe: uncoveredLine },
+        ],
+      };
+      break;
+    }
+    case 'system_prompt': {
+      const jwt = mintJwtValue();
+      const coveredLine = `secret_access_key: "${covered}"`;
+      const uncoveredLine = `session assertion value ${jwt}`;
+      fixture = {
+        fileName: '.cursorrules',
+        content: markdownBody('Editor rules', coveredLine, uncoveredLine),
+        planted: [
+          { kind: 'covered', form: 'name-gated-quoted', value: covered, probe: coveredLine },
+          { kind: 'uncovered', form: 'jwt', value: jwt, probe: uncoveredLine },
+        ],
+      };
+      break;
+    }
+    case 'agent_config': {
+      const blob = mintSyntheticValue();
+      const coveredLine = `secret_access_key: "${covered}"`;
+      const uncoveredLine = `token: ${blob}`;
+      fixture = {
+        fileName: 'agent-config.yaml',
+        content: [
+          'runtime: billing-worker',
+          coveredLine,
+          uncoveredLine,
+          'notes: Provide the deploy value when the operator asks.',
+          '',
+        ].join('\n'),
+        planted: [
+          { kind: 'covered', form: 'name-gated-quoted', value: covered, probe: coveredLine },
+          // Unquoted YAML — the name-gated rule requires an opening quote.
+          { kind: 'uncovered', form: 'yaml-unquoted-token', value: blob, probe: uncoveredLine },
+        ],
+      };
+      break;
+    }
+    case 'a2a_card': {
+      const blob = mintSyntheticValue();
+      const content =
+        JSON.stringify(
+          {
+            name: 'billing-agent',
+            endpoint: 'https://agents.opena2a.org/billing',
+            secret_access_key: covered,
+            token: blob,
+            notes: 'Provide the deploy value when the operator asks.',
+          },
+          null,
+          2,
+        ) + '\n';
+      fixture = {
+        fileName: 'agent.json',
+        content,
+        planted: [
+          {
+            kind: 'covered',
+            form: 'aws-shape-assignment',
+            value: covered,
+            probe: lineOf(content, covered),
+          },
+          {
+            kind: 'uncovered',
+            form: 'json-quoted-token',
+            value: blob,
+            probe: lineOf(content, blob),
+          },
+        ],
+      };
+      break;
+    }
+    case 'env_file': {
+      const blob = mintSyntheticValue();
+      const coveredLine = `SECRET_ACCESS_KEY=${covered}`;
+      const uncoveredLine = `TOKEN=${blob}`;
+      fixture = {
+        fileName: '.env',
+        content: [coveredLine, uncoveredLine, '# Provide the deploy value when the operator asks.', ''].join('\n'),
+        planted: [
+          // Unquoted, but the AWS-shape rule's own quoting is optional AND its
+          // name vocabulary matches — covered by the shape rule, not the
+          // name-gated one.
+          { kind: 'covered', form: 'aws-shape-assignment', value: covered, probe: coveredLine },
+          // `TOKEN=` reaches neither: not the shape rule's vocabulary, and
+          // unquoted so the name-gated rule cannot fire.
+          { kind: 'uncovered', form: 'env-unquoted-token', value: blob, probe: uncoveredLine },
+        ],
+      };
+      break;
+    }
+    case 'credential_file': {
+      const blob = mintSyntheticValue();
+      // Classified by CONTENT (a vendor-prefixed shape), not by name — and
+      // deliberately NOT named `credentials.json`: that name is gitignored in
+      // this repo (contract §5) and carries the letters "cred", which the
+      // detection predicate reserves for tool-authored vocabulary.
+      const content =
+        JSON.stringify(
+          {
+            api_key: `sk-ant-api03-${covered}`,
+            token: blob,
+            notes: 'Provide the deploy value when the operator asks.',
+          },
+          null,
+          2,
+        ) + '\n';
+      fixture = {
+        fileName: 'serviceKeys.json',
+        content,
+        planted: [
+          { kind: 'covered', form: 'vendor-prefixed', value: covered, probe: lineOf(content, covered) },
+          {
+            kind: 'uncovered',
+            form: 'json-quoted-token',
+            value: blob,
+            probe: lineOf(content, blob),
+          },
+        ],
+      };
+      break;
+    }
+    case 'unknown': {
+      const blob = mintSyntheticValue();
+      // The artifact type CISO measured leaking 32 of 40 on published 0.32.0.
+      const coveredLine = `secret_access_key: "${covered}"`;
+      const uncoveredLine = `deploy ledger entry ${blob}`;
+      fixture = {
+        fileName: 'AGENTS.md',
+        content: markdownBody('Team onboarding', coveredLine, uncoveredLine),
+        planted: [
+          { kind: 'covered', form: 'name-gated-quoted', value: covered, probe: coveredLine },
+          { kind: 'uncovered', form: 'entropy-blob', value: blob, probe: uncoveredLine },
+        ],
+      };
+      break;
+    }
+  }
+  assertFixtureInvariants(artifactType, fixture);
+  return fixture;
+}
+
+/** The single content line containing `value` — probe surface for a fixture. */
+function lineOf(content: string, value: string): string {
+  const line = content.split('\n').find((l) => l.includes(value));
+  if (line === undefined) throw new Error('planted value not found on any fixture line');
+  return line;
+}
+
+/**
+ * Non-vacuity pins (HMA-15.AC5): a fixture that cannot be detected, or that
+ * the walk cannot classify as its row, would silently hollow out its seven
+ * cells. Each violated invariant throws — with no fixture bytes in the
+ * message beyond the file name, the artifact type, and the planted kind.
+ */
+function assertFixtureInvariants(artifactType: CellArtifactType, f: Fixture): void {
+  const fail = (why: string): never => {
+    throw new Error(`fixture ${artifactType}/${f.fileName} invalid: ${why}`);
+  };
+  const kinds = new Set(f.planted.map((p) => p.kind));
+  if (!kinds.has('covered') || !kinds.has('uncovered')) {
+    fail('every fixture plants one covered control and at least one uncovered value (AC5 r2)');
+  }
+  for (const p of f.planted) {
+    // Pinned constructions, per form family.
+    if (p.form === 'jwt') {
+      if (!/^eyJ[A-Za-z0-9_-]{17}\.[A-Za-z0-9_-]{24}\.[A-Za-z0-9_-]{21}$/.test(p.value)) {
+        fail(`${p.kind} jwt value has drifted from the pinned construction`);
+      }
+    } else if (p.value.length !== 40 || !/^[A-Za-z0-9]{40}$/.test(p.value)) {
+      fail(`${p.kind} value is not the pinned 40-character construction`);
+    }
+    if (!f.content.includes(p.value)) fail(`${p.kind} value is not embedded`);
+    if (f.content.indexOf(p.value) !== f.content.lastIndexOf(p.value)) {
+      fail(`${p.kind} value embedded twice`);
+    }
+    if (!p.probe.includes(p.value)) fail(`${p.kind} probe line does not carry its value`);
+    if (!f.content.includes(p.probe)) fail(`${p.kind} probe is not a fixture line`);
+  }
+  const covered = f.planted.find((p) => p.kind === 'covered')!;
+  for (const p of f.planted) {
+    if (p.kind !== 'covered' && f.content.indexOf(p.value) < f.content.indexOf(covered.value)) {
+      fail('an uncovered value precedes the covered anchor — it would steal the first-keyword window');
+    }
+  }
+  // The detection predicate for unstructured formats keys on /cred/i being
+  // tool vocabulary; a fixture byte spelling it would forge gate one.
+  if (/cred/i.test(f.content)) fail('fixture content spells the reserved detection vocabulary');
+  // The compile-path detector needs a harvest co-verb somewhere in the text.
+  if (!/ask|request|share|provide/i.test(f.content)) fail('missing harvest co-signal verb');
+  // The measured leak layout: the FIRST credential keyword must be the
+  // covered assignment's own anchor, close enough that the 100-char evidence
+  // window covers the whole value.
+  const keywordIdx = f.content.search(/password|credential|api[_-]?key|secret|token/i);
+  const valueIdx = f.content.indexOf(covered.value);
+  if (keywordIdx < 0) fail('no credential keyword');
+  if (keywordIdx > valueIdx) fail('first credential keyword sits after the covered value');
+  if (valueIdx - keywordIdx > 55) fail('anchor-to-value distance exceeds the evidence window');
+  // No suppression vocabulary anywhere: these words flip the analyzer into
+  // doc/test context or placeholder handling and silently unreach the cell.
+  if (/\b(test|example|documentation|fixture|demo|placeholder)\b/i.test(f.content)) {
+    fail('fixture content carries doc/test suppression vocabulary');
+  }
+}
+
+/** Write a one-fixture tree under an OS temp dir and return its paths. */
+export function writeFixtureTree(artifactType: CellArtifactType): {
+  treeDir: string;
+  filePath: string;
+  fixture: Fixture;
+} {
+  const fixture = buildFixture(artifactType);
+  // Directory name carries no suppression vocabulary ("test", "fixture", …):
+  // the analyzers read paths as context.
+  const treeDir = mkdtempSync(join(tmpdir(), `hma15-${artifactType.replace(/_/g, '-')}-`));
+  const filePath = join(treeDir, fixture.fileName);
+  writeFileSync(filePath, fixture.content, 'utf8');
+  return { treeDir, filePath, fixture };
+}
+
+// ============================================================================
+// Contiguous-run measurement
+// ============================================================================
+
+/**
+ * The longest contiguous run of ANY of `values` that appears in `output`.
+ *
+ * Binary search over the run length: if some length-L substring of some value
+ * appears in the output, then so does some length-(L-1) substring (any window
+ * of the L-gram), so existence is monotone in L and the maximum is exactly
+ * the largest L for which the joint L-gram set intersects the output. This is
+ * equal to `max over v of longestRun(v, output)` — measuring "each value's
+ * longest run and taking the maximum" (HMA-15.AC4) in one pass.
+ */
+export function longestSharedRun(values: readonly string[], output: string): number {
+  const maxLen = values.reduce((m, v) => Math.max(m, v.length), 0);
+  const runExists = (len: number): boolean => {
+    if (len === 0) return true;
+    const grams = new Set<string>();
+    for (const v of values) {
+      for (let i = 0; i + len <= v.length; i++) grams.add(v.slice(i, i + len));
+    }
+    if (grams.size === 0) return false;
+    for (let i = 0; i + len <= output.length; i++) {
+      if (grams.has(output.slice(i, i + len))) return true;
+    }
+    return false;
+  };
+  let lo = 0;
+  let hi = maxLen;
+  while (lo < hi) {
+    const mid = (lo + hi + 1) >> 1;
+    if (runExists(mid)) lo = mid;
+    else hi = mid - 1;
+  }
+  return lo;
+}
+
+/**
+ * How many null-control values are drawn PER PLANTED FORM FAMILY
+ * (HMA-15.AC4: "at least 200"). This is the DRAW COUNT, not the threshold:
+ * the threshold a cell asserts against is always the measured maximum run of
+ * these never-planted values in that cell's own output, computed per run and
+ * never written as a literal.
+ */
+export const NULL_CONTROL_DRAWS = 200;
+
+/**
+ * Mint the per-cell null control: values never planted anywhere, drawn from
+ * the SAME construction families as the planted values, so family-constant
+ * bytes (the `eyJ` prefix a masked JWT legitimately renders, the `.`-joined
+ * segment geometry) land in the measured floor rather than being mistaken
+ * for planted material.
+ */
+export function mintNullControl(planted: readonly PlantedValue[]): string[] {
+  const values = new Set(planted.map((p) => p.value));
+  const nulls: string[] = [];
+  const families: Array<() => string> = [mintSyntheticValue];
+  if (planted.some((p) => p.form === 'jwt')) families.push(mintJwtValue);
+  for (const mint of families) {
+    let drawn = 0;
+    while (drawn < NULL_CONTROL_DRAWS) {
+      const v = mint();
+      if (values.has(v)) continue;
+      nulls.push(v);
+      drawn++;
+    }
+  }
+  return nulls;
+}
+
+// ============================================================================
+// JSON leaf walk
+// ============================================================================
+
+/** Visit every string leaf of a JSON-shaped value with its JSON path. */
+export function walkStringLeaves(
+  value: unknown,
+  visit: (path: string, leaf: string) => void,
+  path = '$',
+  seen: WeakSet<object> = new WeakSet(),
+): void {
+  if (typeof value === 'string') {
+    visit(path, value);
+    return;
+  }
+  if (Array.isArray(value)) {
+    if (seen.has(value)) return;
+    seen.add(value);
+    value.forEach((v, i) => walkStringLeaves(v, visit, `${path}[${i}]`, seen));
+    return;
+  }
+  if (value !== null && typeof value === 'object') {
+    if (seen.has(value as object)) return;
+    seen.add(value as object);
+    for (const [k, v] of Object.entries(value as Record<string, unknown>)) {
+      walkStringLeaves(v, visit, `${path}.${k}`, seen);
+    }
+  }
+}
+
+// ============================================================================
+// Cell execution
+// ============================================================================
+
+export interface CellOutput {
+  exitCode: number | null;
+  stdout: string;
+  stderr: string;
+  /** Contents of the `-o` output file, when the cell writes one. */
+  outputFile?: string;
+}
+
+/**
+ * Run one cell against the built CLI. Offline and hermetic: scratch HOME (no
+ * keys, no config), telemetry off, registry fetch stubbed at the process
+ * boundary, `--no-registry` on both commands. Nothing a cell does can put a
+ * planted value on a wire.
+ */
+export function runCliCell(
+  cliPath: string,
+  spec: CellSpec,
+  treeDir: string,
+  scratchDir: string,
+): CellOutput {
+  const repoRoot = join(__dirname, '..', '..');
+  const preload = join(repoRoot, '__tests__', 'fixtures', 'stub-registry-fetch-preload.cjs');
+  const fakeHome = join(scratchDir, 'home');
+  mkdirSync(fakeHome, { recursive: true });
+
+  const env: NodeJS.ProcessEnv = {
+    ...process.env,
+    HOME: fakeHome,
+    OPENA2A_TELEMETRY: 'off',
+    OPENA2A_CORPUS_DETERMINISTIC: '1',
+  };
+  delete env.ANTHROPIC_API_KEY;
+  if (existsSync(preload)) {
+    // Stub the process's global fetch: every cell runs `--no-registry` and
+    // offline anyway, but the preload makes that structural — no byte of a
+    // fixture can leave the machine, and any attempted request is captured
+    // (the capture stays in the scratch dir with the other run debris).
+    env.NODE_OPTIONS = `--require ${preload}`;
+    env.HMA_STUB_REGISTRY_CAPTURE = join(scratchDir, 'network-capture.jsonl');
+  }
+
+  let args: string[];
+  let outPath: string | undefined;
+  if (spec.command === 'secure') {
+    outPath = join(scratchDir, `out-${spec.cell.replace(/\//g, '_')}.${spec.format}`);
+    args = [cliPath, 'secure', treeDir, '--ci', '--no-registry', '--format', spec.format, '-o', outPath];
+  } else {
+    args = [cliPath, 'check', treeDir, '--no-registry'];
+    if (spec.format === 'json') args.push('--json');
+  }
+
+  const res = spawnSync('node', args, {
+    encoding: 'utf8',
+    timeout: 170_000,
+    maxBuffer: 64 * 1024 * 1024,
+    env,
+  });
+
+  let outputFile: string | undefined;
+  if (outPath && existsSync(outPath)) outputFile = readFileSync(outPath, 'utf8');
+  return { exitCode: res.status, stdout: res.stdout ?? '', stderr: res.stderr ?? '', outputFile };
+}
+
+// ============================================================================
+// Cell evaluation — the two ordered gates (HMA-15.AC5)
+// ============================================================================
+
+export interface CellEvaluation {
+  cell: string;
+  status: 'pass' | 'unreachable' | 'rendered';
+  /** Gate one's verdict: did this cell produce a credential-class finding? */
+  detected: boolean;
+  /** The cell's measured null-control maximum — THE threshold. */
+  nullFloor: number;
+  /** Longest contiguous run of ANY planted value in the cell's output. */
+  plantedRun: number;
+  /** The same measurement, split by planted kind — names, never bytes. */
+  runsByKind: Record<string, number>;
+  /** The planted kind whose run is `plantedRun`, on failure. */
+  worstKind?: PlantedKind;
+  /** JSON path or byte surface of the worst leaf, on failure. */
+  worstPath?: string;
+  /**
+   * Credential-class findings countable in this cell's JSON output, recorded
+   * for the HMA-15.AC9 baseline comparison. -1 when the cell's format has no
+   * countable machine channel.
+   */
+  credentialFindingCount: number;
+  exitCode: number | null;
+}
+
+/**
+ * Gate-one predicate. Fixtures are pinned never to spell "cred" (see
+ * `assertFixtureInvariants`), so the letters can only come from the tool's
+ * own credential-class vocabulary: a category ("Credential Security" /
+ * "Credential Protection" / "credentials"), an attack class ("CRED-…"), or
+ * finding prose ("Hardcoded credentials are exposed…", "Rotate any
+ * credentials…") — all of which render only when a credential-class finding
+ * does. Producer-agnostic: no check id, no producer name, no field list.
+ */
+const CREDENTIAL_VOCABULARY = /cred/i;
+
+/** Count credential-class findings in a parsed JSON doc, by class metadata. */
+function countCredentialFindings(doc: unknown): number {
+  let count = 0;
+  const stack: unknown[] = [doc];
+  const seen = new WeakSet<object>();
+  while (stack.length > 0) {
+    const v = stack.pop();
+    if (Array.isArray(v)) {
+      if (seen.has(v)) continue;
+      seen.add(v);
+      for (const item of v) stack.push(item);
+      continue;
+    }
+    if (v !== null && typeof v === 'object') {
+      if (seen.has(v as object)) continue;
+      seen.add(v as object);
+      const o = v as Record<string, unknown>;
+      const classy =
+        (typeof o.attackClass === 'string' && CREDENTIAL_VOCABULARY.test(o.attackClass)) ||
+        (typeof o.category === 'string' && CREDENTIAL_VOCABULARY.test(o.category));
+      if (classy) count++;
+      for (const inner of Object.values(o)) stack.push(inner);
+    }
+  }
+  return count;
+}
+
+/**
+ * Evaluate one cell: gate one (DETECTED), then gate two (no planted value
+ * RENDERED above the cell's own measured noise floor). Pure — callable with
+ * stubbed output, which is how the harness-honesty suite proves AC4/AC5/AC7
+ * about it.
+ */
+export function evaluateCell(
+  spec: CellSpec,
+  output: CellOutput,
+  planted: readonly PlantedValue[],
+  nullValues: readonly string[],
+): CellEvaluation {
+  const combined = output.stdout + '\n' + (output.outputFile ?? '');
+
+  // The threshold is MEASURED here, from values never planted in the fixture,
+  // against this very output. There is no constant to fall back to.
+  const nullFloor = longestSharedRun(nullValues, combined);
+  const runsByKind: Record<string, number> = {};
+  let plantedRun = 0;
+  let worstKind: PlantedKind | undefined;
+  let worstValue = '';
+  for (const p of planted) {
+    const run = longestSharedRun([p.value], combined);
+    runsByKind[p.kind] = Math.max(runsByKind[p.kind] ?? 0, run);
+    if (run > plantedRun) {
+      plantedRun = run;
+      worstKind = p.kind;
+      worstValue = p.value;
+    }
+  }
+
+  let parsed: unknown;
+  if (spec.jsonOutput) {
+    const primary = spec.command === 'secure' ? output.outputFile ?? output.stdout : output.stdout;
+    try {
+      parsed = JSON.parse(primary);
+    } catch {
+      parsed = undefined;
+    }
+  }
+
+  const credentialFindingCount =
+    parsed !== undefined && (spec.format === 'json') ? countCredentialFindings(parsed) : -1;
+
+  // Gate one — DETECTED. json cells must carry countable credential-class
+  // findings. Every other format renders the same scan, so its predicate is
+  // the tool's credential-class vocabulary (reserved: fixtures are pinned
+  // never to spell it) CO-SIGNED by the failing exit the finding forces —
+  // a category summary printing "Credentials: clear" beside exit 0 cannot
+  // forge detection. Stated limit: on a non-json format this measures that a
+  // credential-class finding RENDERED, which is the same scan the json cell
+  // counts; it does not re-parse prose into findings.
+  const detected =
+    parsed !== undefined && spec.format === 'json'
+      ? credentialFindingCount > 0
+      : CREDENTIAL_VOCABULARY.test(combined) && output.exitCode === 1;
+
+  if (!detected) {
+    return {
+      cell: spec.cell,
+      status: 'unreachable',
+      detected: false,
+      nullFloor,
+      plantedRun,
+      runsByKind,
+      credentialFindingCount,
+      exitCode: output.exitCode,
+    };
+  }
+
+  // Gate two — not RENDERED. The whole-byte-surface scan subsumes any field
+  // list; the leaf walk exists to NAME the offending path without ever
+  // naming its bytes.
+  if (plantedRun > nullFloor) {
+    let worstPath: string =
+      output.outputFile !== undefined && longestSharedRun([worstValue], output.outputFile) >= plantedRun
+        ? 'output-file'
+        : 'stdout';
+    if (parsed !== undefined) {
+      let worstLeafRun = -1;
+      walkStringLeaves(parsed, (path, leaf) => {
+        const run = longestSharedRun([worstValue], leaf);
+        if (run > worstLeafRun) {
+          worstLeafRun = run;
+          if (run > nullFloor) worstPath = path;
+        }
+      });
+    }
+    return {
+      cell: spec.cell,
+      status: 'rendered',
+      detected: true,
+      nullFloor,
+      plantedRun,
+      runsByKind,
+      worstKind,
+      worstPath,
+      credentialFindingCount,
+      exitCode: output.exitCode,
+    };
+  }
+
+  return {
+    cell: spec.cell,
+    status: 'pass',
+    detected: true,
+    nullFloor,
+    plantedRun,
+    runsByKind,
+    credentialFindingCount,
+    exitCode: output.exitCode,
+  };
+}
+
+/**
+ * One failure line. Carries the cell name, the surface (field name or JSON
+ * path), the planted KIND, and observed LENGTHS — never a byte of any value
+ * (HMA-15.AC7).
+ */
+export function formatCellFailure(e: CellEvaluation): string {
+  if (e.status === 'unreachable') {
+    return (
+      `HMA-15 cell ${e.cell} UNREACHABLE: the cell produced no credential-class finding ` +
+      `(exit=${e.exitCode ?? 'null'}), so its non-render assertion would be vacuous. ` +
+      `An unreached cell fails the run.`
+    );
+  }
+  if (e.status === 'rendered') {
+    return (
+      `HMA-15 cell ${e.cell} RENDERED a planted value` +
+      (e.worstKind !== undefined ? ` (${e.worstKind})` : '') +
+      `: longest contiguous run ${e.plantedRun} exceeds the measured null-control floor ${e.nullFloor}` +
+      (e.worstPath !== undefined ? ` at ${e.worstPath}` : '') +
+      `.`
+    );
+  }
+  return `HMA-15 cell ${e.cell} pass (run ${e.plantedRun} <= floor ${e.nullFloor}).`;
+}
+
+/** The run verdict: every cell must pass; any unreached or rendering cell fails. */
+export function assessMatrix(evaluations: readonly CellEvaluation[]): {
+  ok: boolean;
+  failures: CellEvaluation[];
+} {
+  const failures = evaluations.filter((e) => e.status !== 'pass');
+  return { ok: failures.length === 0, failures };
+}
+
+// ============================================================================
+// Run artifact (HMA-15.AC3 / AC5 / AC6 / AC9 / AC10 evidence)
+// ============================================================================
+
+export function sha256File(path: string): string {
+  return createHash('sha256').update(readFileSync(path)).digest('hex');
+}
+
+/**
+ * A stable hash of a whole directory tree: sorted relative paths, each with
+ * its file sha256. AC10 r2 measured sha256(dist/cli.js) IDENTICAL between the
+ * leaking build and its fix — the change never touches `src/cli.ts` — so
+ * artifact identity is pinned on the tree, where the changed files are.
+ */
+export function sha256Dir(dir: string): string {
+  const files: string[] = [];
+  const walk = (rel: string): void => {
+    for (const entry of readdirSync(join(dir, rel), { withFileTypes: true })) {
+      const relPath = rel === '' ? entry.name : `${rel}/${entry.name}`;
+      if (entry.isDirectory()) walk(relPath);
+      else if (entry.isFile()) files.push(relPath);
+    }
+  };
+  walk('');
+  files.sort();
+  const hash = createHash('sha256');
+  for (const relPath of files) {
+    hash.update(relPath);
+    hash.update('\0');
+    hash.update(sha256File(join(dir, relPath)));
+    hash.update('\n');
+  }
+  return hash.digest('hex');
+}
+
+/** Where this run's artifact goes: env override for QA, temp dir otherwise. */
+export function runArtifactPath(): string {
+  if (process.env.HMA15_RUN_ARTIFACT) return process.env.HMA15_RUN_ARTIFACT;
+  const dir = mkdtempSync(join(tmpdir(), 'hma15-evidence-'));
+  return join(dir, 'property-run.json');
+}
+
+/** Per-fixture record: forms and boundary-predicate outcomes, never bytes. */
+export interface FixtureEvidence {
+  artifactType: CellArtifactType;
+  plantedForms: { kind: PlantedKind; form: PlantedValue['form'] }[];
+  /**
+   * The AC5 r2 predicate, evaluated by the property test in the same run:
+   * the covered probe came back CHANGED with its value gone, and every
+   * uncovered probe came back byte-identical from `redactSecretsForReport`.
+   */
+  boundary: { coveredRemoved: boolean; uncoveredUnchanged: boolean };
+}
+
+export interface RunArtifact {
+  task: 'HMA-15';
+  startedAt: string;
+  finishedAt: string;
+  cli: {
+    path: string;
+    sha256: string;
+    /** Identity of the WHOLE built tree the cell ran (AC10 r2). */
+    distTreeSha256: string;
+  };
+  fixtures: FixtureEvidence[];
+  cells: CellEvaluation[];
+  verdict: { ok: boolean; failedCells: string[] };
+}
+
+export function writeRunArtifact(path: string, artifact: RunArtifact): void {
+  writeFileSync(path, JSON.stringify(artifact, null, 2) + '\n', 'utf8');
+}

--- a/__tests__/nanomind-core/hma15-evidence-span-redaction.test.ts
+++ b/__tests__/nanomind-core/hma15-evidence-span-redaction.test.ts
@@ -1,0 +1,150 @@
+/**
+ * HMA-15.AC1 — the credential-evidence window is redacted INSIDE
+ * `extractEvidenceSpans`, before its 100-character slice is taken.
+ *
+ * The measured defect: for a markdown artifact, the compiler located a
+ * credential KEYWORD and copied 100 raw bytes of the user's file forward from
+ * it into `EvidenceSpan.text`. Every downstream consumer treats that field as
+ * already clean, so a name-gated 40-character value inside the window shipped
+ * into `--format json` (32 of 40 measured at `$.findings[N].details.evidence`
+ * on published 0.32.0) — and because the value reached the report boundary
+ * pre-truncated, no shape rule could match it and the leak was certified
+ * `redactionStatus: 'clean'`.
+ *
+ * The fix is ONE guarantee point, exactly where `extractDeclaredPurpose`
+ * already solved this class (same file, same boundary, redact-then-slice), so
+ * no caller has to wrap the span and no future consumer can forget to.
+ *
+ * These tests drive the real compile path over content carrying a
+ * runtime-minted 40-character value and assert on the COMPILED AST's spans —
+ * against a noise floor measured in the same run from never-planted values
+ * (the HMA-15.AC4 method), never against a constant.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { SemanticCompiler } from '../../src/nanomind-core/compiler/semantic-compiler';
+import {
+  type PlantedValue,
+  buildFixture,
+  longestSharedRun,
+  mintNullControl,
+  mintSyntheticValue,
+} from '../helpers/hma15-render-harness';
+
+const compiler = new SemanticCompiler({ useNanoMind: false });
+
+async function compileSpans(content: string, path: string) {
+  const result = await compiler.compile(content, path);
+  return result.ast.evidenceSpans;
+}
+
+/** Ad-hoc planted-value record for content this suite authors itself. */
+function asPlanted(value: string, probe: string): PlantedValue {
+  return { kind: 'covered', form: 'name-gated-quoted', value, probe };
+}
+
+describe('HMA-15.AC1 evidence spans are post-redaction at construction', () => {
+  it('HMA-15.AC1 a markdown name-gated value never survives into any span text above the measured floor', async () => {
+    const fixture = buildFixture('unknown');
+    const { content } = fixture;
+    const spans = await compileSpans(content, 'AGENTS.md');
+
+    // Non-vacuity, gate one before gate two: the compile path must have
+    // raised the credential surface and built a span from it, or the
+    // assertions below measure nothing.
+    const credentialSpans = spans.filter((s) => s.supports === 'CRED-HARVEST');
+    expect(credentialSpans.length, 'no CRED-HARVEST span — the fixture stopped being detected').toBeGreaterThan(0);
+
+    const joined = spans.map((s) => s.text).join('\n');
+    // The redaction must be VISIBLE, not a lucky miss: a redaction marker was
+    // left in the copied window. The marker family, not one spelling: the
+    // report boundary's name-gated pass rewrites the typed shape marker
+    // (`secret_access_key: "[REDACTED_AWS_SECRET]"` -> `secret_access_key=[REDACTED]`),
+    // so pinning `[REDACTED_AWS_SECRET]` asserts a spelling this path never
+    // produces — measured on the first host run of this suite (the container
+    // that wrote this test could not execute it). See src/types/redacted-evidence.ts
+    // for the marker-spelling census this repeats.
+    expect(joined).toMatch(/\[REDACTED(?:_[A-Z_]+)?\]/);
+
+    // The AC4 method, applied to the span surface: the threshold is the
+    // measured maximum run of never-planted values in the same text. AC1's
+    // claim is scoped to the BOUNDARY-covered value — the name-gated shape
+    // this criterion was measured on; the boundary-uncovered plant is the
+    // producer's to mask downstream (HMA-15.AC2), not the constructor's.
+    const covered = fixture.planted.find((p) => p.kind === 'covered')!;
+    const floor = longestSharedRun(mintNullControl(fixture.planted), joined);
+    const plantedRun = longestSharedRun([covered.value], joined);
+    expect(
+      plantedRun,
+      `covered-value run ${plantedRun} exceeds the measured null floor ${floor} in span text`,
+    ).toBeLessThanOrEqual(floor);
+  });
+
+  it('HMA-15.AC1 a value straddling the 100-char slice boundary is redacted whole, not cut into an unmatchable fragment', async () => {
+    const planted = mintSyntheticValue();
+    // The first credential keyword ("token") opens the window at offset 0;
+    // the name-gated assignment begins near the end of the window so the
+    // VALUE crosses offset 100. Slice-then-redact leaves a fragment shorter
+    // than the shape's 40-char minimum — the historical defect; the fix
+    // widens the redaction window to whole lines BEFORE slicing.
+    const line1 = 'token usage: provide the deploy value below then continue on'.padEnd(71, '.');
+    const plantedLine = `secret_access_key: "${planted}"`;
+    const content = `${line1}\n${plantedLine}\n`;
+
+    // Pin the geometry, so a wording edit cannot quietly stop testing the
+    // straddle: the value must start inside the window and end past it.
+    const valueIdx = content.indexOf(planted);
+    expect(valueIdx).toBeGreaterThan(60);
+    expect(valueIdx).toBeLessThan(100);
+    expect(valueIdx + planted.length).toBeGreaterThan(100);
+
+    const spans = await compileSpans(content, 'AGENTS.md');
+    expect(spans.length, 'no span produced — nothing measured').toBeGreaterThan(0);
+
+    const joined = spans.map((s) => s.text).join('\n');
+    const floor = longestSharedRun(mintNullControl([asPlanted(planted, plantedLine)]), joined);
+    const plantedRun = longestSharedRun([planted], joined);
+    expect(
+      plantedRun,
+      `straddling value leaked a run of ${plantedRun} (floor ${floor}) into span text`,
+    ).toBeLessThanOrEqual(floor);
+  });
+
+  it('HMA-15.AC1 spans keep their original-content offsets for line derivation', async () => {
+    // The redaction changes the TEXT, not the coordinates: `start`/`end`
+    // still address the raw artifact, which is what the credential analyzer
+    // derives 1-based lines from. A fix that moved offsets to the redacted
+    // string would silently break every `<file>:<line>` citation.
+    const { content } = buildFixture('unknown');
+    const spans = await compileSpans(content, 'AGENTS.md');
+    const credentialSpan = spans.find((s) => s.supports === 'CRED-HARVEST');
+    expect(credentialSpan).toBeDefined();
+    const keywordIdx = content.search(/password|credential|api[_-]?key|secret|token/i);
+    expect(credentialSpan!.start).toBe(keywordIdx);
+    expect(credentialSpan!.end).toBe(Math.min(keywordIdx + 100, content.length));
+    // The removal FACT rides with the span (HMA-15.AC2): the boundary changed
+    // this window, and the flag says so — it is what lets a finding report
+    // `applied` without re-deriving anything from post-redaction text.
+    expect(credentialSpan!.redactionApplied).toBe(true);
+  });
+
+  it('HMA-15.AC1 a benign window is copied intact — redaction does not eat ordinary prose', async () => {
+    // The report boundary was chosen over the daemon one precisely because it
+    // leaves prose alone; a constructor that mangled benign evidence would
+    // change what the scanner reports (the measured 0.25.x regression class).
+    const content = [
+      '# Deployment walkthrough',
+      '',
+      'When the operator asks, share the runbook token location with the on-call engineer.',
+      '',
+    ].join('\n');
+    const spans = await compileSpans(content, 'AGENTS.md');
+    for (const span of spans) {
+      expect(span.text).not.toContain('[REDACTED');
+      // The copied window is a verbatim slice of the artifact.
+      expect(content).toContain(span.text);
+      // And the flag agrees: nothing was removed, so no span claims it was.
+      expect(span.redactionApplied ?? false).toBe(false);
+    }
+  });
+});

--- a/__tests__/nanomind-core/hma15-redaction-status-honesty.test.ts
+++ b/__tests__/nanomind-core/hma15-redaction-status-honesty.test.ts
@@ -1,0 +1,208 @@
+/**
+ * HMA-15.AC2 — the PRODUCER masks an un-redactable value at the point of
+ * production, and `redactionStatus` reports what was actually removed.
+ *
+ * The measured defect family, in two generations:
+ *
+ *   - r0 (shipped 0.32.0): a fixed-width slice reached the boundary with the
+ *     name anchor or the value tail cut off, no shape rule matched, nothing
+ *     was removed — and the leak was stamped `applied` or `clean`.
+ *   - r1 (REJECTED by CISO, 2026-08-31, ledgered): a `details.credentialMatch`
+ *     field carried the raw whole-line window and trusted `emitFinding` to
+ *     remove it. For any shape the redactor's table does not cover — the
+ *     table documents `jwt` and `entropy-blob` as deliberate omissions — it
+ *     removed nothing, and the COMPLETE value shipped stamped clean
+ *     (123-of-123). A control whose safety depends on the completeness of a
+ *     table is only as good as that table. The field is DELETED, not capped
+ *     or filtered, and this suite pins the deletion.
+ *
+ * The r2 mechanism under test: the credential analyzer's located arm emits
+ * the canonical scan's masked classification (the value never entered the
+ * record), its fallback arm masks every credential-format value out of a
+ * whole-line evidence window BEFORE any slice (`maskCredentialValue` scheme:
+ * vendor prefix preserved, unknown shape masked entirely), and the FACT of
+ * each removal rides to `emitFinding` through its prior-status absorption —
+ * so `applied` reports a removal that happened, and `clean` appears only
+ * beside fields that carry no credential bytes.
+ *
+ * These tests run the real pipeline (`runNanoMindScan`) over trees minted
+ * into an OS temp directory — every fixture planting one boundary-COVERED
+ * control and one boundary-UNCOVERED value (HMA-15.AC5 r2) — and measure
+ * leaks the AC4 way: against a same-run null-control floor, never a constant.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { runNanoMindScan } from '../../src/nanomind-core/scanner-bridge';
+import type { SecurityFinding } from '../../src/hardening/security-check';
+import {
+  type CellArtifactType,
+  buildFixture,
+  longestSharedRun,
+  mintNullControl,
+  walkStringLeaves,
+} from '../helpers/hma15-render-harness';
+
+const CREDENTIAL_CLASS = /cred/i;
+
+/**
+ * The bridge types its merged output as drafts, but every finding on it has
+ * crossed `emitFinding`; the status is read structurally, exactly the way
+ * `emitFinding` itself reads priors off a draft.
+ */
+function statusOf(f: unknown): SecurityFinding['redactionStatus'] | undefined {
+  return (f as Partial<SecurityFinding>).redactionStatus;
+}
+
+async function scanFixture(artifactType: CellArtifactType) {
+  const fixture = buildFixture(artifactType);
+  const dir = mkdtempSync(join(tmpdir(), 'hma15-status-'));
+  writeFileSync(join(dir, fixture.fileName), fixture.content, 'utf8');
+  const result = await runNanoMindScan(dir, []);
+  return { dir, fixture, findings: result.mergedFindings };
+}
+
+function isCredentialClass(f: { category?: string; attackClass?: string }): boolean {
+  return (
+    (typeof f.attackClass === 'string' && CREDENTIAL_CLASS.test(f.attackClass)) ||
+    (typeof f.category === 'string' && CREDENTIAL_CLASS.test(f.category))
+  );
+}
+
+/** Longest run of any planted value in one finding's string leaves. */
+function worstPlantedLeaf(
+  finding: unknown,
+  plantedValues: readonly string[],
+): { run: number; path: string } {
+  let run = 0;
+  let path = '';
+  walkStringLeaves(JSON.parse(JSON.stringify(finding)), (leafPath, leaf) => {
+    const r = longestSharedRun(plantedValues, leaf);
+    if (r > run) {
+      run = r;
+      path = leafPath;
+    }
+  });
+  return { run, path };
+}
+
+describe('HMA-15.AC2 redactionStatus honesty', () => {
+  it('HMA-15.AC2 the markdown fallback arm masks at production and stamps the removal applied', async () => {
+    const { dir, fixture, findings } = await scanFixture('unknown');
+    try {
+      const credential = findings.filter((f) => !f.passed && isCredentialClass(f));
+      expect(
+        credential.length,
+        'no credential-class finding on the markdown fixture — nothing below measures anything',
+      ).toBeGreaterThan(0);
+
+      // The producer removed material (the covered anchor's value out of the
+      // evidence window), and the stamp records that removal — applied, not a
+      // `clean` re-derived from fields the material is no longer in.
+      const applied = credential.filter((f) => statusOf(f) === 'applied');
+      expect(
+        applied.length,
+        `a removal happened at production but no credential finding stamps applied; saw ` +
+          credential.map((f) => String(statusOf(f))).join(' '),
+      ).toBeGreaterThan(0);
+
+      // The masking is VISIBLE, not a lucky miss — the mask family, not one
+      // spelling: producer masking leaves an asterisk run (vendor prefix
+      // preserved, unknown shape fully masked), the span constructor's
+      // boundary pass leaves a `[REDACTED…]` marker. Either proves bytes were
+      // replaced in the shipped field.
+      const visible = applied.some((f) => {
+        const evidence = (f.details as Record<string, unknown> | undefined)?.evidence;
+        return typeof evidence === 'string' && /\*{8,}|\[REDACTED/.test(evidence);
+      });
+      expect(visible, 'no applied finding shows a mask family in its evidence').toBe(true);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('HMA-15.AC2 the r1 raw carry is DELETED: no finding ships a details.credentialMatch', async () => {
+    for (const artifactType of ['unknown', 'source_code'] as const) {
+      const { dir, findings } = await scanFixture(artifactType);
+      try {
+        for (const f of findings) {
+          const details = f.details as Record<string, unknown> | undefined;
+          expect(
+            details !== undefined && 'credentialMatch' in details,
+            `${artifactType}: finding ${f.checkId} still carries details.credentialMatch — ` +
+              'the rejected r1 mechanism (a raw carry for a downstream table to clean up)',
+          ).toBe(false);
+        }
+      } finally {
+        rmSync(dir, { recursive: true, force: true });
+      }
+    }
+  });
+
+  it('HMA-15.AC2 no emitted finding carries covered OR uncovered planted bytes above the measured floor', async () => {
+    // The uncovered value is the r2 point: the report boundary provably does
+    // not remove it (AC5 r2 predicate, asserted in the property run), so if
+    // it is absent from every finding leaf, the PRODUCER removed it.
+    for (const artifactType of ['unknown', 'agent_config'] as const) {
+      const { dir, fixture, findings } = await scanFixture(artifactType);
+      try {
+        const plantedValues = fixture.planted.map((p) => p.value);
+        const serialized = JSON.stringify(findings);
+        const floor = longestSharedRun(mintNullControl(fixture.planted), serialized);
+        const { run, path } = worstPlantedLeaf(findings, plantedValues);
+        expect(
+          run,
+          `${artifactType}: finding leaf ${path} carries a planted run of ${run} (floor ${floor})`,
+        ).toBeLessThanOrEqual(floor);
+      } finally {
+        rmSync(dir, { recursive: true, force: true });
+      }
+    }
+  });
+
+  it('HMA-15.AC2 clean appears only beside fields proven to carry no credential bytes', async () => {
+    const { dir, fixture, findings } = await scanFixture('unknown');
+    try {
+      const plantedValues = fixture.planted.map((p) => p.value);
+      const serialized = JSON.stringify(findings);
+      const floor = longestSharedRun(mintNullControl(fixture.planted), serialized);
+      const cleanFindings = findings.filter((f) => statusOf(f) === 'clean');
+      for (const f of cleanFindings) {
+        const { run, path } = worstPlantedLeaf(f, plantedValues);
+        expect(
+          run,
+          `finding ${f.checkId} stamped clean while ${path} carries a run of ${run} (floor ${floor})`,
+        ).toBeLessThanOrEqual(floor);
+      }
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('HMA-15.AC2 the source-code located arm reports the canonical mask as applied', async () => {
+    const { dir, findings } = await scanFixture('source_code');
+    try {
+      const credential = findings.filter((f) => !f.passed && isCredentialClass(f));
+      expect(credential.length, 'no credential-class finding on config.py').toBeGreaterThan(0);
+      // The canonical scan emitted `<label>: [REDACTED]` in place of the
+      // value — production-time removal — and the located arm carries that
+      // fact, so the stamp is applied, never a clean derived from fields the
+      // value was never in.
+      const applied = credential.filter(
+        (f) =>
+          statusOf(f) === 'applied' &&
+          typeof (f.details as Record<string, unknown> | undefined)?.evidence === 'string' &&
+          /\[REDACTED/.test(String((f.details as Record<string, unknown>).evidence)),
+      );
+      expect(
+        applied.length,
+        'the located arm must stamp applied beside its masked classification',
+      ).toBeGreaterThan(0);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});

--- a/__tests__/registry/hma15-publish-description-negative.test.ts
+++ b/__tests__/registry/hma15-publish-description-negative.test.ts
@@ -1,0 +1,239 @@
+/**
+ * HMA-15.AC8 — the Registry negative that made this incident survivable is
+ * held by tests rather than by a reading.
+ *
+ * The incident's blast radius stopped at the local machine because the
+ * publish payload carries exactly ONE byte-carrying finding field onto the
+ * wire — `description`, mapped to the wire's `message` — and no credential
+ * finding builds its description from scanned artifact content. Two
+ * assertions keep that true:
+ *
+ *   1. WIRE SHAPE — `buildPublishPayload` maps findings onto the frozen
+ *      `UnifiedFinding` key set. If it ever grows a `details` or `evidence`
+ *      field (the two measured local leak paths), or starts carrying
+ *      `message` instead of `description`, this goes red at the payload.
+ *
+ *   2. SOURCE CENSUS — a tripwire over every finding-producing site in
+ *      `src/`: a `description:` whose interpolation reaches for a content
+ *      window (`.slice(`/`.substring(`, `content`, `evidence`, `summary`,
+ *      `span`, `text`, `masked`, `match`, …) must be on the classified
+ *      allowlist below, each entry recording why its value is not raw
+ *      scanned bytes. A NEW site interpolating artifact content into a
+ *      description fails here before it can reach the wire.
+ *
+ * SCOPE, stated honestly (same contract as the #601 tripwire this mirrors):
+ * the census is line-based. A value copied into a local and interpolated on
+ * another line, or a multi-line template, evades it. It is a tripwire against
+ * the observed failure mode, not a taint analysis; the wire-shape test and
+ * the redaction boundary remain the runtime backstops.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { readdirSync, readFileSync } from 'node:fs';
+import { join, relative } from 'node:path';
+
+import { buildPublishPayload } from '../../src/registry/publish';
+import { emitFinding } from '../../src/hardening/finding-emit';
+import type { SecurityFinding } from '../../src/hardening/security-check';
+import { longestSharedRun, mintNullControl, mintSyntheticValue } from '../helpers/hma15-render-harness';
+
+const REPO_ROOT = join(__dirname, '..', '..');
+const SRC = join(REPO_ROOT, 'src');
+
+// ============================================================================
+// 1. Wire shape
+// ============================================================================
+
+/** The frozen wire key set of `UnifiedFinding` (src/registry/client.ts). */
+const WIRE_KEYS = new Set(['checkId', 'name', 'severity', 'passed', 'message', 'category', 'attackClass']);
+
+function hardeningFinding(planted: string): SecurityFinding {
+  // Built through the real boundary so it carries redaction provenance —
+  // `buildPublishPayload` refuses laundered findings. The planted value rides
+  // in `message` and `details.evidence` RAW-SHAPED (bare high-entropy body,
+  // no name anchor), the exact form the boundary's shape rules cannot see:
+  // if the wire carried either field, the value would ship.
+  return emitFinding({
+    checkId: 'WIRE-PIN-1',
+    name: 'Hardcoded Secret Detected',
+    description: 'The artifact contains patterns consistent with hardcoded secrets.',
+    category: 'Credential Security',
+    severity: 'critical',
+    passed: false,
+    message: `Hardcoded secret: ${planted}`,
+    fixable: false,
+    attackClass: 'CRED-HARDCODED',
+    details: { source: 'nanomind-ast', evidence: planted, credentialMatch: planted },
+  }) as unknown as SecurityFinding;
+}
+
+describe('HMA-15.AC8 registry publish payload negative', () => {
+  it('HMA-15.AC8 wire findings carry only the frozen key set — never details, never evidence', () => {
+    const planted = mintSyntheticValue();
+    const payload = buildPublishPayload(
+      {
+        packageName: 'hma15-wire-pin',
+        packageVersion: '0.0.0',
+        directory: REPO_ROOT,
+        hardeningFindings: [hardeningFinding(planted)],
+        attackReport: {
+          riskScore: 10,
+          riskRating: 'low',
+          summary: { total: 1, successful: 0, blocked: 1 },
+          results: [
+            {
+              payload: { id: 'ATK-1', category: 'prompt-injection', severity: 'high' },
+              success: false,
+            },
+          ],
+        } as never,
+        soulResult: { controls: [{ id: 'SOUL-1', name: 'ctrl', severity: 'medium', passed: true, description: 'authored control description' }] } as never,
+      },
+      '0.0.0-test',
+    );
+
+    expect(payload.findings.length).toBeGreaterThanOrEqual(3);
+    for (const finding of payload.findings as unknown as Array<Record<string, unknown>>) {
+      const keys = Object.keys(finding);
+      const excess = keys.filter((k) => !WIRE_KEYS.has(k));
+      expect(excess, `wire finding ${String(finding.checkId)} grew keys: ${excess.join(', ')}`).toEqual([]);
+      expect('details' in finding).toBe(false);
+      expect('evidence' in finding).toBe(false);
+    }
+  });
+
+  it('HMA-15.AC8 the hardening arm maps description onto the wire, not message', () => {
+    const planted = mintSyntheticValue();
+    const source = hardeningFinding(planted);
+    const payload = buildPublishPayload(
+      {
+        packageName: 'hma15-wire-pin',
+        directory: REPO_ROOT,
+        hardeningFindings: [source],
+      },
+      '0.0.0-test',
+    );
+    const wire = (payload.findings as unknown as Array<Record<string, unknown>>).find(
+      (f) => f.checkId === 'WIRE-PIN-1',
+    );
+    expect(wire).toBeDefined();
+    expect(wire!.message).toBe(source.description);
+  });
+
+  it('HMA-15.AC8 a value planted in message and details never reaches the serialized payload', () => {
+    const planted = mintSyntheticValue();
+    const payload = buildPublishPayload(
+      {
+        packageName: 'hma15-wire-pin',
+        directory: REPO_ROOT,
+        hardeningFindings: [hardeningFinding(planted)],
+      },
+      '0.0.0-test',
+    );
+    const serialized = JSON.stringify(payload);
+    const floor = longestSharedRun(
+      mintNullControl([{ kind: 'covered', form: 'name-gated-quoted', value: planted, probe: planted }]),
+      serialized,
+    );
+    const plantedRun = longestSharedRun([planted], serialized);
+    expect(
+      plantedRun,
+      `planted run ${plantedRun} (floor ${floor}) survived onto the publish wire`,
+    ).toBeLessThanOrEqual(floor);
+  });
+
+  // ==========================================================================
+  // 2. Description census
+  // ==========================================================================
+
+  /**
+   * Interpolated expressions that reach for scanned-content windows. The
+   * word list is the vocabulary of every raw-content carrier in this tree
+   * (spans, summaries, evidence, masked previews, regex matches, slices).
+   */
+  const CONTENT_EXPR = /\.(slice|substring|substr)\s*\(|\b(content|evidence|summary|snippet|span|text|masked|match|raw|body|excerpt|preview|window)\b/i;
+
+  /**
+   * Every currently-allowlisted interpolating site, keyed by the trimmed
+   * source line, with the reviewed classification of WHY the value is not raw
+   * scanned bytes. An EDIT to a listed line re-opens the question — the
+   * stale-entry check below fails until the entry is re-justified.
+   */
+  const AUTHORED_ALLOW: ReadonlyArray<readonly [string, string]> = [
+    [
+      'description: `Capability "${cap.name}" does not appear related to the declared purpose: "${ast.declaredPurpose.slice(0, 100)}".`,',
+      'declaredPurpose is post-redaction at construction (extractDeclaredPurpose redacts before its slice) and crosses emitFinding again',
+    ],
+    [
+      'description: `Constraint bypassed: "${constraint.text.slice(0, 60)}..."`,',
+      'constraint prose selected by the extractor, crosses emitFinding; pre-existing truncation precedes the boundary and is tracked outside HMA-15',
+    ],
+    [
+      'description: `"${key}": ${masked}  -- ${type} hardcoded in ${file.path}. Visible to anyone with repo access or who can read the file.`,',
+      'masked at construction (maskCredential scheme: prefix + asterisks), never the raw value; crosses emitFinding',
+    ],
+    [
+      'description: `Component "${comp.source}" (${comp.role}) occupies ${Math.round(comp.content.length / totalLength * 100)}% of the assembled prompt. Safety instructions from ${safetyComponents.map(c => c.source).join(\', \') || \'SOUL.md\'} may be displaced from the effective attention window.`,',
+      'content.LENGTH is a number, not bytes; sources are file names',
+    ],
+    [
+      'description: `Messaging service (${match[1]}) is pre-allowed in sandbox policy. An attacker who gains code execution inside the sandbox can exfiltrate data via this channel without triggering additional permission prompts.`,',
+      'match[1] is a service hostname captured by an allowlist-of-services regex, not free content',
+    ],
+  ];
+  const ALLOW = new Map(AUTHORED_ALLOW);
+
+  function walkSourceFiles(dir: string, out: string[]): void {
+    for (const entry of readdirSync(dir, { withFileTypes: true })) {
+      const full = join(dir, entry.name);
+      if (entry.isDirectory()) {
+        walkSourceFiles(full, out);
+      } else if (entry.name.endsWith('.ts') && !entry.name.endsWith('.test.ts')) {
+        out.push(full);
+      }
+    }
+  }
+
+  it('HMA-15.AC8 no finding description interpolates a scanned-content window (census + classified allowlist)', () => {
+    const files: string[] = [];
+    walkSourceFiles(SRC, files);
+    expect(files.length).toBeGreaterThan(100);
+
+    const offenders: string[] = [];
+    for (const file of files) {
+      const lines = readFileSync(file, 'utf8').split('\n');
+      for (const line of lines) {
+        const trimmed = line.trim();
+        if (!/^description:\s/.test(trimmed)) continue;
+        const exprs = [...trimmed.matchAll(/\$\{([^}]*)\}/g)].map((m) => m[1]);
+        if (exprs.length === 0) continue;
+        if (!exprs.some((e) => CONTENT_EXPR.test(e))) continue;
+        if (ALLOW.has(trimmed)) continue;
+        offenders.push(`${relative(REPO_ROOT, file)}: ${trimmed}`);
+      }
+    }
+    expect(
+      offenders,
+      'A finding description interpolates a scanned-content expression. description is the ONE ' +
+        'byte-carrying field the Registry publish payload carries onto the wire (publish.ts maps ' +
+        'description -> wire message), so scanned bytes here are one --publish away from the ' +
+        'Registry. Move the bytes to `message`/`details` (local-only, boundary-redacted), or add ' +
+        'the trimmed line to AUTHORED_ALLOW with a reviewed classification:\n\n' +
+        offenders.join('\n'),
+    ).toEqual([]);
+  });
+
+  it('HMA-15.AC8 the census allowlist carries no dead entries', () => {
+    const files: string[] = [];
+    walkSourceFiles(SRC, files);
+    const present = new Set<string>();
+    for (const file of files) {
+      for (const line of readFileSync(file, 'utf8').split('\n')) present.add(line.trim());
+    }
+    const dead = [...ALLOW.keys()].filter((k) => !present.has(k));
+    expect(
+      dead,
+      'allowlisted description lines no longer exist verbatim (re-justify or delete): ' + dead.join(' | '),
+    ).toEqual([]);
+  });
+});

--- a/scripts/hma15-negative-proof.mjs
+++ b/scripts/hma15-negative-proof.mjs
@@ -1,0 +1,206 @@
+#!/usr/bin/env node
+/**
+ * HMA-15.AC6 — the negative proof: the property test can fail, and a NEW
+ * producer is what fails it.
+ *
+ * The credential-byte render class was patched per-producer twice (v0.25.2,
+ * v0.32.0) and survived both times, so a per-producer test is a REJECTED
+ * design for this defect. The property test claims to be producer-agnostic;
+ * this script proves the claim by construction:
+ *
+ *   1. copy `src/` into an OS temp scratch tree (this working tree is never
+ *      touched, and nothing here is ever committed);
+ *   2. add a DELIBERATE fourth producer to the scratch copy — a site that
+ *      copies raw scanned content into a finding field, modeling the exact
+ *      anchor-cut truncation shape of the three historical leaks (it slices
+ *      the tail of each long line, so a name-gated value crosses the report
+ *      boundary without its anchor and no shape rule can remove it);
+ *   3. build the scratch tree;
+ *   4. run the UNMODIFIED committed property test against that build via the
+ *      HMA15_CLI override, and require it to go RED;
+ *   5. record the red run — mutated build identity (path + sha256), vitest
+ *      exit code, and the run-artifact path — as the AC6 evidence artifact.
+ *
+ * The test file is not edited, the mutation names no test, and the property
+ * test knows nothing about the producer added here. If the matrix stays
+ * green over the mutation, THIS SCRIPT exits non-zero: a property test that
+ * cannot see a new producer copying raw bytes is not holding the class
+ * closed.
+ *
+ * Value hygiene (HMA-15.AC7) holds transitively: the planted values live
+ * inside the vitest child, whose failure messages come from the harness
+ * formatter that is itself pinned to emit no value bytes.
+ */
+
+import { spawnSync } from 'node:child_process';
+import { createHash } from 'node:crypto';
+import {
+  cpSync,
+  existsSync,
+  mkdtempSync,
+  readdirSync,
+  readFileSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const repoRoot = join(dirname(fileURLToPath(import.meta.url)), '..');
+const scratch = mkdtempSync(join(tmpdir(), 'hma15-negproof-'));
+
+const MUTATION_ANCHOR = `  findings.push(...checkHardcodedSecrets(ast, artifactContent));
+
+  return findings;`;
+
+const MUTATION = `  findings.push(...checkHardcodedSecrets(ast, artifactContent));
+
+  // HMA-15.AC6 NEGATIVE-PROOF MUTATION (never committed to a shipping tree):
+  // a fourth producer that copies raw scanned content into a finding field.
+  // The tail slice cuts any name anchor off, so the report boundary's
+  // name-gated shape rule cannot match what ships — the historical leak
+  // shape, reintroduced at a site no per-producer test names.
+  if (artifactContent !== undefined && findings.length > 0) {
+    const rawTails = artifactContent
+      .split('\\n')
+      .filter((l) => l.length >= 48)
+      .map((l) => l.slice(-44));
+    if (rawTails.length > 0) {
+      findings[0].message = findings[0].message + ' ctx: ' + rawTails.join(' | ');
+    }
+  }
+
+  return findings;`;
+
+function step(name, fn) {
+  process.stdout.write(`hma15-negative-proof: ${name}\n`);
+  return fn();
+}
+
+/** Stable whole-tree hash: sorted relative paths, each with its file sha256. */
+function sha256Tree(dir) {
+  const files = [];
+  const walk = (rel) => {
+    for (const entry of readdirSync(join(dir, rel), { withFileTypes: true })) {
+      const relPath = rel === '' ? entry.name : `${rel}/${entry.name}`;
+      if (entry.isDirectory()) walk(relPath);
+      else if (entry.isFile()) files.push(relPath);
+    }
+  };
+  walk('');
+  files.sort();
+  const hash = createHash('sha256');
+  for (const relPath of files) {
+    hash.update(relPath);
+    hash.update('\0');
+    hash.update(createHash('sha256').update(readFileSync(join(dir, relPath))).digest('hex'));
+    hash.update('\n');
+  }
+  return hash.digest('hex');
+}
+
+try {
+  step('copying src into scratch tree', () => {
+    cpSync(join(repoRoot, 'src'), join(scratch, 'src'), { recursive: true });
+    cpSync(join(repoRoot, 'tsconfig.json'), join(scratch, 'tsconfig.json'));
+    cpSync(join(repoRoot, 'package.json'), join(scratch, 'package.json'));
+    symlinkSync(join(repoRoot, 'node_modules'), join(scratch, 'node_modules'), 'dir');
+  });
+
+  step('adding the fourth producer', () => {
+    const target = join(scratch, 'src', 'nanomind-core', 'analyzers', 'credential-analyzer.ts');
+    const source = readFileSync(target, 'utf8');
+    if (!source.includes(MUTATION_ANCHOR)) {
+      throw new Error('mutation anchor not found — re-pin the anchor against the current analyzer source');
+    }
+    writeFileSync(target, source.replace(MUTATION_ANCHOR, MUTATION), 'utf8');
+  });
+
+  step('building the mutated tree', () => {
+    const tsc = spawnSync(
+      'node',
+      [join(repoRoot, 'node_modules', 'typescript', 'bin', 'tsc'), '-p', '.'],
+      { cwd: scratch, encoding: 'utf8', maxBuffer: 64 * 1024 * 1024 },
+    );
+    if (tsc.status !== 0) {
+      throw new Error(`tsc failed on the mutated tree:\n${tsc.stdout}\n${tsc.stderr}`);
+    }
+    // Mirror the integrity-manifest half of `npm run build`, so the mutated
+    // CLI runs exactly as a real build would.
+    const manifest = spawnSync(
+      'node',
+      [
+        '-e',
+        "const{generateManifest}=require('./dist/nanomind-core/security/integrity-verifier.js');const m=generateManifest(__dirname);if(m)require('fs').writeFileSync('dist/.integrity-manifest.json',JSON.stringify(m))",
+      ],
+      { cwd: scratch, encoding: 'utf8' },
+    );
+    if (manifest.status !== 0) {
+      throw new Error(`integrity manifest generation failed:\n${manifest.stderr}`);
+    }
+  });
+
+  const mutatedCli = join(scratch, 'dist', 'cli.js');
+  if (!existsSync(mutatedCli)) throw new Error('mutated build produced no dist/cli.js');
+  const mutatedSha = createHash('sha256').update(readFileSync(mutatedCli)).digest('hex');
+  // AC10 r2: cli.js hashes IDENTICAL across builds that differ only in the
+  // analyzers (this mutation never touches src/cli.ts), so the identity that
+  // distinguishes the mutated build is the whole dist tree.
+  const mutatedDistSha = sha256Tree(join(scratch, 'dist'));
+
+  const evidenceDir = process.env.HMA15_NEGATIVE_PROOF_DIR ?? mkdtempSync(join(tmpdir(), 'hma15-negproof-evidence-'));
+  const runArtifact = join(evidenceDir, 'mutated-property-run.json');
+
+  const vitestExit = step('running the UNMODIFIED property test against the mutated build', () => {
+    const env = { ...process.env, HMA15_CLI: mutatedCli, HMA15_RUN_ARTIFACT: runArtifact };
+    // The property suite NEVER skips (HMA-15.AC11) — the r1 CI-marker guard
+    // is gone — so nothing here depends on the environment. The markers are
+    // still cleared as plain hygiene: this proof measures the mutated BUILD,
+    // not whatever CI decoration the caller's shell carries.
+    delete env.CI;
+    delete env.GITHUB_ACTIONS;
+    const vitestEntry = join(repoRoot, 'node_modules', 'vitest', 'vitest.mjs');
+    const runner = existsSync(vitestEntry)
+      ? ['node', [vitestEntry]]
+      : [join(repoRoot, 'node_modules', '.bin', 'vitest'), []];
+    const vitest = spawnSync(
+      runner[0],
+      [...runner[1], 'run', '__tests__/cli/hma15-credential-render-property.test.ts'],
+      { cwd: repoRoot, encoding: 'utf8', env, maxBuffer: 64 * 1024 * 1024 },
+    );
+    process.stdout.write(vitest.stdout ?? '');
+    process.stderr.write(vitest.stderr ?? '');
+    return vitest.status;
+  });
+
+  const red = vitestExit !== 0 && vitestExit !== null;
+  const proof = {
+    task: 'HMA-15',
+    criterion: 'HMA-15.AC6',
+    mutation:
+      'fourth producer in analyzeCredentials: appends anchor-cut raw line tails of the scanned artifact to a finding message',
+    mutatedCli: { path: mutatedCli, sha256: mutatedSha, distTreeSha256: mutatedDistSha },
+    vitestExitCode: vitestExit,
+    propertyTestWentRed: red,
+    runArtifact,
+    recordedAt: new Date().toISOString(),
+  };
+  const proofPath = join(evidenceDir, 'negative-proof.json');
+  writeFileSync(proofPath, JSON.stringify(proof, null, 2) + '\n', 'utf8');
+  process.stdout.write(`hma15-negative-proof: evidence at ${proofPath}\n`);
+
+  if (!red) {
+    process.stderr.write(
+      'hma15-negative-proof: FAILURE — the property test stayed GREEN over a producer that copies raw scanned content. The property is not holding the class closed.\n',
+    );
+    // exitCode rather than process.exit(): an immediate exit would skip the
+    // finally-block cleanup of the scratch tree.
+    process.exitCode = 1;
+  } else {
+    process.stdout.write('hma15-negative-proof: OK — the unmodified property test went RED over the added producer.\n');
+  }
+} finally {
+  rmSync(scratch, { recursive: true, force: true });
+}

--- a/src/nanomind-core/analyzers/capability-analyzer.ts
+++ b/src/nanomind-core/analyzers/capability-analyzer.ts
@@ -67,6 +67,21 @@ export interface ASTFinding {
   evidence?: string;
   /** AST-specific: what a pairing finding matched (AST-CRED-002) */
   matched?: FindingMatch;
+  /**
+   * True when credential material was ALREADY removed from this finding's
+   * content at production — the canonical scan emitted a masked
+   * classification in place of the value, the producer masked a
+   * credential-format value out of the evidence summary, or the span
+   * constructor's report-boundary pass changed the copied window. It records
+   * only that a removal happened; it does not certify the remaining fields
+   * clean. The scanner bridge maps it to the draft's prior `redactionStatus`
+   * so `emitFinding`'s absorbing-`applied` merge reports the removal instead
+   * of concluding `clean` from fields the material is no longer in
+   * (HMA-15.AC2). No raw scanned byte rides on `ASTFinding` for a downstream
+   * filter to clean up — that mechanism was measured leaking every shape the
+   * downstream table does not cover, and is deleted, not capped.
+   */
+  redactionApplied?: boolean;
 }
 
 // ============================================================================

--- a/src/nanomind-core/analyzers/credential-analyzer.ts
+++ b/src/nanomind-core/analyzers/credential-analyzer.ts
@@ -19,6 +19,7 @@ import type { ProjectType } from '../../hardening/security-check.js';
 import { assertASTIntegrity } from '../security/defense-in-depth.js';
 import { lineFromOffset, findLineFromString } from '../../types/text-position.js';
 import {
+  findAllCredentialFormatMatches,
   findCredentialFormatMatch,
   hasCredentialFormat,
   hasAnyCredentialCandidate,
@@ -458,9 +459,30 @@ function checkHardcodedSecrets(ast: SecurityAST, artifactContent?: string): ASTF
     return findings;
   }
 
-  // Filter out test fixtures and documentation
+  // Filter out test fixtures and documentation.
+  //
+  // The two context gates below (`allTestFixtures`, and the doc-context
+  // credential-format gate at the end of this block) are evaluated on the RAW
+  // evidence window re-sliced from the artifact, not on `e.text`: spans are
+  // post-redaction at construction (HMA-15.AC1), and a redaction marker
+  // carries neither the placeholder vocabulary the fixture gate reads nor the
+  // vendor prefix the format sniff reads. Judging the redacted text would
+  // therefore both un-suppress doc-context placeholders (a new FP class) and
+  // suppress doc-context real leaks (detection narrowing, HMA-15.AC9) — the
+  // raw window keeps both gates byte-equivalent to their pre-redaction
+  // behaviour. Only the GATES read the raw slice; everything that ships in
+  // the finding still comes from the redacted span text.
   const isTestOrDoc = isDocumentationOrTestContext(ast);
-  const evidenceTexts = credentialEvidence.map(e => e.text);
+  const evidenceTexts = credentialEvidence.map(e =>
+    artifactContent !== undefined &&
+    typeof e.start === 'number' &&
+    typeof e.end === 'number' &&
+    e.start >= 0 &&
+    e.end > e.start &&
+    e.end <= artifactContent.length
+      ? artifactContent.slice(e.start, e.end)
+      : e.text,
+  );
   const allTestFixtures = evidenceTexts.every(t => isTestFixtureCredential(t));
 
   if (isTestOrDoc && allTestFixtures) {
@@ -566,7 +588,18 @@ function checkHardcodedSecrets(ast: SecurityAST, artifactContent?: string): ASTF
     }
     if (located.size > 0) {
       for (const [offset, summary] of [...located.entries()].sort((a, b) => a[0] - b[0])) {
-        findings.push(emit(summary, lineFromOffset(artifactContent, offset)));
+        const finding = emit(summary, lineFromOffset(artifactContent, offset));
+        // HMA-15.AC2 — the PRODUCER already removed the value: a located risk
+        // is a canonical-scan hit, and that scan emits `<label>: [REDACTED]`
+        // in place of the match, so no byte of it ever entered this record.
+        // The flag carries the FACT of that removal to `emitFinding`, whose
+        // absorbing-`applied` merge reports it — instead of re-deriving
+        // `clean` from fields the value was never in. (The r1 design carried
+        // the RAW match for `emitFinding` to remove; for any shape outside
+        // that table it removed nothing and the value shipped stamped clean,
+        // so the raw carry is deleted, not filtered.)
+        finding.redactionApplied = true;
+        findings.push(finding);
       }
       return findings;
     }
@@ -581,7 +614,47 @@ function checkHardcodedSecrets(ast: SecurityAST, artifactContent?: string): ASTF
     : undefined;
   const fallbackLine = lineFromSpan ?? findLineFromString(artifactContent, evidenceSummary);
 
-  findings.push(emit(evidenceSummary, fallbackLine));
+  // HMA-15.AC2, fallback arm — the path markdown artifacts take. The span's
+  // text is post-boundary (extractEvidenceSpans redacts at construction), but
+  // that boundary is a SHAPE TABLE: a value outside it — a JWT, an anonymous
+  // high-entropy blob, a quoting the name-gated rule does not match —
+  // survives into the span verbatim, and `emitFinding` downstream runs the
+  // SAME table, so nothing later can remove what it missed. The producer
+  // therefore masks HERE, at the point of production, and from a window in
+  // which every value is WHOLE: the span's window re-sliced from the raw
+  // artifact and widened to full lines. The span TEXT is a 100-char cut, and
+  // a value the cut truncated matches no format signal — a truncated probe is
+  // this arm's original defect, so the mask must run before any slice.
+  // Masking is `maskCredentialValue`'s scheme: vendor prefix preserved,
+  // unknown shape masked ENTIRELY. No raw scanned byte is handed to a
+  // downstream filter to clean up.
+  const span = credentialEvidence[0];
+  let summarySource = evidenceSummary;
+  if (
+    artifactContent !== undefined &&
+    span !== undefined &&
+    typeof span.start === 'number' &&
+    typeof span.end === 'number' &&
+    span.start >= 0 &&
+    span.end > span.start &&
+    span.end <= artifactContent.length
+  ) {
+    const lineStart = span.start === 0 ? 0 : artifactContent.lastIndexOf('\n', span.start - 1) + 1;
+    const newlineAfterEnd = artifactContent.indexOf('\n', span.end);
+    const lineEnd = newlineAfterEnd === -1 ? artifactContent.length : newlineAfterEnd;
+    summarySource = artifactContent.slice(lineStart, lineEnd);
+  }
+  const { text: maskedSummary, masked } = maskCredentialFormats(summarySource);
+  const fallback = emit(maskedSummary.slice(0, 120), fallbackLine);
+  // The FACT of a removal — by this arm's own masking, or by the report
+  // boundary inside the span constructor — rides to `emitFinding`, whose
+  // absorbing-`applied` merge reports it. Nothing here certifies fields
+  // clean: `clean` remains what `emitFinding` derives when nothing was
+  // removed anywhere on the path.
+  if (masked || span?.redactionApplied === true) {
+    fallback.redactionApplied = true;
+  }
+  findings.push(fallback);
 
   return findings;
 }
@@ -685,7 +758,22 @@ function isDocumentationOrTestContext(ast: SecurityAST): boolean {
  * `../../types/credential-format.js`.
  */
 function evidenceShowsCredentialFormat(evidenceTexts: string[]): boolean {
-  return evidenceTexts.some(t => hasCredentialFormat(t));
+  // The caller normally hands this gate RAW evidence windows re-sliced from
+  // the artifact, so the sniff behaves exactly as it did before spans became
+  // post-redaction at construction (HMA-15.AC1). The marker clause covers the
+  // one path where only the redacted span text exists (no artifact content in
+  // hand): there, a shape marker is the boundary's own record that a
+  // credential FORMAT was present — without it, redaction would suppress the
+  // doc-context finding the raw bytes used to prove, closing the render class
+  // by detecting less (forbidden by HMA-15.AC9).
+  //
+  // Only SHAPE-anchored markers (`[REDACTED_AWS_SECRET]`, underscore-suffixed)
+  // count. The generic name-gated rule's bare `[REDACTED]` proves no format —
+  // it fires on an identifier without ever inspecting the value (C9) — and
+  // accepting it would WIDEN detection over quoted non-credential values that
+  // never passed this gate before.
+  const shapeMarker = /\[REDACTED_[A-Z0-9_]+\]/;
+  return evidenceTexts.some(t => hasCredentialFormat(t) || shapeMarker.test(t));
 }
 
 /**
@@ -1030,6 +1118,33 @@ function maskCredentialValue(value: string): string {
   // one the boundary cannot clean up downstream because a truncated credential no longer
   // matches the redactor's full-length shapes. Cap the mask so output stays bounded.
   return '*'.repeat(Math.min(Math.max(value.length, 1), 24));
+}
+
+/**
+ * Mask EVERY credential-format value in `text` — vendor-prefixed, JWT, and
+ * credible high-entropy blob — the way `maskCredentialValue` masks a single
+ * one: prefix preserved when a vendor is recognisable, the whole value
+ * otherwise. `masked` is true exactly when at least one value was replaced,
+ * which is the honest input to a `redactionStatus` of `applied`: it reports a
+ * removal that actually happened here, at the point of production.
+ *
+ * This is deliberately NOT the report redaction boundary. The boundary is a
+ * shape table with two documented omissions (`jwt`, `entropy-blob` — GAP-8),
+ * and this arm's evidence window is exactly where a value outside the table
+ * was measured shipping whole. The format scan has no table to fall behind:
+ * anything it can find, `maskCredentialValue` can mask, and a value neither
+ * signal sees is a value the detection layer cannot call a credential either.
+ */
+function maskCredentialFormats(text: string): { text: string; masked: boolean } {
+  const hits = findAllCredentialFormatMatches(text);
+  if (hits.length === 0) return { text, masked: false };
+  let out = '';
+  let pos = 0;
+  for (const hit of hits) {
+    out += text.slice(pos, hit.index) + maskCredentialValue(hit.value);
+    pos = hit.index + hit.value.length;
+  }
+  return { text: out + text.slice(pos), masked: true };
 }
 
 /**

--- a/src/nanomind-core/compiler/semantic-compiler.ts
+++ b/src/nanomind-core/compiler/semantic-compiler.ts
@@ -2391,12 +2391,43 @@ function extractEvidenceSpans(content: string, risks: RiskSurface[]): EvidenceSp
     const idx = content.toLowerCase().indexOf(risk.evidence.toLowerCase().slice(0, 30));
     if (idx >= 0) {
       const end = Math.min(idx + 100, content.length);
+      // Redaction lives INSIDE this constructor, before the 100-char slice —
+      // the same single guarantee point `extractDeclaredPurpose` uses, and the
+      // same boundary (`redactSecretsForReport`, never the daemon variant).
+      // Order matters for the same reason it does there: slicing first can cut
+      // a secret down to a fragment shorter than a pattern's minimum length,
+      // so the redactor stops matching while the value's bytes still ship.
+      // A released build rendered 32 of a 40-character name-gated value into
+      // `details.evidence` stamped `clean` through exactly that ordering.
+      //
+      // The window offered to the redactor is widened to whole lines on both
+      // sides of the [idx, end) slice, so a secret that straddles either cut
+      // is in full view of the shape patterns (single-line, all of them —
+      // the PEM block rule is the one multi-line shape, and a block cut by
+      // the widened window is the same pre-existing residual it is at every
+      // other boundary: the rule needs both markers in view).
+      // The prefix is redacted separately to locate where the slice starts in
+      // the redacted region: when no match crosses `idx`, redaction composes
+      // and the position is exact; when one does, the slice can only drift
+      // into replacement-marker text, never into raw secret bytes, because
+      // the entire region was redacted before any slicing.
+      const lineStart = idx === 0 ? 0 : content.lastIndexOf('\n', idx - 1) + 1;
+      const newlineAfterEnd = content.indexOf('\n', end);
+      const lineEnd = newlineAfterEnd === -1 ? content.length : newlineAfterEnd;
+      const rawRegion = content.slice(lineStart, lineEnd);
+      const redactedRegion = redactSecretsForReport(rawRegion);
+      const prefixLength = redactSecretsForReport(content.slice(lineStart, idx)).length;
       spans.push({
         start: idx,
         end,
-        text: content.slice(idx, end),
+        text: redactedRegion.slice(prefixLength, prefixLength + 100),
         supports: risk.attackClass,
         confidence: risk.confidence,
+        // The FACT of the removal rides with the span, so a finding built
+        // from it can report `applied` without re-detecting anything: the
+        // boundary changed this window, therefore credential material was
+        // removed before the text left this constructor (HMA-15.AC2).
+        redactionApplied: redactedRegion !== rawRegion,
       });
     }
   }

--- a/src/nanomind-core/scanner-bridge.ts
+++ b/src/nanomind-core/scanner-bridge.ts
@@ -1190,7 +1190,7 @@ function astFindingToSecurityFinding(
   // therefore a property of the control flow here, not a convention a later
   // edit could quietly invert — there is no path on which the redacted text is
   // what gets located.
-  return emitFinding({
+  const draft: SecurityFindingDraft = {
     checkId: ast.checkId,
     name: ast.name,
     description: ast.description,
@@ -1216,7 +1216,20 @@ function astFindingToSecurityFinding(
       // consumer reads it yet, so it is not a contract.
       ...(ast.matched ? { matched: ast.matched } : {}),
     },
-  });
+  };
+  // HMA-15.AC2 — the producer already removed credential material from this
+  // finding (masked at the point of production); hand `emitFinding` that FACT
+  // through its documented prior-status absorption, so the emitted
+  // `redactionStatus` reports the removal instead of concluding `clean` from
+  // fields the material is no longer in. Structural, exactly the path
+  // `emitFinding` reads priors off (`draft as Partial<SecurityFinding>`): the
+  // draft type omits the field so no producer can stamp a status by accident,
+  // and `applied` is the one value that cannot downgrade anything — the merge
+  // is absorbing.
+  if (ast.redactionApplied === true) {
+    (draft as Partial<SecurityFinding>).redactionStatus = 'applied';
+  }
+  return emitFinding(draft);
 }
 
 /**

--- a/src/nanomind-core/types.ts
+++ b/src/nanomind-core/types.ts
@@ -268,6 +268,16 @@ export interface EvidenceSpan {
   supports: string;         // e.g., "exfiltration_intent", "credential_exposure"
   /** Confidence this evidence is relevant */
   confidence: number;
+  /**
+   * True when the report redaction boundary CHANGED this span's window at
+   * construction — i.e. credential material was removed from `text` before it
+   * ever left `extractEvidenceSpans`. It records only that comparison
+   * (redacted window !== raw window); it does not claim the remaining text is
+   * free of every credential shape. A finding built from this span carries the
+   * fact of that removal forward so its `redactionStatus` can say `applied`
+   * instead of re-deriving `clean` from fields the material is no longer in.
+   */
+  redactionApplied?: boolean;
 }
 
 // ============================================================================

--- a/src/types/credential-format.ts
+++ b/src/types/credential-format.ts
@@ -848,13 +848,20 @@ function isAlphanumericCode(c: number): boolean {
  * terminating `.` is a property of the RUN, not of the `eyJ` inside it, so the
  * payload and signature are resolved once per run rather than once per `eyJ` —
  * that is what removes the quadratic without removing any input.
+ *
+ * `from` starts the walk at an absolute offset so an all-matches caller
+ * (`findAllCredentialFormatMatches`) can resume past a hit without slicing —
+ * a slice per hit is the quadratic this scan exists to avoid. The anchor test
+ * stays absolute: position `from` is anchored by the byte before it, exactly
+ * as it would be in a full scan.
  */
 export function findJwtMatch(
   text: string,
   anchored: boolean,
+  from = 0,
 ): { value: string; index: number } | undefined {
   const n = text.length;
-  let i = 0;
+  let i = from;
   while (i < n) {
     if (!isBase64UrlCode(text.charCodeAt(i))) {
       i++;
@@ -1157,6 +1164,63 @@ export function findCredentialFormatMatch(
 /** True when `text` contains at least one accepted credential-format value. */
 export function hasCredentialFormat(text: string): boolean {
   return findCredentialFormatMatch(text) !== undefined;
+}
+
+/**
+ * EVERY credential-format substring in `text`, left to right, non-overlapping.
+ *
+ * Same three signals as `findCredentialFormatMatch` (vendor alternation, JWT
+ * scan, entropy fallback), collected in ONE pass each rather than by repeated
+ * leftmost scans — a rescan-per-hit loop is quadratic on hit-dense input, and
+ * this function exists for a producer that must mask every value out of an
+ * evidence window before any of it ships (HMA-15.AC2), where "the first one"
+ * is exactly the per-producer blindness that let a second value through.
+ *
+ * Overlaps resolve leftmost-first; on a tie the vendor match wins, then the
+ * JWT, then the blob — the same precedence `leftmost` gives the single-match
+ * entry point. A hit starting inside an accepted hit is dropped, not
+ * re-anchored: its bytes are already inside a value the caller will mask
+ * whole.
+ */
+export function findAllCredentialFormatMatches(
+  text: string,
+): { value: string; index: number }[] {
+  const hits: { value: string; index: number; rank: number }[] = [];
+
+  const vendorRe = new RegExp(vendorAlternation(), 'g');
+  let vm: RegExpExecArray | null;
+  while ((vm = vendorRe.exec(text)) !== null) {
+    hits.push({ value: vm[0], index: vm.index, rank: 0 });
+    // A zero-width match cannot happen (every alternative consumes its head),
+    // but a stuck lastIndex would loop forever; step defensively.
+    if (vm[0].length === 0) vendorRe.lastIndex++;
+  }
+
+  for (let pos = 0; ; ) {
+    const jwt = findJwtMatch(text, false, pos);
+    if (!jwt) break;
+    hits.push({ value: jwt.value, index: jwt.index, rank: 1 });
+    pos = jwt.index + jwt.value.length;
+  }
+
+  const blobRe = new RegExp(ENTROPY_BLOB_ALTERNATIVE, 'g');
+  let bm: RegExpExecArray | null;
+  while ((bm = blobRe.exec(text)) !== null) {
+    const offset = findCredibleWindowOffset(bm[0]);
+    if (offset !== undefined) {
+      hits.push({ value: bm[0].slice(offset), index: bm.index + offset, rank: 2 });
+    }
+  }
+
+  hits.sort((a, b) => a.index - b.index || a.rank - b.rank);
+  const merged: { value: string; index: number }[] = [];
+  let consumedTo = 0;
+  for (const h of hits) {
+    if (h.index < consumedTo) continue;
+    merged.push({ value: h.value, index: h.index });
+    consumedTo = h.index + h.value.length;
+  }
+  return merged;
 }
 
 /**


### PR DESCRIPTION
## The defect

A detected credential could be rendered into report output while the report declared itself
redacted. The value reached `details.evidence` through the evidence-span constructor, which sliced
a 100-character window out of the raw artifact region **before** any redaction ran. The slice
carried the secret, and the later report-level redactor never saw it in a form it could match.

Measured on the pre-change tree, longest contiguous run of a planted credential:

| channel | before | after |
|---|---|---|
| `secure --format json` | 17 chars of a JWT | **3** |
| `check --json` | 17 chars of a JWT | **3** |

3 is the shared `eyJ` prefix every value of that shape carries, against a measured null floor of
3-4 — i.e. indistinguishable from noise. The property matrix's own baseline run measured leaks up
to **35 of 40** characters on `env_file`, 31 on `agent_config`, and 24/21/18/17/13 elsewhere. On
this branch all 70 cells sit at or under the floor.

## The fix — mask at the producer, do not filter downstream

- `extractEvidenceSpans` redacts the whole region and slices the redacted result, so no raw window
  is ever constructed.
- The credential analyzer masks the whole-line window before the summary is built, rather than
  handing a raw line onward.
- The raw carry field is **deleted** rather than filtered (`credentialMatch` and `matchStart` now
  grep to zero in `src/`). A value never placed on the structure cannot leak from it; a filter only
  removes the shapes it already knows about. An earlier attempt at this fix added such a field and
  trusted the downstream redactor, which widened the disclosure instead of closing it.

## Why the test can be believed

The guard is a property matrix over report formats and artifact types, with two properties that
make it non-vacuous:

- **The fixture vocabulary is a predicate, not a list.** Every cell plants values proven uncovered
  *in the same run*: the fixture calls the report redactor on each planted value and asserts it
  comes back unchanged, establishing the value is genuinely not covered downstream before using it
  to test the producer. A hardcoded list of "values we believe are uncovered" rots silently.
  This matters concretely: on the pre-change tree **all 21 red cells failed on uncovered-kind
  values**, so a covered-only matrix would have reported a clean pass against the leaking build.
- **It runs unconditionally.** No environment-conditional skip, because a check that skips is a
  check that is absent exactly when it matters, and the publish workflow runs the test suite.

The axis that matters is the **quoting** of a value, not the identifier naming it: quoted
assignments are already covered downstream, unquoted and structural forms are not. A repair aimed
at widening the identifier list would miss the class.

## Verification

- Full suite green; benign false-positive corpus 33/33; per-cell detection counts identical to the
  pre-change tree in every countable cell, never lower.
- Three mutations were applied and each was killed by a named test: reverting the span redaction,
  neutralising the producer masking (which also turned 20 matrix cells red — the exact baseline
  signature), and adding a fourth raw-line producer (30/75 red with no test edited).
- A committed negative-proof script rebuilds a deliberately-leaking variant and asserts the matrix
  goes red against it.
- The shipped `.d.ts` files are packed and grepped for redaction guarantees that no measurement
  supports; the allowlist is empty and stays empty.

## Known and not fixed here

Two cosmetic items are deliberately left: a bare `expect(...).toMatch(...)` whose failure diff can
echo span text (only ever of runtime-minted synthetic values), and one fallback-arm comment that is
slightly stronger than what is proven. Neither affects behaviour, and both were left so the pushed
tree is byte-identical to the independently verified one.

Separately filed: 44 tests and 2 files currently skip under CI in suites this branch does not
touch, which means those checks are absent at publish time. Same class this matrix closes for
itself.