### PR TITLE
Pin @opena2a/aim-sdk to 1.3.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@noble/ed25519": "^2.3.0",
         "@noble/post-quantum": "^0.2.1",
         "@opena2a/aim-core": "^0.1.2",
-        "@opena2a/aim-sdk": "1.3.0",
+        "@opena2a/aim-sdk": "1.3.1",
         "@opena2a/check-core": "0.3.0",
         "@opena2a/cli-ui": "0.5.2",
         "@opena2a/contribute": "^0.3.0",
@@ -640,9 +640,9 @@
       }
     },
     "node_modules/@opena2a/aim-sdk": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@opena2a/aim-sdk/-/aim-sdk-1.3.0.tgz",
-      "integrity": "sha512-1J216nHoxp9hHJVuD+q4rQy7pg7KLdJZjX8kiemt+FmgNOb5Gpo4ZOM0k5YkpFMaqmA1xAbOB8I2inCShsaCHA==",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@opena2a/aim-sdk/-/aim-sdk-1.3.1.tgz",
+      "integrity": "sha512-y5eisHAYuaFqMda5Tg5RLkxfoiK07BrtYImxeLGTpuYlZCioRvksmpExxEBQyt6gVFU75Y/dUSpqMUgWZ7McMA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@noble/ed25519": "^2.1.0",

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "@noble/ed25519": "^2.3.0",
     "@noble/post-quantum": "^0.2.1",
     "@opena2a/aim-core": "^0.1.2",
-    "@opena2a/aim-sdk": "1.3.0",
+    "@opena2a/aim-sdk": "1.3.1",
     "@opena2a/check-core": "0.3.0",
     "@opena2a/cli-ui": "0.5.2",
     "@opena2a/contribute": "^0.3.0",


### PR DESCRIPTION
## Summary

Exact pin bump 1.3.0 -> 1.3.1 (package.json + package-lock.json only).

1.3.1 fixes the NetworkMonitor ss parser that read the columns of `ss -tpn` while running `ss -tpn state established`, so the Linux monitor never reported an established connection. The E2E-003 timeout on the ubuntu job in #696 traces to that parser. Published with SLSA v1 provenance: `npm view @opena2a/aim-sdk dist.attestations`.

## Tests

Pre-push hook suite green on this host.