### PR TITLE
Make the contribute flush tests hermetic: inject the registry health probe

### DIFF
--- a/__tests__/telemetry/contribute.test.ts
+++ b/__tests__/telemetry/contribute.test.ts
@@ -9,7 +9,7 @@
  *   - Delayed consent tip after 3rd scan
  */
 
-import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { describe, it, expect, beforeAll, afterAll, beforeEach, afterEach, vi } from 'vitest';
 import * as fs from 'fs';
 import * as path from 'path';
 import * as os from 'os';
@@ -22,6 +22,8 @@ import {
   queueAndMaybeFlush,
   flushQueue,
   submitContribution,
+  _setRegistryHealthProbe,
+  _resetRegistryHealthProbe,
   type ContributionEvent,
 } from '../../src/telemetry/contribute';
 import {
@@ -41,6 +43,71 @@ import type { SecurityFinding } from '../../src/hardening';
 function createTempDir(): string {
   return fs.mkdtempSync(path.join(os.tmpdir(), 'contribute-test-'));
 }
+
+/** The real `~/.opena2a` this run must not write into. See the beforeAll below. */
+const REAL_OPENA2A_DIR = path.join(os.homedir(), '.opena2a');
+
+/**
+ * Registry base URL for the flush tests. Loopback discard port: nothing is
+ * listening and nothing routes off the machine, so a regression that puts a
+ * real request back on this path fails loudly instead of passing against the
+ * production registry. The health probe is stubbed as well -- this is the
+ * belt to that brace.
+ */
+const UNROUTABLE_REGISTRY_URL = 'http://127.0.0.1:9';
+
+/**
+ * mtime of a file, or null when it does not exist. Either answer is a fine
+ * baseline — the assertion is that it is the SAME answer afterwards.
+ */
+function mtimeOrNull(p: string): number | null {
+  try {
+    return fs.statSync(p).mtimeMs;
+  } catch {
+    return null;
+  }
+}
+
+// ---------------------------------------------------------------
+// Hermeticity: a per-run scratch OPENA2A_HOME for the whole file
+// ---------------------------------------------------------------
+//
+// Recorded for HMA-20.AC3: the scratch home is set HERE, in this file, not in
+// vitest.setup.ts. Both were allowed; this file is the smaller blast radius,
+// because vitest.setup.ts is loaded by all 373 test files in the suite and two
+// sibling branches are editing test files right now.
+//
+// src/telemetry/contribute.ts honours OPENA2A_HOME for all three of the files
+// it owns — contribute-health.json, contribute-retry.json, contribute-ping.json
+// — and reads the variable lazily inside each path helper, so setting it in a
+// hook (rather than before the import) is enough.
+//
+// KNOWN LIMIT, deliberately left: `@opena2a/contribute`'s dist/queue.js binds
+// `QUEUE_PATH = join(homedir(), '.opena2a', 'contribute-queue.json')` at module
+// load and never consults OPENA2A_HOME, so `queueEvent`/`clearQueue` in this
+// file still touch the developer's real ~/.opena2a/contribute-queue.json. That
+// is a change to the published package, not to this repository, and is out of
+// HMA-20's scope. The same is true of contributor-salt via dist/contributor.js.
+//
+// The nested describes that set their own OPENA2A_HOME still work: they capture
+// the value on entry (which is this scratch dir) and restore it on exit.
+let suiteHome: string;
+let suiteHomeOriginalEnv: string | undefined;
+
+beforeAll(() => {
+  suiteHome = createTempDir();
+  suiteHomeOriginalEnv = process.env.OPENA2A_HOME;
+  process.env.OPENA2A_HOME = suiteHome;
+});
+
+afterAll(() => {
+  if (suiteHomeOriginalEnv === undefined) {
+    delete process.env.OPENA2A_HOME;
+  } else {
+    process.env.OPENA2A_HOME = suiteHomeOriginalEnv;
+  }
+  cleanupDir(suiteHome);
+});
 
 function cleanupDir(dir: string): void {
   fs.rmSync(dir, { recursive: true, force: true });
@@ -350,20 +417,34 @@ describe('queueEvent', () => {
 });
 
 // ---------------------------------------------------------------
-// flushQueue (with mocked fetch)
+// flushQueue (with mocked fetch AND a stubbed health probe)
 // ---------------------------------------------------------------
+//
+// `flushQueue` will not call `submitBatch` until its pre-flight health probe
+// says the registry is up, and that probe is a live node:https GET whose
+// verdict is cached on disk for five minutes — the stubbed global `fetch` does
+// not intercept it. Every test below therefore supplies its own verdict through
+// `_setRegistryHealthProbe`. Nothing here reaches the network, and nothing here
+// depends on what a previous run cached.
 
 describe('flushQueue', () => {
+  let healthProbe: ReturnType<typeof vi.fn>;
+
   beforeEach(() => {
     sharedClearQueue();
+    // Default verdict for this block: registry is up. Individual tests read
+    // `healthProbe.mock.calls` to assert whether the probe was consulted.
+    healthProbe = vi.fn(async () => true);
+    _setRegistryHealthProbe(healthProbe as never);
   });
 
   afterEach(() => {
+    _resetRegistryHealthProbe();
     vi.unstubAllGlobals();
     sharedClearQueue();
   });
 
-  it('submits batch to /api/v1/contribute endpoint', async () => {
+  it('HMA-20.AC1 submits batch to /api/v1/contribute endpoint', async () => {
     const response = { ok: true, json: async () => ({}) };
     vi.stubGlobal('fetch', vi.fn().mockResolvedValueOnce(response));
 
@@ -382,6 +463,11 @@ describe('flushQueue', () => {
     const ok = await flushQueue();
 
     expect(ok).toBe(true);
+    // The probe was consulted for the default registry, and answered from the
+    // stub above rather than from api.oa2a.org.
+    expect(healthProbe).toHaveBeenCalledWith('https://api.oa2a.org');
+    // A string comparison against a recorded mock call -- the stubbed `fetch`
+    // never opened a connection to this URL.
     const fetchCall = (fetch as any).mock.calls[0];
     expect(fetchCall[0]).toBe('https://api.oa2a.org/api/v1/contribute');
     expect(fetchCall[1].method).toBe('POST');
@@ -391,7 +477,7 @@ describe('flushQueue', () => {
     expect(events).toHaveLength(0);
   });
 
-  it('uses custom registry URL when provided', async () => {
+  it('HMA-20.AC1 uses custom registry URL when provided', async () => {
     const response = { ok: true, json: async () => ({}) };
     vi.stubGlobal('fetch', vi.fn().mockResolvedValueOnce(response));
 
@@ -402,13 +488,17 @@ describe('flushQueue', () => {
       timestamp: new Date().toISOString(),
     });
 
-    await flushQueue('https://custom.registry.example.com');
+    // Deliberately unroutable: port 9 (discard) on loopback. If the seam ever
+    // regresses and something here does open a socket, this test hangs or
+    // refuses instead of quietly succeeding against a real host.
+    await flushQueue(UNROUTABLE_REGISTRY_URL);
 
+    expect(healthProbe).toHaveBeenCalledWith(UNROUTABLE_REGISTRY_URL);
     const fetchCall = (fetch as any).mock.calls[0];
-    expect(fetchCall[0]).toBe('https://custom.registry.example.com/api/v1/contribute');
+    expect(fetchCall[0]).toBe(`${UNROUTABLE_REGISTRY_URL}/api/v1/contribute`);
   });
 
-  it('keeps events in queue on network failure', async () => {
+  it('HMA-20.AC2 keeps events in queue on network failure', async () => {
     vi.stubGlobal('fetch', vi.fn().mockRejectedValueOnce(new Error('ECONNREFUSED')));
 
     queueEvent({
@@ -418,17 +508,40 @@ describe('flushQueue', () => {
       timestamp: new Date().toISOString(),
     });
 
-    const ok = await flushQueue();
+    const ok = await flushQueue(UNROUTABLE_REGISTRY_URL);
     expect(ok).toBe(false);
+
+    // The failure came from the POST, not from the pre-flight probe: the probe
+    // ran and said "healthy", so this is the submit path being exercised.
+    expect(healthProbe).toHaveBeenCalledTimes(1);
+    expect((fetch as any).mock.calls).toHaveLength(1);
 
     // Events should still be in queue
     const events = getQueuedEvents();
     expect(events.length).toBeGreaterThanOrEqual(1);
   });
 
-  it('returns true for empty queue', async () => {
+  it('HMA-20.AC3 returns true for empty queue without touching the real home', async () => {
+    // The scratch home from the file-level beforeAll is in force, and it is not
+    // the developer's ~/.opena2a.
+    expect(process.env.OPENA2A_HOME).toBe(suiteHome);
+    expect(process.env.OPENA2A_HOME).not.toBe(REAL_OPENA2A_DIR);
+
+    const before = ['contribute-health.json', 'contribute-retry.json'].map(f =>
+      mtimeOrNull(path.join(REAL_OPENA2A_DIR, f)),
+    );
+
     const ok = await flushQueue();
     expect(ok).toBe(true);
+
+    // Empty queue short-circuits ahead of the probe -- no verdict is needed,
+    // so no health cache is consulted or written anywhere.
+    expect(healthProbe).not.toHaveBeenCalled();
+
+    const after = ['contribute-health.json', 'contribute-retry.json'].map(f =>
+      mtimeOrNull(path.join(REAL_OPENA2A_DIR, f)),
+    );
+    expect(after).toEqual(before);
   });
 });
 
@@ -436,17 +549,24 @@ describe('flushQueue', () => {
 // submitContribution (legacy compat)
 // ---------------------------------------------------------------
 
+// `submitContribution` is a thin wrapper over `flushQueue`, so it inherits the
+// same pre-flight health probe and needs the same stub.
 describe('submitContribution', () => {
+  let healthProbe: ReturnType<typeof vi.fn>;
+
   beforeEach(() => {
     sharedClearQueue();
+    healthProbe = vi.fn(async () => true);
+    _setRegistryHealthProbe(healthProbe as never);
   });
 
   afterEach(() => {
+    _resetRegistryHealthProbe();
     vi.unstubAllGlobals();
     sharedClearQueue();
   });
 
-  it('queues event and flushes (legacy compat)', async () => {
+  it('HMA-20.AC1 queues event and flushes (legacy compat)', async () => {
     const response = { ok: true, json: async () => ({}) };
     vi.stubGlobal('fetch', vi.fn().mockResolvedValueOnce(response));
 
@@ -457,12 +577,16 @@ describe('submitContribution', () => {
       timestamp: new Date().toISOString(),
     };
 
-    const result = await submitContribution(event, 'https://custom.example.com');
+    const result = await submitContribution(event, UNROUTABLE_REGISTRY_URL);
     expect(result.success).toBe(true);
+    expect(healthProbe).toHaveBeenCalledWith(UNROUTABLE_REGISTRY_URL);
   });
 
-  it('handles network errors gracefully', async () => {
+  it('HMA-20.AC3 handles network errors gracefully, recording retry state under the scratch home', async () => {
     vi.stubGlobal('fetch', vi.fn().mockRejectedValueOnce(new Error('ECONNREFUSED')));
+
+    const realRetry = path.join(REAL_OPENA2A_DIR, 'contribute-retry.json');
+    const realRetryBefore = mtimeOrNull(realRetry);
 
     const event: ContributionEvent = {
       type: 'scan_result',
@@ -471,8 +595,13 @@ describe('submitContribution', () => {
       timestamp: new Date().toISOString(),
     };
 
-    const result = await submitContribution(event);
+    const result = await submitContribution(event, UNROUTABLE_REGISTRY_URL);
     expect(result.success).toBe(false);
+
+    // The failed flush recorded backoff state. It landed in the scratch
+    // OPENA2A_HOME, and the developer's copy was left alone.
+    expect(fs.existsSync(path.join(suiteHome, 'contribute-retry.json'))).toBe(true);
+    expect(mtimeOrNull(realRetry)).toBe(realRetryBefore);
   });
 });
 

--- a/src/telemetry/contribute.ts
+++ b/src/telemetry/contribute.ts
@@ -298,6 +298,46 @@ async function checkRegistryHealth(baseUrl: string): Promise<boolean> {
   }
 }
 
+// ---------------------------------------------------------------------------
+// Health-probe seam
+// ---------------------------------------------------------------------------
+//
+// `flushQueue` runs the pre-flight health check above before it will call
+// `submitBatch`, and that check is the one piece of the flush path a test
+// cannot reach: it is a live `node:https` GET, not the global `fetch` that the
+// suite stubs, and its verdict is cached on disk for five minutes under
+// $OPENA2A_HOME. So the three tests in __tests__/telemetry/contribute.test.ts
+// that assert on the stubbed `fetch` were really asserting two things they
+// never named — that api.oa2a.org was up, and that the previous run had left a
+// `healthy: true` in contribute-health.json. When either was false the probe
+// short-circuited the flush, `fetch` was never called, and they failed with
+// `expected false to be true`. That is what turned the test matrix red twice on
+// main (2026-08-30 macos, 2026-08-31 ubuntu), not shared queue state.
+//
+// The probe is therefore reached through this one-entry indirection so a test
+// can hand `flushQueue` a verdict directly. Nothing on the production path
+// changes: the default is `checkRegistryHealth` itself — same URL, same
+// 3-second timeout, same 5-minute on-disk cache — and nothing outside the
+// suite calls the setter.
+
+export type RegistryHealthProbe = (baseUrl: string) => Promise<boolean>;
+
+let registryHealthProbe: RegistryHealthProbe = checkRegistryHealth;
+
+/**
+ * Test seam: replace the pre-flight registry health probe.
+ * Pair every call with `_resetRegistryHealthProbe` in an `afterEach` — the
+ * binding is module-level and outlives the test that set it.
+ */
+export function _setRegistryHealthProbe(probe: RegistryHealthProbe): void {
+  registryHealthProbe = probe;
+}
+
+/** Test seam: restore the production `node:https` probe. */
+export function _resetRegistryHealthProbe(): void {
+  registryHealthProbe = checkRegistryHealth;
+}
+
 /**
  * Send a scan_ping heartbeat event if more than PING_INTERVAL_MS has elapsed.
  * Tells the registry this tool is installed and active — used for adoption stats.
@@ -487,8 +527,10 @@ export async function flushQueue(
     return true;
   }
 
-  // Pre-flight health check — skip submission if registry is down
-  const healthy = await checkRegistryHealth(url);
+  // Pre-flight health check — skip submission if registry is down.
+  // Goes through the seam above so the suite can supply a verdict instead of
+  // depending on the live registry and the on-disk cache.
+  const healthy = await registryHealthProbe(url);
   if (!healthy) {
     recordFailure(readRetryState());
     return false;


### PR DESCRIPTION
## What

Three `flushQueue` tests in `__tests__/telemetry/contribute.test.ts` were asserting two things they never named: that the production registry's `/health` answered within 3 seconds, and that the previous run had cached `healthy: true` on disk. The pre-flight probe is a live `node:https` GET, not the stubbed global `fetch`, and its verdict is cached for five minutes under `$OPENA2A_HOME`. When either condition was false the probe short-circuited the flush, `fetch` was never called, and the tests failed with `expected false to be true`. That is what turned the test matrix red on main twice (2026-08-30 macos, 2026-08-31 ubuntu), not shared queue state.

The probe now goes through a one-entry seam (`_setRegistryHealthProbe` / `_resetRegistryHealthProbe`, test-only, module-level binding reset in `afterEach`). The production default is `checkRegistryHealth` itself: same URL, same timeout, same cache. Every test that exercises `flushQueue` supplies its own verdict, and the suite runs under a scratch `OPENA2A_HOME` so it no longer writes the developer's real `~/.opena2a/`.

## Measured

| check | base a598f61 | this branch |
|---|---|---|
| `npx vitest run __tests__/telemetry/contribute.test.ts` with `OPENA2A_HOME` seeded `{"healthy":false}` | 3 failed / 22 passed | 25 passed |
| five runs, fresh scratch `OPENA2A_HOME` each | – | 25 passed x5 |
| `~/.opena2a/contribute-health.json` mtime across a run with the variable unset | changes | unchanged |
| `CI=true GITHUB_ACTIONS=true npm test` | – | 371 files passed, 4967 passed / 44 skipped / 10 todo |
| plain `npm test` (the pre-push hook's invocation) | – | 373 files passed, 5007 passed / 4 skipped / 10 todo, exit 0 |
| `git diff --name-only` | – | `src/telemetry/contribute.ts`, `__tests__/telemetry/contribute.test.ts` |

No test deleted, skipped or marked todo. Known limit, not fixed here: the `@opena2a/contribute` package's queue writer hardcodes `homedir()/.opena2a/contribute-queue.json` and ignores `OPENA2A_HOME`.
