### PR TITLE
Detect name-gated AWS-shaped secrets of 40+ characters, not exactly 40

### DIFF
--- a/__tests__/nanomind-core/name-gated-credential-width.test.ts
+++ b/__tests__/nanomind-core/name-gated-credential-width.test.ts
@@ -66,7 +66,17 @@ function runCli(target: string): { failedCred: ReportFinding[]; stdout: string }
   });
   const stdout = run.stdout ?? '';
   const start = stdout.indexOf('{');
-  const parsed = start >= 0 ? JSON.parse(stdout.slice(start)) : {};
+  // Fail loudly rather than returning an empty finding list. Every negative
+  // assertion in this file compares against [], so a spawn that never ran would
+  // satisfy all of them silently — the scanner reporting nothing and the scanner
+  // never starting must not look the same to a test.
+  if (start < 0) {
+    throw new Error(
+      `the scanner produced no JSON for ${target} (status ${run.status}, signal ${run.signal}); `
+        + `stderr: ${(run.stderr ?? '').slice(0, 400)}`,
+    );
+  }
+  const parsed = JSON.parse(stdout.slice(start));
   const all: ReportFinding[] = parsed.allFindings ?? parsed.findings ?? [];
   return {
     failedCred: all.filter(f => f.passed === false && /^AST-CRED-/.test(f.checkId)),
@@ -74,9 +84,15 @@ function runCli(target: string): { failedCred: ReportFinding[]; stdout: string }
   };
 }
 
+// A 64-character run over the value alphabet, assigned to an identifier the
+// name gate does not match. Long enough that the widened body reaches it, so
+// the assertion can actually fail if the name gate ever stops bounding it.
+const BENIGN_BLOB = 'a1B2c3D4e5F6g7H8i9J0kLmNoPqRsTuVwXyZ01234567890abcdefghijklmnopq';
+
 let root: string;
 const credFindingsByWidth = new Map<number, ReportFinding[]>();
 let proseFailedCred: ReportFinding[] = [];
+let benignBlobFailedCred: ReportFinding[] = [];
 
 beforeAll(() => {
   root = mkdtempSync(path.join(tmpdir(), 'hma17-'));
@@ -96,6 +112,14 @@ beforeAll(() => {
     `AWS_SECRET_ACCESS_KEY = "${PROSE_SENTENCE}"\n`,
   );
   proseFailedCred = runCli(proseDir).failedCred;
+
+  const blobDir = path.join(root, 'benign-blob');
+  mkdirSync(blobDir, { recursive: true });
+  writeFileSync(
+    path.join(blobDir, 'config.py'),
+    `BUILD_MANIFEST_DIGEST = "${BENIGN_BLOB}"\n`,
+  );
+  benignBlobFailedCred = runCli(blobDir).failedCred;
 }, 1_200_000);
 
 afterAll(() => {
@@ -151,20 +175,56 @@ describe('HMA-17 name-gated credential width', () => {
     const patterns = accessor!();
     expect(patterns.length).toBeGreaterThanOrEqual(1);
 
-    // A character class, a fixed-width quantifier closing the capture, then a
-    // negative lookahead over the SAME class text. `{40}` consumes exactly N
-    // characters and the lookahead rejects the N+1th, so any entry with this
-    // shape detects exactly one width and nothing longer — the defect this
-    // suite exists for. Measured at origin/main a598f61 the population was
-    // exactly one (semantic-compiler.ts:1657); this refuses a re-introduction.
-    const fixedWidthSameAlphabetLookahead = /(\[[^\]]+\])\{\d+\}\)?\(\?!\1/;
-    const offenders = patterns
-      .filter(p => fixedWidthSameAlphabetLookahead.test(p.regex.source))
-      .map(p => `${p.label}: /${p.regex.source}/`);
+    // A character class, then a quantifier with an UPPER BOUND closing the
+    // capture, then a negative lookahead over the same class. Both `{N}` and
+    // `{N,M}` are offenders and the range form is the trap: the quantifier can
+    // consume at most M characters, the lookahead then rejects the M+1th, and
+    // backtracking cannot help because every shorter length hits the same
+    // rejection — so a secret longer than M is invisible exactly as it was
+    // under `{40}`. Measured on this pattern's own shape: `{40}` misses at 41,
+    // and `{40,256}` misses at 257, 300 and 1000 while matching 40 through 256.
+    // Only an open lower bound `{N,}` is safe here.
+    //
+    // The class-text comparison is deliberately semantic rather than a byte
+    // backreference: `[A-Za-z0-9/+]` and `[A-Za-z0-9+/]` are the same class and
+    // a `\1` match would miss the reordered spelling.
+    const boundedBodyThenLookahead = /\[([^\]]+)\]\{\d+(,\d*)?\}\)?\s*\(\?!\s*\[([^\]]+)\]/g;
+    const sortChars = (s: string) => s.split('').sort().join('');
+    const offenders: string[] = [];
+    for (const p of patterns) {
+      boundedBodyThenLookahead.lastIndex = 0;
+      for (const m of p.regex.source.matchAll(boundedBodyThenLookahead)) {
+        const [, bodyClass, upperBound, aheadClass] = m;
+        // `{N,}` (no upper bound) is the safe form this fix introduced.
+        if (upperBound === ',') continue;
+        if (sortChars(bodyClass) !== sortChars(aheadClass)) continue;
+        offenders.push(`${p.label}: /${p.regex.source}/`);
+      }
+    }
     expect(
       offenders,
-      'these name-gated shapes pin an exact width and then forbid a same-alphabet '
-        + 'continuation, so any longer secret is invisible; use a lower bound {N,} instead',
+      'these name-gated shapes cap the value width and then forbid a same-alphabet '
+        + 'continuation, so any secret longer than the cap is invisible; use an open '
+        + 'lower bound {N,} instead — a range {N,M} moves the blind spot, it does not '
+        + 'remove it',
+    ).toEqual([]);
+  }, 30_000);
+
+  it('HMA-17.AC4b a long benign alphabet-only run on a line the name gate does not match stays unreported', () => {
+    // The paired negative AC4 cannot supply. AC4's fixture is prose whose
+    // longest [A-Za-z0-9/+] run is far below the 40-character minimum, so it
+    // passes under every quantifier this diff could have used and cannot fail
+    // under the change it guards. The risk the widening actually opens is a
+    // long alphanumeric run — a hash, a base64 blob, an integrity string —
+    // and what keeps that from firing is the NAME GATE, which this change does
+    // not touch. So the assertion that can fail is: an unmistakable 64-character
+    // blob on a line whose identifier is not credential-named stays silent.
+    expect(BENIGN_BLOB.length).toBeGreaterThanOrEqual(41);
+    expect(/^[A-Za-z0-9/+]+$/.test(BENIGN_BLOB)).toBe(true);
+    expect(
+      benignBlobFailedCred.map(f => f.checkId),
+      'a long alphabet-only run assigned to a non-credential identifier must not be '
+        + 'reported: the widened body is bounded by the name gate, not by the value width',
     ).toEqual([]);
   }, 30_000);
 });

--- a/__tests__/nanomind-core/name-gated-credential-width.test.ts
+++ b/__tests__/nanomind-core/name-gated-credential-width.test.ts
@@ -1,0 +1,170 @@
+/**
+ * HMA-17 — a name-gated secret longer than 40 characters is invisible.
+ *
+ * The name-gated AWS-secret shape in
+ * `src/nanomind-core/compiler/semantic-compiler.ts` pinned its value body to
+ * exactly `{40}` and then forbade a further same-alphabet character with a
+ * trailing lookahead. `{40}` consumes forty characters and the lookahead
+ * rejects the forty-first, so a 41+ character secret assigned to
+ * `AWS_SECRET_ACCESS_KEY` matched nothing. Measured on origin/main a598f61
+ * (2026-09-01) with the built CLI: width 40 -> AST-CRED-003; widths 41, 50,
+ * 64, 128 -> no credential finding.
+ *
+ * The CLI is driven through `src/cli.ts` with the repo's own `tsx`, not the
+ * compiled binary, for the same reason `deterministic-floor-cli.test.ts`
+ * documents: a spawn suite gated on the built entry can silently skip, and a
+ * criterion whose evidence can silently skip is not evidence.
+ */
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { spawnSync } from 'node:child_process';
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import * as semanticCompiler from '../../src/nanomind-core/compiler/semantic-compiler';
+
+const REPO_ROOT = path.join(__dirname, '..', '..');
+const TSX = path.join(REPO_ROOT, 'node_modules', '.bin', 'tsx');
+const CLI_SRC = path.join(REPO_ROOT, 'src', 'cli.ts');
+
+/**
+ * Deterministic values over the shape's own alphabet `[A-Za-z0-9/+]`,
+ * generated once by an LCG and frozen here as literals so the fixture bytes
+ * are reviewable. Each shares the 40-char prefix (widths are prefixes of one
+ * another), has 31+ distinct characters (clears the <=6 low-entropy sentinel
+ * filter), and contains none of the placeholder markers
+ * (FAKE/EXAMPLE/PLACEHOLDER/...) that would suppress the hit.
+ */
+const VALUE_BY_WIDTH: Record<number, string> = {
+  40: 'gxg5HAuq1wTHXV6j47e9uPLYosPaq4SB1mZRHNET',
+  41: 'gxg5HAuq1wTHXV6j47e9uPLYosPaq4SB1mZRHNETo',
+  50: 'gxg5HAuq1wTHXV6j47e9uPLYosPaq4SB1mZRHNETobefRzLwbv',
+  64: 'gxg5HAuq1wTHXV6j47e9uPLYosPaq4SB1mZRHNETobefRzLwbvdKmfvfUohc1Y2G',
+  128: 'gxg5HAuq1wTHXV6j47e9uPLYosPaq4SB1mZRHNETobefRzLwbvdKmfvfUohc1Y2GAMa/usvmBwcQavaouGK01MFUSaifP7ZSaDWJwfRANWSx89utg0fg1qRDvYTivK2+',
+};
+const WIDTHS = [40, 41, 50, 64, 128] as const;
+
+/**
+ * The paired negative for the widening: a natural-language sentence of 66
+ * characters on the name-gated line. Removing a fixed upper bound from a
+ * credential shape is exactly the change that starts matching English, so
+ * this must stay at zero credential findings.
+ */
+const PROSE_SENTENCE =
+  'the deployment guide explains how operators rotate this value safely';
+
+interface ReportFinding {
+  checkId: string;
+  severity: string;
+  passed?: boolean;
+}
+
+function runCli(target: string): { failedCred: ReportFinding[]; stdout: string } {
+  const run = spawnSync(TSX, [CLI_SRC, 'secure', target, '--no-registry', '--json'], {
+    encoding: 'utf-8',
+    timeout: 180_000,
+    env: { ...process.env, NO_COLOR: '1' },
+  });
+  const stdout = run.stdout ?? '';
+  const start = stdout.indexOf('{');
+  const parsed = start >= 0 ? JSON.parse(stdout.slice(start)) : {};
+  const all: ReportFinding[] = parsed.allFindings ?? parsed.findings ?? [];
+  return {
+    failedCred: all.filter(f => f.passed === false && /^AST-CRED-/.test(f.checkId)),
+    stdout,
+  };
+}
+
+let root: string;
+const credFindingsByWidth = new Map<number, ReportFinding[]>();
+let proseFailedCred: ReportFinding[] = [];
+
+beforeAll(() => {
+  root = mkdtempSync(path.join(tmpdir(), 'hma17-'));
+  for (const width of WIDTHS) {
+    const dir = path.join(root, `w${width}`);
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(
+      path.join(dir, 'config.py'),
+      `AWS_SECRET_ACCESS_KEY = "${VALUE_BY_WIDTH[width]}"\n`,
+    );
+    credFindingsByWidth.set(width, runCli(dir).failedCred);
+  }
+  const proseDir = path.join(root, 'prose');
+  mkdirSync(proseDir, { recursive: true });
+  writeFileSync(
+    path.join(proseDir, 'config.py'),
+    `AWS_SECRET_ACCESS_KEY = "${PROSE_SENTENCE}"\n`,
+  );
+  proseFailedCred = runCli(proseDir).failedCred;
+}, 1_200_000);
+
+afterAll(() => {
+  if (root) rmSync(root, { recursive: true, force: true });
+});
+
+describe('HMA-17 name-gated credential width', () => {
+  it('HMA-17.AC1 a 50-character name-gated value in a .py fixture produces a failed AST-CRED-* finding', () => {
+    const failed = credFindingsByWidth.get(50) ?? [];
+    expect(
+      failed.length,
+      'a 50-character secret assigned to AWS_SECRET_ACCESS_KEY must produce at least one '
+        + 'failed AST-CRED-* finding; on origin/main a598f61 the {40}-pinned body plus the '
+        + 'same-alphabet lookahead makes any 41+ character secret invisible',
+    ).toBeGreaterThanOrEqual(1);
+  }, 30_000);
+
+  for (const width of WIDTHS) {
+    it(`HMA-17.AC2 width ${width}: the name-gated fixture produces a failed AST-CRED-* finding`, () => {
+      const failed = credFindingsByWidth.get(width) ?? [];
+      expect(
+        failed.length,
+        `body length ${width} assigned to AWS_SECRET_ACCESS_KEY must be detected; the shape `
+          + 'declares a canonical MINIMUM of 40, not an exact width',
+      ).toBeGreaterThanOrEqual(1);
+    }, 30_000);
+  }
+
+  it('HMA-17.AC4 a natural-language sentence of 50+ characters on the name-gated line produces zero failed AST-CRED-* findings', () => {
+    expect(PROSE_SENTENCE.length).toBeGreaterThanOrEqual(50);
+    expect(
+      proseFailedCred.map(f => f.checkId),
+      'prose assigned to AWS_SECRET_ACCESS_KEY must not be reported as a credential: the '
+        + 'value alphabet [A-Za-z0-9/+] excludes spaces, and the widening must not relax it',
+    ).toEqual([]);
+  }, 30_000);
+
+  it('HMA-17.AC5 no name-gated pattern pairs a fixed-width {N} body with a trailing lookahead over the same alphabet', () => {
+    // Namespace import, not a named one: on origin/main this export does not
+    // exist, and a named import would fail the whole file at module init
+    // rather than reporting which arm is red.
+    const accessor = (
+      semanticCompiler as unknown as {
+        nameGatedCredentialPatternsForTest?: () => Array<{ label: string; regex: RegExp }>;
+      }
+    ).nameGatedCredentialPatternsForTest;
+    expect(
+      typeof accessor,
+      'the compiler must export nameGatedCredentialPatternsForTest so this class is '
+        + 'asserted structurally rather than swept by hand',
+    ).toBe('function');
+
+    const patterns = accessor!();
+    expect(patterns.length).toBeGreaterThanOrEqual(1);
+
+    // A character class, a fixed-width quantifier closing the capture, then a
+    // negative lookahead over the SAME class text. `{40}` consumes exactly N
+    // characters and the lookahead rejects the N+1th, so any entry with this
+    // shape detects exactly one width and nothing longer — the defect this
+    // suite exists for. Measured at origin/main a598f61 the population was
+    // exactly one (semantic-compiler.ts:1657); this refuses a re-introduction.
+    const fixedWidthSameAlphabetLookahead = /(\[[^\]]+\])\{\d+\}\)?\(\?!\1/;
+    const offenders = patterns
+      .filter(p => fixedWidthSameAlphabetLookahead.test(p.regex.source))
+      .map(p => `${p.label}: /${p.regex.source}/`);
+    expect(
+      offenders,
+      'these name-gated shapes pin an exact width and then forbid a same-alphabet '
+        + 'continuation, so any longer secret is invisible; use a lower bound {N,} instead',
+    ).toEqual([]);
+  }, 30_000);
+});

--- a/src/nanomind-core/compiler/semantic-compiler.ts
+++ b/src/nanomind-core/compiler/semantic-compiler.ts
@@ -1631,7 +1631,7 @@ const CANONICAL_CREDENTIAL_PATTERNS: Array<{ label: string; regex: RegExp }> = [
  * flood of false positives (any 40-char base64 blob, hash, or random id would
  * hit). They are only flagged when the assignment TARGET names the credential.
  *
- * AWS secret access key is the canonical case: a 40-char `[A-Za-z0-9/+]` value.
+ * AWS secret access key is the canonical case: a 40+-char `[A-Za-z0-9/+]` value.
  * We require `aws … secret|private …` within a short window before the value
  * (the standard gitleaks approach), so `awsSecretAccessKey = "<40>"` and
  * `AWS_SECRET_ACCESS_KEY=<40>` fire, but a bare 40-char blob, a git SHA, or a
@@ -1645,7 +1645,7 @@ const CANONICAL_CREDENTIAL_PATTERNS: Array<{ label: string; regex: RegExp }> = [
 const NAME_GATED_CREDENTIAL_PATTERNS: Array<{ label: string; regex: RegExp }> = [
   {
     label: 'AWS secret access key',
-    // Two name anchors, both ending in `key`, then assignment + 40-char value:
+    // Two name anchors, both ending in `key`, then assignment + 40+-char value:
     //   (a) `aws … secret|private … key` — `AWS_SECRET_ACCESS_KEY`, `awsSecretKey`
     //   (b) `secret[_ ]access[_ ]key` — the AWS-specific full phrase, distinctive
     //       enough WITHOUT a nearby `aws` token, so it also catches the very
@@ -1654,7 +1654,20 @@ const NAME_GATED_CREDENTIAL_PATTERNS: Array<{ label: string; regex: RegExp }> = 
     // The `key` token rejects `aws secretsmanager arn:` / `aws secret etag =`
     // + 40-char-id false positives; JSON `"awsSecretAccessKey":"<40>"` is
     // handled by the `["'\s]*[:=]+` operator class.
-    regex: /(?:aws.{0,16}?(?:secret|private).{0,16}?key|secret[_\s.-]?access[_\s.-]?key)["'\s]*[:=]+>?\s*["']?([A-Za-z0-9/+]{40})(?![A-Za-z0-9/+])/gi,
+    //
+    // `{40,}` is a LOWER bound, not `{40}`: the canonical AWS width is the
+    // minimum a real secret can have, and this shape previously pinned the
+    // body to exactly `{40}` and then forbade a same-alphabet continuation
+    // with `(?![A-Za-z0-9/+])` — the `{40}` consumed forty characters and the
+    // lookahead rejected the forty-first, so any 41+ character secret matched
+    // NOTHING. The greedy `{40,}` consumes the whole same-alphabet run, which
+    // preserves the lookahead's boundary semantics (it can only succeed at
+    // the end of the run) without capping the width. The redaction mirror in
+    // `security/defense-in-depth.ts` already used `{40,}`.
+    // `name-gated-credential-width.test.ts` (HMA-17.AC5) structurally rejects
+    // any re-introduction of a fixed-width body paired with a same-alphabet
+    // lookahead in this list.
+    regex: /(?:aws.{0,16}?(?:secret|private).{0,16}?key|secret[_\s.-]?access[_\s.-]?key)["'\s]*[:=]+>?\s*["']?([A-Za-z0-9/+]{40,})(?![A-Za-z0-9/+])/gi,
   },
 ];
 
@@ -1702,6 +1715,17 @@ export function canonicalCredentialLabelsForTest(): string[] {
     ...CANONICAL_CREDENTIAL_PATTERNS.map(p => p.label),
     ...NAME_GATED_CREDENTIAL_PATTERNS.map(p => p.label),
   ];
+}
+
+/**
+ * Test-only accessor for the name-gated pattern list. Exported so
+ * `__tests__/nanomind-core/name-gated-credential-width.test.ts` can assert a
+ * STRUCTURAL invariant over every entry — no fixed-width `{N}` body paired
+ * with a trailing lookahead over the same alphabet, the shape that made any
+ * 41+ character AWS secret invisible — instead of hand-sweeping the list.
+ */
+export function nameGatedCredentialPatternsForTest(): Array<{ label: string; regex: RegExp }> {
+  return NAME_GATED_CREDENTIAL_PATTERNS;
 }
 
 function scanCanonicalCredentialFormats(content: string): CanonicalCredentialHit[] {


### PR DESCRIPTION
A name-gated AWS-shaped secret **longer than 40 characters was never detected**.

The shape pinned its value body to exactly `{40}` and then forbade a same-alphabet continuation:

```
([A-Za-z0-9/+]{40})(?![A-Za-z0-9/+])
```

The quantifier consumed forty characters and the lookahead rejected the forty-first, so a 41+
character value assigned to `AWS_SECRET_ACCESS_KEY` matched nothing. Backtracking cannot rescue it,
because the connector before the value cannot consume an alphabet character, so the value's start
is pinned. The body is now a lower bound, `{40,}`.

## Detection, measured by width

Against the built CLI on a `.py` fixture, before and after:

| body length | before | after |
|---|---|---|
| 40 | detected | detected |
| 41 | **nothing** | detected |
| 50 | **nothing** | detected |
| 64 | **nothing** | detected |
| 128 | **nothing** | detected |

## Red first

`__tests__/nanomind-core/name-gated-credential-width.test.ts` fails against the previous regex and
passes here. Run against the base with only the source reverted: **6 of 8 failing** — the 50-char
case, all four widths above 40, and the structural guard. The two that pass on base are
preserved-behaviour assertions and are meant to.

## No new false positives

The three committed oracle suites are byte-identical either side of the change:

```
benign-fp-regression + scanner-fp-regression + pinned-credential-shapes
  base: 111 passed | 2 skipped        head: 111 passed | 2 skipped
```

An independent differential over real corpus — the repository's own files and `node_modules`,
about 60 MB — found **0 new and 0 lost** findings. The widening is a strict superset at the same
pinned start, so nothing that matched before stops matching.

## What an adversarial review changed here

The regex is as delivered. Three of its findings were about the tests, and all three are fixed:

- **The false-positive control could not fail.** Its fixture's longest run over the value alphabet
  is about ten characters, thirty short of the pattern's minimum, so it passed under every
  quantifier the change could have used. Added the negative it could not supply: a 64-character
  alphabet-only blob on a **non-credential** identifier must stay silent, which fails if the name
  gate ever stops bounding the body.
- **The structural guard was byte-exact and evadable.** It now rejects a capped body of any kind and
  compares character classes semantically, so a reordered but identical class cannot slip past.
- **The CLI helper returned an empty list when the scanner failed to start.** Every negative
  assertion compares against an empty array, so a spawn that never ran satisfied all of them. It
  throws now, naming the exit status and stderr.

The review also recommended bounding the quantifier to `{40,256}`. **That is refused, with a
measurement**, because it reintroduces the defect this PR removes:

| body length | `{40}` | `{40,}` | `{40,256}` |
|---|---|---|---|
| 41 | miss | match | match |
| 256 | miss | match | match |
| 257 | miss | match | **miss** |
| 1000 | miss | match | **miss** |

A cap plus a same-alphabet lookahead moves the blind spot rather than removing it: the quantifier
takes at most M, the lookahead rejects the M+1th, and every shorter length hits the same rejection.
The strengthened structural guard now fails on exactly that shape — verified by mutating the source
to `{40,256}` and watching the guard go red, which the previous byte-exact guard did not.

The review's remaining note is that `{40,}` is unbounded: a megabyte-long run on a name-gated line
is reported as a credential. Worth knowing and recorded, but it is a pre-existing class rather than
something this change creates — other `{40,}` patterns already in the tree share the behaviour, the
path that reaches this one caps input well below where it matters, and the reported evidence is the
literal `[REDACTED]`, with none of the captured value reaching output.

## Scope and suite

`git diff --name-only` is the one source file and the one test file. Nothing under `.github/`, no
change to `.hmaignore`, no test deleted or marked todo, and the vendor-prefixed shapes elsewhere in
the file are untouched — verified structurally, not by eye.

`hackmyagent secure --ci` reports 95/100; its one finding is Container Isolation in a Dockerfile
this diff does not touch.

**Full suite:** three tests in `__tests__/telemetry/contribute.test.ts` are non-deterministic on this
machine. They are unrelated to this change and pre-existing: the same file fails identically, in
isolation, on the base commit with none of this applied. Tracked separately. Every other file passes
(371 of 374, the rest skipped).
